### PR TITLE
Fixes to get the nightly tests to run through on Caldera with serial MPI

### DIFF
--- a/ctest/runcdash-nwsc-intel-mpiserial.sh
+++ b/ctest/runcdash-nwsc-intel-mpiserial.sh
@@ -28,7 +28,7 @@ fi
 cd "$PIO_DASHBOARD_ROOT"
 
 if [ ! -d src ]; then
-  git clone https://github.com/Katetc/ParallelIO src
+  git clone https://github.com/PARALLELIO/ParallelIO src
 fi
 cd src
 

--- a/ctest/runcdash-nwsc-intel-mpiserial.sh
+++ b/ctest/runcdash-nwsc-intel-mpiserial.sh
@@ -28,7 +28,7 @@ fi
 cd "$PIO_DASHBOARD_ROOT"
 
 if [ ! -d src ]; then
-  git clone https://github.com/PARALLELIO/ParallelIO src
+  git clone https://github.com/Katetc/ParallelIO src
 fi
 cd src
 

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -156,8 +156,9 @@ iosystem_desc_t *pio_get_iosystem_from_id(int iosysid)
   iosystem_desc_t *ciosystem;
 
   ciosystem = pio_iosystem_list;
+
   while(ciosystem != NULL){
-    // printf("%d ciosystem %ld %ld %d\n",__LINE__,pio_iosystem_list, ciosystem,iosysid);
+    // fprintf(stderr, "%d ciosystem %ld %ld %d\n",__LINE__,pio_iosystem_list, ciosystem,iosysid);
     if(ciosystem->iosysid == iosysid){
       return ciosystem;
     }

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -1,10 +1,10 @@
-////
-/// @file pio_spmd.c
-/// @author Algorithms modeled after spmd_utils in the Community Atmosphere Model; C translation Jim Edwards
-/// @date 2014
-/// @brief MPI_Gather, MPI_Gatherv, and MPI_Alltoallw with flow control options
-///
-/// 
+/**
+ * @file pio_spmd.c
+ * @author Algorithms modeled after spmd_utils in the Community Atmosphere Model; C translation Jim Edwards
+ * @date 2014
+ * @brief MPI_Gather, MPI_Gatherv, and MPI_Alltoallw with flow control options
+ */
+ 
 #ifdef TESTSWAPM
 #include <mpi.h>
 #include <stdlib.h>
@@ -22,9 +22,9 @@
 #include <pio_internal.h>
 #endif
 
-/// 
-/// Wrapper for MPI calls to print the Error string on error
-/// 
+/** 
+ ** @brief Wrapper for MPI calls to print the Error string on error
+ */
 void CheckMPIReturn(const int ierr,const char file[],const int line)
 {
   
@@ -39,9 +39,9 @@ void CheckMPIReturn(const int ierr,const char file[],const int line)
 }
 
 
-///
-///  pio_fc_gather provides the functionality of MPI_Gather with flow control options
-///
+/**
+ **  @brief Provides the functionality of MPI_Gather with flow control options
+ */
 
 int pio_fc_gather( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype,
 		   void *recvbuf, const int recvcnt, const MPI_Datatype recvtype, const int root, 
@@ -126,10 +126,9 @@ int pio_fc_gather( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype
   
 
 
-///
-///  pio_fc_gatherv provides the functionality of MPI_Gatherv with flow control options
-///
-
+/**
+ **  @brief Provides the functionality of MPI_Gatherv with flow control options
+ */
 
 int pio_fc_gatherv( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype,
 		    void *recvbuf, const int recvcnts[], const int displs[],
@@ -211,7 +210,7 @@ int pio_fc_gatherv( void *sendbuf, const int sendcnt, const MPI_Datatype sendtyp
 }
 
 ///
-///  Returns the smallest power of 2 greater than i
+///  @brief Returns the smallest power of 2 greater than i
 ///  
 int ceil2(const int i)
 {
@@ -223,8 +222,8 @@ int ceil2(const int i)
 }
 
 ///
-///  Given integers p and k between 0 and np-1  
-///  
+///  @brief Given integers p and k between 0 and np-1,  
+///  if (p+1)^k <= np-1 then return (p+1)^k else -1
 int pair(const int np, const int p, const int k)
 {
   int q = (p+1) ^ k ;
@@ -232,11 +231,9 @@ int pair(const int np, const int p, const int k)
   return pair;
 }
 
-
-///
-///  pio_swapm provides the functionality of MPI_Alltoallw with flow control options
-///
-
+/**
+ **  @brief Provides the functionality of MPI_Alltoallw with flow control options
+ */
 int pio_swapm(void *sndbuf,   int sndlths[], int sdispls[],  MPI_Datatype stypes[], 
 	      void *rcvbuf,  int rcvlths[],  int rdispls[],  MPI_Datatype rtypes[], 
 	       MPI_Comm comm,const  bool handshake, bool isend,const  int max_requests)

--- a/src/flib/piolib_mod.F90
+++ b/src/flib/piolib_mod.F90
@@ -877,6 +877,7 @@ contains
     if(present(base)) lbase=base
     ierr = PIOc_Init_Intracomm_from_F90(comp_comm,num_iotasks,stride,lbase,rearr,iosystem%iosysid)
 
+    call CheckMPIReturn("Bad Initialization in PIO_Init_Intracomm:  ", ierr,__FILE__,__LINE__)
 #ifdef TIMING
     call t_stopf("PIO:init")
 #endif

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -111,8 +111,15 @@ CONTAINS
     !   --stride
 
     CALL Read_input()
+    IF (pio_tf_world_sz_ < pio_tf_num_io_tasks_) THEN
+       pio_tf_num_io_tasks_ = pio_tf_world_sz_
+    END IF
+    IF (pio_tf_num_io_tasks_ <= 1 .AND. pio_tf_stride_ > 1) THEN
+       pio_tf_stride_ = 1
+    END IF
     IF (pio_tf_num_io_tasks_ == 0) THEN
-      pio_tf_num_io_tasks_ = pio_tf_world_sz_ / pio_tf_stride_;
+      pio_tf_num_io_tasks_ = pio_tf_world_sz_ / pio_tf_stride_
+      IF (pio_tf_num_io_tasks_ < 1) pio_tf_num_io_tasks_ = 1
     END IF
     !IF (pio_tf_world_rank_ == 0) THEN
     !  PRINT *, "PIO_TF: stride=", pio_tf_stride_, ", io_tasks=",&


### PR DESCRIPTION
Fixes to get the nightly tests to run through on Caldera with serial MPI. Better handling of bad task configurations at init time, plus added logic to the test that prevents asking for bad configurations when running serially. Also includes a few updates to Doxygen comments in the spmd module as I was reading through it last week. These changes pass all nightly/unit tests on Caldera.