### PR TITLE
Added ifdefs around the MPIAlltoall call in the case of OPENMPI which…

### DIFF
--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -248,6 +248,7 @@ int pio_swapm(void *sndbuf,   int sndlths[], int sdispls[],  MPI_Datatype stypes
   CheckMPIReturn(MPI_Comm_size(comm, &nprocs),__FILE__,__LINE__);
   CheckMPIReturn(MPI_Comm_rank(comm, &mytask),__FILE__,__LINE__);
 
+#ifndef OPEN_MPI
   if(max_requests == 0) {
 #ifdef DEBUG
     int totalrecv=0;
@@ -263,6 +264,7 @@ int pio_swapm(void *sndbuf,   int sndlths[], int sdispls[],  MPI_Datatype stypes
     CheckMPIReturn(MPI_Alltoallw( sndbuf, sndlths, sdispls, stypes, rcvbuf, rcvlths, rdispls, rtypes, comm),__FILE__,__LINE__);
     return PIO_NOERR;
   }
+#endif
 
   int tag;
   int offset_t;

--- a/tests/unit/driver.F90
+++ b/tests/unit/driver.F90
@@ -28,6 +28,7 @@ Program pio_unit_test_driver
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, my_rank, ierr)
   call MPI_Comm_size(MPI_COMM_WORLD, ntasks , ierr)
+  !! call MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
   master_task = my_rank.eq.0
 
   if (master_task) then


### PR DESCRIPTION
… doesn't seem to like one of the MPI types used. This allows all of the nightly tests on Hobart to complete.