### PR TITLE
Bringing in ACME changes to PIO1 branch

### DIFF
--- a/pio/box_rearrange.F90.in
+++ b/pio/box_rearrange.F90.in
@@ -2,8 +2,8 @@
 !>
 !!
 !! @file 
-!! $Revision$
-!! $LastChangedDate$
+!! $Revision: 819 $
+!! $LastChangedDate: 2013-05-31 13:32:27 -0500 (Fri, 31 May 2013) $
 !! @brief
 !!  Perform data rearrangement with each io processor
 !!  owning a rectangular box in the output domain
@@ -29,39 +29,7 @@
 ! cache communication pattern for rearranger in the ioDesc
 #define BOX_CACHE 1
 
-
-! communication algorithm options
-#define COLLECTIVE 0
-#define POINT_TO_POINT 1
-#define FLOW_CONTROL 2
-#define DEF_P2P_HANDSHAKE .true.
-#define DEF_P2P_ISEND .false.
-#define DEF_P2P_MAXREQ 64
-
-#ifndef _MPISERIAL
-#ifndef _NO_FLOW_CONTROL
-#define _USE_COMP2IO_FC 1
-#define _USE_IO2COMP_FC 1
-#endif  
-#endif
-!
-! The completely unreadable nature of the following lines is required by some compilers
-!
-#ifdef _USE_ALLTOALLW
-#define DEF_COMP2IO_OPTION 0
-#define DEF_IO2COMP_OPTION 0
-#else
-#ifdef _USE_COMP2IO_FC
-#define DEF_COMP2IO_OPTION 2
-#else
-#define DEF_COMP2IO_OPTION 1
-#endif
-#ifdef _USE_IO2COMP_FC
-#define DEF_IO2COMP_OPTION 2
-#else
-#define DEF_IO2COMP_OPTION 1
-#endif
-#endif
+#include "rearr_options.h"
 
 !> 
 !! \def TAG
@@ -74,7 +42,7 @@
 module box_rearrange
 
   use pio_kinds, only : pio_offset, r4, r8, i4, i8
-  use pio_types, only : io_desc_t, iosystem_desc_t
+  use pio_types !, only : io_desc_t, iosystem_desc_t
 #ifdef NO_MPI2
   use pio_support, only : MPI_TYPE_CREATE_INDEXED_BLOCK, piodie, &
                           Debug, DebugIO, CheckMPIReturn, pio_fc_gather_offset
@@ -212,20 +180,39 @@ subroutine box_rearrange_comp2io_{TYPE} (IOsystem, ioDesc, s1, src, niodof, &
 #else
 
 
-  ! begin
+  ! FIXME: Ideally the iodesc should contain the rearr and
+  ! the rearr_opts - however the current code sets the
+  ! rearr and rearr_opts on the IOsystem
+
+  ! The rearranger options in IODESC overrides the defaults
+  if(IOsystem%rearr_opts%comm_type == PIO_rearr_comm_p2p) then
+    if( (IOsystem%rearr_opts%comm_fc_opts%fcd == PIO_rearr_comm_fc_2d_disable) .or.&
+        (IOsystem%rearr_opts%comm_fc_opts%fcd == PIO_rearr_comm_fc_1d_io2comp) ) then
+      pio_option = POINT_TO_POINT
+    else
+      pio_option = FLOW_CONTROL
+    end if
+  else
+    pio_option = COLLECTIVE
+  end if
+
+  ! The rearranger options passed in to this function overrides
+  ! both the defaults and the options in IODESC
   if ( present( comm_option ) ) then
      if ((comm_option == COLLECTIVE) &
          .or. (comm_option == POINT_TO_POINT) &
          .or. (comm_option == FLOW_CONTROL)) then
          pio_option = comm_option
       endif
-  else
-     pio_option = DEF_COMP2IO_OPTION
   endif
+
   if (pio_option == FLOW_CONTROL) then
-    pio_hs     = DEF_P2P_HANDSHAKE
-    pio_isend  = DEF_P2P_ISEND
-    pio_maxreq = DEF_P2P_MAXREQ
+    pio_hs     = IOsystem%rearr_opts%comm_fc_opts%enable_hs
+    pio_isend  = IOsystem%rearr_opts%comm_fc_opts%enable_isend
+    pio_maxreq = IOsystem%rearr_opts%comm_fc_opts%max_pend_req
+
+    ! The rearranger options passed to this function overrides
+    ! both the default and the options in IODESC
     if ( present(fc_options) ) then
       if (fc_options(1) == 0) then
         pio_hs = .false.
@@ -477,19 +464,39 @@ subroutine box_rearrange_io2comp_{TYPE} (IOsystem,ioDesc,s1, iobuf,s2, compbuf, 
   end do
 
 #else
+  ! FIXME: Ideally the iodesc should contain the rearr and
+  ! the rearr_opts - however the current code sets the
+  ! rearr and rearr_opts on the IOsystem
+
+  ! The rearranger options in IODESC overrides the defaults
+  if(IOsystem%rearr_opts%comm_type == PIO_rearr_comm_p2p) then
+    if( (IOsystem%rearr_opts%comm_fc_opts%fcd == PIO_rearr_comm_fc_2d_disable) .or.&
+        (IOsystem%rearr_opts%comm_fc_opts%fcd == PIO_rearr_comm_fc_1d_comp2io) ) then
+      pio_option = POINT_TO_POINT
+    else
+      pio_option = FLOW_CONTROL
+    end if
+  else
+    pio_option = COLLECTIVE
+  end if
+
+  ! The rearranger options passed in to this function overrides
+  ! both the defaults and the options in IODESC
   if ( present( comm_option ) ) then
      if ((comm_option == COLLECTIVE) &
          .or. (comm_option == POINT_TO_POINT) &
          .or. (comm_option == FLOW_CONTROL)) then
          pio_option = comm_option
       endif
-  else
-     pio_option = DEF_IO2COMP_OPTION
   endif
+
   if (pio_option == FLOW_CONTROL) then
-    pio_hs     = DEF_P2P_HANDSHAKE
-    pio_isend  = DEF_P2P_ISEND
-    pio_maxreq = DEF_P2P_MAXREQ
+    pio_hs     = IOsystem%rearr_opts%comm_fc_opts%enable_hs
+    pio_isend  = IOsystem%rearr_opts%comm_fc_opts%enable_isend
+    pio_maxreq = IOsystem%rearr_opts%comm_fc_opts%max_pend_req
+
+    ! The rearranger options passed to this function overrides
+    ! both the default and the options in IODESC
     if ( present(fc_options) ) then
       if (fc_options(1) == 0) then
         pio_hs = .false.
@@ -1336,7 +1343,7 @@ end subroutine box_rearrange_io2comp_{TYPE}
        do i=1,nrecvs
           recv_counts(rfrom(i)+1) = rcount(i)
        enddo
-       
+
        rbuf_size = sum(recv_counts)
        call alloc_check(rindex, rbuf_size, 'rindex buffer')
        rindex = 0

--- a/pio/box_rearrange.F90.in
+++ b/pio/box_rearrange.F90.in
@@ -42,7 +42,7 @@
 module box_rearrange
 
   use pio_kinds, only : pio_offset, r4, r8, i4, i8
-  use pio_types !, only : io_desc_t, iosystem_desc_t
+  use pio_types
 #ifdef NO_MPI2
   use pio_support, only : MPI_TYPE_CREATE_INDEXED_BLOCK, piodie, &
                           Debug, DebugIO, CheckMPIReturn, pio_fc_gather_offset

--- a/pio/box_rearrange.F90.in
+++ b/pio/box_rearrange.F90.in
@@ -280,7 +280,6 @@ subroutine box_rearrange_comp2io_{TYPE} (IOsystem, ioDesc, s1, src, niodof, &
       endif
     end do
 
-#ifdef _USE_ALLTOALLW
     if (pio_option == COLLECTIVE) then
 
       call MPI_ALLTOALLW(src,  a2a_sendcounts, a2a_displs, a2a_sendtypes, &
@@ -288,14 +287,11 @@ subroutine box_rearrange_comp2io_{TYPE} (IOsystem, ioDesc, s1, src, niodof, &
                          IOsystem%union_comm, ierror                       )
       call CheckMPIReturn('box_rearrange', ierror)
     else
-#endif
       call pio_swapm( nprocs, myrank,                            &
         src,  ndof,   a2a_sendcounts, a2a_displs, a2a_sendtypes, &
         dest, niodof, a2a_recvcounts, a2a_displs, a2a_recvtypes, &
         IOsystem%union_comm, pio_hs, pio_isend, pio_maxreq        )
-#ifdef _USE_ALLTOALLW
     endif
-#endif
     call dealloc_check(a2a_sendcounts)
     call dealloc_check(a2a_displs)
     call dealloc_check(a2a_sendtypes)
@@ -567,21 +563,17 @@ subroutine box_rearrange_io2comp_{TYPE} (IOsystem,ioDesc,s1, iobuf,s2, compbuf, 
       end do
     endif
 
-#ifdef _USE_ALLTOALLW
     if (pio_option == COLLECTIVE) then
       call MPI_ALLTOALLW(iobuf,   a2a_sendcounts, a2a_displs, a2a_sendtypes, &
                          compbuf, a2a_recvcounts, a2a_displs, a2a_recvtypes, &
                          IOsystem%union_comm, ierror                          )
       call CheckMPIReturn(subName, ierror)
     else
-#endif
       call pio_swapm( nprocs, myrank,                               &
         iobuf,   niodof, a2a_sendcounts, a2a_displs, a2a_sendtypes, &
         compbuf, ndof,   a2a_recvcounts, a2a_displs, a2a_recvtypes, &
         IOsystem%union_comm, pio_hs, pio_isend, pio_maxreq           )
-#ifdef _USE_ALLTOALLW
     endif
-#endif
     call dealloc_check(a2a_sendcounts)
     call dealloc_check(a2a_displs)
     call dealloc_check(a2a_sendtypes)

--- a/pio/box_rearrange.F90.in
+++ b/pio/box_rearrange.F90.in
@@ -50,6 +50,9 @@ module box_rearrange
   use pio_support, only : piodie, Debug, DebugIO, CheckMPIReturn, pio_fc_gather_offset
                           
 #endif
+#ifdef TIMING
+  use perf_mod, only : t_startf, t_stopf  !_EXTERNAL
+#endif
   use alloc_mod,      only : alloc_check, dealloc_check
   use pio_spmd_utils, only : pio_swapm
 #ifndef NO_MPIMOD
@@ -282,15 +285,27 @@ subroutine box_rearrange_comp2io_{TYPE} (IOsystem, ioDesc, s1, src, niodof, &
 
     if (pio_option == COLLECTIVE) then
 
+#ifdef TIMING
+      call t_startf("a2a_box_rear_comp2io_{TYPE}")
+#endif
       call MPI_ALLTOALLW(src,  a2a_sendcounts, a2a_displs, a2a_sendtypes, &
                          dest, a2a_recvcounts, a2a_displs, a2a_recvtypes, &
                          IOsystem%union_comm, ierror                       )
+#ifdef TIMING
+      call t_stopf("a2a_box_rear_comp2io_{TYPE}")
+#endif
       call CheckMPIReturn('box_rearrange', ierror)
     else
+#ifdef TIMING
+      call t_startf("swapm_box_rear_comp2io_{TYPE}")
+#endif
       call pio_swapm( nprocs, myrank,                            &
         src,  ndof,   a2a_sendcounts, a2a_displs, a2a_sendtypes, &
         dest, niodof, a2a_recvcounts, a2a_displs, a2a_recvtypes, &
         IOsystem%union_comm, pio_hs, pio_isend, pio_maxreq        )
+#ifdef TIMING
+       call t_stopf("swapm_box_rear_comp2io_{TYPE}")
+#endif
     endif
     call dealloc_check(a2a_sendcounts)
     call dealloc_check(a2a_displs)
@@ -307,6 +322,9 @@ subroutine box_rearrange_comp2io_{TYPE} (IOsystem, ioDesc, s1, src, niodof, &
     endif
 #endif
 
+#ifdef TIMING
+    call t_startf("p2p_box_rear_comp2io_{TYPE}")
+#endif
     !
     ! send data from comp procs
     !
@@ -361,6 +379,10 @@ subroutine box_rearrange_comp2io_{TYPE} (IOsystem, ioDesc, s1, src, niodof, &
     end do
 
     call dealloc_check(sreq, 'send requests')
+
+#ifdef TIMING
+    call t_stopf("p2p_box_rear_comp2io_{TYPE}")
+#endif
 
 #if DEBUG_BARRIER
     call MPI_BARRIER(IOsystem%union_comm,ierror)
@@ -564,15 +586,29 @@ subroutine box_rearrange_io2comp_{TYPE} (IOsystem,ioDesc,s1, iobuf,s2, compbuf, 
     endif
 
     if (pio_option == COLLECTIVE) then
+
+#ifdef TIMING
+      call t_startf("a2a_box_rear_io2comp_{TYPE}")
+#endif
       call MPI_ALLTOALLW(iobuf,   a2a_sendcounts, a2a_displs, a2a_sendtypes, &
                          compbuf, a2a_recvcounts, a2a_displs, a2a_recvtypes, &
                          IOsystem%union_comm, ierror                          )
+#ifdef TIMING
+      call t_stopf("a2a_box_rear_io2comp_{TYPE}")
+#endif
       call CheckMPIReturn(subName, ierror)
     else
+
+#ifdef TIMING
+      call t_startf("swapm_box_rear_io2comp_{TYPE}")
+#endif
       call pio_swapm( nprocs, myrank,                               &
         iobuf,   niodof, a2a_sendcounts, a2a_displs, a2a_sendtypes, &
         compbuf, ndof,   a2a_recvcounts, a2a_displs, a2a_recvtypes, &
         IOsystem%union_comm, pio_hs, pio_isend, pio_maxreq           )
+#ifdef TIMING
+      call t_stopf("swapm_box_rear_io2comp_{TYPE}")
+#endif
     endif
     call dealloc_check(a2a_sendcounts)
     call dealloc_check(a2a_displs)
@@ -582,6 +618,9 @@ subroutine box_rearrange_io2comp_{TYPE} (IOsystem,ioDesc,s1, iobuf,s2, compbuf, 
 
   else
 
+#ifdef TIMING
+    call t_startf("p2p_box_rear_io2comp_{TYPE}")
+#endif
     call alloc_check(rreq, num_iotasks, 'recv requests')
 
     !
@@ -641,6 +680,9 @@ subroutine box_rearrange_io2comp_{TYPE} (IOsystem,ioDesc,s1, iobuf,s2, compbuf, 
 
       call dealloc_check(sreq,'send requests')
     endif
+#ifdef TIMING
+    call t_stopf("p2p_box_rear_io2comp_{TYPE}")
+#endif
 
   endif ! POINT_TO_POINT
 #endif  /* not _MPISERIAL */

--- a/pio/box_rearrange.F90.in
+++ b/pio/box_rearrange.F90.in
@@ -786,11 +786,11 @@ end subroutine box_rearrange_io2comp_{TYPE}
        do j=1,ndim
           if ( gcoord(j) < lb(j,i) ) then
              i = max(1,i-decompstep(j))
-             if(k>5000) print *,__FILE__,__LINE__,i,gcoord(:),lb(:,i),ub(:,i)
+             if(k>5000) print *,__PIO_FILE__,__LINE__,i,gcoord(:),lb(:,i),ub(:,i)
              cycle loop_ioproc
           else  if(gcoord(j) >= ub(j,i) ) then
              i = min(nioproc,i+decompstep(j))
-             if(k>5000) print *,__FILE__,__LINE__,i,gcoord(:),lb(:,i),ub(:,i)
+             if(k>5000) print *,__PIO_FILE__,__LINE__,i,gcoord(:),lb(:,i),ub(:,i)
              cycle loop_ioproc
           endif
        end do

--- a/pio/calcdecomp.F90
+++ b/pio/calcdecomp.F90
@@ -168,7 +168,7 @@ contains
     kount=mykount
 
 !    if(myiorank>=0 .and. myiorank<use_io_procs) then
-!       print *,__FILE__,__LINE__,use_io_procs,gdims,start,kount
+!       print *,__PIO_FILE__,__LINE__,use_io_procs,gdims,start,kount
 !    endif
 
 

--- a/pio/ionf_mod.F90
+++ b/pio/ionf_mod.F90
@@ -259,9 +259,9 @@ contains
        case(PIO_iotype_netcdf, pio_iotype_netcdf4c, pio_iotype_netcdf4p)
           if (File%fh>0) then
              ierr = nf90_sync(File%fh)
-             if(Debug) print *,__FILE__,__LINE__,ierr
+             if(Debug) print *,__PIO_FILE__,__LINE__,ierr
              ierr= nf90_close(File%fh)
-             if(Debug) print *,__FILE__,__LINE__,ierr
+             if(Debug) print *,__PIO_FILE__,__LINE__,ierr
           endif
 #endif
        case default

--- a/pio/pio.F90
+++ b/pio/pio.F90
@@ -2,8 +2,8 @@
 !! @file 
 !! @brief User interface Module for PIO, this is the only file a user program should 'use'
 !! 
-!! $Revision$
-!! $LastChangedDate$
+!! $Revision: 856 $
+!! $LastChangedDate: 2013-11-19 15:48:54 -0600 (Tue, 19 Nov 2013) $
 !<
 
 module pio
@@ -19,7 +19,11 @@ module pio
        pio_dupiodesc, pio_finalize, pio_set_hint, pio_getnumiotasks, pio_file_is_open, &
        pio_setnum_OST, pio_getnum_OST
 
-  use pio_types, only : io_desc_t, file_desc_t, var_desc_t, iosystem_desc_t, &
+  use pio_types, only : io_desc_t, file_desc_t, var_desc_t, iosystem_desc_t,&
+    pio_rearr_opt_t, pio_rearr_comm_fc_opt_t, pio_rearr_comm_fc_2d_enable,&
+    pio_rearr_comm_fc_1d_comp2io, pio_rearr_comm_fc_1d_io2comp,&
+    pio_rearr_comm_fc_2d_disable, pio_rearr_comm_unlimited_pend_req,&
+    pio_rearr_comm_p2p, pio_rearr_comm_coll,&
 	pio_int, pio_real, pio_double, pio_noerr, iotype_netcdf, &
 	iotype_pnetcdf, iotype_binary, iotype_direct_pbinary, iotype_pbinary, &
         PIO_iotype_binary, PIO_iotype_direct_pbinary, PIO_iotype_pbinary, &
@@ -63,12 +67,14 @@ module pio
   use pionfget_mod, only : PIO_get_var   => get_var
 
   use calcdecomp, only : pio_set_blocksize
+   
+
+
   implicit none
   public
 ! Added for pio2 compatability
   integer, parameter :: pio_offset_kind = pio_offset
   integer, parameter :: pio_rearr_subset = pio_rearr_box
-
 contains
   function pio_iam_iotask(iosystem) result(task)
     type(iosystem_desc_t), intent(in) :: iosystem

--- a/pio/pio_msg_callbacks.F90
+++ b/pio/pio_msg_callbacks.F90
@@ -242,7 +242,7 @@ subroutine writedarray_handler(iosystem)
   call mpi_bcast(fillv, 1, mpi_integer , iosystem%compmaster, iosystem%intercomm, ierr)
 
   file=> lookupfile(fh)
-  if(debugasync) print *,__FILE__,__LINE__,v%varid,iod_id
+  if(debugasync) print *,__PIO_FILE__,__LINE__,v%varid,iod_id
   iodesc => lookupiodesc(iod_id)
 #ifndef _MPISERIAL
   select case(type)
@@ -296,7 +296,7 @@ subroutine readdarray_handler(iosystem)
   real(r4) :: areal(1)
   real(r8) :: adouble(1)
 
-  if(debugasync) print *,__FILE__,__LINE__
+  if(debugasync) print *,__PIO_FILE__,__LINE__
   
   call mpi_bcast(fh, 1, mpi_integer, iosystem%compmaster, iosystem%intercomm, ierr)
   call mpi_bcast(v%varid, 1, mpi_integer, iosystem%compmaster, iosystem%intercomm, ierr)
@@ -306,7 +306,7 @@ subroutine readdarray_handler(iosystem)
 
   file=> lookupfile(fh)
 
-  if(debugasync) print *,__FILE__,__LINE__,iod_id, type
+  if(debugasync) print *,__PIO_FILE__,__LINE__,iod_id, type
 
   iodesc => lookupiodesc(iod_id)
 #ifndef _MPISERIAL

--- a/pio/pio_msg_mod.F90
+++ b/pio/pio_msg_mod.F90
@@ -299,14 +299,14 @@ contains
 
 
 
-       if(debugasync) print *,__FILE__,__LINE__,index
+       if(debugasync) print *,__PIO_FILE__,__LINE__,index
     end if
     iodesc%async_id=index
     list_item%index=index
     list_item%iodesc => iodesc
 
 
-    if(debugasync) print *,__FILE__,__LINE__,index,list_item%iodesc%async_id
+    if(debugasync) print *,__PIO_FILE__,__LINE__,index,list_item%iodesc%async_id
 
   end subroutine add_to_iodesc_list
 
@@ -353,7 +353,7 @@ contains
           if(debugasync) then
              list_item=> top_iodesc
              do while(associated(list_item))
-                print *,__FILE__,__LINE__,id,list_item%index,list_item%iodesc%async_id
+                print *,__PIO_FILE__,__LINE__,id,list_item%index,list_item%iodesc%async_id
                 list_item=>list_item%next
              enddo
           endif
@@ -430,10 +430,10 @@ contains
     nullify(iodesc)
     do while(associated(list_item%iodesc) )
 
-       if(debugasync) print *,__FILE__,__LINE__,list_item%index,async_id,list_item%iodesc%async_id
+       if(debugasync) print *,__PIO_FILE__,__LINE__,list_item%index,async_id,list_item%iodesc%async_id
        if(abs(list_item%iodesc%async_id) == async_id) then
           iodesc => list_item%iodesc
-          if(debugasync) print *,__FILE__,__LINE__,async_id,list_item%index,iodesc%write%n_elemtype
+          if(debugasync) print *,__PIO_FILE__,__LINE__,async_id,list_item%index,iodesc%write%n_elemtype
           exit
        end if
        list_item=>list_item%next

--- a/pio/pio_types.F90
+++ b/pio/pio_types.F90
@@ -3,8 +3,8 @@
 !! @file 
 !! @brief Derived datatypes and constants for PIO
 !! 
-!! $Revision$
-!! $LastChangedDate$
+!! $Revision: 943 $
+!! $LastChangedDate: 2014-02-14 10:20:17 -0600 (Fri, 14 Feb 2014) $
 !<
 module pio_types
     use pio_kinds
@@ -34,6 +34,80 @@ module pio_types
         integer(i4) :: length
     end type
 
+!>
+!! @defgroup PIO_rearr_method PIO_rearr_method
+!! @public 
+!! @brief The three choices to control rearrangement are:
+!! @details
+!!  - PIO_rearr_none : Do not use any form of rearrangement
+!!  - PIO_rearr_box : Use a PIO internal box rearrangement
+!>
+    integer(i4), public, parameter :: PIO_rearr_none = 0
+    integer(i4), public, parameter :: PIO_rearr_box =  1
+
+!>
+!! @defgroup PIO_rearr_comm_t PIO_rearr_comm_t
+!! @public 
+!! @brief The two choices for rearranger communication
+!! @details
+!!  - PIO_rearr_comm_p2p : Point to point
+!!  - PIO_rearr_comm_coll : Collective
+!>
+    enum, bind(c)
+      enumerator :: PIO_rearr_comm_p2p = 0
+      enumerator :: PIO_rearr_comm_coll
+    end enum
+
+!>
+!! @defgroup PIO_rearr_comm_dir PIO_rearr_comm_dir
+!! @public 
+!! @brief The four choices for rearranger communication direction
+!! @details
+!!  - PIO_rearr_comm_fc_2d_enable : COMM procs to IO procs and vice versa
+!!  - PIO_rearr_comm_fc_1d_comp2io: COMM procs to IO procs only
+!!  - PIO_rearr_comm_fc_1d_io2comp: IO procs to COMM procs only
+!!  - PIO_rearr_comm_fc_2d_disable: Disable flow control
+!>
+    enum, bind(c)
+      enumerator :: PIO_rearr_comm_fc_2d_enable = 0
+      enumerator :: PIO_rearr_comm_fc_1d_comp2io
+      enumerator :: PIO_rearr_comm_fc_1d_io2comp
+      enumerator :: PIO_rearr_comm_fc_2d_disable
+    end enum
+
+!>
+!! @defgroup PIO_rearr_comm_fc_options PIO_rearr_comm_fc_options
+!! @brief Type that defines the PIO rearranger options
+!! @details
+!!  - fcd : @copydoc PIO_rearr_comm_dir
+!!  - enable_hs : Enable handshake (true/false) 
+!!  - enable_isend : Enable Isends (true/false)
+!!  - max_pend_req : Maximum pending requests (To indicated unlimited
+!!                    number of requests use PIO_REARR_COMM_UNLIMITED_PEND_REQ)
+!>
+    type, public :: PIO_rearr_comm_fc_opt_t
+      integer :: fcd                  ! Flow control direction
+      logical :: enable_hs            ! Enable handshake?
+      logical :: enable_isend         ! Enable isends?
+      integer :: max_pend_req         ! Maximum pending requests
+    end type PIO_rearr_comm_fc_opt_t
+
+    integer, public, parameter :: PIO_REARR_COMM_UNLIMITED_PEND_REQ = -1
+!>
+!! @defgroup PIO_rearr_options PIO_rearr_options
+!! @brief Type that defines the PIO rearranger options
+!! @details
+!!  - comm_type : @copydoc PIO_rearr_comm_t
+!!  - comm_fc_opts : @copydoc PIO_rearr_comm_fc_options
+!>
+    type, public :: PIO_rearr_opt_t
+      integer                         :: comm_type
+      type(PIO_rearr_comm_fc_opt_t)   :: comm_fc_opts
+    end type PIO_rearr_opt_t
+
+    public :: PIO_rearr_comm_p2p, PIO_rearr_comm_coll,&
+              PIO_rearr_comm_fc_2d_enable, PIO_rearr_comm_fc_1d_comp2io,&
+              PIO_rearr_comm_fc_1d_io2comp, PIO_rearr_comm_fc_2d_disable
 
     !------------------------------------
     !  a file descriptor data structure
@@ -79,6 +153,8 @@ module pio_types
         logical(log_kind)        :: async_interface=.false.    ! .true. if using the async interface model
         integer(i4)              :: rearr         ! type of rearranger
                                                   ! e.g. rearr_{none,box}
+        !integer(i4), dimension(IOSYS_REARR_OPT_MAX) :: rearr_opts ! Rearranger options - see PIO_rearr_opt_t for details
+        type(PIO_rearr_opt_t)   :: rearr_opts       ! Rearranger options
 	integer(i4)              :: error_handling ! how pio handles errors
         integer(i4),pointer      :: ioranks(:) => null()         ! the computational ranks for the IO tasks
 
@@ -242,16 +318,6 @@ module pio_types
         iotype_netcdf  = PIO_iotype_netcdf
 
 
-!>
-!! @defgroup PIO_rearr_method PIO_rearr_method
-!! @public 
-!! @brief The three choices to control rearrangement are:
-!! @details
-!!  - PIO_rearr_none : Do not use any form of rearrangement
-!!  - PIO_rearr_box : Use a PIO internal box rearrangement
-!>
-    integer(i4), public, parameter :: PIO_rearr_none = 0
-    integer(i4), public, parameter :: PIO_rearr_box =  1
 
 !> 
 !! @public

--- a/pio/piodarray.F90.in
+++ b/pio/piodarray.F90.in
@@ -503,6 +503,7 @@ contains
     File%iosystem%comp_rank,' UseRearranger: ',UseRearranger,iodesc%glen, iodesc%iomap%start, len
 #ifdef TIMING
     call t_startf("pio_rearrange_write")
+    call t_startf("pre_pio_write_nf")
 #endif
     if(UseRearranger) then 
        if (IOproc) then 
@@ -638,6 +639,7 @@ contains
     endif
 
 #ifdef TIMING
+    call t_stopf("pre_pio_write_nf")
     call t_startf("pio_write_nf")
 #endif
     ierr = write_nf(File,IOBUF,varDesc,iodesc,start,count, request) 
@@ -648,11 +650,17 @@ contains
     call dealloc_check(count)
 
     if(IOPROC) then
+#ifdef TIMING
+       call t_startf("post_pio_write_nf")
+#endif
        if(file%iotype==pio_iotype_pnetcdf) then
           call add_data_to_buffer(File, IOBUF, request)
        else if(Userearranger) then
           deallocate(iobuf)
        end if
+#ifdef TIMING
+       call t_stopf("post_pio_write_nf")
+#endif
     end if
 
     !   call MPI_Barrier(File%iosystem%comp_comm,ierr)
@@ -1249,7 +1257,13 @@ contains
     this_buffsize = size(iobuf)*c_sizeof(iobuf(1))
     file%buffsize=file%buffsize+this_buffsize
     total_buffsize = total_buffsize+this_buffsize
+#ifdef TIMING
+    call t_startf("allred_add_data_to_buf")
+#endif
     call MPI_ALLREDUCE(total_buffsize,maxbuffsize,1,MPI_INTEGER,MPI_MAX,file%iosystem%io_comm, mpierr)
+#ifdef TIMING
+    call t_stopf("allred_add_data_to_buf")
+#endif
 
     if(maxbuffsize > pio_buffer_size_limit) then
        call darray_write_complete(File)

--- a/pio/piodarray.F90.in
+++ b/pio/piodarray.F90.in
@@ -207,7 +207,7 @@ contains
        if(debugasync) print *,__PIO_FILE__,__LINE__
     endif
 
-    if(debugasync .and. ios%ioproc) print *,__FILE__,__LINE__,iodesc%async_id
+    if(debugasync .and. ios%ioproc) print *,__PIO_FILE__,__LINE__,iodesc%async_id
 
     select case(File%iotype)
     case(pio_iotype_pbinary, pio_iotype_direct_pbinary)
@@ -996,7 +996,7 @@ contains
           call alloc_check(IOBUF,0,'IOBUF')
        end if
     endif
-!    print *,__FILE__,__LINE__,ndims, fndims, start(1:fndims),count(1:fndims),vardesc%rec
+!    print *,__PIO_FILE__,__LINE__,ndims, fndims, start(1:fndims),count(1:fndims),vardesc%rec
 
 #ifdef TIMING
     call t_startf("pio_read_nf")
@@ -1308,7 +1308,7 @@ contains
 #ifdef _PNETCDF
        ierr  = nfmpi_wait_all(file%fh, cnt-1, array_of_requests, status)
 #endif
-       if(DEBUG) print *,__FILE__,__LINE__,status, ierr, total_buffsize
+       if(DEBUG) print *,__PIO_FILE__,__LINE__,status, ierr, total_buffsize
 
        ptr=>file%data_list_top
        do while(associated(ptr))

--- a/pio/piolib_mod.F90
+++ b/pio/piolib_mod.F90
@@ -840,7 +840,7 @@ contains
     !---------------------
     glength= product(int(dims,kind=PIO_OFFSET))
     if(glength > huge(ndisp)) then
-       print *,__FILE__,__LINE__,dims,glength
+       print *,__PIO_FILE__,__LINE__,dims,glength
        call piodie( __PIO_FILE__,__LINE__, &
             'requested array size too large for this interface ')       
     endif
@@ -1517,7 +1517,7 @@ contains
          if(check) call checkmpireturn('genindexedblock: after call to type_commit: ',ierr)
 !         if(debug) then
 !            call mpi_type_get_envelope(filetype, nints, nadds, ndtypes, comb, ierr)
-!            print *,__FILE__,__LINE__,nints,nadds,ndtypes,comb,ierr
+!            print *,__PIO_FILE__,__LINE__,nints,nadds,ndtypes,comb,ierr
 !         endif
        endif
 
@@ -1783,7 +1783,7 @@ contains
 
     iotmp2(:)=0 
     call MPI_allreduce(iotmp, iotmp2, iosystem%num_tasks, MPI_INTEGER, MPI_SUM, comp_comm, ierr)
-    call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+    call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
     call alloc_check(iosystem%ioranks,n_iotasks,'init:n_ioranks')
     j=1
     iosystem%iomaster = -1
@@ -1986,11 +1986,11 @@ contains
              iam = -1
           end if
           call mpi_allreduce(iam, io_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
           ! Find the rank of the comp leader in peer_comm
           iam = -1
           call mpi_allreduce(iam, comp_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
           ! create the intercomm
           call mpi_intercomm_create(io_comm, 0, peer_comm, comp_leader, i, iosystem(i)%intercomm, ierr)
           ! create the union_comm
@@ -1999,7 +1999,7 @@ contains
           ! Find the rank of the io leader in peer_comm
           iam = -1
           call mpi_allreduce(iam, io_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
 
           ! Find the rank of the comp leader in peer_comm
           iosystem(i)%comp_rank = -1
@@ -2012,7 +2012,7 @@ contains
              end if
           end if
           call mpi_allreduce(iam, comp_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
 
           ! create the intercomm
           call mpi_intercomm_create(comp_comms(i), 0, peer_comm, io_leader, i, iosystem(i)%intercomm, ierr)
@@ -2062,11 +2062,11 @@ contains
           if(Debugasync) print *,__PIO_FILE__,__LINE__
           
           call MPI_allreduce(iosystem(i)%comproot, j, 1, MPI_INTEGER, MPI_MAX,iosystem(i)%union_comm,ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
           
           iosystem%comproot=j
           call MPI_allreduce(iosystem(i)%ioroot, j, 1, MPI_INTEGER, MPI_MAX,iosystem(i)%union_comm,ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
 
           iosystem%ioroot=j
 
@@ -2097,7 +2097,7 @@ contains
           call alloc_check(iosystem(i)%ioranks, iosystem(i)%num_iotasks,'init:n_ioranks')
           if(Debugasync) print *,__PIO_FILE__,__LINE__,iotmp
           call MPI_allreduce(iotmp,iosystem(i)%ioranks,iosystem(i)%num_iotasks,MPI_INTEGER,MPI_MAX,iosystem(i)%union_comm,ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
 
           if(Debugasync) print *,__PIO_FILE__,__LINE__,iosystem(i)%ioranks
           call dealloc_check(iotmp)
@@ -2200,7 +2200,7 @@ contains
     endif
     iotmp2(:)=0 
     call MPI_allreduce(iotmp,iotmp2,num_tasks,MPI_INTEGER,MPI_SUM,comm,ierr)
-    call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+    call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__PIO_FILE__,__LINE__)
 
     numiotasks=SUM(iotmp2)
 

--- a/pio/pionfatt_mod.F90.in
+++ b/pio/pionfatt_mod.F90.in
@@ -155,7 +155,7 @@ contains
 !       case(iotype_netcdf,PIO_iotype_netcdf4c,PIO_iotype_netcdf4p)
        case(iotype_netcdf,PIO_iotype_netcdf4c)
           if (Ios%io_rank==0) then
-             if(debug) print *,__FILE__,__LINE__,name,value
+             if(debug) print *,__PIO_FILE__,__LINE__,name,value
              ierr=nf90_put_att(File%fh,varid,name,value)
           endif
        case(PIO_iotype_netcdf4p)

--- a/pio/pionfput_mod.F90.in
+++ b/pio/pionfput_mod.F90.in
@@ -125,7 +125,7 @@ contains
           ierr = nfmpi_begin_indep_data(File%fh)
           
           if(Ios%io_rank==0 .and. (ierr==NF_EINDEP .or. ierr==PIO_NOERR)) then
-             print *,__FILE__,__LINE__,index,count,trim(ival)
+             print *,__PIO_FILE__,__LINE__,index,count,trim(ival)
              ierr = nfmpi_put_vara (File%fh, varid, int(index,kind=PIO_OFFSET), &
                   int(count,kind=PIO_OFFSET), ival, int(count,kind=PIO_OFFSET), &
                   MPI_CHARACTER)
@@ -134,7 +134,7 @@ contains
              ierr = nfmpi_end_indep_data(File%fh)
           end if
 !#else
-!          print *,__FILE__,__LINE__,index,count,trim(ival)
+!          print *,__PIO_FILE__,__LINE__,index,count,trim(ival)
 !            ierr = nfmpi_put_vara_all (File%fh, varid, int(index,kind=PIO_OFFSET), &
 !                  int(count,kind=PIO_OFFSET), ival)
 !#endif

--- a/pio/pionfwrite_mod.F90.in
+++ b/pio/pionfwrite_mod.F90.in
@@ -1,3 +1,4 @@
+#define __PIO_FILE__ "pionfwrite_mod.F90"
 !>
 !! @file 
 !! $Revision$
@@ -121,11 +122,11 @@ contains
           ! allocate space on root for copy of iobuf etc.
           iobuf_size=size(IOBUF)
           if(File%iosystem%num_iotasks>1) then
-             if(Debug) print *,__FILE__,__LINE__
+             if(Debug) print *,__PIO_FILE__,__LINE__
              call MPI_ALLREDUCE(iobuf_size,max_iobuf_size, &
                   1,MPI_INTEGER,MPI_MAX,File%iosystem%IO_comm,mpierr)
              call CheckMPIReturn(subName, mpierr)
-             if(Debug) print *,__FILE__,__LINE__,iobuf_size
+             if(Debug) print *,__PIO_FILE__,__LINE__,iobuf_size
              if (File%iosystem%io_rank==0) then
                    call alloc_check(temp_iobuf,max_iobuf_size)
              else
@@ -147,7 +148,7 @@ contains
 
           temp_count(1:ndims)=int(count(1:ndims))
 
-          if(Debug) print *,__FILE__,__LINE__,ndims,temp_start(1:ndims),temp_count(1:ndims)
+          if(Debug) print *,__PIO_FILE__,__LINE__,ndims,temp_start(1:ndims),temp_count(1:ndims)
 
           ! Every i/o proc send data to root
 

--- a/pio/rearr_options.h
+++ b/pio/rearr_options.h
@@ -1,0 +1,39 @@
+#ifndef REARR_OPTIONS_H
+#define REARR_OPTIONS_H
+
+! communication algorithm options
+#define COLLECTIVE 0
+#define POINT_TO_POINT 1
+#define FLOW_CONTROL 2
+
+! Default values for POINT_TO_POINT and FLOW_CONTROL
+#define DEF_P2P_HANDSHAKE .true.
+#define DEF_P2P_ISEND .false.
+#define DEF_P2P_MAXREQ 64
+
+#ifndef _MPISERIAL
+#ifndef _NO_FLOW_CONTROL
+#define _USE_COMP2IO_FC 1
+#define _USE_IO2COMP_FC 1
+#endif  
+#endif
+!
+! The completely unreadable nature of the following lines is required by some compilers
+!
+#ifdef _USE_ALLTOALLW
+#define DEF_COMP2IO_OPTION 0
+#define DEF_IO2COMP_OPTION 0
+#else
+#ifdef _USE_COMP2IO_FC
+#define DEF_COMP2IO_OPTION 2
+#else
+#define DEF_COMP2IO_OPTION 1
+#endif
+#ifdef _USE_IO2COMP_FC
+#define DEF_IO2COMP_OPTION 2
+#else
+#define DEF_IO2COMP_OPTION 1
+#endif
+#endif
+
+#endif

--- a/pio/rearr_options.h
+++ b/pio/rearr_options.h
@@ -11,29 +11,4 @@
 #define DEF_P2P_ISEND .false.
 #define DEF_P2P_MAXREQ 64
 
-#ifndef _MPISERIAL
-#ifndef _NO_FLOW_CONTROL
-#define _USE_COMP2IO_FC 1
-#define _USE_IO2COMP_FC 1
-#endif  
-#endif
-!
-! The completely unreadable nature of the following lines is required by some compilers
-!
-#ifdef _USE_ALLTOALLW
-#define DEF_COMP2IO_OPTION 0
-#define DEF_IO2COMP_OPTION 0
-#else
-#ifdef _USE_COMP2IO_FC
-#define DEF_COMP2IO_OPTION 2
-#else
-#define DEF_COMP2IO_OPTION 1
-#endif
-#ifdef _USE_IO2COMP_FC
-#define DEF_IO2COMP_OPTION 2
-#else
-#define DEF_IO2COMP_OPTION 1
-#endif
-#endif
-
 #endif


### PR DESCRIPTION
This change brings in all ACME changes in PIO1 to the PIO1 branch
(pio1_0).
* Moving PIO rearranger options from compile-time to runtime.
  The rearranger options can now be provided via an optional
  argument to PIO_init()
* Some additional timers in PIO
* Changing __FILE__ to __PIO_FILE__ to overcome build failures with
  pgi
