### PR TITLE
Fix lengths of names of atts/vars/dims sent to tasks where rank != 0 for serial io types

### DIFF
--- a/src/clib/ncparser.pl
+++ b/src/clib/ncparser.pl
@@ -301,7 +301,7 @@ print F
 		  print F "    if(name != NULL){ \n";
 		  print F "      int slen;\n";
 		  print F "      if(ios->iomaster)\n";
-		  print F "        slen = (int) strlen(name);\n";
+		  print F "        slen = (int) strlen(name) + 1;\n";
 		  print F "      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);\n";
 		  print F "      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);\n    }\n";
 
@@ -316,7 +316,7 @@ print F
 		  print F  "    if(name != NULL){ \n";
 		  print F "      int slen;\n";
 		  print F "      if(ios->iomaster)\n";
-		  print F "        slen = (int) strlen(name);\n";
+		  print F "        slen = (int) strlen(name) + 1;\n";
 		  print F "      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);\n";
 		  print F "      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);\n    }\n";
 		  print F "      if(lenp != NULL) mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);\n";
@@ -324,7 +324,7 @@ print F
 		  print F "    if(name != NULL){\n";
 		  print F "      int slen;\n";
 		  print F "      if(ios->iomaster)\n";
-		  print F "        slen = (int) strlen(name);\n";
+		  print F "        slen = (int) strlen(name) + 1;\n";
 		  print F "      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);\n";
 		  print F "      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);\n    }\n";
 	      }elsif($func =~ /inq_vardimid/){

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -558,7 +558,7 @@ int PIOc_inq_varname (int ncid, int varid, char *name)
     if(name != NULL){
       int slen;
       if(ios->iomaster)
-        slen = (int) strlen(name);
+        slen = (int) strlen(name) + 1;
       mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
       mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
     }
@@ -1826,7 +1826,7 @@ int PIOc_inq_attname (int ncid, int varid, int attnum, char *name)
     if(name != NULL){
       int slen;
       if(ios->iomaster)
-        slen = (int) strlen(name);
+        slen = (int) strlen(name) + 1;
       mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
       mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
     }
@@ -3267,7 +3267,7 @@ int PIOc_inq_dimname (int ncid, int dimid, char *name)
     if(name != NULL){
       int slen;
       if(ios->iomaster)
-        slen = (int) strlen(name);
+        slen = (int) strlen(name) + 1;
       mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
       mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
     }

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -14,8 +14,167 @@
 #include <pio_internal.h>
 
 /** 
- * @ingroup PIOc_inq_att
- * The PIO-C interface for the NetCDF function nc_inq_att.
+ * @ingroup PIOc_inq
+ * The PIO-C interface for the NetCDF function nc_inq.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq (int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+      if(ndimsp != NULL)
+        mpierr = MPI_Bcast(ndimsp, 1, MPI_INT, ios->ioroot, ios->my_comm);
+       if(nvarsp != NULL)
+        mpierr = MPI_Bcast(nvarsp, 1, MPI_INT, ios->ioroot, ios->my_comm);
+       if(ngattsp != NULL)
+        mpierr = MPI_Bcast(ngattsp, 1, MPI_INT, ios->ioroot, ios->my_comm);
+       if(unlimdimidp != NULL)
+        mpierr = MPI_Bcast(unlimdimidp, 1, MPI_INT, ios->ioroot, ios->my_comm);
+   if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_dimname
+ * The PIO-C interface for the NetCDF function nc_inq_dimname.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_dimname (int ncid, int dimid, char *name) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_DIMNAME;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_dimname(file->fh, dimid, name);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_dimname(file->fh, dimid, name);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_dimname(file->fh, dimid, name);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    if(name != NULL){
+      int slen;
+      if(ios->iomaster)
+        slen = (int) strlen(name) + 1;
+      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
+      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
+    }
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_short
+ * The PIO-C interface for the NetCDF function nc_put_att_short.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -25,11 +184,9 @@
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
- * @param xtypep a pointer that will get the type of the attribute.
- * @param lenp a pointer that will get the number of values 
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Offset *lenp) 
+int PIOc_put_att_short (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const short *op) 
 {
   int ierr;
   int msg;
@@ -45,7 +202,7 @@ int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Of
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_INQ_ATT;
+  msg = PIO_MSG_PUT_ATT_SHORT;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -59,19 +216,19 @@ int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Of
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);;
+      ierr = nc_put_att_short(file->fh, varid, name, xtype, (size_t)len, op);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);;
+	ierr = nc_put_att_short(file->fh, varid, name, xtype, (size_t)len, op);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_att(file->fh, varid, name, xtypep, lenp);;
+      ierr = ncmpi_put_att_short(file->fh, varid, name, xtype, len, op);;
       break;
 #endif
     default:
@@ -84,15 +241,163 @@ int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Of
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(xtypep != NULL) mpierr = MPI_Bcast(xtypep , 1, MPI_INT, ios->ioroot, ios->my_comm);
-  if(lenp != NULL) mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_inq_format
- * The PIO-C interface for the NetCDF function nc_inq_format.
+ * @ingroup PIOc_rename_dim
+ * The PIO-C interface for the NetCDF function nc_rename_dim.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_rename_dim (int ncid, int dimid, const char *name) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_RENAME_DIM;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_rename_dim(file->fh, dimid, name);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_rename_dim(file->fh, dimid, name);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_rename_dim(file->fh, dimid, name);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_get_att_double
+ * The PIO-C interface for the NetCDF function nc_get_att_double.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_get_att_double (int ncid, int varid, const char *name, double *ip) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_GET_ATT_DOUBLE;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_get_att_double(file->fh, varid, name, ip);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_get_att_double(file->fh, varid, name, ip);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_get_att_double(file->fh, varid, name, ip);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
+    sprintf(errstr,"name %s in file %s",name,__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+      if(ierr == PIO_NOERR){
+        PIO_Offset attlen;
+        PIOc_inq_attlen(file->fh, varid, name, &attlen);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_DOUBLE, ios->ioroot, ios->my_comm);
+      }
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_set_fill
+ * The PIO-C interface for the NetCDF function nc_set_fill.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -101,10 +406,9 @@ int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Of
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
- * @param formatp a pointer that will get the file format 
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_format (int ncid, int *formatp) 
+int PIOc_set_fill (int ncid, int fillmode, int *old_modep) 
 {
   int ierr;
   int msg;
@@ -120,7 +424,7 @@ int PIOc_inq_format (int ncid, int *formatp)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_INQ_FORMAT;
+  msg = PIO_MSG_SET_FILL;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -134,19 +438,19 @@ int PIOc_inq_format (int ncid, int *formatp)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_format(file->fh, formatp);;
+      ierr = nc_set_fill(file->fh, fillmode, old_modep);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_inq_format(file->fh, formatp);;
+	ierr = nc_set_fill(file->fh, fillmode, old_modep);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_format(file->fh, formatp);;
+      ierr = ncmpi_set_fill(file->fh, fillmode, old_modep);;
       break;
 #endif
     default:
@@ -159,157 +463,6 @@ int PIOc_inq_format (int ncid, int *formatp)
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(formatp , 1, MPI_INT, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_varid
- * The PIO-C interface for the NetCDF function nc_inq_varid.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @param varidp a pointer that will get the variable id 
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_varid (int ncid, const char *name, int *varidp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_VARID;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_varid(file->fh, name, varidp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_varid(file->fh, name, varidp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_varid(file->fh, name, varidp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(varidp,1, MPI_INT, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_varnatts
- * The PIO-C interface for the NetCDF function nc_inq_varnatts.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @param nattsp a pointer that will get the number of attributes 
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_varnatts (int ncid, int varid, int *nattsp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_VARNATTS;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_varnatts(file->fh, varid, nattsp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_varnatts(file->fh, varid, nattsp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_varnatts(file->fh, varid, nattsp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(nattsp,1, MPI_INT, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
@@ -397,176 +550,6 @@ int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims, const in
 }
 
 /** 
- * @ingroup PIOc_inq_var
- * The PIO-C interface for the NetCDF function nc_inq_var.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @param xtypep a pointer that will get the type of the attribute.
- * @param nattsp a pointer that will get the number of attributes 
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_var (int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp, int *nattsp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_VAR;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    if(xtypep != NULL) mpierr = MPI_Bcast(xtypep , 1, MPI_INT, ios->ioroot, ios->my_comm);
-    if(ndimsp != NULL){ mpierr = MPI_Bcast(ndimsp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
-      file->varlist[varid].ndims = (*ndimsp);}
-      if(nattsp != NULL) mpierr = MPI_Bcast(nattsp,1, MPI_INT, ios->ioroot, ios->my_comm);
-    if(name != NULL){ 
-      int slen;
-      if(ios->iomaster)
-        slen = (int) strlen(name);
-      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
-      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
-    }
-    if(dimidsp != NULL) {int ndims;
-      PIOc_inq_varndims(file->fh, varid, &ndims);
-      mpierr = MPI_Bcast(dimidsp , ndims, MPI_INT, ios->ioroot, ios->my_comm);
-     }
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_varname
- * The PIO-C interface for the NetCDF function nc_inq_varname.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_varname (int ncid, int varid, char *name) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_VARNAME;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_varname(file->fh, varid, name);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_varname(file->fh, varid, name);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_varname(file->fh, varid, name);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    if(name != NULL){
-      int slen;
-      if(ios->iomaster)
-        slen = (int) strlen(name) + 1;
-      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
-      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
-    }
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
  * @ingroup PIOc_put_att_double
  * The PIO-C interface for the NetCDF function nc_put_att_double.
  *
@@ -640,20 +623,20 @@ int PIOc_put_att_double (int ncid, int varid, const char *name, nc_type xtype, P
 }
 
 /** 
- * @ingroup PIOc_put_att_int
- * The PIO-C interface for the NetCDF function nc_put_att_int.
+ * @ingroup PIOc_inq_dim
+ * The PIO-C interface for the NetCDF function nc_inq_dim.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
  * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
+ * @param lenp a pointer that will get the number of values 
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_put_att_int (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const int *op) 
+int PIOc_inq_dim (int ncid, int dimid, char *name, PIO_Offset *lenp) 
 {
   int ierr;
   int msg;
@@ -669,7 +652,7 @@ int PIOc_put_att_int (int ncid, int varid, const char *name, nc_type xtype, PIO_
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_INT;
+  msg = PIO_MSG_INQ_DIM;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -683,19 +666,19 @@ int PIOc_put_att_int (int ncid, int varid, const char *name, nc_type xtype, PIO_
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_int(file->fh, varid, name, xtype, (size_t)len, op);;
+      ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_put_att_int(file->fh, varid, name, xtype, (size_t)len, op);;
+	ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_int(file->fh, varid, name, xtype, len, op);;
+      ierr = ncmpi_inq_dim(file->fh, dimid, name, lenp);;
       break;
 #endif
     default:
@@ -708,86 +691,21 @@ int PIOc_put_att_int (int ncid, int varid, const char *name, nc_type xtype, PIO_
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_rename_att
- * The PIO-C interface for the NetCDF function nc_rename_att.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_rename_att (int ncid, int varid, const char *name, const char *newname) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_RENAME_ATT;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_rename_att(file->fh, varid, name, newname);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_rename_att(file->fh, varid, name, newname);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_rename_att(file->fh, varid, name, newname);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    if(name != NULL){ 
+      int slen;
+      if(ios->iomaster)
+        slen = (int) strlen(name) + 1;
+      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
+      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
     }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+      if(lenp != NULL) mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_get_att_ubyte
- * The PIO-C interface for the NetCDF function nc_get_att_ubyte.
+ * @ingroup PIOc_get_att_uchar
+ * The PIO-C interface for the NetCDF function nc_get_att_uchar.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -799,7 +717,7 @@ int PIOc_rename_att (int ncid, int varid, const char *name, const char *newname)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip) 
+int PIOc_get_att_uchar (int ncid, int varid, const char *name, unsigned char *ip) 
 {
   int ierr;
   int msg;
@@ -815,7 +733,7 @@ int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_UBYTE;
+  msg = PIO_MSG_GET_ATT_UCHAR;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -829,19 +747,19 @@ int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_ubyte(file->fh, varid, name, ip);;
+      ierr = nc_get_att_uchar(file->fh, varid, name, ip);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_get_att_ubyte(file->fh, varid, name, ip);;
+	ierr = nc_get_att_uchar(file->fh, varid, name, ip);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_ubyte(file->fh, varid, name, ip);;
+      ierr = ncmpi_get_att_uchar(file->fh, varid, name, ip);;
       break;
 #endif
     default:
@@ -857,26 +775,27 @@ int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip
       if(ierr == PIO_NOERR){
         PIO_Offset attlen;
         PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_BYTE, ios->ioroot, ios->my_comm);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_UNSIGNED_CHAR, ios->ioroot, ios->my_comm);
       }
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_inq_natts
- * The PIO-C interface for the NetCDF function nc_inq_natts.
+ * @ingroup PIOc_inq_var_fill
+ * The PIO-C interface for the NetCDF function nc_inq_var_fill.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
  * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_natts (int ncid, int *ngattsp) 
+int PIOc_inq_var_fill (int ncid, int varid, int *no_fill, void *fill_value) 
 {
   int ierr;
   int msg;
@@ -892,7 +811,7 @@ int PIOc_inq_natts (int ncid, int *ngattsp)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_INQ_NATTS;
+  msg = PIO_MSG_INQ_VAR_FILL;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -906,19 +825,19 @@ int PIOc_inq_natts (int ncid, int *ngattsp)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_natts(file->fh, ngattsp);;
+      ierr = nc_inq_var_fill(file->fh, varid, no_fill, fill_value);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_inq_natts(file->fh, ngattsp);;
+	ierr = nc_inq_var_fill(file->fh, varid, no_fill, fill_value);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_natts(file->fh, ngattsp);;
+      ierr = ncmpi_inq_var_fill(file->fh, varid, no_fill, fill_value);;
       break;
 #endif
     default:
@@ -931,14 +850,164 @@ int PIOc_inq_natts (int ncid, int *ngattsp)
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(ngattsp,1, MPI_INT, ios->ioroot, ios->my_comm);
+    mpierr = MPI_Bcast(fill_value, 1, MPI_INT, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_del_att
- * The PIO-C interface for the NetCDF function nc_del_att.
+ * @ingroup PIOc_inq_attid
+ * The PIO-C interface for the NetCDF function nc_inq_attid.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @param idp a pointer that will get the id of the variable or attribute.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_attid (int ncid, int varid, const char *name, int *idp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_ATTID;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_attid(file->fh, varid, name, idp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_attid(file->fh, varid, name, idp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_attid(file->fh, varid, name, idp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(idp , 1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_vartype
+ * The PIO-C interface for the NetCDF function nc_inq_vartype.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @param xtypep a pointer that will get the type of the attribute.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_VARTYPE;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_vartype(file->fh, varid, xtypep);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_vartype(file->fh, varid, xtypep);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_vartype(file->fh, varid, xtypep);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(xtypep , 1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_schar
+ * The PIO-C interface for the NetCDF function nc_put_att_schar.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -950,7 +1019,7 @@ int PIOc_inq_natts (int ncid, int *ngattsp)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_del_att (int ncid, int varid, const char *name) 
+int PIOc_put_att_schar (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const signed char *op) 
 {
   int ierr;
   int msg;
@@ -966,7 +1035,7 @@ int PIOc_del_att (int ncid, int varid, const char *name)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_DEL_ATT;
+  msg = PIO_MSG_PUT_ATT_SCHAR;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -980,19 +1049,19 @@ int PIOc_del_att (int ncid, int varid, const char *name)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_del_att(file->fh, varid, name);;
+      ierr = nc_put_att_schar(file->fh, varid, name, xtype, (size_t)len, op);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_del_att(file->fh, varid, name);;
+	ierr = nc_put_att_schar(file->fh, varid, name, xtype, (size_t)len, op);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_del_att(file->fh, varid, name);;
+      ierr = ncmpi_put_att_schar(file->fh, varid, name, xtype, len, op);;
       break;
 #endif
     default:
@@ -1010,19 +1079,20 @@ int PIOc_del_att (int ncid, int varid, const char *name)
 }
 
 /** 
- * @ingroup PIOc_inq
- * The PIO-C interface for the NetCDF function nc_inq.
+ * @ingroup PIOc_inq_vardimid
+ * The PIO-C interface for the NetCDF function nc_inq_vardimid.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
  * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq (int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp) 
+int PIOc_inq_vardimid (int ncid, int varid, int *dimidsp) 
 {
   int ierr;
   int msg;
@@ -1038,7 +1108,7 @@ int PIOc_inq (int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_INQ;
+  msg = PIO_MSG_INQ_VARDIMID;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -1052,19 +1122,19 @@ int PIOc_inq (int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);;
+      ierr = nc_inq_vardimid(file->fh, varid, dimidsp);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);;
+	ierr = nc_inq_vardimid(file->fh, varid, dimidsp);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);;
+      ierr = ncmpi_inq_vardimid(file->fh, varid, dimidsp);;
       break;
 #endif
     default:
@@ -1077,21 +1147,18 @@ int PIOc_inq (int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-      if(ndimsp != NULL)
-        mpierr = MPI_Bcast(ndimsp, 1, MPI_INT, ios->ioroot, ios->my_comm);
-       if(nvarsp != NULL)
-        mpierr = MPI_Bcast(nvarsp, 1, MPI_INT, ios->ioroot, ios->my_comm);
-       if(ngattsp != NULL)
-        mpierr = MPI_Bcast(ngattsp, 1, MPI_INT, ios->ioroot, ios->my_comm);
-       if(unlimdimidp != NULL)
-        mpierr = MPI_Bcast(unlimdimidp, 1, MPI_INT, ios->ioroot, ios->my_comm);
-   if(errstr != NULL) free(errstr);
+    if(ierr==PIO_NOERR){
+      int ndims;
+      PIOc_inq_varndims(file->fh, varid, &ndims);
+      mpierr = MPI_Bcast(dimidsp , ndims, MPI_INT, ios->ioroot, ios->my_comm);
+     }
+  if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_get_att_text
- * The PIO-C interface for the NetCDF function nc_get_att_text.
+ * @ingroup PIOc_get_att_ushort
+ * The PIO-C interface for the NetCDF function nc_get_att_ushort.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -1103,7 +1170,7 @@ int PIOc_inq (int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip) 
+int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *ip) 
 {
   int ierr;
   int msg;
@@ -1119,7 +1186,7 @@ int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_TEXT;
+  msg = PIO_MSG_GET_ATT_USHORT;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -1133,19 +1200,19 @@ int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_text(file->fh, varid, name, ip);;
+      ierr = nc_get_att_ushort(file->fh, varid, name, ip);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_get_att_text(file->fh, varid, name, ip);;
+	ierr = nc_get_att_ushort(file->fh, varid, name, ip);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_text(file->fh, varid, name, ip);;
+      ierr = ncmpi_get_att_ushort(file->fh, varid, name, ip);;
       break;
 #endif
     default:
@@ -1161,15 +1228,90 @@ int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip)
       if(ierr == PIO_NOERR){
         PIO_Offset attlen;
         PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_CHAR, ios->ioroot, ios->my_comm);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_UNSIGNED_SHORT, ios->ioroot, ios->my_comm);
       }
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_get_att_short
- * The PIO-C interface for the NetCDF function nc_get_att_short.
+ * @ingroup PIOc_inq_varid
+ * The PIO-C interface for the NetCDF function nc_inq_varid.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @param varidp a pointer that will get the variable id 
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_varid (int ncid, const char *name, int *varidp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_VARID;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_varid(file->fh, name, varidp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_varid(file->fh, name, varidp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_varid(file->fh, name, varidp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(varidp,1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_attlen
+ * The PIO-C interface for the NetCDF function nc_inq_attlen.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -1179,9 +1321,10 @@ int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip)
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
+ * @param lenp a pointer that will get the number of values 
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip) 
+int PIOc_inq_attlen (int ncid, int varid, const char *name, PIO_Offset *lenp) 
 {
   int ierr;
   int msg;
@@ -1197,7 +1340,7 @@ int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_SHORT;
+  msg = PIO_MSG_INQ_ATTLEN;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -1211,19 +1354,19 @@ int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_short(file->fh, varid, name, ip);;
+      ierr = nc_inq_attlen(file->fh, varid, name, (size_t *)lenp);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_get_att_short(file->fh, varid, name, ip);;
+	ierr = nc_inq_attlen(file->fh, varid, name, (size_t *)lenp);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_short(file->fh, varid, name, ip);;
+      ierr = ncmpi_inq_attlen(file->fh, varid, name, lenp);;
       break;
 #endif
     default:
@@ -1232,22 +1375,18 @@ int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip)
   }
 
    if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
-    sprintf(errstr,"name %s in file %s",name,__FILE__);
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-      if(ierr == PIO_NOERR){
-        PIO_Offset attlen;
-        PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_SHORT, ios->ioroot, ios->my_comm);
-      }
+    mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_put_att_long
- * The PIO-C interface for the NetCDF function nc_put_att_long.
+ * @ingroup PIOc_inq_atttype
+ * The PIO-C interface for the NetCDF function nc_inq_atttype.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -1257,9 +1396,10 @@ int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip)
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
+ * @param xtypep a pointer that will get the type of the attribute.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_put_att_long (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long *op) 
+int PIOc_inq_atttype (int ncid, int varid, const char *name, nc_type *xtypep) 
 {
   int ierr;
   int msg;
@@ -1275,7 +1415,7 @@ int PIOc_put_att_long (int ncid, int varid, const char *name, nc_type xtype, PIO
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_LONG;
+  msg = PIO_MSG_INQ_ATTTYPE;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -1289,19 +1429,19 @@ int PIOc_put_att_long (int ncid, int varid, const char *name, nc_type xtype, PIO
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_long(file->fh, varid, name, xtype, (size_t)len, op);;
+      ierr = nc_inq_atttype(file->fh, varid, name, xtypep);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_put_att_long(file->fh, varid, name, xtype, (size_t)len, op);;
+	ierr = nc_inq_atttype(file->fh, varid, name, xtypep);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_long(file->fh, varid, name, xtype, len, op);;
+      ierr = ncmpi_inq_atttype(file->fh, varid, name, xtypep);;
       break;
 #endif
     default:
@@ -1314,222 +1454,7 @@ int PIOc_put_att_long (int ncid, int varid, const char *name, nc_type xtype, PIO
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_redef
- * The PIO-C interface for the NetCDF function nc_redef.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_redef (int ncid) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_REDEF;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_redef(file->fh);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_redef(file->fh);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_redef(file->fh);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_set_fill
- * The PIO-C interface for the NetCDF function nc_set_fill.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_set_fill (int ncid, int fillmode, int *old_modep) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_SET_FILL;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_set_fill(file->fh, fillmode, old_modep);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_set_fill(file->fh, fillmode, old_modep);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_set_fill(file->fh, fillmode, old_modep);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_enddef
- * The PIO-C interface for the NetCDF function nc_enddef.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_enddef (int ncid) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_ENDDEF;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_enddef(file->fh);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_enddef(file->fh);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_enddef(file->fh);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(xtypep , 1, MPI_INT, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
@@ -1608,8 +1533,8 @@ int PIOc_rename_var (int ncid, int varid, const char *name)
 }
 
 /** 
- * @ingroup PIOc_put_att_short
- * The PIO-C interface for the NetCDF function nc_put_att_short.
+ * @ingroup PIOc_inq_natts
+ * The PIO-C interface for the NetCDF function nc_inq_natts.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -1618,10 +1543,9 @@ int PIOc_rename_var (int ncid, int varid, const char *name)
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_put_att_short (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const short *op) 
+int PIOc_inq_natts (int ncid, int *ngattsp) 
 {
   int ierr;
   int msg;
@@ -1637,7 +1561,7 @@ int PIOc_put_att_short (int ncid, int varid, const char *name, nc_type xtype, PI
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_SHORT;
+  msg = PIO_MSG_INQ_NATTS;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -1651,19 +1575,19 @@ int PIOc_put_att_short (int ncid, int varid, const char *name, nc_type xtype, PI
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_short(file->fh, varid, name, xtype, (size_t)len, op);;
+      ierr = nc_inq_natts(file->fh, ngattsp);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_put_att_short(file->fh, varid, name, xtype, (size_t)len, op);;
+	ierr = nc_inq_natts(file->fh, ngattsp);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_short(file->fh, varid, name, xtype, len, op);;
+      ierr = ncmpi_inq_natts(file->fh, ngattsp);;
       break;
 #endif
     default:
@@ -1676,6 +1600,390 @@ int PIOc_put_att_short (int ncid, int varid, const char *name, nc_type xtype, PI
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(ngattsp,1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_ulonglong
+ * The PIO-C interface for the NetCDF function nc_put_att_ulonglong.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_put_att_ulonglong (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned long long *op) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_PUT_ATT_ULONGLONG;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_put_att_ulonglong(file->fh, varid, name, xtype, (size_t)len, op);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_put_att_ulonglong(file->fh, varid, name, xtype, (size_t)len, op);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_put_att_ulonglong(file->fh, varid, name, xtype, len, op);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_var
+ * The PIO-C interface for the NetCDF function nc_inq_var.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @param xtypep a pointer that will get the type of the attribute.
+ * @param nattsp a pointer that will get the number of attributes 
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_var (int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp, int *nattsp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_VAR;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    if(xtypep != NULL) mpierr = MPI_Bcast(xtypep , 1, MPI_INT, ios->ioroot, ios->my_comm);
+    if(ndimsp != NULL){ mpierr = MPI_Bcast(ndimsp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
+      file->varlist[varid].ndims = (*ndimsp);}
+      if(nattsp != NULL) mpierr = MPI_Bcast(nattsp,1, MPI_INT, ios->ioroot, ios->my_comm);
+    if(name != NULL){ 
+      int slen;
+      if(ios->iomaster)
+        slen = (int) strlen(name) + 1;
+      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
+      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
+    }
+    if(dimidsp != NULL) {int ndims;
+      PIOc_inq_varndims(file->fh, varid, &ndims);
+      mpierr = MPI_Bcast(dimidsp , ndims, MPI_INT, ios->ioroot, ios->my_comm);
+     }
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_rename_att
+ * The PIO-C interface for the NetCDF function nc_rename_att.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_rename_att (int ncid, int varid, const char *name, const char *newname) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_RENAME_ATT;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_rename_att(file->fh, varid, name, newname);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_rename_att(file->fh, varid, name, newname);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_rename_att(file->fh, varid, name, newname);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_ushort
+ * The PIO-C interface for the NetCDF function nc_put_att_ushort.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_put_att_ushort (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned short *op) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_PUT_ATT_USHORT;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_put_att_ushort(file->fh, varid, name, xtype, (size_t)len, op);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_put_att_ushort(file->fh, varid, name, xtype, (size_t)len, op);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_put_att_ushort(file->fh, varid, name, xtype, len, op);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_dimid
+ * The PIO-C interface for the NetCDF function nc_inq_dimid.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param idp a pointer that will get the id of the variable or attribute.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_dimid (int ncid, const char *name, int *idp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_DIMID;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_dimid(file->fh, name, idp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_dimid(file->fh, name, idp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_dimid(file->fh, name, idp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(idp , 1, MPI_INT, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
@@ -1749,6 +2057,236 @@ int PIOc_put_att_text (int ncid, int varid, const char *name, PIO_Offset len, co
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_get_att_uint
+ * The PIO-C interface for the NetCDF function nc_get_att_uint.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_GET_ATT_UINT;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_get_att_uint(file->fh, varid, name, ip);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_get_att_uint(file->fh, varid, name, ip);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_get_att_uint(file->fh, varid, name, ip);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
+    sprintf(errstr,"name %s in file %s",name,__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+      if(ierr == PIO_NOERR){
+        PIO_Offset attlen;
+        PIOc_inq_attlen(file->fh, varid, name, &attlen);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_UNSIGNED, ios->ioroot, ios->my_comm);
+      }
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_format
+ * The PIO-C interface for the NetCDF function nc_inq_format.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param formatp a pointer that will get the file format 
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_format (int ncid, int *formatp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_FORMAT;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_format(file->fh, formatp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_format(file->fh, formatp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_format(file->fh, formatp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(formatp , 1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_get_att_long
+ * The PIO-C interface for the NetCDF function nc_get_att_long.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_get_att_long (int ncid, int varid, const char *name, long *ip) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_GET_ATT_LONG;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_get_att_long(file->fh, varid, name, ip);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_get_att_long(file->fh, varid, name, ip);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_get_att_long(file->fh, varid, name, ip);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
+    sprintf(errstr,"name %s in file %s",name,__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+      if(ierr == PIO_NOERR){
+        PIO_Offset attlen;
+        PIOc_inq_attlen(file->fh, varid, name, &attlen);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_LONG, ios->ioroot, ios->my_comm);
+      }
   if(errstr != NULL) free(errstr);
   return ierr;
 }
@@ -1835,8 +2373,8 @@ int PIOc_inq_attname (int ncid, int varid, int attnum, char *name)
 }
 
 /** 
- * @ingroup PIOc_get_att_ulonglong
- * The PIO-C interface for the NetCDF function nc_get_att_ulonglong.
+ * @ingroup PIOc_inq_att
+ * The PIO-C interface for the NetCDF function nc_inq_att.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -1846,9 +2384,11 @@ int PIOc_inq_attname (int ncid, int varid, int attnum, char *name)
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
+ * @param xtypep a pointer that will get the type of the attribute.
+ * @param lenp a pointer that will get the number of values 
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long long *ip) 
+int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Offset *lenp) 
 {
   int ierr;
   int msg;
@@ -1864,7 +2404,7 @@ int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_ULONGLONG;
+  msg = PIO_MSG_INQ_ATT;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -1878,19 +2418,240 @@ int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_ulonglong(file->fh, varid, name, ip);;
+      ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_get_att_ulonglong(file->fh, varid, name, ip);;
+	ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_ulonglong(file->fh, varid, name, ip);;
+      ierr = ncmpi_inq_att(file->fh, varid, name, xtypep, lenp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(xtypep != NULL) mpierr = MPI_Bcast(xtypep , 1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(lenp != NULL) mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_long
+ * The PIO-C interface for the NetCDF function nc_put_att_long.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_put_att_long (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long *op) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_PUT_ATT_LONG;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_put_att_long(file->fh, varid, name, xtype, (size_t)len, op);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_put_att_long(file->fh, varid, name, xtype, (size_t)len, op);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_put_att_long(file->fh, varid, name, xtype, len, op);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_unlimdim
+ * The PIO-C interface for the NetCDF function nc_inq_unlimdim.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_unlimdim (int ncid, int *unlimdimidp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_UNLIMDIM;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_unlimdim(file->fh, unlimdimidp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_unlimdim(file->fh, unlimdimidp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_unlimdim(file->fh, unlimdimidp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(unlimdimidp,1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_get_att_float
+ * The PIO-C interface for the NetCDF function nc_get_att_float.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_get_att_float (int ncid, int varid, const char *name, float *ip) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_GET_ATT_FLOAT;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_get_att_float(file->fh, varid, name, ip);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_get_att_float(file->fh, varid, name, ip);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_get_att_float(file->fh, varid, name, ip);;
       break;
 #endif
     default:
@@ -1906,27 +2667,26 @@ int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long
       if(ierr == PIO_NOERR){
         PIO_Offset attlen;
         PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_UNSIGNED_LONG_LONG, ios->ioroot, ios->my_comm);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_FLOAT, ios->ioroot, ios->my_comm);
       }
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_get_att_ushort
- * The PIO-C interface for the NetCDF function nc_get_att_ushort.
+ * @ingroup PIOc_inq_ndims
+ * The PIO-C interface for the NetCDF function nc_inq_ndims.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
  * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *ip) 
+int PIOc_inq_ndims (int ncid, int *ndimsp) 
 {
   int ierr;
   int msg;
@@ -1942,7 +2702,7 @@ int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_USHORT;
+  msg = PIO_MSG_INQ_NDIMS;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -1956,19 +2716,532 @@ int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_ushort(file->fh, varid, name, ip);;
+      ierr = nc_inq_ndims(file->fh, ndimsp);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_get_att_ushort(file->fh, varid, name, ip);;
+	ierr = nc_inq_ndims(file->fh, ndimsp);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_ushort(file->fh, varid, name, ip);;
+      ierr = ncmpi_inq_ndims(file->fh, ndimsp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(ndimsp , 1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_int
+ * The PIO-C interface for the NetCDF function nc_put_att_int.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_put_att_int (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const int *op) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_PUT_ATT_INT;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_put_att_int(file->fh, varid, name, xtype, (size_t)len, op);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_put_att_int(file->fh, varid, name, xtype, (size_t)len, op);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_put_att_int(file->fh, varid, name, xtype, len, op);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_nvars
+ * The PIO-C interface for the NetCDF function nc_inq_nvars.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_nvars (int ncid, int *nvarsp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_NVARS;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_nvars(file->fh, nvarsp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_nvars(file->fh, nvarsp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_nvars(file->fh, nvarsp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(nvarsp,1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_enddef
+ * The PIO-C interface for the NetCDF function nc_enddef.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_enddef (int ncid) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_ENDDEF;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_enddef(file->fh);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_enddef(file->fh);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_enddef(file->fh);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_uchar
+ * The PIO-C interface for the NetCDF function nc_put_att_uchar.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_put_att_uchar (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_PUT_ATT_UCHAR;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_put_att_uchar(file->fh, varid, name, xtype, (size_t)len, op);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_put_att_uchar(file->fh, varid, name, xtype, (size_t)len, op);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_put_att_uchar(file->fh, varid, name, xtype, len, op);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_longlong
+ * The PIO-C interface for the NetCDF function nc_put_att_longlong.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_put_att_longlong (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long long *op) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_PUT_ATT_LONGLONG;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_put_att_longlong(file->fh, varid, name, xtype, (size_t)len, op);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_put_att_longlong(file->fh, varid, name, xtype, (size_t)len, op);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_put_att_longlong(file->fh, varid, name, xtype, len, op);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_inq_varnatts
+ * The PIO-C interface for the NetCDF function nc_inq_varnatts.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @param nattsp a pointer that will get the number of attributes 
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_inq_varnatts (int ncid, int varid, int *nattsp) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_INQ_VARNATTS;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_inq_varnatts(file->fh, varid, nattsp);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_inq_varnatts(file->fh, varid, nattsp);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_inq_varnatts(file->fh, varid, nattsp);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    mpierr = MPI_Bcast(nattsp,1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_get_att_ubyte
+ * The PIO-C interface for the NetCDF function nc_get_att_ubyte.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_GET_ATT_UBYTE;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_get_att_ubyte(file->fh, varid, name, ip);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_get_att_ubyte(file->fh, varid, name, ip);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_get_att_ubyte(file->fh, varid, name, ip);;
       break;
 #endif
     default:
@@ -1984,15 +3257,15 @@ int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *
       if(ierr == PIO_NOERR){
         PIO_Offset attlen;
         PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_UNSIGNED_SHORT, ios->ioroot, ios->my_comm);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_BYTE, ios->ioroot, ios->my_comm);
       }
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_put_att_ulonglong
- * The PIO-C interface for the NetCDF function nc_put_att_ulonglong.
+ * @ingroup PIOc_get_att_text
+ * The PIO-C interface for the NetCDF function nc_get_att_text.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -2004,7 +3277,7 @@ int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_put_att_ulonglong (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned long long *op) 
+int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip) 
 {
   int ierr;
   int msg;
@@ -2020,7 +3293,7 @@ int PIOc_put_att_ulonglong (int ncid, int varid, const char *name, nc_type xtype
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_ULONGLONG;
+  msg = PIO_MSG_GET_ATT_TEXT;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -2034,19 +3307,97 @@ int PIOc_put_att_ulonglong (int ncid, int varid, const char *name, nc_type xtype
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_ulonglong(file->fh, varid, name, xtype, (size_t)len, op);;
+      ierr = nc_get_att_text(file->fh, varid, name, ip);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_put_att_ulonglong(file->fh, varid, name, xtype, (size_t)len, op);;
+	ierr = nc_get_att_text(file->fh, varid, name, ip);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_ulonglong(file->fh, varid, name, xtype, len, op);;
+      ierr = ncmpi_get_att_text(file->fh, varid, name, ip);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
+    sprintf(errstr,"name %s in file %s",name,__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+      if(ierr == PIO_NOERR){
+        PIO_Offset attlen;
+        PIOc_inq_attlen(file->fh, varid, name, &attlen);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_CHAR, ios->ioroot, ios->my_comm);
+      }
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_del_att
+ * The PIO-C interface for the NetCDF function nc_del_att.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_del_att (int ncid, int varid, const char *name) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_DEL_ATT;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_del_att(file->fh, varid, name);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_del_att(file->fh, varid, name);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_del_att(file->fh, varid, name);;
       break;
 #endif
     default:
@@ -2138,82 +3489,8 @@ int PIOc_inq_dimlen (int ncid, int dimid, PIO_Offset *lenp)
 }
 
 /** 
- * @ingroup PIOc_inq_var_fill
- * The PIO-C interface for the NetCDF function nc_inq_var_fill.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_var_fill (int ncid, int varid, int *no_fill, void *fill_value) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_VAR_FILL;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_var_fill(file->fh, varid, no_fill, fill_value);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_var_fill(file->fh, varid, no_fill, fill_value);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_var_fill(file->fh, varid, no_fill, fill_value);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(fill_value, 1, MPI_INT, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_get_att_uint
- * The PIO-C interface for the NetCDF function nc_get_att_uint.
+ * @ingroup PIOc_get_att_schar
+ * The PIO-C interface for the NetCDF function nc_get_att_schar.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -2225,7 +3502,7 @@ int PIOc_inq_var_fill (int ncid, int varid, int *no_fill, void *fill_value)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip) 
+int PIOc_get_att_schar (int ncid, int varid, const char *name, signed char *ip) 
 {
   int ierr;
   int msg;
@@ -2241,7 +3518,7 @@ int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_UINT;
+  msg = PIO_MSG_GET_ATT_SCHAR;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -2255,19 +3532,19 @@ int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_uint(file->fh, varid, name, ip);;
+      ierr = nc_get_att_schar(file->fh, varid, name, ip);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_get_att_uint(file->fh, varid, name, ip);;
+	ierr = nc_get_att_schar(file->fh, varid, name, ip);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_uint(file->fh, varid, name, ip);;
+      ierr = ncmpi_get_att_schar(file->fh, varid, name, ip);;
       break;
 #endif
     default:
@@ -2283,15 +3560,15 @@ int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip)
       if(ierr == PIO_NOERR){
         PIO_Offset attlen;
         PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_UNSIGNED, ios->ioroot, ios->my_comm);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_CHAR, ios->ioroot, ios->my_comm);
       }
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_get_att_longlong
- * The PIO-C interface for the NetCDF function nc_get_att_longlong.
+ * @ingroup PIOc_get_att_ulonglong
+ * The PIO-C interface for the NetCDF function nc_get_att_ulonglong.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -2303,7 +3580,7 @@ int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att_longlong (int ncid, int varid, const char *name, long long *ip) 
+int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long long *ip) 
 {
   int ierr;
   int msg;
@@ -2319,7 +3596,7 @@ int PIOc_get_att_longlong (int ncid, int varid, const char *name, long long *ip)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_LONGLONG;
+  msg = PIO_MSG_GET_ATT_ULONGLONG;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -2333,19 +3610,19 @@ int PIOc_get_att_longlong (int ncid, int varid, const char *name, long long *ip)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_longlong(file->fh, varid, name, ip);;
+      ierr = nc_get_att_ulonglong(file->fh, varid, name, ip);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_get_att_longlong(file->fh, varid, name, ip);;
+	ierr = nc_get_att_ulonglong(file->fh, varid, name, ip);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_longlong(file->fh, varid, name, ip);;
+      ierr = ncmpi_get_att_ulonglong(file->fh, varid, name, ip);;
       break;
 #endif
     default:
@@ -2361,299 +3638,8 @@ int PIOc_get_att_longlong (int ncid, int varid, const char *name, long long *ip)
       if(ierr == PIO_NOERR){
         PIO_Offset attlen;
         PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_LONG_LONG, ios->ioroot, ios->my_comm);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_UNSIGNED_LONG_LONG, ios->ioroot, ios->my_comm);
       }
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_put_att_schar
- * The PIO-C interface for the NetCDF function nc_put_att_schar.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_put_att_schar (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const signed char *op) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_SCHAR;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_schar(file->fh, varid, name, xtype, (size_t)len, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_att_schar(file->fh, varid, name, xtype, (size_t)len, op);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_schar(file->fh, varid, name, xtype, len, op);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_put_att_float
- * The PIO-C interface for the NetCDF function nc_put_att_float.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_put_att_float (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const float *op) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_FLOAT;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_float(file->fh, varid, name, xtype, (size_t)len, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_att_float(file->fh, varid, name, xtype, (size_t)len, op);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_float(file->fh, varid, name, xtype, len, op);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_nvars
- * The PIO-C interface for the NetCDF function nc_inq_nvars.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_nvars (int ncid, int *nvarsp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_NVARS;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_nvars(file->fh, nvarsp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_nvars(file->fh, nvarsp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_nvars(file->fh, nvarsp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(nvarsp,1, MPI_INT, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_rename_dim
- * The PIO-C interface for the NetCDF function nc_rename_dim.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_rename_dim (int ncid, int dimid, const char *name) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_RENAME_DIM;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_rename_dim(file->fh, dimid, name);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_rename_dim(file->fh, dimid, name);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_rename_dim(file->fh, dimid, name);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
@@ -2738,314 +3724,8 @@ int PIOc_inq_varndims (int ncid, int varid, int *ndimsp)
 }
 
 /** 
- * @ingroup PIOc_get_att_long
- * The PIO-C interface for the NetCDF function nc_get_att_long.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_get_att_long (int ncid, int varid, const char *name, long *ip) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_LONG;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_long(file->fh, varid, name, ip);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_get_att_long(file->fh, varid, name, ip);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_long(file->fh, varid, name, ip);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
-    sprintf(errstr,"name %s in file %s",name,__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-      if(ierr == PIO_NOERR){
-        PIO_Offset attlen;
-        PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_LONG, ios->ioroot, ios->my_comm);
-      }
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_dim
- * The PIO-C interface for the NetCDF function nc_inq_dim.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param lenp a pointer that will get the number of values 
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_dim (int ncid, int dimid, char *name, PIO_Offset *lenp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_DIM;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_dim(file->fh, dimid, name, lenp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    if(name != NULL){ 
-      int slen;
-      if(ios->iomaster)
-        slen = (int) strlen(name);
-      mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
-      mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
-    }
-      if(lenp != NULL) mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_dimid
- * The PIO-C interface for the NetCDF function nc_inq_dimid.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param idp a pointer that will get the id of the variable or attribute.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_dimid (int ncid, const char *name, int *idp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_DIMID;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_dimid(file->fh, name, idp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_dimid(file->fh, name, idp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_dimid(file->fh, name, idp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(idp , 1, MPI_INT, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_unlimdim
- * The PIO-C interface for the NetCDF function nc_inq_unlimdim.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_unlimdim (int ncid, int *unlimdimidp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_UNLIMDIM;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_unlimdim(file->fh, unlimdimidp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_unlimdim(file->fh, unlimdimidp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_unlimdim(file->fh, unlimdimidp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(unlimdimidp,1, MPI_INT, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_vardimid
- * The PIO-C interface for the NetCDF function nc_inq_vardimid.
+ * @ingroup PIOc_inq_varname
+ * The PIO-C interface for the NetCDF function nc_inq_varname.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -3057,7 +3737,7 @@ int PIOc_inq_unlimdim (int ncid, int *unlimdimidp)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_vardimid (int ncid, int varid, int *dimidsp) 
+int PIOc_inq_varname (int ncid, int varid, char *name) 
 {
   int ierr;
   int msg;
@@ -3073,7 +3753,7 @@ int PIOc_inq_vardimid (int ncid, int varid, int *dimidsp)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_INQ_VARDIMID;
+  msg = PIO_MSG_INQ_VARNAME;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -3087,171 +3767,19 @@ int PIOc_inq_vardimid (int ncid, int varid, int *dimidsp)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_vardimid(file->fh, varid, dimidsp);;
+      ierr = nc_inq_varname(file->fh, varid, name);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_inq_vardimid(file->fh, varid, dimidsp);;
+	ierr = nc_inq_varname(file->fh, varid, name);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_vardimid(file->fh, varid, dimidsp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    if(ierr==PIO_NOERR){
-      int ndims;
-      PIOc_inq_varndims(file->fh, varid, &ndims);
-      mpierr = MPI_Bcast(dimidsp , ndims, MPI_INT, ios->ioroot, ios->my_comm);
-     }
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_attlen
- * The PIO-C interface for the NetCDF function nc_inq_attlen.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @param lenp a pointer that will get the number of values 
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_attlen (int ncid, int varid, const char *name, PIO_Offset *lenp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_ATTLEN;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_attlen(file->fh, varid, name, (size_t *)lenp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_attlen(file->fh, varid, name, (size_t *)lenp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_attlen(file->fh, varid, name, lenp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_dimname
- * The PIO-C interface for the NetCDF function nc_inq_dimname.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_dimname (int ncid, int dimid, char *name) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_DIMNAME;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_dimname(file->fh, dimid, name);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_dimname(file->fh, dimid, name);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_dimname(file->fh, dimid, name);;
+      ierr = ncmpi_inq_varname(file->fh, varid, name);;
       break;
 #endif
     default:
@@ -3271,456 +3799,6 @@ int PIOc_inq_dimname (int ncid, int dimid, char *name)
       mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm);
       mpierr = MPI_Bcast(name, slen, MPI_CHAR, ios->ioroot, ios->my_comm);
     }
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_put_att_ushort
- * The PIO-C interface for the NetCDF function nc_put_att_ushort.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_put_att_ushort (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned short *op) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_USHORT;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_ushort(file->fh, varid, name, xtype, (size_t)len, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_att_ushort(file->fh, varid, name, xtype, (size_t)len, op);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_ushort(file->fh, varid, name, xtype, len, op);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_get_att_float
- * The PIO-C interface for the NetCDF function nc_get_att_float.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_get_att_float (int ncid, int varid, const char *name, float *ip) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_FLOAT;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_float(file->fh, varid, name, ip);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_get_att_float(file->fh, varid, name, ip);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_float(file->fh, varid, name, ip);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
-    sprintf(errstr,"name %s in file %s",name,__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-      if(ierr == PIO_NOERR){
-        PIO_Offset attlen;
-        PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_FLOAT, ios->ioroot, ios->my_comm);
-      }
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_put_att_longlong
- * The PIO-C interface for the NetCDF function nc_put_att_longlong.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_put_att_longlong (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long long *op) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_LONGLONG;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_longlong(file->fh, varid, name, xtype, (size_t)len, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_att_longlong(file->fh, varid, name, xtype, (size_t)len, op);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_longlong(file->fh, varid, name, xtype, len, op);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_put_att_uint
- * The PIO-C interface for the NetCDF function nc_put_att_uint.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_put_att_uint (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned int *op) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_UINT;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_uint(file->fh, varid, name, xtype, (size_t)len, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_att_uint(file->fh, varid, name, xtype, (size_t)len, op);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_uint(file->fh, varid, name, xtype, len, op);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_get_att_schar
- * The PIO-C interface for the NetCDF function nc_get_att_schar.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_get_att_schar (int ncid, int varid, const char *name, signed char *ip) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_SCHAR;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_schar(file->fh, varid, name, ip);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_get_att_schar(file->fh, varid, name, ip);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_schar(file->fh, varid, name, ip);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
-    sprintf(errstr,"name %s in file %s",name,__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-      if(ierr == PIO_NOERR){
-        PIO_Offset attlen;
-        PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_CHAR, ios->ioroot, ios->my_comm);
-      }
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_attid
- * The PIO-C interface for the NetCDF function nc_inq_attid.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @param idp a pointer that will get the id of the variable or attribute.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_attid (int ncid, int varid, const char *name, int *idp) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_ATTID;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_attid(file->fh, varid, name, idp);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_attid(file->fh, varid, name, idp);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_attid(file->fh, varid, name, idp);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(idp , 1, MPI_INT, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
@@ -3800,19 +3878,20 @@ int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp)
 }
 
 /** 
- * @ingroup PIOc_inq_ndims
- * The PIO-C interface for the NetCDF function nc_inq_ndims.
+ * @ingroup PIOc_put_att_uint
+ * The PIO-C interface for the NetCDF function nc_put_att_uint.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
  * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_ndims (int ncid, int *ndimsp) 
+int PIOc_put_att_uint (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned int *op) 
 {
   int ierr;
   int msg;
@@ -3828,7 +3907,7 @@ int PIOc_inq_ndims (int ncid, int *ndimsp)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_INQ_NDIMS;
+  msg = PIO_MSG_PUT_ATT_UINT;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -3842,19 +3921,19 @@ int PIOc_inq_ndims (int ncid, int *ndimsp)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_ndims(file->fh, ndimsp);;
+      ierr = nc_put_att_uint(file->fh, varid, name, xtype, (size_t)len, op);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_inq_ndims(file->fh, ndimsp);;
+	ierr = nc_put_att_uint(file->fh, varid, name, xtype, (size_t)len, op);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_ndims(file->fh, ndimsp);;
+      ierr = ncmpi_put_att_uint(file->fh, varid, name, xtype, len, op);;
       break;
 #endif
     default:
@@ -3867,27 +3946,25 @@ int PIOc_inq_ndims (int ncid, int *ndimsp)
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(ndimsp , 1, MPI_INT, ios->ioroot, ios->my_comm);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_inq_vartype
- * The PIO-C interface for the NetCDF function nc_inq_vartype.
+ * @ingroup PIOc_get_att_short
+ * The PIO-C interface for the NetCDF function nc_get_att_short.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
  * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
- * @param xtypep a pointer that will get the type of the attribute.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep) 
+int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip) 
 {
   int ierr;
   int msg;
@@ -3903,7 +3980,7 @@ int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_INQ_VARTYPE;
+  msg = PIO_MSG_GET_ATT_SHORT;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -3917,19 +3994,96 @@ int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_vartype(file->fh, varid, xtypep);;
+      ierr = nc_get_att_short(file->fh, varid, name, ip);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_inq_vartype(file->fh, varid, xtypep);;
+	ierr = nc_get_att_short(file->fh, varid, name, ip);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_vartype(file->fh, varid, xtypep);;
+      ierr = ncmpi_get_att_short(file->fh, varid, name, ip);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
+    sprintf(errstr,"name %s in file %s",name,__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
+      if(ierr == PIO_NOERR){
+        PIO_Offset attlen;
+        PIOc_inq_attlen(file->fh, varid, name, &attlen);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_SHORT, ios->ioroot, ios->my_comm);
+      }
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_redef
+ * The PIO-C interface for the NetCDF function nc_redef.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_redef (int ncid) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_REDEF;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_redef(file->fh);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_redef(file->fh);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_redef(file->fh);;
       break;
 #endif
     default:
@@ -3942,7 +4096,79 @@ int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep)
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(xtypep , 1, MPI_INT, ios->ioroot, ios->my_comm);
+  if(errstr != NULL) free(errstr);
+  return ierr;
+}
+
+/** 
+ * @ingroup PIOc_put_att_ubyte
+ * The PIO-C interface for the NetCDF function nc_put_att_ubyte.
+ *
+ * This routine is called collectively by all tasks in the communicator 
+ * ios.union_comm. For more information on the underlying NetCDF commmand
+ * please read about this function in the NetCDF documentation at: 
+ * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
+ *
+ * @param ncid the ncid of the open file, obtained from
+ * PIOc_openfile() or PIOc_createfile().
+ * @param varid the variable ID.
+ * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ */
+int PIOc_put_att_ubyte (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op) 
+{
+  int ierr;
+  int msg;
+  int mpierr;
+  iosystem_desc_t *ios;
+  file_desc_t *file;
+  char *errstr;
+
+  errstr = NULL;
+  ierr = PIO_NOERR;
+
+  file = pio_get_file_from_id(ncid);
+  if(file == NULL)
+    return PIO_EBADID;
+  ios = file->iosystem;
+  msg = PIO_MSG_PUT_ATT_UBYTE;
+
+  if(ios->async_interface && ! ios->ioproc){
+    if(ios->compmaster) 
+      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+  }
+
+
+  if(ios->ioproc){
+    switch(file->iotype){
+#ifdef _NETCDF
+#ifdef _NETCDF4
+    case PIO_IOTYPE_NETCDF4P:
+      ierr = nc_put_att_ubyte(file->fh, varid, name, xtype, (size_t)len, op);;
+      break;
+    case PIO_IOTYPE_NETCDF4C:
+#endif
+    case PIO_IOTYPE_NETCDF:
+      if(ios->io_rank==0){
+	ierr = nc_put_att_ubyte(file->fh, varid, name, xtype, (size_t)len, op);;
+      }
+      break;
+#endif
+#ifdef _PNETCDF
+    case PIO_IOTYPE_PNETCDF:
+      ierr = ncmpi_put_att_ubyte(file->fh, varid, name, xtype, len, op);;
+      break;
+#endif
+    default:
+      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+  }
+
+   if(ierr != PIO_NOERR){
+    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+    sprintf(errstr,"in file %s",__FILE__);
+  }
+  ierr = check_netcdf(file, ierr, errstr,__LINE__);
   if(errstr != NULL) free(errstr);
   return ierr;
 }
@@ -4026,8 +4252,8 @@ int PIOc_get_att_int (int ncid, int varid, const char *name, int *ip)
 }
 
 /** 
- * @ingroup PIOc_get_att_double
- * The PIO-C interface for the NetCDF function nc_get_att_double.
+ * @ingroup PIOc_get_att_longlong
+ * The PIO-C interface for the NetCDF function nc_get_att_longlong.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -4039,7 +4265,7 @@ int PIOc_get_att_int (int ncid, int varid, const char *name, int *ip)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att_double (int ncid, int varid, const char *name, double *ip) 
+int PIOc_get_att_longlong (int ncid, int varid, const char *name, long long *ip) 
 {
   int ierr;
   int msg;
@@ -4055,7 +4281,7 @@ int PIOc_get_att_double (int ncid, int varid, const char *name, double *ip)
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_DOUBLE;
+  msg = PIO_MSG_GET_ATT_LONGLONG;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -4069,19 +4295,19 @@ int PIOc_get_att_double (int ncid, int varid, const char *name, double *ip)
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_double(file->fh, varid, name, ip);;
+      ierr = nc_get_att_longlong(file->fh, varid, name, ip);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_get_att_double(file->fh, varid, name, ip);;
+	ierr = nc_get_att_longlong(file->fh, varid, name, ip);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_double(file->fh, varid, name, ip);;
+      ierr = ncmpi_get_att_longlong(file->fh, varid, name, ip);;
       break;
 #endif
     default:
@@ -4097,15 +4323,15 @@ int PIOc_get_att_double (int ncid, int varid, const char *name, double *ip)
       if(ierr == PIO_NOERR){
         PIO_Offset attlen;
         PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_DOUBLE, ios->ioroot, ios->my_comm);
+        mpierr = MPI_Bcast(ip , (int) attlen, MPI_LONG_LONG, ios->ioroot, ios->my_comm);
       }
   if(errstr != NULL) free(errstr);
   return ierr;
 }
 
 /** 
- * @ingroup PIOc_put_att_ubyte
- * The PIO-C interface for the NetCDF function nc_put_att_ubyte.
+ * @ingroup PIOc_put_att_float
+ * The PIO-C interface for the NetCDF function nc_put_att_float.
  *
  * This routine is called collectively by all tasks in the communicator 
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -4117,7 +4343,7 @@ int PIOc_get_att_double (int ncid, int varid, const char *name, double *ip)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_put_att_ubyte (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op) 
+int PIOc_put_att_float (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const float *op) 
 {
   int ierr;
   int msg;
@@ -4133,7 +4359,7 @@ int PIOc_put_att_ubyte (int ncid, int varid, const char *name, nc_type xtype, PI
   if(file == NULL)
     return PIO_EBADID;
   ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_UBYTE;
+  msg = PIO_MSG_PUT_ATT_FLOAT;
 
   if(ios->async_interface && ! ios->ioproc){
     if(ios->compmaster) 
@@ -4147,19 +4373,19 @@ int PIOc_put_att_ubyte (int ncid, int varid, const char *name, nc_type xtype, PI
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_ubyte(file->fh, varid, name, xtype, (size_t)len, op);;
+      ierr = nc_put_att_float(file->fh, varid, name, xtype, (size_t)len, op);;
       break;
     case PIO_IOTYPE_NETCDF4C:
 #endif
     case PIO_IOTYPE_NETCDF:
       if(ios->io_rank==0){
-	ierr = nc_put_att_ubyte(file->fh, varid, name, xtype, (size_t)len, op);;
+	ierr = nc_put_att_float(file->fh, varid, name, xtype, (size_t)len, op);;
       }
       break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_ubyte(file->fh, varid, name, xtype, len, op);;
+      ierr = ncmpi_put_att_float(file->fh, varid, name, xtype, len, op);;
       break;
 #endif
     default:
@@ -4172,232 +4398,6 @@ int PIOc_put_att_ubyte (int ncid, int varid, const char *name, nc_type xtype, PI
     sprintf(errstr,"in file %s",__FILE__);
   }
   ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_inq_atttype
- * The PIO-C interface for the NetCDF function nc_inq_atttype.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @param xtypep a pointer that will get the type of the attribute.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_inq_atttype (int ncid, int varid, const char *name, nc_type *xtypep) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_INQ_ATTTYPE;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_inq_atttype(file->fh, varid, name, xtypep);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_inq_atttype(file->fh, varid, name, xtypep);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_inq_atttype(file->fh, varid, name, xtypep);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-    mpierr = MPI_Bcast(xtypep , 1, MPI_INT, ios->ioroot, ios->my_comm);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_put_att_uchar
- * The PIO-C interface for the NetCDF function nc_put_att_uchar.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_put_att_uchar (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_ATT_UCHAR;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_put_att_uchar(file->fh, varid, name, xtype, (size_t)len, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_att_uchar(file->fh, varid, name, xtype, (size_t)len, op);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_put_att_uchar(file->fh, varid, name, xtype, len, op);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-    sprintf(errstr,"in file %s",__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-  if(errstr != NULL) free(errstr);
-  return ierr;
-}
-
-/** 
- * @ingroup PIOc_get_att_uchar
- * The PIO-C interface for the NetCDF function nc_get_att_uchar.
- *
- * This routine is called collectively by all tasks in the communicator 
- * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
- * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
- */
-int PIOc_get_att_uchar (int ncid, int varid, const char *name, unsigned char *ip) 
-{
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  char *errstr;
-
-  errstr = NULL;
-  ierr = PIO_NOERR;
-
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_ATT_UCHAR;
-
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
-  }
-
-
-  if(ios->ioproc){
-    switch(file->iotype){
-#ifdef _NETCDF
-#ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_att_uchar(file->fh, varid, name, ip);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
-#endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_get_att_uchar(file->fh, varid, name, ip);;
-      }
-      break;
-#endif
-#ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      ierr = ncmpi_get_att_uchar(file->fh, varid, name, ip);;
-      break;
-#endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-    }
-  }
-
-   if(ierr != PIO_NOERR){
-    errstr = (char *) malloc((strlen(name)+strlen(__FILE__) + 40)* sizeof(char));
-    sprintf(errstr,"name %s in file %s",name,__FILE__);
-  }
-  ierr = check_netcdf(file, ierr, errstr,__LINE__);
-      if(ierr == PIO_NOERR){
-        PIO_Offset attlen;
-        PIOc_inq_attlen(file->fh, varid, name, &attlen);
-        mpierr = MPI_Bcast(ip , (int) attlen, MPI_UNSIGNED_CHAR, ios->ioroot, ios->my_comm);
-      }
   if(errstr != NULL) free(errstr);
   return ierr;
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -26,6 +26,8 @@ if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
         PRIVATE -ffree-line-length-none)
 endif()
 
+add_executable (test_names EXCLUDE_FROM_ALL test_names.c)
+target_link_libraries (test_names pioc)
 add_executable (test_nc4 EXCLUDE_FROM_ALL test_nc4.c)
 target_link_libraries (test_nc4 pioc)
 
@@ -35,6 +37,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
 #        PRIVATE -mismatch_all)
 endif ()
 
+add_dependencies (tests test_names)
 add_dependencies (tests test_nc4)
 add_dependencies (tests pio_unit_test)
 
@@ -42,6 +45,8 @@ add_dependencies (tests pio_unit_test)
 set (DEFAULT_TEST_TIMEOUT 240)
 
 if (PIO_USE_MPISERIAL)
+    add_test(NAME test_names
+        COMMAND test_names)
     add_test(NAME test_nc4
         COMMAND test_nc4)
     add_test(NAME pio_unit_test
@@ -49,6 +54,10 @@ if (PIO_USE_MPISERIAL)
     set_tests_properties(pio_unit_test
         PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 else ()
+    add_mpi_test(test_names
+        EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_names
+        NUMPROCS 4
+        TIMEOUT ${DEFAULT_TEST_TIMEOUT})
     add_mpi_test(test_nc4
         EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_nc4
         NUMPROCS 4

--- a/tests/unit/test_names.c
+++ b/tests/unit/test_names.c
@@ -1,0 +1,294 @@
+/**
+ * @file 
+ * Tests for names of vars, atts, and dims.
+ *
+ */
+#include <pio.h>
+#ifdef TIMING
+#include <gptl.h>
+#endif
+
+#define NUM_NETCDF_FLAVORS 4
+#define NDIM 3
+#define X_DIM_LEN 400
+#define Y_DIM_LEN 400
+#define NUM_TIMESTEPS 6
+#define VAR_NAME "foo"
+#define START_DATA_VAL 42
+#define ERR_AWFUL 1111
+#define VAR_CACHE_SIZE (1024 * 1024)
+#define VAR_CACHE_NELEMS 10
+#define VAR_CACHE_PREEMPTION 0.5
+
+/** Handle MPI errors. This should only be used with MPI library
+ * function calls. */
+#define MPIERR(e) do {                                                  \
+	MPI_Error_string(e, err_buffer, &resultlen);			\
+	fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
+	MPI_Finalize();							\
+	return ERR_AWFUL;							\
+    } while (0) 
+
+/** Handle non-MPI errors by finalizing the MPI library and exiting
+ * with an exit code. */
+#define ERR(e) do {				\
+        fprintf(stderr, "Error %d in %s, line %d\n", e, __FILE__, __LINE__); \
+	MPI_Finalize();				\
+	return e;				\
+    } while (0) 
+
+/** Global err buffer for MPI. */
+char err_buffer[MPI_MAX_ERROR_STRING];
+int resultlen;
+
+/** The dimension names. */
+char dim_name[NDIM][NC_MAX_NAME + 1] = {"timestep", "x", "y"};
+
+/** Length of the dimensions in the sample data. */
+int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
+
+/** Length of chunksizes to use in netCDF-4 files. */
+size_t chunksize[NDIM] = {2, X_DIM_LEN/2, Y_DIM_LEN/2};
+
+/** Run Tests for NetCDF-4 Functions.
+ *
+ * @param argc argument count
+ * @param argv array of arguments
+ */
+int
+main(int argc, char **argv)
+{
+    int verbose = 1;
+    
+    /** Zero-based rank of processor. */
+    int my_rank;
+
+    /** Number of processors involved in current execution. */
+    int ntasks;
+
+    /** Specifies the flavor of netCDF output format. */
+    int iotype;
+
+    /** Different output flavors. */
+    int format[NUM_NETCDF_FLAVORS] = {PIO_IOTYPE_PNETCDF, 
+				      PIO_IOTYPE_NETCDF,
+				      PIO_IOTYPE_NETCDF4C,
+				      PIO_IOTYPE_NETCDF4P};
+
+    /** Names for the output files. */
+    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"test_nc4_pnetcdf.nc",
+							  "test_nc4_classic.nc",
+							  "test_nc4_serial4.nc",
+							  "test_nc4_parallel4.nc"};
+	
+    /** Number of processors that will do IO. In this test we
+     * will do IO from all processors. */
+    int niotasks;
+
+    /** Stride in the mpi rank between io tasks. Always 1 in this
+     * test. */
+    int ioproc_stride = 1;
+
+    /** Number of the aggregator? Always 0 in this test. */
+    int numAggregator = 0;
+
+    /** Zero based rank of first processor to be used for I/O. */
+    int ioproc_start = 0;
+
+    /** The dimension IDs. */
+    int dimids[NDIM];
+
+    /** Array index per processing unit. */
+    PIO_Offset elements_per_pe;
+
+    /** The ID for the parallel I/O system. */
+    int iosysid;
+
+    /** The ncid of the netCDF file. */
+    int ncid = 0;
+
+    /** The ID of the netCDF varable. */
+    int varid;
+
+    /** Storage of netCDF-4 files (contiguous vs. chunked). */
+    int storage;
+
+    /** Chunksizes set in the file. */
+    size_t my_chunksize[NDIM];
+    
+    /** The shuffle filter setting in the netCDF-4 test file. */
+    int shuffle;
+    
+    /** Non-zero if deflate set for the variable in the netCDF-4 test file. */
+    int deflate;
+
+    /** The deflate level set for the variable in the netCDF-4 test file. */
+    int deflate_level;
+
+    /** Non-zero if fletcher32 filter is used for variable. */
+    int fletcher32;
+
+    /** Endianness of variable. */
+    int endianness;
+
+    /* Size of the file chunk cache. */
+    size_t chunk_cache_size;
+
+    /* Number of elements in file cache. */
+    size_t nelems;
+
+    /* File cache preemption. */
+    float preemption;
+
+    /* Size of the var chunk cache. */
+    size_t var_cache_size;
+
+    /* Number of elements in var cache. */
+    size_t var_cache_nelems;
+
+    /* Var cache preemption. */    
+    float var_cache_preemption;
+    
+    /** The I/O description ID. */
+    int ioid;
+
+    /** A buffer for sample data. */
+    float *buffer;
+
+    /** A buffer for reading data back from the file. */
+    int *read_buffer;
+
+    /** The decomposition mapping. */
+    PIO_Offset *compdof;
+
+    /** Return code. */
+    int ret;
+
+    /** Index for loops. */
+    int fmt, d, d1, i;
+    
+#ifdef TIMING    
+    /* Initialize the GPTL timing library. */
+    if ((ret = GPTLinitialize ()))
+	return ret;
+#endif    
+    
+    /* Initialize MPI. */
+    if ((ret = MPI_Init(&argc, &argv)))
+	MPIERR(ret);
+
+    /* Learn my rank and the total number of processors. */
+    if ((ret = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
+	MPIERR(ret);
+    if ((ret = MPI_Comm_size(MPI_COMM_WORLD, &ntasks)))
+	MPIERR(ret);
+
+    /* Check that a valid number of processors was specified. */
+    if (!(ntasks == 1 || ntasks == 2 || ntasks == 4 ||
+	  ntasks == 8 || ntasks == 16))
+	fprintf(stderr, "Number of processors must be 1, 2, 4, 8, or 16!\n");
+    if (verbose)
+	printf("%d: ParallelIO Library example1 running on %d processors.\n",
+	       my_rank, ntasks);
+
+    /* keep things simple - 1 iotask per MPI process */    
+    niotasks = ntasks; 
+
+    /* Initialize the PIO IO system. This specifies how
+     * many and which processors are involved in I/O. */
+    if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, niotasks, ioproc_stride,
+				   ioproc_start, PIO_REARR_SUBSET, &iosysid)))
+	ERR(ret);
+
+    /* Describe the decomposition. This is a 1-based array, so add 1! */
+    elements_per_pe = X_DIM_LEN * Y_DIM_LEN / ntasks;
+    if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
+	return PIO_ENOMEM;
+    for (i = 0; i < elements_per_pe; i++) {
+	compdof[i] = my_rank * elements_per_pe + i + 1;
+    }
+	
+    /* Create the PIO decomposition for this test. */
+    if (verbose)
+	printf("rank: %d Creating decomposition...\n", my_rank);
+    if ((ret = PIOc_InitDecomp(iosysid, PIO_FLOAT, 2, &dim_len[1], (PIO_Offset)elements_per_pe,
+			       compdof, &ioid, NULL, NULL, NULL)))
+	ERR(ret);
+    free(compdof);
+
+    /* How many flavors will we be running for? */
+    int num_flavors = 0;
+    int fmtidx = 0;
+#ifdef _PNETCDF
+    num_flavors++;
+    format[fmtidx++] = PIO_IOTYPE_PNETCDF;
+#endif
+#ifdef _NETCDF
+    num_flavors++;
+    format[fmtidx++] = PIO_IOTYPE_NETCDF;
+#endif
+#ifdef _NETCDF4
+    num_flavors += 2;
+    format[fmtidx++] = PIO_IOTYPE_NETCDF4C;
+    format[fmtidx] = PIO_IOTYPE_NETCDF4P;
+#endif
+    
+    /* Use PIO to create the example file in each of the four
+     * available ways. */
+    for (fmt = 0; fmt < num_flavors; fmt++) 
+    {
+	/* Create the netCDF output file. */
+	if (verbose)
+	    printf("rank: %d Creating sample file %s with format %d...\n",
+		   my_rank, filename[fmt], format[fmt]);
+	if ((ret = PIOc_createfile(iosysid, &ncid, &(format[fmt]), filename[fmt],
+				   PIO_CLOBBER)))
+	    ERR(ret);
+	
+	/* Define netCDF dimensions and variable. */
+	if (verbose)
+	    printf("rank: %d Defining netCDF metadata...\n", my_rank);
+	for (d = 0; d < NDIM; d++) {
+	    if (verbose)
+		printf("rank: %d Defining netCDF dimension %s, length %d\n", my_rank,
+		       dim_name[d], dim_len[d]);
+	    if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
+		ERR(ret);
+	}
+	if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM, dimids, &varid)))
+	    ERR(ret);
+
+	if ((ret = PIOc_enddef(ncid)))
+	    ERR(ret);
+
+	/* Close the netCDF file. */
+	if (verbose)
+	    printf("rank: %d Closing the sample data file...\n", my_rank);
+	if ((ret = PIOc_closefile(ncid)))
+	    ERR(ret);
+    }
+	
+    /* Free the PIO decomposition. */
+    if (verbose)
+	printf("rank: %d Freeing PIO decomposition...\n", my_rank);
+    if ((ret = PIOc_freedecomp(iosysid, ioid)))
+	ERR(ret);
+	
+    /* Finalize the IO system. */
+    if (verbose)
+	printf("rank: %d Freeing PIO resources...\n", my_rank);
+    if ((ret = PIOc_finalize(iosysid)))
+	ERR(ret);
+
+    /* Finalize the MPI library. */
+    MPI_Finalize();
+
+#ifdef TIMING    
+    /* Finalize the GPTL timing library. */
+    if ((ret = GPTLfinalize ()))
+	return ret;
+#endif    
+    
+
+    return 0;
+}

--- a/tests/unit/test_names.c
+++ b/tests/unit/test_names.c
@@ -14,6 +14,7 @@
 #define Y_DIM_LEN 400
 #define NUM_TIMESTEPS 6
 #define VAR_NAME "foo"
+#define ATT_NAME "bar"
 #define START_DATA_VAL 42
 #define ERR_AWFUL 1111
 #define VAR_CACHE_SIZE (1024 * 1024)
@@ -50,6 +51,103 @@ int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
 /** Length of chunksizes to use in netCDF-4 files. */
 size_t chunksize[NDIM] = {2, X_DIM_LEN/2, Y_DIM_LEN/2};
 
+/** Check the dimension names.
+ *
+ * @param my_rank rank of process
+ * @param ncid ncid of open netCDF file
+ * 
+ * @returns 0 for success, error code otherwise. */
+int
+check_dim_names(int my_rank, int ncid, int verbose)
+{
+    char dim_name[NC_MAX_NAME + 1];
+    char zero_dim_name[NC_MAX_NAME + 1];
+    int ret;
+
+    for (int d = 0; d < NDIM; d++)
+    {
+	strcpy(dim_name, "11111111111111111111111111111111");
+	if ((ret = PIOc_inq_dimname(ncid, d, dim_name)))
+	    return ret;
+	if (verbose)
+	    printf("my_rank %d dim %d name %s\n", my_rank, d, dim_name);
+
+	/* Did other ranks get the same name? */
+	if (!my_rank)
+	    strcpy(zero_dim_name, dim_name);
+	/* if (verbose) */
+	/*     printf("rank %d dim_name %s zero_dim_name %s\n", my_rank, dim_name, zero_dim_name); */
+	if ((ret = MPI_Bcast(&zero_dim_name, strlen(dim_name) + 1, MPI_CHAR, 0,
+				MPI_COMM_WORLD)))
+	    MPIERR(ret);
+	if (strcmp(dim_name, zero_dim_name))
+	    return ERR_AWFUL;
+    }
+    return 0;
+}
+
+/** Check the variable name.
+ *
+ * @param my_rank rank of process
+ * @param ncid ncid of open netCDF file
+ * 
+ * @returns 0 for success, error code otherwise. */
+int
+check_var_name(int my_rank, int ncid, int verbose)
+{
+    char var_name[NC_MAX_NAME + 1];
+    char zero_var_name[NC_MAX_NAME + 1];
+    int ret;
+
+    strcpy(var_name, "11111111111111111111111111111111");
+    if ((ret = PIOc_inq_varname(ncid, 0, var_name)))
+	return ret;
+    if (verbose)
+	printf("my_rank %d var name %s\n", my_rank, var_name);
+
+    /* Did other ranks get the same name? */
+    if (!my_rank)
+	strcpy(zero_var_name, var_name);
+    if ((ret = MPI_Bcast(&zero_var_name, strlen(var_name) + 1, MPI_CHAR, 0,
+			 MPI_COMM_WORLD)))
+	MPIERR(ret);
+    if (strcmp(var_name, zero_var_name))
+	return ERR_AWFUL;
+    return 0;
+}
+
+/** Check the attribute name.
+ *
+ * @param my_rank rank of process
+ * @param ncid ncid of open netCDF file
+ * 
+ * @returns 0 for success, error code otherwise. */
+int
+check_att_name(int my_rank, int ncid, int verbose)
+{
+    char att_name[NC_MAX_NAME + 1];
+    char zero_att_name[NC_MAX_NAME + 1];
+    int ret;
+
+    strcpy(att_name, "11111111111111111111111111111111");
+    if ((ret = PIOc_inq_attname(ncid, NC_GLOBAL, 0, att_name)))
+	return ret;
+    if (verbose)
+	printf("my_rank %d att name %s\n", my_rank, att_name);
+
+    /* Did everyone ranks get the same length name? */
+/*    if (strlen(att_name) != strlen(ATT_NAME))
+      return ERR_AWFUL;*/
+    if (!my_rank)
+    	strcpy(zero_att_name, att_name);
+    if ((ret = MPI_Bcast(&zero_att_name, strlen(att_name) + 1, MPI_CHAR, 0,
+    			 MPI_COMM_WORLD)))
+    	MPIERR(ret);
+    if (strcmp(att_name, zero_att_name))
+    	return ERR_AWFUL;
+    return 0;
+}
+
 /** Run Tests for NetCDF-4 Functions.
  *
  * @param argc argument count
@@ -76,10 +174,10 @@ main(int argc, char **argv)
 				      PIO_IOTYPE_NETCDF4P};
 
     /** Names for the output files. */
-    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"test_nc4_pnetcdf.nc",
-							  "test_nc4_classic.nc",
-							  "test_nc4_serial4.nc",
-							  "test_nc4_parallel4.nc"};
+    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"test_names_pnetcdf.nc",
+							  "test_names_classic.nc",
+							  "test_names_serial4.nc",
+							  "test_names_parallel4.nc"};
 	
     /** Number of processors that will do IO. In this test we
      * will do IO from all processors. */
@@ -255,7 +353,26 @@ main(int argc, char **argv)
 	    if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
 		ERR(ret);
 	}
+
+	/* Check the dimension names. */
+	if ((ret = check_dim_names(my_rank, ncid, verbose)))
+	    ERR(ret);
+
+	/* Define a global attribute. */
+	int att_val = 42;
+	if ((ret = PIOc_put_att_int(ncid, NC_GLOBAL, ATT_NAME, NC_INT, 1, &att_val)))
+	    ERR(ret);
+
+	/* Check the attribute name. */
+	if ((ret = check_att_name(my_rank, ncid, verbose)))
+	    ERR(ret);
+
+	/* Define a variable. */
 	if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM, dimids, &varid)))
+	    ERR(ret);
+
+	/* Check the variable name. */
+	if ((ret = check_var_name(my_rank, ncid, verbose)))
 	    ERR(ret);
 
 	if ((ret = PIOc_enddef(ncid)))
@@ -266,6 +383,11 @@ main(int argc, char **argv)
 	    printf("rank: %d Closing the sample data file...\n", my_rank);
 	if ((ret = PIOc_closefile(ncid)))
 	    ERR(ret);
+
+	/* Put a barrier here to make verbose output look better. */
+	if ((ret = MPI_Barrier(MPI_COMM_WORLD)))
+	    MPIERR(ret);
+
     }
 	
     /* Free the PIO decomposition. */


### PR DESCRIPTION
In current code, the null terminator is not broadcast to tasks where rank != 0 for serial formats on PIOc_inq_varname/dimname/attname.