### PR TITLE
Fortran implementation if inq_var_deflate, removed szip functions, fixed C bug in inq_deflate

### DIFF
--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -168,12 +168,12 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
 	    break;
 #endif
 	case PIO_IOTYPE_NETCDF:
-	    return PIO_ENOTNC4;
+	    ierr = PIO_ENOTNC4;
 	    break;
 #endif
 #ifdef _PNETCDF
 	case PIO_IOTYPE_PNETCDF:
-	    return PIO_ENOTNC4;
+	    ierr = PIO_ENOTNC4;
 	    break;
 #endif
 	default:
@@ -189,117 +189,24 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
     }
 
     /* Check the netCDF return code, and broadcast it to all tasks. */
-    ierr = check_netcdf(file, ierr, errstr,__LINE__);
+    printf("about to check_netcdf ierr = %d errstr = %s\n", ierr, errstr);
+    ierr = check_netcdf(file, ierr, errstr, __LINE__);
+    printf("after check_netcdf ierr = %d errstr = %s\n", ierr, errstr);
 
     /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
     /* Broadcast results to all tasks. */
-    if (shufflep)
-	ierr = MPI_Bcast(shufflep, 1, MPI_INT, ios->ioroot, ios->my_comm);
-    if (deflatep)
-	ierr = MPI_Bcast(deflatep, 1, MPI_INT, ios->ioroot, ios->my_comm);
-    if (deflate_levelp)
-	ierr = MPI_Bcast(deflate_levelp, 1, MPI_INT, ios->ioroot, ios->my_comm);
-    return ierr;
-}    
-
-/**
- * @ingroup PIO_inq_var
- * Inquire about szip settings for a variable.
- *
- * This function only applies to netCDF-4 files. When used with netCDF
- * classic files, the error PIO_ENOTNC4 will be returned.
- *
- * Szip is a read-only compression format in netCDF-4. Only raw HDF5
- * can create szip files, but netcdf-4 can read them.
- *
- * See the <a
- * href="http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html">netCDF
- * variable documentation</a> for details about the operation of this
- * function.
- * 
- * @param ncid the ncid of the open file.
- * @param varid the ID of the variable to set chunksizes for.
- * @param options_maskp will get the options mask.
- * @param pixels_per_block will get the pixels per block.
- * 
- * @return PIO_NOERR for success, otherwise an error code.
- */
-int PIOc_inq_var_szip(int ncid, int varid, int *options_maskp,
-		      int *pixels_per_blockp)
-{
-    int ierr;
-    int msg;
-    int mpierr;
-    iosystem_desc_t *ios;
-    file_desc_t *file;
-    char *errstr;
-
-    errstr = NULL;
-    ierr = PIO_NOERR;
-
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
-    ios = file->iosystem;
-    msg = PIO_MSG_INQ_VAR_SZIP;
-
-    if (ios->async_interface && ! ios->ioproc)
+    if (ierr == PIO_NOERR)
     {
-	if (ios->compmaster) 
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&(file->fh),1, MPI_INT, 0, ios->intercomm);
+	if (shufflep)
+	    ierr = MPI_Bcast(shufflep, 1, MPI_INT, ios->ioroot, ios->my_comm);
+	if (deflatep)
+	    ierr = MPI_Bcast(deflatep, 1, MPI_INT, ios->ioroot, ios->my_comm);
+	if (deflate_levelp)
+	    ierr = MPI_Bcast(deflate_levelp, 1, MPI_INT, ios->ioroot, ios->my_comm);
     }
-
-    if (ios->ioproc)
-    {
-	switch (file->iotype)
-	{
-#ifdef _NETCDF
-#ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_inq_var_szip(file->fh, varid, options_maskp, pixels_per_blockp);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (!ios->io_rank)
-		ierr = nc_inq_var_szip(file->fh, varid, options_maskp, pixels_per_blockp);
-	    break;
-#endif
-	case PIO_IOTYPE_NETCDF:
-	    return PIO_ENOTNC4;
-	    break;
-#endif
-#ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    return PIO_ENOTNC4;
-	    break;
-#endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
-    }
-
-    /* Allocate an error string if needed. */
-    if (ierr != PIO_NOERR)
-    {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
-    }
-
-    /* Check for netCDF error. */
-    ierr = check_netcdf(file, ierr, errstr,__LINE__);
-
-    /* Free the error string if it was allocated. */
-    if (errstr != NULL)
-	free(errstr);
-
-    /* Broadcast results to all tasks. */
-    if (options_maskp)
-	ierr = MPI_Bcast(options_maskp, 1, MPI_INT, ios->ioroot, ios->my_comm);
-    if (pixels_per_blockp)
-	ierr = MPI_Bcast(pixels_per_blockp, 1, MPI_INT, ios->ioroot, ios->my_comm);
-	
     return ierr;
 }    
 

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -96,7 +96,7 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
     /* Check the netCDF return code, and broadcast it to all tasks. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free the error string if there is no error. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -191,7 +191,7 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
     /* Check the netCDF return code, and broadcast it to all tasks. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free the error string if there is no error. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -290,7 +290,7 @@ int PIOc_inq_var_szip(int ncid, int varid, int *options_maskp,
     /* Check for netCDF error. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free unused error string. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -393,7 +393,7 @@ int PIOc_def_var_fletcher32(int ncid, int varid, int fletcher32)
     /* Check for netCDF error. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free unused error string. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -484,7 +484,7 @@ int PIOc_inq_var_fletcher32(int ncid, int varid, int *fletcher32p)
     /* Check the netCDF return code, and broadcast it to all tasks. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free the error string if there is no error. */
+    /* Free the error stringif it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -584,7 +584,7 @@ int PIOc_def_var_chunking(int ncid, int varid, int storage,
     /* Check for netCDF error. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free unused error string. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -681,7 +681,7 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, size_t *chunksizes
     /* Check the netCDF return code, and broadcast it to all tasks. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free the error string if there is no error. */
+    /* Free the error stringif it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -783,7 +783,7 @@ int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
     /* Check for netCDF error. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free unused error string. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -878,7 +878,7 @@ int PIOc_def_var_endian(int ncid, int varid, int endian)
     /* Check for netCDF error. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free unused error string. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -969,7 +969,7 @@ int PIOc_inq_var_endian(int ncid, int varid, int *endianp)
     /* Check the netCDF return code, and broadcast it to all tasks. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free the error string if there is no error. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -1062,7 +1062,7 @@ int PIOc_set_chunk_cache(int iotype, int io_rank, size_t size,
     /* Check for netCDF error. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free unused error string. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -1157,7 +1157,7 @@ int PIOc_get_chunk_cache(int iotype, int io_rank, size_t *sizep,
     /* Check for netCDF error. */
     /* ierr = check_netcdf(file, ierr, errstr,__LINE__);*/
 
-    /* Free unused error string. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -1263,7 +1263,7 @@ int PIOc_set_var_chunk_cache(int ncid, int varid, size_t size, size_t nelems,
     /* Check for netCDF error. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free unused error string. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 
@@ -1359,7 +1359,7 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, size_t *sizep, size_t *nelemsp
     /* Check the netCDF return code, and broadcast it to all tasks. */
     ierr = check_netcdf(file, ierr, errstr,__LINE__);
 
-    /* Free the error string if there is no error. */
+    /* Free the error string if it was allocated. */
     if (errstr != NULL)
 	free(errstr);
 

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -45,7 +45,6 @@ module pio
        PIO_inq_vardimid ,&
        PIO_inq_varnatts ,&
        PIO_inq_var_deflate ,&
-       PIO_inq_var_szip ,&
        PIO_inq_dimid ,      &
        PIO_inq_dimname ,  &
        PIO_inq_dimlen ,    &

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -45,6 +45,7 @@ module pio
        PIO_inq_vardimid ,&
        PIO_inq_varnatts ,&
        PIO_inq_var_deflate ,&
+       PIO_inq_var_szip ,&
        PIO_inq_dimid ,      &
        PIO_inq_dimname ,  &
        PIO_inq_dimlen ,    &

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -44,7 +44,7 @@ module pio
        PIO_inq_varndims ,&
        PIO_inq_vardimid ,&
        PIO_inq_varnatts ,&
-       PIO_inq_vardeflate ,&
+       PIO_inq_var_deflate ,&
        PIO_inq_dimid ,      &
        PIO_inq_dimname ,  &
        PIO_inq_dimlen ,    &

--- a/src/flib/pio_nf.F90
+++ b/src/flib/pio_nf.F90
@@ -23,6 +23,7 @@ module pio_nf
        pio_inq_vardimid                                     ,   &
        pio_inq_varnatts                                     ,   &
        pio_inq_var_deflate                                   ,    &       
+       pio_inq_var_szip                                   ,    &       
        pio_inquire_variable                                 , &
        pio_inquire_dimension                                , &
        pio_inq_dimname                                      , &
@@ -109,6 +110,12 @@ module pio_nf
           inq_var_deflate_desc                                 , &
           inq_var_deflate_vid                                  , &
           inq_var_deflate_id
+  end interface
+  interface pio_inq_var_szip
+     module procedure &
+          inq_var_szip_desc                                 , &
+          inq_var_szip_vid                                  , &
+          inq_var_szip_id
   end interface
   interface pio_inquire_dimension
      module procedure &
@@ -1078,6 +1085,68 @@ contains
 
     ierr = PIOc_inq_var_deflate(ncid, varid-1, shuffle, deflate, deflate_level)
   end function inq_var_deflate_id
+  
+!>
+!!  @defgroup PIO_inq_var PIO_inq_var_szip
+!<
+!>
+!! @public 
+!! @ingroup PIO_inq_var_szip
+!! @brief Gets metadata information for netcdf file.
+!! @details
+!! @param File @copydoc file_desc_t
+!! @param vardesc @copydoc var_desc_t
+!! @param type : The type of variable
+!! @retval ierr @copydoc error_return
+!<
+  integer function inq_var_szip_desc(File, vardesc, options_mask, pixels_per_block) result(ierr)
+
+    type (File_desc_t), intent(in) :: File
+    type (Var_desc_t), intent(in) :: vardesc
+    integer, intent(out) :: options_mask
+    integer, intent(out) :: pixels_per_block
+
+    ierr = pio_inq_var_szip(File%fh, vardesc%varid, options_mask, pixels_per_block)
+  end function inq_var_szip_desc
+
+!>
+!! @public 
+!! @ingroup PIO_inq_var_szip
+!! @brief Gets metadata information for netcdf file.
+!<
+  integer function inq_var_szip_vid(File, varid, options_mask, pixels_per_block) result(ierr)
+
+    type (File_desc_t), intent(in) :: File
+    integer, intent(in) :: varid
+    integer, intent(out) :: options_mask
+    integer, intent(out) :: pixels_per_block
+
+    ierr = pio_inq_var_szip(File%fh, varid, options_mask, pixels_per_block)
+  end function inq_var_szip_vid
+!>
+!! @public 
+!! @ingroup PIO_inq_var_szip
+!! @brief Gets metadata information for netcdf file.
+!<
+  integer function inq_var_szip_id(ncid, varid, options_mask, pixels_per_block) result(ierr)
+    integer, intent(in) :: ncid
+    integer, intent(in) :: varid
+    integer, intent(out) :: options_mask
+    integer, intent(out) :: pixels_per_block
+
+    interface
+       integer(C_INT) function PIOc_inq_var_szip(ncid, varid, options_mask, pixels_per_block) &
+            bind(C, name="PIOc_inq_var_szip")
+         use iso_c_binding
+         integer(C_INT), value :: ncid
+         integer(C_INT), value :: varid
+         integer(C_INT) :: options_mask
+         integer(C_INT) :: pixels_per_block
+       end function PIOc_inq_var_szip
+    end interface
+
+    ierr = PIOc_inq_var_szip(ncid, varid-1, options_mask, pixels_per_block)
+  end function inq_var_szip_id
   
 !>
 !! @defgroup PIO_inq_varname

--- a/src/flib/pio_nf.F90
+++ b/src/flib/pio_nf.F90
@@ -22,7 +22,7 @@ module pio_nf
        pio_inq_varndims                                     ,   &
        pio_inq_vardimid                                     ,   &
        pio_inq_varnatts                                     ,   &
-       pio_inq_vardeflate                                   ,    &       
+       pio_inq_var_deflate                                   ,    &       
        pio_inquire_variable                                 , &
        pio_inquire_dimension                                , &
        pio_inq_dimname                                      , &
@@ -104,11 +104,11 @@ module pio_nf
           inq_varnatts_vid                                  ,    &
           inq_varnatts_id
   end interface
-  interface pio_inq_vardeflate
+  interface pio_inq_var_deflate
      module procedure &
-          inq_vardeflate_desc                                 , &
-          inq_vardeflate_vid                                  , &
-          inq_vardeflate_id
+          inq_var_deflate_desc                                 , &
+          inq_var_deflate_vid                                  , &
+          inq_var_deflate_id
   end interface
   interface pio_inquire_dimension
      module procedure &
@@ -1012,11 +1012,11 @@ contains
   end function inq_varnatts_id
 
 !>
-!!  @defgroup PIO_inq_vardeflate PIO_inq_vardeflate
+!!  @defgroup PIO_inq_var_deflate PIO_inq_var_deflate
 !<
 !>
 !! @public 
-!! @ingroup PIO_inq_vardeflate
+!! @ingroup PIO_inq_var_deflate
 !! @brief Gets metadata information for netcdf file.
 !! @details
 !! @param File @copydoc file_desc_t
@@ -1024,7 +1024,7 @@ contains
 !! @param type : The type of variable
 !! @retval ierr @copydoc error_return
 !<
-  integer function inq_vardeflate_desc(File, vardesc, shuffle, deflate, &
+  integer function inq_var_deflate_desc(File, vardesc, shuffle, deflate, &
        deflate_level) result(ierr)
 
     type (File_desc_t), intent(in) :: File
@@ -1033,15 +1033,15 @@ contains
     integer, intent(out) :: deflate
     integer, intent(out) :: deflate_level
 
-    ierr = pio_inq_vardeflate(File%fh, vardesc%varid, shuffle, deflate, deflate_level)
-  end function inq_vardeflate_desc
+    ierr = pio_inq_var_deflate(File%fh, vardesc%varid, shuffle, deflate, deflate_level)
+  end function inq_var_deflate_desc
 
 !>
 !! @public 
-!! @ingroup PIO_inq_vardeflate
+!! @ingroup PIO_inq_var_deflate
 !! @brief Gets metadata information for netcdf file.
 !<
-  integer function inq_vardeflate_vid(File, varid, shuffle, deflate, deflate_level) result(ierr)
+  integer function inq_var_deflate_vid(File, varid, shuffle, deflate, deflate_level) result(ierr)
 
     type (File_desc_t), intent(in) :: File
     integer, intent(in) :: varid
@@ -1049,14 +1049,14 @@ contains
     integer, intent(out) :: deflate
     integer, intent(out) :: deflate_level
 
-    ierr = pio_inq_vardeflate(File%fh, varid, shuffle, deflate, deflate_level)
-  end function inq_vardeflate_vid
+    ierr = pio_inq_var_deflate(File%fh, varid, shuffle, deflate, deflate_level)
+  end function inq_var_deflate_vid
 !>
 !! @public 
-!! @ingroup PIO_inq_vardeflate
+!! @ingroup PIO_inq_var_deflate
 !! @brief Gets metadata information for netcdf file.
 !<
-  integer function inq_vardeflate_id(ncid, varid, shuffle, deflate, &
+  integer function inq_var_deflate_id(ncid, varid, shuffle, deflate, &
        deflate_level) result(ierr)
     integer, intent(in) :: ncid
     integer, intent(in) :: varid
@@ -1077,7 +1077,7 @@ contains
     end interface
 
     ierr = PIOc_inq_var_deflate(ncid, varid-1, shuffle, deflate, deflate_level)
-  end function inq_vardeflate_id
+  end function inq_var_deflate_id
   
 !>
 !! @defgroup PIO_inq_varname

--- a/tests/unit/driver.F90
+++ b/tests/unit/driver.F90
@@ -167,6 +167,10 @@ Program pio_unit_test_driver
            if (master_task) write(*,"(3x,A,1x)", advance="no") "testing PIO_enddef..."
            call test_enddef(test_id, err_msg)
            call parse(err_msg, fail_cnt)
+
+           if (master_task) write(*,"(3x,A,1x)", advance="no") "testing PIO_enddef..."
+           call test_nc4(test_id, err_msg)
+           call parse(err_msg, fail_cnt)
         end if
 
 

--- a/tests/unit/driver.F90
+++ b/tests/unit/driver.F90
@@ -168,7 +168,7 @@ Program pio_unit_test_driver
            call test_enddef(test_id, err_msg)
            call parse(err_msg, fail_cnt)
 
-           if (master_task) write(*,"(3x,A,1x)", advance="no") "testing PIO_enddef..."
+           if (master_task) write(*,"(3x,A,1x)", advance="no") "testing PIO netCDF-4 functions..."
            call test_nc4(test_id, err_msg)
            call parse(err_msg, fail_cnt)
         end if

--- a/tests/unit/ncdf_tests.F90
+++ b/tests/unit/ncdf_tests.F90
@@ -393,22 +393,37 @@ Contains
     ret_val = PIO_inq_vardeflate(pio_file, pio_var, shuffle, deflate, deflate_level)
 
     ! Should not have worked except for netCDF-4/HDF5 serial.
-    if (iotype .eq. PIO_iotype_netcdf4c .and. ret_val .ne. PIO_NOERR) then
-       err_msg = "Could not turn on compression for variable foo2222"
+    if (iotype .eq. PIO_iotype_netcdf4c) then
+       if (ret_val .ne. PIO_NOERR) then
+          err_msg = "Got error trying to inquire about deflate on for serial netcdf-4 file"
+          call PIO_closefile(pio_file)
+          return
+       else
+          if (shuffle .ne. 0 .or. deflate .ne. 1 .or. deflate_level .ne. 4) then
+             err_msg = "Wrong values for deflate and shuffle for serial netcdf-4 file"
+             call PIO_closefile(pio_file)
+             return
+          end if
+       end if
+       err_msg = "Could not turn inquire about compression for variable foo2222"
        call PIO_closefile(pio_file)
        return
-    else if (iotype .eq. PIO_iotype_pnetcdf .and. ret_val .eq. PIO_NOERR) then
-       err_msg = "Did not get expected error when trying to turn deflate on for non-netcdf-4 file"
+    else if (iotype .eq. PIO_iotype_pnetcdf .or. iotype .eq. PIO_iotype_netcdf .and. ret_val .eq. PIO_NOERR) then
+       err_msg = "Did not get expected error when trying to check deflate for non-netcdf-4 file"
        call PIO_closefile(pio_file)
        return
-    else if (iotype .eq. PIO_iotype_netcdf .and. ret_val .eq. PIO_NOERR) then
-       err_msg = "Did not get expected error when trying to turn deflate on for non-netcdf-4 file"
-       call PIO_closefile(pio_file)
-       return
-    else if (iotype .eq. PIO_iotype_netcdf4p .and. ret_val .ne. PIO_NOERR) then
-       err_msg = "Did not get expected error when trying to turn deflate on for parallel netcdf-4 file"
-       call PIO_closefile(pio_file)
-       return
+    else if (iotype .eq. PIO_iotype_netcdf4p) then
+       if (ret_val .ne. PIO_NOERR) then
+          err_msg = "Got error trying to inquire about deflate on for parallel netcdf-4 file"
+          call PIO_closefile(pio_file)
+          return
+       else
+          if (shuffle .ne. 0 .or. deflate .ne. 0) then
+             err_msg = "Wrong values for deflate and shuffle for parallel netcdf-4 file"
+             call PIO_closefile(pio_file)
+             return
+          end if
+       end if
     end if
 
     ! Write foo2

--- a/tests/unit/ncdf_tests.F90
+++ b/tests/unit/ncdf_tests.F90
@@ -280,7 +280,6 @@ Contains
     integer :: shuffle
     integer :: deflate
     integer :: deflate_level
-    integer :: dim_len
 
     shuffle = 0
     deflate = 1
@@ -291,14 +290,12 @@ Contains
     compdof = 2*my_rank+(/1,2/)  ! Where in the global array each task writes
     data_to_write = 1+my_rank
 
-    print *, 'calling PIO_initdecomp'
     call PIO_initdecomp(pio_iosystem, PIO_int, dims, compdof, iodesc_nCells)
 
     filename = fnames(test_id)
     iotype   = iotypes(test_id)
 
     ! Open existing file, write data to it
-    print *, 'calling PIO_openfile'
     ret_val = PIO_openfile(pio_iosystem, pio_file, iotype, filename, PIO_write)
     if (ret_val .ne. PIO_NOERR) then
        ! Error in PIO_openfile
@@ -307,7 +304,6 @@ Contains
     end if
 
     ! Enter define mode
-    print *, 'calling PIO_redef'
     ret_val = PIO_redef(pio_file)
     if (ret_val .ne. PIO_NOERR) then
        ! Error in PIO_redef
@@ -317,18 +313,14 @@ Contains
     end if
 
     ! Define a new dimension M1.
-    dim_len = int(2*ntasks,pio_offset_kind)
-    print *, 'calling PIO_def_dim, dim_len = ', dim_len
-    ret_val = PIO_def_dim(pio_file, 'M111222', dim_len, pio_dim)
+    ret_val = PIO_def_dim(pio_file, 'M111222', int(2*ntasks,pio_offset_kind), pio_dim)
     if (ret_val .ne. PIO_NOERR) then
        err_msg = "Could not define dimension M111222"
-       print *, ret_val
        call PIO_closefile(pio_file)
        return
     end if
 
     ! Define a new variable
-    print *, 'calling PIO_def_var'
     ret_val = PIO_def_var(pio_file, 'foo2222', PIO_int, (/pio_dim/), pio_var)
     if (ret_val .ne. PIO_NOERR) then
        err_msg = "Could not define variable foo2222"
@@ -337,10 +329,8 @@ Contains
     end if
 
     ! Try to turn on compression for this variable.
-    print *, 'calling PIO_def_var_deflate ', pio_file%fh, pio_var%varid, shuffle, deflate, deflate_level
     ret_val = PIO_def_var_deflate(pio_file, pio_var, shuffle, deflate, &
          deflate_level)
-    print *, 'PIO_def_var_deflate returned ', ret_val
 
     ! Should not have worked except for netCDF-4/HDF5 serial.
     if (iotype .eq. PIO_iotype_netcdf4c .and. ret_val .ne. PIO_NOERR) then
@@ -361,7 +351,6 @@ Contains
        return
     end if
 
-    print *, 'calling PIO_put_att'
     ret_val = PIO_put_att(pio_file, pio_var, "max_val", ntasks)
     if (ret_val .ne. PIO_NOERR) then
        ! Error in PIO_put_att
@@ -370,7 +359,6 @@ Contains
        return
     end if
 
-    print *, 'calling PIO_put_att'
     ret_val = PIO_put_att(pio_file, PIO_global, "created_by", "PIO unit tests")
     if (ret_val .ne. PIO_NOERR) then
        ! Error in PIO_put_att
@@ -380,67 +368,59 @@ Contains
     end if
 
     ! Leave define mode
-    print *, 'calling PIO_enddef'
     ret_val = PIO_enddef(pio_file)
     if (ret_val .ne. PIO_NOERR) then
-       print *,__FILE__,__LINE__,ret_val
        err_msg = "Could not end define mode"
        return
     end if
 
     ! Check the compression settings of the variables.
-    print *, 'calling PIO_inq_var_deflate'    
     ret_val = PIO_inq_var_deflate(pio_file, pio_var, shuffle, deflate, deflate_level)
 
-    ! ! Should not have worked except for netCDF-4/HDF5 serial.
-    ! if (iotype .eq. PIO_iotype_netcdf4c) then
-    !    if (ret_val .ne. PIO_NOERR) then
-    !       err_msg = "Got error trying to inquire about deflate on for serial netcdf-4 file"
-    !       call PIO_closefile(pio_file)
-    !       return
-    !    else
-    !       if (shuffle .ne. 0 .or. deflate .ne. 1 .or. deflate_level .ne. 4) then
-    !          err_msg = "Wrong values for deflate and shuffle for serial netcdf-4 file"
-    !          call PIO_closefile(pio_file)
-    !          return
-    !       end if
-    !    end if
-    ! else if ((iotype .eq. PIO_iotype_pnetcdf .or. iotype .eq. PIO_iotype_netcdf) .and. ret_val .eq. PIO_NOERR) then
-    !    err_msg = "Did not get expected error when trying to check deflate for non-netcdf-4 file"
-    !    call PIO_closefile(pio_file)
-    !    return
-    ! else if (iotype .eq. PIO_iotype_netcdf4p) then
-    !    if (ret_val .ne. PIO_NOERR) then
-    !       err_msg = "Got error trying to inquire about deflate on for parallel netcdf-4 file"
-    !       call PIO_closefile(pio_file)
-    !       return
-    !    else
-    !       if (shuffle .ne. 0 .or. deflate .ne. 0) then
-    !          err_msg = "Wrong values for deflate and shuffle for parallel netcdf-4 file"
-    !          call PIO_closefile(pio_file)
-    !          return
-    !       end if
-    !    end if
-    ! end if
+    ! Should not have worked except for netCDF-4/HDF5 serial.
+    if (iotype .eq. PIO_iotype_netcdf4c) then
+       if (ret_val .ne. PIO_NOERR) then
+          err_msg = "Got error trying to inquire about deflate on for serial netcdf-4 file"
+          call PIO_closefile(pio_file)
+          return
+       else
+          if (shuffle .ne. 0 .or. deflate .ne. 1 .or. deflate_level .ne. 4) then
+             err_msg = "Wrong values for deflate and shuffle for serial netcdf-4 file"
+             call PIO_closefile(pio_file)
+             return
+          end if
+       end if
+    else if ((iotype .eq. PIO_iotype_pnetcdf .or. iotype .eq. PIO_iotype_netcdf) .and. ret_val .eq. PIO_NOERR) then
+       err_msg = "Did not get expected error when trying to check deflate for non-netcdf-4 file"
+       call PIO_closefile(pio_file)
+       return
+    else if (iotype .eq. PIO_iotype_netcdf4p) then
+       if (ret_val .ne. PIO_NOERR) then
+          err_msg = "Got error trying to inquire about deflate on for parallel netcdf-4 file"
+          call PIO_closefile(pio_file)
+          return
+       else
+          if (shuffle .ne. 0 .or. deflate .ne. 0) then
+             err_msg = "Wrong values for deflate and shuffle for parallel netcdf-4 file"
+             call PIO_closefile(pio_file)
+             return
+          end if
+       end if
+    end if
 
     ! Write foo2
-    print *, 'calling PIO_write_darray, data_to_write = ', data_to_write, 'iodesc_nCells = ', iodesc_nCells
     call PIO_write_darray(pio_file, pio_var, iodesc_nCells, data_to_write, ret_val)
     if (ret_val .ne. PIO_NOERR) then
-       ! Error in PIO_write_darray
        err_msg = "Could not write data"
        return
     end if
 
     ! Close file
-    print *, 'calling PIO_closefile'
     call PIO_closefile(pio_file)
 
     ! Free decomp
-    print *, 'calling PIO_freedecomp'
     call PIO_freedecomp(pio_iosystem, iodesc_nCells)
     call mpi_barrier(MPI_COMM_WORLD,ret_val)
     
-    print *, 'err_msg = ', err_msg
   End Subroutine test_nc4
 end module ncdf_tests

--- a/tests/unit/ncdf_tests.F90
+++ b/tests/unit/ncdf_tests.F90
@@ -390,7 +390,7 @@ Contains
     end if
 
     ! Check the compression settings of the variables.
-    ret_val = PIO_inq_vardeflate(pio_file, pio_var, shuffle, deflate, deflate_level)
+    ret_val = PIO_inq_var_deflate(pio_file, pio_var, shuffle, deflate, deflate_level)
 
     ! Should not have worked except for netCDF-4/HDF5 serial.
     if (iotype .eq. PIO_iotype_netcdf4c) then

--- a/tests/unit/ncdf_tests.F90
+++ b/tests/unit/ncdf_tests.F90
@@ -390,26 +390,26 @@ Contains
     end if
 
     ! Check the compression settings of the variables.
-    ! ret_val = PIO_inq_vardeflate(pio_file, pio_var, shuffle, deflate, deflate_level)
+    ret_val = PIO_inq_vardeflate(pio_file, pio_var, shuffle, deflate, deflate_level)
 
-    ! ! Should not have worked except for netCDF-4/HDF5 serial.
-    ! if (iotype .eq. PIO_iotype_netcdf4c .and. ret_val .ne. PIO_NOERR) then
-    !    err_msg = "Could not turn on compression for variable foo2222"
-    !    call PIO_closefile(pio_file)
-    !    return
-    ! else if (iotype .eq. PIO_iotype_pnetcdf .and. ret_val .eq. PIO_NOERR) then
-    !    err_msg = "Did not get expected error when trying to turn deflate on for non-netcdf-4 file"
-    !    call PIO_closefile(pio_file)
-    !    return
-    ! else if (iotype .eq. PIO_iotype_netcdf .and. ret_val .eq. PIO_NOERR) then
-    !    err_msg = "Did not get expected error when trying to turn deflate on for non-netcdf-4 file"
-    !    call PIO_closefile(pio_file)
-    !    return
-    ! else if (iotype .eq. PIO_iotype_netcdf4p .and. ret_val .ne. PIO_NOERR) then
-    !    err_msg = "Did not get expected error when trying to turn deflate on for parallel netcdf-4 file"
-    !    call PIO_closefile(pio_file)
-    !    return
-    ! end if
+    ! Should not have worked except for netCDF-4/HDF5 serial.
+    if (iotype .eq. PIO_iotype_netcdf4c .and. ret_val .ne. PIO_NOERR) then
+       err_msg = "Could not turn on compression for variable foo2222"
+       call PIO_closefile(pio_file)
+       return
+    else if (iotype .eq. PIO_iotype_pnetcdf .and. ret_val .eq. PIO_NOERR) then
+       err_msg = "Did not get expected error when trying to turn deflate on for non-netcdf-4 file"
+       call PIO_closefile(pio_file)
+       return
+    else if (iotype .eq. PIO_iotype_netcdf .and. ret_val .eq. PIO_NOERR) then
+       err_msg = "Did not get expected error when trying to turn deflate on for non-netcdf-4 file"
+       call PIO_closefile(pio_file)
+       return
+    else if (iotype .eq. PIO_iotype_netcdf4p .and. ret_val .ne. PIO_NOERR) then
+       err_msg = "Did not get expected error when trying to turn deflate on for parallel netcdf-4 file"
+       call PIO_closefile(pio_file)
+       return
+    end if
 
     ! Write foo2
     print *, 'calling PIO_write_darray'

--- a/tests/unit/test_nc4.c
+++ b/tests/unit/test_nc4.c
@@ -288,6 +288,9 @@ main(int argc, char **argv)
 	if ((ret = PIOc_createfile(iosysid, &ncid, &(format[fmt]), filename[fmt],
 				   PIO_CLOBBER)))
 	    ERR(ret);
+
+	/* Set error handling. */
+	PIOc_Set_File_Error_Handling(ncid, PIO_RETURN_ERROR);
 	
 	/* Define netCDF dimensions and variable. */
 	if (verbose)
@@ -346,9 +349,8 @@ main(int argc, char **argv)
 	    if ((ret = PIOc_inq_var_deflate(ncid, 0, &shuffle, &deflate, &deflate_level)))
 	    	ERR(ret);
 
-	    /** For serial netCDF-4, only processor rank 0 gets the
-	     * answers. Also deflate is turned on by default */
-	    if (format[fmt] == PIO_IOTYPE_NETCDF4C && !my_rank)
+	    /** For serial netCDF-4 deflate is turned on by default */
+	    if (format[fmt] == PIO_IOTYPE_NETCDF4C)
 		if (shuffle || !deflate || deflate_level != 1)
 		    ERR(ERR_AWFUL);
 


### PR DESCRIPTION
# PIO_inq_var_deflate

PIO_inq_var_deflate works in fortran. The fortran version is tested in ncdf_tests.F90 in a new test subroutine test_nc4.

# szip functions

There are some szip-related functions for netCDF-4 that I had added to the PIO C API. After further consideration I have taken them out again. I don't think there will be much of a use among the PIO audience.

Szip files are used a lot by NASA, but the only consequence of not having the inq_szip functions is that programs like ncdump cannot be written without it. However, I doubt anyone will be writing a version of ncdump for PIO. Szipped data will still be readable by PIO - the szip decompression of the data is done automatically in the HDF5 layer.

# Bug Fix

Thanks to this fortran work and some emails with Jim, I have a better understanding of how error codes are supposed to work in PIO. I have fixed a bug in the C implementation of inq_var_deflate, and changed the test to reflect this.