### PR TITLE
changed example data size, added valgrind suppression file

### DIFF
--- a/examples/c/example2.c
+++ b/examples/c/example2.c
@@ -48,8 +48,8 @@
  * responsibilty for writing and reading them will be spread between
  * all the processors used to run this example. */
 /**@{*/
-#define X_DIM_LEN 400
-#define Y_DIM_LEN 400
+#define X_DIM_LEN 20
+#define Y_DIM_LEN 30
 /**@}*/
 
 /** The number of timesteps of data to write. */

--- a/examples/c/valsupp_example1.supp
+++ b/examples/c/valsupp_example1.supp
@@ -1,0 +1,15 @@
+{
+   cond_jump_1
+   Memcheck:Cond
+   fun:MPIC_Waitall
+   fun:MPIR_Alltoallw_intra
+   fun:MPIR_Alltoallw
+   fun:MPIR_Alltoallw_impl
+   fun:PMPI_Alltoallw
+   fun:pio_swapm
+   fun:rearrange_comp2io
+   fun:PIOc_write_darray_multi
+   fun:flush_buffer
+   fun:PIOc_sync
+   fun:main
+}


### PR DESCRIPTION
The example test was taking noticeable time so I reduced the sample size.

I added the valgrind suppression file to allow me to use valgrind on an on-going basis to make sure I'm not leaking memory in any of the async work.