### PR TITLE
Implementation of PIOc_strerror() and pio_strerror() to get strings associated with error codes

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -440,7 +440,7 @@ enum PIO_ERROR_HANDLERS
 #if defined(__cplusplus)
 extern "C" {
 #endif
-    const char *PIOc_strerror(int pioerr);
+    int PIOc_strerror(int pioerr, char *errstr);
     int PIOc_freedecomp(int iosysid, int ioid);
     int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Offset *lenp); 
     int PIOc_inq_format (int ncid, int *formatp); 

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -325,6 +325,7 @@ enum PIO_ERROR_HANDLERS
     PIO_RETURN_ERROR = (-53)  
 };
 
+/** Define the netCDF-based error codes. */
 #if defined( _PNETCDF) || defined(_NETCDF)
 #define PIO_GLOBAL NC_GLOBAL
 #define PIO_UNLIMITED NC_UNLIMITED
@@ -417,25 +418,29 @@ enum PIO_ERROR_HANDLERS
 #define PIO_EBADCHUNK NC_EBADCHUNK
 #define PIO_ENOTBUILT NC_ENOTBUILT
 #define PIO_EDISKLESS NC_EDISKLESS
-
 #define PIO_FILL_DOUBLE NC_FILL_DOUBLE
 #define PIO_FILL_FLOAT NC_FILL_FLOAT
 #define PIO_FILL_INT NC_FILL_INT
 #define PIO_FILL_CHAR NC_FILL_CHAR
+#endif /*  defined( _PNETCDF) || defined(_NETCDF) */
 
-#endif
+/** Define the extra error codes for the parallel-netcdf library. */
 #ifdef _PNETCDF
 #define PIO_EINDEP  NC_EINDEP
-#else
+#else  /* _PNETCDF */
 #define PIO_EINDEP  (-203) 
-#endif
+#endif /* _PNETCDF */
 
+/** Define error codes for PIO. */
 #define PIO_EBADIOTYPE  -255
+
+/** ??? */
 #define PIO_REQ_NULL (NC_REQ_NULL-1)
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
+    const char *PIOc_strerror(int pioerr);
     int PIOc_freedecomp(int iosysid, int ioid);
     int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Offset *lenp); 
     int PIOc_inq_format (int ncid, int *formatp); 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -17,6 +17,49 @@ int pio_log_level = 0;
 int my_rank;
 #endif /* PIO_ENABLE_LOGGING */
 
+/** Return a string description of an error code. If zero is passed, a
+ * null is returned.
+ *
+ * @param pioerr the error code returned by a PIO function call. 
+ *
+ * @return Pointer to a constant string with the error message. 
+ */
+const char *PIOc_strerror(int pioerr)
+{
+
+    /* System error? */
+    if(pioerr > 0)
+    {
+	const char *cp = (const char *)strerror(pioerr);
+	if(!cp)
+	    return "Unknown Error";
+	return cp;
+    }
+
+    /* Not an error? */
+    if (pioerr == PIO_NOERR)
+	return "No error";
+
+    /* NetCDF error? */
+#if defined( _PNETCDF) || defined(_NETCDF)
+    /* The if condition is somewhat confusing becuase netCDF uses
+     * negative error codes.*/
+    if (pioerr <= NC2_ERR && pioerr >= NC4_LAST_ERROR)
+	return nc_strerror(pioerr);
+#else /* defined( _PNETCDF) || defined(_NETCDF) */
+    if (pioerr <= NC2_ERR && pioerr >= NC4_LAST_ERROR)
+	return "NetCDF error code, PIO not built with netCDF.";
+#endif /* defined( _PNETCDF) || defined(_NETCDF) */
+	
+    /* Handle PIO errors. */
+    switch(pioerr) {
+    case PIO_EBADIOTYPE:
+	return "Bad IO type";
+    default:
+	return "unknown PIO error";
+    }
+}
+
 /** Set the logging level. Set to -1 for nothing, 0 for errors only, 1
  * for important logging, and so on. Log levels below 1 are only
  * printed on the io/component root. If the library is not built with

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -60,6 +60,7 @@ module pio
        PIO_get_chunk_cache, &
        PIO_set_var_chunk_cache, &
        PIO_get_var_chunk_cache
+!       PIO_strerror,          &
 
   use pionfatt_mod, only : PIO_put_att   => put_att,        &
        PIO_get_att   => get_att

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -59,8 +59,8 @@ module pio
        PIO_set_chunk_cache, &
        PIO_get_chunk_cache, &
        PIO_set_var_chunk_cache, &
-       PIO_get_var_chunk_cache
-!       PIO_strerror,          &
+       PIO_get_var_chunk_cache, &
+       PIO_strerror
 
   use pionfatt_mod, only : PIO_put_att   => put_att,        &
        PIO_get_att   => get_att

--- a/src/flib/pio_nf.F90
+++ b/src/flib/pio_nf.F90
@@ -37,8 +37,8 @@ module pio_nf
        pio_set_var_chunk_cache                              , &
        pio_get_var_chunk_cache                              , &
        pio_redef                                            , &
-       pio_set_log_level                                    
-!       pio_strerror
+       pio_set_log_level                                    , &
+       pio_strerror
 !       pio_copy_att    to be done
 
   interface pio_def_var
@@ -195,10 +195,10 @@ module pio_nf
           set_log_level                                      
   end interface pio_set_log_level
 
-  ! interface pio_strerror
-  !    module procedure &
-  !         strerror
-  ! end interface pio_strerror
+  interface pio_strerror
+     module procedure &
+          strerror
+  end interface pio_strerror
 
   interface pio_inquire
      module procedure &
@@ -684,28 +684,34 @@ contains
     end interface
     ierr = PIOc_set_log_level(log_level)
   end function set_log_level
-!>
-!! @defgroup PIO_strerror
-!<
-!> 
-!! @ingroup PIO_strerror
-!! Returns a descriptive string for an error code.
-!! 
-!! @param errcode the error code
-!! @retval a description of the error
+
+  !>
+  !! @defgroup PIO_strerror
   !<
-  ! function strerror(errcode) result(errmsg)
-  !   integer, intent(in) :: errcode
-  !   Character(LEN=80) :: errmsg    
-  !   interface
-  !      Function PIOc_strerror(errcode) BIND(C)
-  !        USE ISO_C_BINDING, ONLY: C_INT, C_PTR
-  !        Integer(C_INT), VALUE :: errcode
-  !        Type(C_PTR)           :: PIOc_strerror
-  !      End Function PIOc_strerror
-  !   end interface
-  !   strerror = PIOc_strerror(errcode)
-  ! end function strerror
+  !> 
+  !! @ingroup PIO_strerror
+  !! Returns a descriptive string for an error code.
+  !! 
+  !! @param errcode the error code
+  !! @retval a description of the error
+  !<
+  integer function strerror(errcode, errmsg) result(ierr)
+    integer, intent(in) :: errcode
+    character(len=*), intent(out) :: errmsg
+    interface
+       integer(C_INT) function PIOc_strerror(errcode, errmsg) &
+            bind(C, name="PIOc_strerror")
+         use iso_c_binding
+         integer(C_INT), value :: errcode
+         character(C_CHAR) :: errmsg(*)
+       end function PIOc_strerror
+    end interface
+    errmsg = C_NULL_CHAR
+    ierr = PIOc_strerror(errcode, errmsg)
+    call replace_c_null(errmsg)
+
+  end function strerror
+
 !> 
 !! @public
 !! @ingroup PIO_redef

--- a/src/flib/pio_nf.F90
+++ b/src/flib/pio_nf.F90
@@ -37,7 +37,8 @@ module pio_nf
        pio_set_var_chunk_cache                              , &
        pio_get_var_chunk_cache                              , &
        pio_redef                                            , &
-       pio_set_log_level
+       pio_set_log_level                                    
+!       pio_strerror
 !       pio_copy_att    to be done
 
   interface pio_def_var
@@ -193,6 +194,11 @@ module pio_nf
      module procedure &
           set_log_level                                      
   end interface pio_set_log_level
+
+  ! interface pio_strerror
+  !    module procedure &
+  !         strerror
+  ! end interface pio_strerror
 
   interface pio_inquire
      module procedure &
@@ -678,6 +684,28 @@ contains
     end interface
     ierr = PIOc_set_log_level(log_level)
   end function set_log_level
+!>
+!! @defgroup PIO_strerror
+!<
+!> 
+!! @ingroup PIO_strerror
+!! Returns a descriptive string for an error code.
+!! 
+!! @param errcode the error code
+!! @retval a description of the error
+  !<
+  ! function strerror(errcode) result(errmsg)
+  !   integer, intent(in) :: errcode
+  !   Character(LEN=80) :: errmsg    
+  !   interface
+  !      Function PIOc_strerror(errcode) BIND(C)
+  !        USE ISO_C_BINDING, ONLY: C_INT, C_PTR
+  !        Integer(C_INT), VALUE :: errcode
+  !        Type(C_PTR)           :: PIOc_strerror
+  !      End Function PIOc_strerror
+  !   end interface
+  !   strerror = PIOc_strerror(errcode)
+  ! end function strerror
 !> 
 !! @public
 !! @ingroup PIO_redef

--- a/tests/unit/driver.F90
+++ b/tests/unit/driver.F90
@@ -55,6 +55,8 @@ Program pio_unit_test_driver
      write(*,"(A,1x,I0,1x,A,1x,I0)") "Running unit tests with", ntasks, &
           "MPI tasks and stride of", stride
 
+!     print *, 'errcode =', -33, ' strerror = ', PIO_strerror(-33)
+
      if (stride.gt.ntasks) then
         stride = ntasks
         write(*,"(A,1x,A,I0)") "WARNING: stride value in namelist is larger than", &

--- a/tests/unit/driver.F90
+++ b/tests/unit/driver.F90
@@ -27,6 +27,9 @@ Program pio_unit_test_driver
   integer, external :: nc_set_log_level2
 #endif
   integer ret_val
+  character(len=80) :: errmsg
+  character(len=80) :: expected
+  
   ! Set up MPI
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, my_rank, ierr)
@@ -54,8 +57,6 @@ Program pio_unit_test_driver
 
      write(*,"(A,1x,I0,1x,A,1x,I0)") "Running unit tests with", ntasks, &
           "MPI tasks and stride of", stride
-
-!     print *, 'errcode =', -33, ' strerror = ', PIO_strerror(-33)
 
      if (stride.gt.ntasks) then
         stride = ntasks
@@ -124,6 +125,16 @@ Program pio_unit_test_driver
   fail_cnt = 0
   test_cnt = 0
 
+  ! Test pio_strerror.
+  ret_val = PIO_strerror(-33, errmsg);
+  print *, 'errcode =', -33, ' strerror = ', errmsg
+  expected = 'NetCDF: Not a valid ID'
+  if (trim(errmsg) .ne. expected) then
+     err_msg = 'expected ' // trim(expected) // ' and got ' // trim(errmsg)
+     print *, err_msg
+     call parse(err_msg, fail_cnt)
+  end if
+     
   do test_id=1,ntest
      if (ltest(test_id)) then
         ! Make sure i is a valid test number
@@ -148,6 +159,7 @@ Program pio_unit_test_driver
 #if defined( _NETCDF4) && defined(LOGGING)
         if(master_task) ierr = nc_set_log_level2(3)
 #endif
+        
         ! test_create()
         if (master_task) write(*,"(3x,A,1x)") "testing PIO_createfile..."
         call test_create(test_id, err_msg)

--- a/tests/unit/test_names.c
+++ b/tests/unit/test_names.c
@@ -1,6 +1,6 @@
 /**
- * @file 
- * Tests for names of vars, atts, and dims.
+ * @file Tests for names of vars, atts, and dims. Also test the
+ * PIOc_strerror() function.
  *
  */
 #include <pio.h>
@@ -148,6 +148,50 @@ check_att_name(int my_rank, int ncid, int verbose)
     return 0;
 }
 
+/** Check the PIOc_strerror() function. 
+ *
+ * @param my_rank the rank of this process.
+ * @param verbose true to get printfs on stdout.
+ *
+ * @return 0 for success, error code otherwise.
+ */
+int
+check_strerror(int my_rank, int verbose) {
+    
+#define NUM_TRIES 7
+    char errstr[PIO_MAX_NAME + 1];
+    int errcode[NUM_TRIES] = {NC2_ERR, PIO_EBADID,
+			      NC_ENOTNC3, NC4_LAST_ERROR - 1, 0, 1,
+			      PIO_EBADIOTYPE};
+    const char *expected[NUM_TRIES] = {"Unknown Error", "NetCDF: Not a valid ID",
+				       "NetCDF: Attempting netcdf-3 operation on netcdf-4 file",
+				       "unknown PIO error", "No error",
+				       nc_strerror(1), "Bad IO type"};
+    int ret = PIO_NOERR;
+
+    for (int try = 0; try < NUM_TRIES; try++)
+    {
+	/* Get the error string for this errcode. */
+	strcpy(errstr, PIOc_strerror(errcode[try]));
+
+	/* Check that it was as expected. */
+	if (strcmp(errstr, expected[try]))
+	    ret = ERR_AWFUL;
+
+	/* Print some output to stdout if required. */
+	if (verbose)
+	{
+	    printf("%d: PIO strerror(%d) = %s\n", my_rank, errcode[try],
+		   errstr);
+	    strcpy(errstr, nc_strerror(errcode[try]));
+	    printf("%d: netCDF strerror(%d) = %s\n", my_rank, errcode[try],
+		   errstr);
+	}
+    }
+
+    return ret;
+}
+
 /** Run Tests for NetCDF-4 Functions.
  *
  * @param argc argument count
@@ -288,6 +332,10 @@ main(int argc, char **argv)
     if (verbose)
 	printf("%d: ParallelIO Library example1 running on %d processors.\n",
 	       my_rank, ntasks);
+
+    /* Check the error string function. */
+    if ((ret = check_strerror(my_rank, verbose)))
+	ERR(ret);
 
     /* keep things simple - 1 iotask per MPI process */    
     niotasks = ntasks; 

--- a/tests/unit/test_names.c
+++ b/tests/unit/test_names.c
@@ -171,8 +171,10 @@ check_strerror(int my_rank, int verbose) {
 
     for (int try = 0; try < NUM_TRIES; try++)
     {
+	char result[PIO_MAX_NAME];
+	
 	/* Get the error string for this errcode. */
-	strcpy(errstr, PIOc_strerror(errcode[try]));
+	PIOc_strerror(errcode[try], errstr);	
 
 	/* Check that it was as expected. */
 	if (strcmp(errstr, expected[try]))


### PR DESCRIPTION
This PR adds PIO wrappers for the nc_strerror() function, which gets the error string associated with an error code.

The code is tested in both fortran and C tests.