### PR TITLE
wrappers for nc_open/nc_create

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -45,24 +45,24 @@
  */
 typedef struct var_desc_t
 {
-    /** The unlimited dimension in the netCDF file (typically the time
-     * dimension). -1 if there is no unlimited dimension. */
-    int record;
+  /** The unlimited dimension in the netCDF file (typically the time
+   * dimension). -1 if there is no unlimited dimension. */
+  int record;
 
-    /** Number of dimensions for this variable. */
-    int ndims;
+  /** Number of dimensions for this variable. */
+  int ndims;
 
-    /** ID of each outstanding pnetcdf request for this variable. */
-    int *request;
+  /** ID of each outstanding pnetcdf request for this variable. */
+  int *request;
 
-    /** Number of requests bending with pnetcdf. */
-    int nreqs;
+  /** Number of requests bending with pnetcdf. */
+  int nreqs;
 
-    /** Buffer that contains the fill value for this variable. */
-    void *fillbuf;
+  /** Buffer that contains the fill value for this variable. */
+  void *fillbuf;
 
-    /** ??? */
-    void *iobuf;
+  /** ??? */
+  void *iobuf;
 } var_desc_t;
 
 /**
@@ -75,10 +75,10 @@ typedef struct var_desc_t
  */
 typedef struct io_region
 {
-    int loffset;
-    PIO_Offset *start;
-    PIO_Offset *count;
-    struct io_region *next;
+  int loffset;
+  PIO_Offset *start;
+  PIO_Offset *count;
+  struct io_region *next;
 } io_region;
  
 /**
@@ -89,46 +89,46 @@ typedef struct io_region
  */
 typedef struct io_desc_t
 {
-    /** The ID of this io_desc_t. */
-    int ioid;
-    int async_id;
-    int nrecvs;
-    int ndof;
-    int ndims;
-    int num_aiotasks;
-    int rearranger;
-    int maxregions;
-    bool needsfill;       // Does this decomp leave holes in the field (true) or write everywhere (false)
+  /** The ID of this io_desc_t. */
+  int ioid;
+  int async_id;
+  int nrecvs;
+  int ndof;
+  int ndims;
+  int num_aiotasks;
+  int rearranger;
+  int maxregions;
+  bool needsfill;       // Does this decomp leave holes in the field (true) or write everywhere (false)
 
-    /** The maximum number of bytes of this iodesc before flushing. */
-    int maxbytes;        
-    MPI_Datatype basetype;
-    PIO_Offset llen;
-    int maxiobuflen;
-    PIO_Offset *gsize;
+  /** The maximum number of bytes of this iodesc before flushing. */
+  int maxbytes;        
+  MPI_Datatype basetype;
+  PIO_Offset llen;
+  int maxiobuflen;
+  PIO_Offset *gsize;
 
-    int *rfrom;
-    int *rcount;
-    int *scount;
-    PIO_Offset *sindex;
-    PIO_Offset *rindex;
+  int *rfrom;
+  int *rcount;
+  int *scount;
+  PIO_Offset *sindex;
+  PIO_Offset *rindex;
 
-    MPI_Datatype *rtype;
-    MPI_Datatype *stype;
-    int num_stypes;
-    int holegridsize;
-    int maxfillregions;
-    io_region *firstregion;
-    io_region *fillregion;
+  MPI_Datatype *rtype;
+  MPI_Datatype *stype;
+  int num_stypes;
+  int holegridsize;
+  int maxfillregions;
+  io_region *firstregion;
+  io_region *fillregion;
 
-    bool handshake;
-    bool isend;
-    int max_requests;
+  bool handshake;
+  bool isend;
+  int max_requests;
   
-    MPI_Comm subset_comm;
+  MPI_Comm subset_comm;
 
-    /** Pointer to the next io_desc_t in the list. */
-    struct io_desc_t *next;
+  /** Pointer to the next io_desc_t in the list. */
+  struct io_desc_t *next;
 } io_desc_t;
 
 /**
@@ -139,92 +139,92 @@ typedef struct io_desc_t
  */
 typedef struct iosystem_desc_t 
 {
-    /** The ID of this iosystem_desc_t. This will be obtained by
-     * calling PIOc_Init_Intercomm() or PIOc_Init_Intracomm(). */
-    int iosysid;
+  /** The ID of this iosystem_desc_t. This will be obtained by
+   * calling PIOc_Init_Intercomm() or PIOc_Init_Intracomm(). */
+  int iosysid;
 
-    /** This is an MPI intra communicator that includes all the tasks in
-     * both the IO and the computation communicators. */
-    MPI_Comm union_comm;
+  /** This is an MPI intra communicator that includes all the tasks in
+   * both the IO and the computation communicators. */
+  MPI_Comm union_comm;
 
-    /** This is an MPI intra communicator that includes all the tasks
-     * involved in IO. */
-    MPI_Comm io_comm;
+  /** This is an MPI intra communicator that includes all the tasks
+   * involved in IO. */
+  MPI_Comm io_comm;
 
-    /** This is an MPI intra communicator that includes all the tasks
-     * involved in computation. */
-    MPI_Comm comp_comm;
+  /** This is an MPI intra communicator that includes all the tasks
+   * involved in computation. */
+  MPI_Comm comp_comm;
 
-    /** This is an MPI inter communicator between IO communicator and
-     * computation communicator. */
-    MPI_Comm intercomm;
+  /** This is an MPI inter communicator between IO communicator and
+   * computation communicator. */
+  MPI_Comm intercomm;
 
-    /** This is a copy (but not an MPI copy) of either the comp (for
-     * non-async) or the union (for async) communicator. */
-    MPI_Comm my_comm;
+  /** This is a copy (but not an MPI copy) of either the comp (for
+   * non-async) or the union (for async) communicator. */
+  MPI_Comm my_comm;
 
-    /** This MPI group contains the processors involved in
-     * computation. */
-    MPI_Group compgroup;
+  /** This MPI group contains the processors involved in
+   * computation. */
+  MPI_Group compgroup;
     
-    /** This MPI group contains the processors involved in I/O. */
-    MPI_Group iogroup;
+  /** This MPI group contains the processors involved in I/O. */
+  MPI_Group iogroup;
 
-    /** The number of tasks in the IO communicator. */
-    int num_iotasks;
+  /** The number of tasks in the IO communicator. */
+  int num_iotasks;
 
-    /** The number of tasks in the computation communicator. */
-    int num_comptasks;
+  /** The number of tasks in the computation communicator. */
+  int num_comptasks;
 
-    /** Rank of this task in the union communicator. */
-    int union_rank;
+  /** Rank of this task in the union communicator. */
+  int union_rank;
 
-    /** The rank of this process in the computation communicator, or -1
-     * if this process is not part of the computation communicator. */
-    int comp_rank;
+  /** The rank of this process in the computation communicator, or -1
+   * if this process is not part of the computation communicator. */
+  int comp_rank;
 
-    /** The rank of this process in the IO communicator, or -1 if this
-     * process is not part of the IO communicator. */
-    int io_rank;
+  /** The rank of this process in the IO communicator, or -1 if this
+   * process is not part of the IO communicator. */
+  int io_rank;
 
-    /** Set to MPI_ROOT if this task is the master of IO communicator, 0
-     * otherwise. */
-    int iomaster;
+  /** Set to MPI_ROOT if this task is the master of IO communicator, 0
+   * otherwise. */
+  int iomaster;
 
-    /** Set to MPI_ROOT if this task is the master of comp communicator, 0
-     * otherwise. */
-    int compmaster;
+  /** Set to MPI_ROOT if this task is the master of comp communicator, 0
+   * otherwise. */
+  int compmaster;
 
-    /** Rank of IO root task (which is rank 0 in io_comm) in the union
-     * communicator. */
-    int ioroot;
+  /** Rank of IO root task (which is rank 0 in io_comm) in the union
+   * communicator. */
+  int ioroot;
 
-    /** Rank of computation root task (which is rank 0 in
-     * comm_comms[cmp]) in the union communicator. */
-    int comproot;
+  /** Rank of computation root task (which is rank 0 in
+   * comm_comms[cmp]) in the union communicator. */
+  int comproot;
 
-    /** An array of the ranks of all IO tasks within the union
-     * communicator. */
-    int *ioranks;
+  /** An array of the ranks of all IO tasks within the union
+   * communicator. */
+  int *ioranks;
 
-    /** Controls handling errors. */
-    int error_handler;
+  /** Controls handling errors. */
+  int error_handler;
 
-    /** The rearranger decides which parts of a distributed array are
-     * handled by which IO tasks. */
-    int default_rearranger;
+  /** The rearranger decides which parts of a distributed array are
+   * handled by which IO tasks. */
+  int default_rearranger;
 
-    /** True if asynchronous interface is in use. */
-    bool async_interface;
+  /** True if asynchronous interface is in use. */
+  bool async_interface;
 
-    /** True if this task is a member of the IO communicator. */
-    bool ioproc;
+  /** True if this task is a member of the IO communicator. */
+  bool ioproc;
 
-    /** MPI Info object. */
-    MPI_Info info;
+  /** MPI Info object. */
+  MPI_Info info;
 
-    /** Pointer to the next iosystem_desc_t in the list. */
-    struct iosystem_desc_t *next;
+  /** Pointer to the next iosystem_desc_t in the list. */
+  struct iosystem_desc_t *next;
 } iosystem_desc_t;
 
 /**
@@ -232,14 +232,14 @@ typedef struct iosystem_desc_t
  */
 typedef struct wmulti_buffer
 {
-    int ioid;
-    int validvars;
-    int arraylen;
-    int *vid;
-    int *frame;
-    void *fillvalue;
-    void *data;
-    struct wmulti_buffer *next;
+  int ioid;
+  int validvars;
+  int arraylen;
+  int *vid;
+  int *frame;
+  void *fillvalue;
+  void *data;
+  struct wmulti_buffer *next;
 } wmulti_buffer;
 
 /**
@@ -249,34 +249,34 @@ typedef struct wmulti_buffer
  */
 typedef struct file_desc_t
 {
-    /** The IO system ID used to open this file. */
-    iosystem_desc_t *iosystem;
+  /** The IO system ID used to open this file. */
+  iosystem_desc_t *iosystem;
 
-    /** The buffersize does not seem to be used anywhere. */
-    /* PIO_Offset buffsize;*/
+  /** The buffersize does not seem to be used anywhere. */
+  /* PIO_Offset buffsize;*/
 
-    /** The ncid returned for this file by the underlying library
-     * (netcdf or pnetcdf). */
-    int fh;
+  /** The ncid returned for this file by the underlying library
+   * (netcdf or pnetcdf). */
+  int fh;
 
-    /** The PIO_TYPE value that was used to open this file. */
-    int iotype;
+  /** The PIO_TYPE value that was used to open this file. */
+  int iotype;
 
-    /** List of variables in this file. */
-    struct var_desc_t varlist[PIO_MAX_VARS];
+  /** List of variables in this file. */
+  struct var_desc_t varlist[PIO_MAX_VARS];
 
-    /** ??? */
-    int mode;
+  /** ??? */
+  int mode;
 
-    /** ??? */
-    struct wmulti_buffer buffer;
+  /** ??? */
+  struct wmulti_buffer buffer;
 
-    /** Pointer to the next file_desc_t in the list of open files. */
-    struct file_desc_t *next;
+  /** Pointer to the next file_desc_t in the list of open files. */
+  struct file_desc_t *next;
 
-    /** True if this task should participate in IO (only true for one
-     * task with netcdf serial files. */
-    int do_io;
+  /** True if this task should participate in IO (only true for one
+   * task with netcdf serial files. */
+  int do_io;
 } file_desc_t;
 
 /**
@@ -284,7 +284,7 @@ typedef struct file_desc_t
  * files. (Not all methods can be used with all netCDF files.)
  */
 enum PIO_IOTYPE
-{
+  {
     /** Parallel Netcdf  (parallel) */
     PIO_IOTYPE_PNETCDF = 1,
 
@@ -296,25 +296,25 @@ enum PIO_IOTYPE
 
     /** NetCDF4 (HDF5) parallel */
     PIO_IOTYPE_NETCDF4P = 4 
-};
+  };
 
 /**
  * These are the supported output data rearrangement methods.
  */
 enum PIO_REARRANGERS
-{
+  {
     /** Box rearranger. */
     PIO_REARR_BOX = 1,
 
     /** Subset rearranger. */
     PIO_REARR_SUBSET = 2
-};
+  };
 
 /**
  * These are the supported error handlers.
  */
 enum PIO_ERROR_HANDLERS
-{
+  {
     /** Errors cause abort. */
     PIO_INTERNAL_ERROR = (-51),
 
@@ -323,7 +323,7 @@ enum PIO_ERROR_HANDLERS
 
     /** Errors are returned to caller with no internal action. */
     PIO_RETURN_ERROR = (-53)  
-};
+  };
 
 /** Define the netCDF-based error codes. */
 #if defined( _PNETCDF) || defined(_NETCDF)
@@ -440,261 +440,263 @@ enum PIO_ERROR_HANDLERS
 #if defined(__cplusplus)
 extern "C" {
 #endif
-    int PIOc_strerror(int pioerr, char *errstr);
-    int PIOc_freedecomp(int iosysid, int ioid);
-    int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Offset *lenp); 
-    int PIOc_inq_format (int ncid, int *formatp); 
-    int PIOc_inq_varid (int ncid, const char *name, int *varidp); 
-    int PIOc_inq_varnatts (int ncid, int varid, int *nattsp); 
-    int PIOc_def_var (int ncid, const char *name, nc_type xtype,  int ndims, const int *dimidsp, int *varidp);
-    int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
-			     int deflate_level);
-    int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep, int *deflatep,
-			     int *deflate_levelp);
-    int PIOc_inq_var_szip(int ncid, int varid, int *options_maskp, int *pixels_per_blockp);
-    int PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunksizesp);
-    int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizesp);
-    int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value);
-    int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep);
-    int PIOc_def_var_endian(int ncid, int varid, int endian);
-    int PIOc_inq_var_endian(int ncid, int varid, int *endianp);
-    int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems, float preemption);
-    int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset *nelemsp, float *preemptionp);
-    int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset nelems,
-				 float preemption);
-    int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nelemsp,
-				 float *preemptionp);
-    int PIOc_inq_var (int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp, int *nattsp); 
-    int PIOc_inq_varname (int ncid, int varid, char *name); 
-    int PIOc_put_att_double (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const double *op); 
-    int PIOc_put_att_int (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const int *op); 
-    int PIOc_rename_att (int ncid, int varid, const char *name, const char *newname); 
-    int PIOc_del_att (int ncid, int varid, const char *name); 
-    int PIOc_inq_natts (int ncid, int *ngattsp); 
-    int PIOc_inq (int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp);  
-    int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip); 
-    int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip); 
-    int PIOc_put_att_long (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long *op); 
-    int PIOc_redef (int ncid); 
-    int PIOc_set_fill (int ncid, int fillmode, int *old_modep); 
-    int PIOc_enddef (int ncid); 
-    int PIOc_rename_var (int ncid, int varid, const char *name); 
-    int PIOc_put_att_short (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const short *op); 
-    int PIOc_put_att_text (int ncid, int varid, const char *name, PIO_Offset len, const char *op); 
-    int PIOc_inq_attname (int ncid, int varid, int attnum, char *name); 
-    int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long long *ip); 
-    int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *ip); 
-    int PIOc_put_att_ulonglong (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned long long *op); 
-    int PIOc_inq_dimlen (int ncid, int dimid, PIO_Offset *lenp); 
-    int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip); 
-    int PIOc_get_att_longlong (int ncid, int varid, const char *name, long long *ip); 
-    int PIOc_put_att_schar (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const signed char *op); 
-    int PIOc_put_att_float (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const float *op); 
-    int PIOc_inq_nvars (int ncid, int *nvarsp); 
-    int PIOc_rename_dim (int ncid, int dimid, const char *name); 
-    int PIOc_inq_varndims (int ncid, int varid, int *ndimsp); 
-    int PIOc_get_att_long (int ncid, int varid, const char *name, long *ip); 
-    int PIOc_inq_dim (int ncid, int dimid, char *name, PIO_Offset *lenp); 
-    int PIOc_inq_dimid (int ncid, const char *name, int *idp); 
-    int PIOc_inq_unlimdim (int ncid, int *unlimdimidp); 
-    int PIOc_inq_vardimid (int ncid, int varid, int *dimidsp); 
-    int PIOc_inq_attlen (int ncid, int varid, const char *name, PIO_Offset *lenp); 
-    int PIOc_inq_dimname (int ncid, int dimid, char *name); 
-    int PIOc_put_att_ushort (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned short *op); 
-    int PIOc_get_att_float (int ncid, int varid, const char *name, float *ip); 
-    int PIOc_sync (int ncid); 
-    int PIOc_put_att_longlong (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long long *op); 
-    int PIOc_put_att_uint (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned int *op); 
-    int PIOc_get_att_schar (int ncid, int varid, const char *name, signed char *ip); 
-    int PIOc_inq_attid (int ncid, int varid, const char *name, int *idp); 
-    int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp); 
-    int PIOc_inq_ndims (int ncid, int *ndimsp); 
-    int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep); 
-    int PIOc_get_att_int (int ncid, int varid, const char *name, int *ip); 
-    int PIOc_get_att_double (int ncid, int varid, const char *name, double *ip); 
-    int PIOc_inq_atttype (int ncid, int varid, const char *name, nc_type *xtypep); 
-    int PIOc_put_att_uchar (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op); 
-    int PIOc_get_att_uchar (int ncid, int varid, const char *name, unsigned char *ip);              
-    int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const int dims[], 
-			const int maplen, const PIO_Offset *compmap, int *ioidp, const int *rearr, 
-			const PIO_Offset *iostart,const PIO_Offset *iocount);
-    int PIOc_Init_Intracomm(const MPI_Comm comp_comm, 
-			    const int num_iotasks, const int stride, 
-			    const int base, const int rearr, int *iosysidp);
-    int PIOc_Init_Intercomm(int component_count, MPI_Comm peer_comm, MPI_Comm *comp_comms,
-			    MPI_Comm io_comm, int *iosysidp);
-    int PIOc_closefile(int ncid);
-    int PIOc_createfile(const int iosysid, int *ncidp,  int *iotype,
-			const char *fname, const int mode);
-    int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
+  int PIOc_strerror(int pioerr, char *errstr);
+  int PIOc_freedecomp(int iosysid, int ioid);
+  int PIOc_inq_att (int ncid, int varid, const char *name, nc_type *xtypep, PIO_Offset *lenp); 
+  int PIOc_inq_format (int ncid, int *formatp); 
+  int PIOc_inq_varid (int ncid, const char *name, int *varidp); 
+  int PIOc_inq_varnatts (int ncid, int varid, int *nattsp); 
+  int PIOc_def_var (int ncid, const char *name, nc_type xtype,  int ndims, const int *dimidsp, int *varidp);
+  int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
+			   int deflate_level);
+  int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep, int *deflatep,
+			   int *deflate_levelp);
+  int PIOc_inq_var_szip(int ncid, int varid, int *options_maskp, int *pixels_per_blockp);
+  int PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunksizesp);
+  int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizesp);
+  int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value);
+  int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep);
+  int PIOc_def_var_endian(int ncid, int varid, int endian);
+  int PIOc_inq_var_endian(int ncid, int varid, int *endianp);
+  int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems, float preemption);
+  int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset *nelemsp, float *preemptionp);
+  int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset nelems,
+			       float preemption);
+  int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nelemsp,
+			       float *preemptionp);
+  int PIOc_inq_var (int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp, int *nattsp); 
+  int PIOc_inq_varname (int ncid, int varid, char *name); 
+  int PIOc_put_att_double (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const double *op); 
+  int PIOc_put_att_int (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const int *op); 
+  int PIOc_rename_att (int ncid, int varid, const char *name, const char *newname); 
+  int PIOc_del_att (int ncid, int varid, const char *name); 
+  int PIOc_inq_natts (int ncid, int *ngattsp); 
+  int PIOc_inq (int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp);  
+  int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip); 
+  int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip); 
+  int PIOc_put_att_long (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long *op); 
+  int PIOc_redef (int ncid); 
+  int PIOc_set_fill (int ncid, int fillmode, int *old_modep); 
+  int PIOc_enddef (int ncid); 
+  int PIOc_rename_var (int ncid, int varid, const char *name); 
+  int PIOc_put_att_short (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const short *op); 
+  int PIOc_put_att_text (int ncid, int varid, const char *name, PIO_Offset len, const char *op); 
+  int PIOc_inq_attname (int ncid, int varid, int attnum, char *name); 
+  int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long long *ip); 
+  int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *ip); 
+  int PIOc_put_att_ulonglong (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned long long *op); 
+  int PIOc_inq_dimlen (int ncid, int dimid, PIO_Offset *lenp); 
+  int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip); 
+  int PIOc_get_att_longlong (int ncid, int varid, const char *name, long long *ip); 
+  int PIOc_put_att_schar (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const signed char *op); 
+  int PIOc_put_att_float (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const float *op); 
+  int PIOc_inq_nvars (int ncid, int *nvarsp); 
+  int PIOc_rename_dim (int ncid, int dimid, const char *name); 
+  int PIOc_inq_varndims (int ncid, int varid, int *ndimsp); 
+  int PIOc_get_att_long (int ncid, int varid, const char *name, long *ip); 
+  int PIOc_inq_dim (int ncid, int dimid, char *name, PIO_Offset *lenp); 
+  int PIOc_inq_dimid (int ncid, const char *name, int *idp); 
+  int PIOc_inq_unlimdim (int ncid, int *unlimdimidp); 
+  int PIOc_inq_vardimid (int ncid, int varid, int *dimidsp); 
+  int PIOc_inq_attlen (int ncid, int varid, const char *name, PIO_Offset *lenp); 
+  int PIOc_inq_dimname (int ncid, int dimid, char *name); 
+  int PIOc_put_att_ushort (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned short *op); 
+  int PIOc_get_att_float (int ncid, int varid, const char *name, float *ip); 
+  int PIOc_sync (int ncid); 
+  int PIOc_put_att_longlong (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long long *op); 
+  int PIOc_put_att_uint (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned int *op); 
+  int PIOc_get_att_schar (int ncid, int varid, const char *name, signed char *ip); 
+  int PIOc_inq_attid (int ncid, int varid, const char *name, int *idp); 
+  int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp); 
+  int PIOc_inq_ndims (int ncid, int *ndimsp); 
+  int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep); 
+  int PIOc_get_att_int (int ncid, int varid, const char *name, int *ip); 
+  int PIOc_get_att_double (int ncid, int varid, const char *name, double *ip); 
+  int PIOc_inq_atttype (int ncid, int varid, const char *name, nc_type *xtypep); 
+  int PIOc_put_att_uchar (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op); 
+  int PIOc_get_att_uchar (int ncid, int varid, const char *name, unsigned char *ip);              
+  int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const int dims[], 
+		      const int maplen, const PIO_Offset *compmap, int *ioidp, const int *rearr, 
+		      const PIO_Offset *iostart,const PIO_Offset *iocount);
+  int PIOc_Init_Intracomm(const MPI_Comm comp_comm, 
+			  const int num_iotasks, const int stride, 
+			  const int base, const int rearr, int *iosysidp);
+  int PIOc_Init_Intercomm(int component_count, MPI_Comm peer_comm, MPI_Comm *comp_comms,
+			  MPI_Comm io_comm, int *iosysidp);
+  int PIOc_closefile(int ncid);
+  int PIOc_createfile(const int iosysid, int *ncidp,  int *iotype,
 		      const char *fname, const int mode);
-    int PIOc_write_darray(const int ncid, const int vid, const int ioid, const PIO_Offset arraylen,
-			  void *array, void *fillvalue);
-    int PIOc_write_darray_multi(const int ncid, const int vid[], const int ioid, const int nvars, const PIO_Offset arraylen,
-				void *array, const int frame[], void *fillvalue[], bool flushtodisk);
+  int PIOc_create(int iosysid, const char *path, int cmode, int *ncidp);  
+  int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
+		    const char *fname, const int mode);
+  int PIOc_open(const int iosysid, const char *path, int mode, int *ncidp);  
+  int PIOc_write_darray(const int ncid, const int vid, const int ioid, const PIO_Offset arraylen,
+			void *array, void *fillvalue);
+  int PIOc_write_darray_multi(const int ncid, const int vid[], const int ioid, const int nvars, const PIO_Offset arraylen,
+			      void *array, const int frame[], void *fillvalue[], bool flushtodisk);
 
-    int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip);
-    int PIOc_put_att_ubyte (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op) ;
-    int PIOc_set_blocksize(const int newblocksize);
-    int PIOc_readmap(const char file[], int *ndims, int *gdims[], PIO_Offset *fmaplen, PIO_Offset *map[], const MPI_Comm comm);
-    int PIOc_readmap_from_f90(const char file[],int *ndims, int *gdims[], PIO_Offset *maplen, PIO_Offset *map[], const int f90_comm);
-    int PIOc_writemap(const char file[], const int ndims, const int gdims[], PIO_Offset maplen, PIO_Offset map[], const MPI_Comm comm);
-    int PIOc_writemap_from_f90(const char file[], const int ndims, const int gdims[], const PIO_Offset maplen, const PIO_Offset map[], const int f90_comm);
-    int PIOc_deletefile(const int iosysid, const char filename[]); 
-    int PIOc_File_is_Open(int ncid);
-    int PIOc_Set_File_Error_Handling(int ncid, int method);
-    int PIOc_advanceframe(int ncid, int varid);
-    int PIOc_setframe(const int ncid, const int varid,const int frame);
-    int PIOc_get_numiotasks(int iosysid, int *numiotasks);
-    int PIOc_get_iorank(int iosysid, int *iorank);
-    int PIOc_get_local_array_size(int ioid);
-    int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method);
-    int PIOc_set_hint(const int iosysid, char hint[], const char hintval[]);
-    int PIOc_Init_Intracomm(const MPI_Comm comp_comm, 
-			    const int num_iotasks, const int stride, 
-			    const int base,const int rearr, int *iosysidp);
-    int PIOc_finalize(const int iosysid);
-    int PIOc_iam_iotask(const int iosysid, bool *ioproc);
-    int PIOc_iotask_rank(const int iosysid, int *iorank);
-    int PIOc_iosystem_is_active(const int iosysid, bool *active);
-    int PIOc_put_vars_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const unsigned char *op) ;
-    int PIOc_get_var1_schar (int ncid, int varid, const PIO_Offset index[], signed char *buf) ;
-    int PIOc_put_vars_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const unsigned short *op) ;
-    int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid, void *IOBUF);
-    int PIOc_put_vars_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const unsigned long long *op) ;
-    int PIOc_get_vars_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned long long *buf) ;
-    int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype)  ;
-    int PIOc_read_darray(const int ncid, const int vid, const int ioid, const PIO_Offset arraylen, void *array);
-    int PIOc_put_vars_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const unsigned int *op) ;
-    int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], signed char *buf)  ;
-    int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned char *op) ;
-    int PIOc_put_var_ushort (int ncid, int varid, const unsigned short *op) ;
-    int PIOc_get_vars_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], short *buf)  ;
-    int PIOc_put_var1_longlong (int ncid, int varid, const PIO_Offset index[], const long long *op)  ;
-    int PIOc_get_var_double (int ncid, int varid, double *buf) ;
-    int PIOc_put_vara_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned char *op) ;
-    int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const short *op)  ;
-    int PIOc_get_vara_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], double *buf) ;
-    int PIOc_put_var1_long (int ncid, int varid, const PIO_Offset index[], const long *ip) ;
-    int PIOc_get_var_int (int ncid, int varid, int *buf) ;
-    int PIOc_put_vars_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const long *op) ;
-    int PIOc_put_var_short (int ncid, int varid, const short *op) ;
-    int PIOc_get_vara_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], char *buf) ;
-    int PIOc_put_vara_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const int *op)  ;
+  int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip);
+  int PIOc_put_att_ubyte (int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op) ;
+  int PIOc_set_blocksize(const int newblocksize);
+  int PIOc_readmap(const char file[], int *ndims, int *gdims[], PIO_Offset *fmaplen, PIO_Offset *map[], const MPI_Comm comm);
+  int PIOc_readmap_from_f90(const char file[],int *ndims, int *gdims[], PIO_Offset *maplen, PIO_Offset *map[], const int f90_comm);
+  int PIOc_writemap(const char file[], const int ndims, const int gdims[], PIO_Offset maplen, PIO_Offset map[], const MPI_Comm comm);
+  int PIOc_writemap_from_f90(const char file[], const int ndims, const int gdims[], const PIO_Offset maplen, const PIO_Offset map[], const int f90_comm);
+  int PIOc_deletefile(const int iosysid, const char filename[]); 
+  int PIOc_File_is_Open(int ncid);
+  int PIOc_Set_File_Error_Handling(int ncid, int method);
+  int PIOc_advanceframe(int ncid, int varid);
+  int PIOc_setframe(const int ncid, const int varid,const int frame);
+  int PIOc_get_numiotasks(int iosysid, int *numiotasks);
+  int PIOc_get_iorank(int iosysid, int *iorank);
+  int PIOc_get_local_array_size(int ioid);
+  int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method);
+  int PIOc_set_hint(const int iosysid, char hint[], const char hintval[]);
+  int PIOc_Init_Intracomm(const MPI_Comm comp_comm, 
+			  const int num_iotasks, const int stride, 
+			  const int base,const int rearr, int *iosysidp);
+  int PIOc_finalize(const int iosysid);
+  int PIOc_iam_iotask(const int iosysid, bool *ioproc);
+  int PIOc_iotask_rank(const int iosysid, int *iorank);
+  int PIOc_iosystem_is_active(const int iosysid, bool *active);
+  int PIOc_put_vars_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const unsigned char *op) ;
+  int PIOc_get_var1_schar (int ncid, int varid, const PIO_Offset index[], signed char *buf) ;
+  int PIOc_put_vars_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const unsigned short *op) ;
+  int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid, void *IOBUF);
+  int PIOc_put_vars_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const unsigned long long *op) ;
+  int PIOc_get_vars_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned long long *buf) ;
+  int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype)  ;
+  int PIOc_read_darray(const int ncid, const int vid, const int ioid, const PIO_Offset arraylen, void *array);
+  int PIOc_put_vars_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const unsigned int *op) ;
+  int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], signed char *buf)  ;
+  int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned char *op) ;
+  int PIOc_put_var_ushort (int ncid, int varid, const unsigned short *op) ;
+  int PIOc_get_vars_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], short *buf)  ;
+  int PIOc_put_var1_longlong (int ncid, int varid, const PIO_Offset index[], const long long *op)  ;
+  int PIOc_get_var_double (int ncid, int varid, double *buf) ;
+  int PIOc_put_vara_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned char *op) ;
+  int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const short *op)  ;
+  int PIOc_get_vara_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], double *buf) ;
+  int PIOc_put_var1_long (int ncid, int varid, const PIO_Offset index[], const long *ip) ;
+  int PIOc_get_var_int (int ncid, int varid, int *buf) ;
+  int PIOc_put_vars_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const long *op) ;
+  int PIOc_put_var_short (int ncid, int varid, const short *op) ;
+  int PIOc_get_vara_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], char *buf) ;
+  int PIOc_put_vara_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const int *op)  ;
 
-    int PIOc_put_var1_ushort (int ncid, int varid, const PIO_Offset index[], const unsigned short *op); 
-    int PIOc_put_vara_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const char *op);  
-    int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const char *op);  
-    int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned short *op); 
-    int PIOc_put_var_ulonglong (int ncid, int varid, const unsigned long long *op); 
-    int PIOc_put_var_int (int ncid, int varid, const int *op); 
-    int PIOc_put_var_longlong (int ncid, int varid, const long long *op); 
-    int PIOc_put_var_schar (int ncid, int varid, const signed char *op); 
-    int PIOc_put_var_uint (int ncid, int varid, const unsigned int *op); 
-    int PIOc_put_var (int ncid, int varid, const void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
-    int PIOc_put_vara_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned short *op); 
-    int PIOc_put_vars_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const short *op);  
-    int PIOc_put_vara_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned int *op); 
-    int PIOc_put_vara_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const signed char *op);  
-    int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned long long *op); 
-    int PIOc_put_var1_uchar (int ncid, int varid, const PIO_Offset index[], const unsigned char *op); 
-    int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const int *op);  
-    int PIOc_put_vars_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const signed char *op);  
-    int PIOc_put_var1 (int ncid, int varid, const PIO_Offset index[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_put_vara_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const float *op);  
-    int PIOc_put_var1_float (int ncid, int varid, const PIO_Offset index[], const float *op);  
-    int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const float *op);  
-    int PIOc_put_var1_text (int ncid, int varid, const PIO_Offset index[], const char *op);  
-    int PIOc_put_vars_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const char *op);  
-    int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long *op); 
-    int PIOc_put_vars_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const double *op);  
-    int PIOc_put_vara_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const long long *op);  
-    int PIOc_put_var_double (int ncid, int varid, const double *op); 
-    int PIOc_put_var_float (int ncid, int varid, const float *op); 
-    int PIOc_put_var1_ulonglong (int ncid, int varid, const PIO_Offset index[], const unsigned long long *op); 
-    int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned int *op); 
-    int PIOc_put_var1_uint (int ncid, int varid, const PIO_Offset index[], const unsigned int *op); 
-    int PIOc_put_var1_int (int ncid, int varid, const PIO_Offset index[], const int *op);  
-    int PIOc_put_vars_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const float *op);  
-    int PIOc_put_vara_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const short *op);  
-    int PIOc_put_var1_schar (int ncid, int varid, const PIO_Offset index[], const signed char *op);  
-    int PIOc_put_vara_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned long long *op); 
-    int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const double *op);  
-    int PIOc_put_vara (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_put_vara_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const long *op); 
-    int PIOc_put_var1_double (int ncid, int varid, const PIO_Offset index[], const double *op);  
-    int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const signed char *op);  
-    int PIOc_put_var_text (int ncid, int varid, const char *op); 
-    int PIOc_put_vars_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const int *op);  
-    int PIOc_put_var1_short (int ncid, int varid, const PIO_Offset index[], const short *op);  
-    int PIOc_put_vars_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const long long *op);  
-    int PIOc_put_vara_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const double *op);  
-    int PIOc_put_vars (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], nc_type xtype, const void *buf);  
-    int PIOc_put_var_uchar (int ncid, int varid, const unsigned char *op); 
-    int PIOc_put_var_long (int ncid, int varid, const long *op); 
-    int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long long *op);
-    int PIOc_get_vara_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], int *buf);
-    int PIOc_get_var1_float (int ncid, int varid, const PIO_Offset index[], float *buf); 
-    int PIOc_get_var1_short (int ncid, int varid, const PIO_Offset index[], short *buf); 
-    int PIOc_get_vars_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], int *buf);                      
-    int PIOc_get_var_text (int ncid, int varid, char *buf); 
-    int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], double *buf); 
-    int PIOc_get_vars_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], signed char *buf);  
-    int PIOc_get_vara_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned short *buf); 
-    int PIOc_get_var1_ushort (int ncid, int varid, const PIO_Offset index[], unsigned short *buf); 
-    int PIOc_get_var_float (int ncid, int varid, float *buf); 
-    int PIOc_get_vars_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned char *buf); 
-    int PIOc_get_var (int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
-    int PIOc_get_var1_longlong (int ncid, int varid, const PIO_Offset index[], long long *buf); 
-    int PIOc_get_vars_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned short *buf); 
-    int PIOc_get_var_long (int ncid, int varid, long *buf); 
-    int PIOc_get_var1_double (int ncid, int varid, const PIO_Offset index[], double *buf); 
-    int PIOc_get_vara_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned int *buf); 
-    int PIOc_get_vars_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], long long *buf); 
-    int PIOc_get_var_longlong (int ncid, int varid, long long *buf); 
-    int PIOc_get_vara_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], short *buf);  
-    int PIOc_get_vara_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], long *buf); 
-    int PIOc_get_var1_int (int ncid, int varid, const PIO_Offset index[], int *buf); 
-    int PIOc_get_var1_ulonglong (int ncid, int varid, const PIO_Offset index[], unsigned long long *buf); 
-    int PIOc_get_var_uchar (int ncid, int varid, unsigned char *buf); 
-    int PIOc_get_vara_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned char *buf); 
-    int PIOc_get_vars_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], float *buf);  
-    int PIOc_get_vars_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], long *buf); 
-    int PIOc_get_var1 (int ncid, int varid, const PIO_Offset index[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
-    int PIOc_get_var_uint (int ncid, int varid, unsigned int *buf); 
-    int PIOc_get_vara (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
-    int PIOc_get_vara_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], signed char *buf); 
-    int PIOc_get_var1_uint (int ncid, int varid, const PIO_Offset index[], unsigned int *buf); 
-    int PIOc_get_vars_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned int *buf); 
-    int PIOc_get_vara_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], float *buf);  
-    int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], char *buf);  
-    int PIOc_get_var1_text (int ncid, int varid, const PIO_Offset index[], char *buf); 
-    int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], int *buf);  
-    int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned int *buf);  
-    int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_get_vars_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], double *buf); 
-    int PIOc_get_vara_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], long long *buf); 
-    int PIOc_get_var_ulonglong (int ncid, int varid, unsigned long long *buf); 
-    int PIOc_get_vara_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned long long *buf); 
-    int PIOc_get_var_short (int ncid, int varid, short *buf); 
-    int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], float *buf);  
-    int PIOc_get_var1_long (int ncid, int varid, const PIO_Offset index[], long *buf); 
-    int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long *buf); 
-    int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned short *buf);  
-    int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long long *buf); 
-    int PIOc_get_vars_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], char *buf);  
-    int PIOc_get_var1_uchar (int ncid, int varid, const PIO_Offset index[], unsigned char *buf); 
-    int PIOc_get_vars (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], nc_type xtype, void *buf);  
-    int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], short *buf);  
-    int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned long long *buf);  
-    int PIOc_get_var_schar (int ncid, int varid, signed char *buf); 
-    int PIOc_iotype_available(const int iotype);
-    int PIOc_set_log_level(int level);
-    int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const void *op);
-    int PIOc_get_att(int ncid, int varid, const char *name, void *ip);
-    int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep);    
+  int PIOc_put_var1_ushort (int ncid, int varid, const PIO_Offset index[], const unsigned short *op); 
+  int PIOc_put_vara_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const char *op);  
+  int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const char *op);  
+  int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned short *op); 
+  int PIOc_put_var_ulonglong (int ncid, int varid, const unsigned long long *op); 
+  int PIOc_put_var_int (int ncid, int varid, const int *op); 
+  int PIOc_put_var_longlong (int ncid, int varid, const long long *op); 
+  int PIOc_put_var_schar (int ncid, int varid, const signed char *op); 
+  int PIOc_put_var_uint (int ncid, int varid, const unsigned int *op); 
+  int PIOc_put_var (int ncid, int varid, const void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
+  int PIOc_put_vara_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned short *op); 
+  int PIOc_put_vars_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const short *op);  
+  int PIOc_put_vara_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned int *op); 
+  int PIOc_put_vara_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const signed char *op);  
+  int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned long long *op); 
+  int PIOc_put_var1_uchar (int ncid, int varid, const PIO_Offset index[], const unsigned char *op); 
+  int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const int *op);  
+  int PIOc_put_vars_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const signed char *op);  
+  int PIOc_put_var1 (int ncid, int varid, const PIO_Offset index[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
+  int PIOc_put_vara_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const float *op);  
+  int PIOc_put_var1_float (int ncid, int varid, const PIO_Offset index[], const float *op);  
+  int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const float *op);  
+  int PIOc_put_var1_text (int ncid, int varid, const PIO_Offset index[], const char *op);  
+  int PIOc_put_vars_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const char *op);  
+  int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long *op); 
+  int PIOc_put_vars_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const double *op);  
+  int PIOc_put_vara_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const long long *op);  
+  int PIOc_put_var_double (int ncid, int varid, const double *op); 
+  int PIOc_put_var_float (int ncid, int varid, const float *op); 
+  int PIOc_put_var1_ulonglong (int ncid, int varid, const PIO_Offset index[], const unsigned long long *op); 
+  int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned int *op); 
+  int PIOc_put_var1_uint (int ncid, int varid, const PIO_Offset index[], const unsigned int *op); 
+  int PIOc_put_var1_int (int ncid, int varid, const PIO_Offset index[], const int *op);  
+  int PIOc_put_vars_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const float *op);  
+  int PIOc_put_vara_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const short *op);  
+  int PIOc_put_var1_schar (int ncid, int varid, const PIO_Offset index[], const signed char *op);  
+  int PIOc_put_vara_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned long long *op); 
+  int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const double *op);  
+  int PIOc_put_vara (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
+  int PIOc_put_vara_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const long *op); 
+  int PIOc_put_var1_double (int ncid, int varid, const PIO_Offset index[], const double *op);  
+  int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const signed char *op);  
+  int PIOc_put_var_text (int ncid, int varid, const char *op); 
+  int PIOc_put_vars_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const int *op);  
+  int PIOc_put_var1_short (int ncid, int varid, const PIO_Offset index[], const short *op);  
+  int PIOc_put_vars_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const long long *op);  
+  int PIOc_put_vara_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const double *op);  
+  int PIOc_put_vars (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
+  int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], nc_type xtype, const void *buf);  
+  int PIOc_put_var_uchar (int ncid, int varid, const unsigned char *op); 
+  int PIOc_put_var_long (int ncid, int varid, const long *op); 
+  int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long long *op);
+  int PIOc_get_vara_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], int *buf);
+  int PIOc_get_var1_float (int ncid, int varid, const PIO_Offset index[], float *buf); 
+  int PIOc_get_var1_short (int ncid, int varid, const PIO_Offset index[], short *buf); 
+  int PIOc_get_vars_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], int *buf);                      
+  int PIOc_get_var_text (int ncid, int varid, char *buf); 
+  int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], double *buf); 
+  int PIOc_get_vars_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], signed char *buf);  
+  int PIOc_get_vara_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned short *buf); 
+  int PIOc_get_var1_ushort (int ncid, int varid, const PIO_Offset index[], unsigned short *buf); 
+  int PIOc_get_var_float (int ncid, int varid, float *buf); 
+  int PIOc_get_vars_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned char *buf); 
+  int PIOc_get_var (int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
+  int PIOc_get_var1_longlong (int ncid, int varid, const PIO_Offset index[], long long *buf); 
+  int PIOc_get_vars_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned short *buf); 
+  int PIOc_get_var_long (int ncid, int varid, long *buf); 
+  int PIOc_get_var1_double (int ncid, int varid, const PIO_Offset index[], double *buf); 
+  int PIOc_get_vara_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned int *buf); 
+  int PIOc_get_vars_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], long long *buf); 
+  int PIOc_get_var_longlong (int ncid, int varid, long long *buf); 
+  int PIOc_get_vara_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], short *buf);  
+  int PIOc_get_vara_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], long *buf); 
+  int PIOc_get_var1_int (int ncid, int varid, const PIO_Offset index[], int *buf); 
+  int PIOc_get_var1_ulonglong (int ncid, int varid, const PIO_Offset index[], unsigned long long *buf); 
+  int PIOc_get_var_uchar (int ncid, int varid, unsigned char *buf); 
+  int PIOc_get_vara_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned char *buf); 
+  int PIOc_get_vars_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], float *buf);  
+  int PIOc_get_vars_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], long *buf); 
+  int PIOc_get_var1 (int ncid, int varid, const PIO_Offset index[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
+  int PIOc_get_var_uint (int ncid, int varid, unsigned int *buf); 
+  int PIOc_get_vara (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
+  int PIOc_get_vara_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], signed char *buf); 
+  int PIOc_get_var1_uint (int ncid, int varid, const PIO_Offset index[], unsigned int *buf); 
+  int PIOc_get_vars_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned int *buf); 
+  int PIOc_get_vara_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], float *buf);  
+  int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], char *buf);  
+  int PIOc_get_var1_text (int ncid, int varid, const PIO_Offset index[], char *buf); 
+  int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], int *buf);  
+  int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned int *buf);  
+  int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
+  int PIOc_get_vars_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], double *buf); 
+  int PIOc_get_vara_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], long long *buf); 
+  int PIOc_get_var_ulonglong (int ncid, int varid, unsigned long long *buf); 
+  int PIOc_get_vara_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned long long *buf); 
+  int PIOc_get_var_short (int ncid, int varid, short *buf); 
+  int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], float *buf);  
+  int PIOc_get_var1_long (int ncid, int varid, const PIO_Offset index[], long *buf); 
+  int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long *buf); 
+  int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned short *buf);  
+  int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long long *buf); 
+  int PIOc_get_vars_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], char *buf);  
+  int PIOc_get_var1_uchar (int ncid, int varid, const PIO_Offset index[], unsigned char *buf); 
+  int PIOc_get_vars (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
+  int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], nc_type xtype, void *buf);  
+  int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], short *buf);  
+  int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned long long *buf);  
+  int PIOc_get_var_schar (int ncid, int varid, signed char *buf); 
+  int PIOc_iotype_available(const int iotype);
+  int PIOc_set_log_level(int level);
+  int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const void *op);
+  int PIOc_get_att(int ncid, int varid, const char *name, void *ip);
+  int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep);    
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -423,12 +423,19 @@ int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
     {
 	if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
 	    return check_mpi(file, mpierr, __FILE__, __LINE__);
-	file->mode = file->mode | PIO_WRITE;  // This flag is implied by netcdf create functions but we need to know if its set
+
+	/* This flag is implied by netcdf create functions but we need
+	   to know if its set. */
+	file->mode = file->mode | PIO_WRITE;  
 	
 	if ((mpierr = MPI_Bcast(&file->fh, 1, MPI_INT, ios->ioroot, ios->union_comm)))
 	    return check_mpi(file, mpierr, __FILE__, __LINE__);
 
+	/* Return the ncid to the caller. */
 	*ncidp = file->fh;
+
+	/* Add the struct with this files info to the global list of
+	 * open files. */
 	pio_add_to_file_list(file);
     }
     

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -262,7 +262,7 @@ PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
     }
     else
     {
-      if (mode & NC_PNETCDF)
+      if (mode & NC_PNETCDF || mode & NC_MPIIO)
 	iotype = PIO_IOTYPE_PNETCDF;
       else
 	iotype = PIO_IOTYPE_NETCDF;
@@ -466,17 +466,17 @@ PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
     /* Figure out the iotype. */
     if (cmode & NC_NETCDF4)
     {
-      if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
-	iotype = PIO_IOTYPE_NETCDF4P;
-      else
-	iotype = PIO_IOTYPE_NETCDF4C;
+	if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
+	    iotype = PIO_IOTYPE_NETCDF4P;
+	else
+	    iotype = PIO_IOTYPE_NETCDF4C;
     }
     else
     {
-      if (cmode & NC_PNETCDF)
-	iotype = PIO_IOTYPE_PNETCDF;
-      else
-	iotype = PIO_IOTYPE_NETCDF;
+	if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
+	    iotype = PIO_IOTYPE_PNETCDF;
+	else
+	    iotype = PIO_IOTYPE_NETCDF;
     }
 
     return PIOc_createfile(iosysid, ncidp, &iotype, filename, cmode);

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -2,21 +2,32 @@
 #include <pio.h>
 #include <pio_internal.h>
 
-/** Open an existing file using PIO library.
+/** Open an existing file using PIO library. This is an internal
+ * function. Depending on the value of the retry parameter, a failed
+ * open operation will be handled differently. If retry is non-zero,
+ * then a failed attempt to open a file with netCDF-4 (serial or
+ * parallel), or parallel-netcdf will be followed by an attempt to
+ * open the file as a serial classic netCDF file. This is an important
+ * feature to some NCAR users. The functionality is exposed to the
+ * user as PIOc_openfile() (which does the retry), and PIOc_open()
+ * (which does not do the retry).
  * 
  * Input parameters are read on comp task 0 and ignored elsewhere.
  *
- * @param iosysid : A defined pio system descriptor (input)
- * @param ncidp : A pio file descriptor (output)
- * @param iotype : A pio output format (input)
- * @param filename : The filename to open 
- * @param mode : The netcdf mode for the open operation
+ * @param iosysid: A defined pio system descriptor (input)
+ * @param ncidp: A pio file descriptor (output)
+ * @param iotype: A pio output format (input)
+ * @param filename: The filename to open 
+ * @param mode: The netcdf mode for the open operation
+ * @param retry: non-zero to automatically retry with netCDF serial
+ * classic.
  *
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_openfile
+ * @private
  */
-int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
-		  const char *filename, const int mode)
+int PIOc_openfile_retry(const int iosysid, int *ncidp, int *iotype,
+			const char *filename, const int mode, int retry)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -92,9 +103,9 @@ int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
 	    if (!mpierr)
 		mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
 	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	      mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
 	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	      mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
 	}
 
         /* Handle MPI errors. */
@@ -154,20 +165,28 @@ int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
 
 	// If we failed to open a file due to an incompatible type of
 	// NetCDF, try it once with just plain old basic NetCDF.
+	if (retry)
+	{
 #ifdef _NETCDF
-	if((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF)) {
-	    if(ios->iomaster) printf("PIO2 pio_file.c retry NETCDF\n");
-	    // reset ierr on all tasks
-	    ierr = PIO_NOERR;
-	    // reset file markers for NETCDF on all tasks
-	    file->iotype = PIO_IOTYPE_NETCDF;
-
-	    // open netcdf file serially on main task
-	    if(ios->io_rank==0){
-		ierr = nc_open(filename, file->mode, &(file->fh)); }
-
-	}
+	    if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
+	    {
+		if (ios->iomaster)
+		    printf("PIO2 pio_file.c retry NETCDF\n");
+		
+		// reset ierr on all tasks
+		ierr = PIO_NOERR;
+		
+		// reset file markers for NETCDF on all tasks
+		file->iotype = PIO_IOTYPE_NETCDF;
+		
+		// open netcdf file serially on main task
+		if(ios->io_rank==0)
+		{
+		    ierr = nc_open(filename, file->mode, &(file->fh));
+		}
+	    }
 #endif
+	}
     }
 
     /* Broadcast and check the return code. */
@@ -195,7 +214,66 @@ int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
     return ierr;
 }
 
-/** Open a new file using pio.  Input parameters are read on comp task
+/** Open an existing file using PIO library.
+ * 
+ * Input parameters are read on comp task 0 and ignored elsewhere.
+ *
+ * @param iosysid : A defined pio system descriptor (input)
+ * @param ncidp : A pio file descriptor (output)
+ * @param iotype : A pio output format (input)
+ * @param filename : The filename to open 
+ * @param mode : The netcdf mode for the open operation
+ *
+ * @return 0 for success, error code otherwise.
+ * @ingroup PIO_openfile
+ */
+int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
+		  const char *filename, const int mode)
+{
+    /* Open the file. If the open fails, try again as netCDF serial
+     * before giving up. */
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1);
+}
+
+/** Open an existing file using PIO library.
+ * 
+ * Input parameters are read on comp task 0 and ignored elsewhere.
+ *
+ * @param iosysid: A defined pio system descriptor
+ * @param path: The filename to open 
+ * @param mode: The netcdf mode for the open operation
+ * @param ncidp: pointer to int where ncid will go
+ *
+ * @return 0 for success, error code otherwise.
+ * @ingroup PIO_openfile
+ */
+int
+PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
+{
+    int iotype;
+
+    /* Figure out the iotype. */
+    if (mode & NC_NETCDF4)
+    {
+      if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
+	iotype = PIO_IOTYPE_NETCDF4P;
+      else
+	iotype = PIO_IOTYPE_NETCDF4C;
+    }
+    else
+    {
+      if (mode & NC_PNETCDF)
+	iotype = PIO_IOTYPE_PNETCDF;
+      else
+	iotype = PIO_IOTYPE_NETCDF;
+    }
+
+    /* Open the file. If the open fails, do not retry as serial
+     * netCDF. Just return the error code. */
+    return PIOc_openfile_retry(iosysid, ncidp, &iotype, path, mode, 0);
+}
+
+/** Create a new file using pio. Input parameters are read on comp task
  * 0 and ignored elsewhere.
  *
  * @public
@@ -370,6 +448,8 @@ int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
  * @param cmode : The netcdf mode for the create operation
  * @param filename : The filename to open 
  * @param ncidp : A pio file descriptor (output)
+ *
+ * @return 0 for success, error code otherwise.
  */
 int
 PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -360,6 +360,41 @@ int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
     return ierr;
 }
 
+/** Open a new file using pio.  Input parameters are read on comp task
+ * 0 and ignored elsewhere.
+ *
+ * @public
+ * @ingroup PIO_create
+ * 
+ * @param iosysid : A defined pio system descriptor (input)
+ * @param cmode : The netcdf mode for the create operation
+ * @param filename : The filename to open 
+ * @param ncidp : A pio file descriptor (output)
+ */
+int
+PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
+{
+    int iotype;            /* The PIO IO type. */
+
+    /* Figure out the iotype. */
+    if (cmode & NC_NETCDF4)
+    {
+      if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
+	iotype = PIO_IOTYPE_NETCDF4P;
+      else
+	iotype = PIO_IOTYPE_NETCDF4C;
+    }
+    else
+    {
+      if (cmode & NC_PNETCDF)
+	iotype = PIO_IOTYPE_PNETCDF;
+      else
+	iotype = PIO_IOTYPE_NETCDF;
+    }
+
+    return PIOc_createfile(iosysid, ncidp, &iotype, filename, cmode);
+}
+
 /** Close a file previously opened with PIO.
  * @ingroup PIO_closefile
  * 

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -544,12 +544,6 @@ int PIOc_finalize(const int iosysid)
   if(ios->intercomm != MPI_COMM_NULL){
     MPI_Comm_free(&(ios->intercomm));
   }
-  if(ios->io_comm != MPI_COMM_NULL){
-    MPI_Comm_free(&(ios->io_comm));
-  }
-  if(ios->comp_comm != MPI_COMM_NULL){
-    MPI_Comm_free(&(ios->comp_comm));
-  }
   if(ios->union_comm != MPI_COMM_NULL){
     MPI_Comm_free(&(ios->union_comm));
   }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -50,6 +50,9 @@ if (PIO_ENABLE_ASYNC AND NOT PIO_USE_MPI_SERIAL)
   add_executable (test_darray_async EXCLUDE_FROM_ALL test_darray_async.c)
   target_link_libraries (test_darray_async pioc)
   add_dependencies (tests test_darray_async)
+  add_executable (test_file EXCLUDE_FROM_ALL test_file.c)
+  target_link_libraries (test_file pioc)
+  add_dependencies (tests test_file)
 endif ()
 add_executable (test_names EXCLUDE_FROM_ALL test_names.c)
 target_link_libraries (test_names pioc)
@@ -87,6 +90,10 @@ else ()
         NUMPROCS 4
         TIMEOUT ${DEFAULT_TEST_TIMEOUT})
   if (PIO_ENABLE_ASYNC)
+    add_mpi_test(test_file
+        EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_file
+        NUMPROCS 4
+        TIMEOUT ${DEFAULT_TEST_TIMEOUT})
     add_mpi_test(test_intercomm
         EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_intercomm
         NUMPROCS 4

--- a/tests/unit/test_file.c
+++ b/tests/unit/test_file.c
@@ -1,0 +1,250 @@
+/**
+ * @file Tests for the file functions PIOc_create, PIOc_open, and
+ * PIOc_close.
+ *
+ */
+#include <pio.h>
+#ifdef TIMING
+#include <gptl.h>
+#endif
+
+#define NUM_NETCDF_FLAVORS 4
+#define NDIM 3
+#define X_DIM_LEN 400
+#define Y_DIM_LEN 400
+#define NUM_TIMESTEPS 6
+#define VAR_NAME "foo"
+#define ATT_NAME "bar"
+#define START_DATA_VAL 42
+#define ERR_AWFUL 1111
+#define VAR_CACHE_SIZE (1024 * 1024)
+#define VAR_CACHE_NELEMS 10
+#define VAR_CACHE_PREEMPTION 0.5
+
+/** Handle MPI errors. This should only be used with MPI library
+ * function calls. */
+#define MPIERR(e) do {                                                  \
+	MPI_Error_string(e, err_buffer, &resultlen);			\
+	fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
+	MPI_Finalize();							\
+	return ERR_AWFUL;							\
+    } while (0) 
+
+/** Handle non-MPI errors by finalizing the MPI library and exiting
+ * with an exit code. */
+#define ERR(e) do {				\
+        fprintf(stderr, "Error %d in %s, line %d\n", e, __FILE__, __LINE__); \
+	MPI_Finalize();				\
+	return e;				\
+    } while (0) 
+
+/** Global err buffer for MPI. */
+char err_buffer[MPI_MAX_ERROR_STRING];
+int resultlen;
+
+/** The dimension names. */
+char dim_name[NDIM][NC_MAX_NAME + 1] = {"timestep", "x", "y"};
+
+/** Length of the dimensions in the sample data. */
+int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
+
+/** Length of chunksizes to use in netCDF-4 files. */
+size_t chunksize[NDIM] = {2, X_DIM_LEN/2, Y_DIM_LEN/2};
+
+
+/** Run Tests for PIO file operations.
+ *
+ * @param argc argument count
+ * @param argv array of arguments
+ */
+int
+main(int argc, char **argv)
+{
+    int verbose = 1;
+    
+    /** Zero-based rank of processor. */
+    int my_rank;
+
+    /** Number of processors involved in current execution. */
+    int ntasks;
+
+    /** Specifies the flavor of netCDF output format. */
+    int iotype;
+
+    /** Different output flavors. */
+    int format[NUM_NETCDF_FLAVORS] = {PIO_IOTYPE_PNETCDF, 
+				      PIO_IOTYPE_NETCDF,
+				      PIO_IOTYPE_NETCDF4C,
+				      PIO_IOTYPE_NETCDF4P};
+
+    /** Names for the output files. */
+    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"test_file_pnetcdf.nc",
+							  "test_file_classic.nc",
+							  "test_file_serial4.nc",
+							  "test_file_parallel4.nc"};
+	
+    /** Number of processors that will do IO. In this test we
+     * will do IO from all processors. */
+    int niotasks;
+
+    /** Stride in the mpi rank between io tasks. Always 1 in this
+     * test. */
+    int ioproc_stride = 1;
+
+    /** Number of the aggregator? Always 0 in this test. */
+    int numAggregator = 0;
+
+    /** Zero based rank of first processor to be used for I/O. */
+    int ioproc_start = 0;
+
+    /** The dimension IDs. */
+    int dimids[NDIM];
+
+    /** Array index per processing unit. */
+    PIO_Offset elements_per_pe;
+
+    /** The ID for the parallel I/O system. */
+    int iosysid;
+
+    /** The ncid of the netCDF file. */
+    int ncid = 0;
+
+    /** The ID of the netCDF varable. */
+    int varid;
+
+    /** The I/O description ID. */
+    int ioid;
+
+    /** A buffer for sample data. */
+    float *buffer;
+
+    /** A buffer for reading data back from the file. */
+    int *read_buffer;
+
+    /** The decomposition mapping. */
+    PIO_Offset *compdof;
+
+    /** Return code. */
+    int ret;
+
+    /** Index for loops. */
+    int fmt, d, d1, i;
+    
+#ifdef TIMING    
+    /* Initialize the GPTL timing library. */
+    if ((ret = GPTLinitialize ()))
+	return ret;
+#endif    
+    
+    /* Initialize MPI. */
+    if ((ret = MPI_Init(&argc, &argv)))
+	MPIERR(ret);
+
+    /* Learn my rank and the total number of processors. */
+    if ((ret = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
+	MPIERR(ret);
+    if ((ret = MPI_Comm_size(MPI_COMM_WORLD, &ntasks)))
+	MPIERR(ret);
+
+    /* Check that a valid number of processors was specified. */
+    if (!(ntasks == 1 || ntasks == 2 || ntasks == 4 ||
+	  ntasks == 8 || ntasks == 16))
+	fprintf(stderr, "Number of processors must be 1, 2, 4, 8, or 16!\n");
+    if (verbose)
+	printf("%d: ParallelIO Library example1 running on %d processors.\n",
+	       my_rank, ntasks);
+
+    /* keep things simple - 1 iotask per MPI process */    
+    niotasks = ntasks; 
+
+    /* Initialize the PIO IO system. This specifies how
+     * many and which processors are involved in I/O. */
+    if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, niotasks, ioproc_stride,
+				   ioproc_start, PIO_REARR_SUBSET, &iosysid)))
+	ERR(ret);
+
+    /* Describe the decomposition. This is a 1-based array, so add 1! */
+    elements_per_pe = X_DIM_LEN * Y_DIM_LEN / ntasks;
+    if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
+	return PIO_ENOMEM;
+    for (i = 0; i < elements_per_pe; i++) {
+	compdof[i] = my_rank * elements_per_pe + i + 1;
+    }
+	
+    /* Create the PIO decomposition for this test. */
+    if (verbose)
+	printf("rank: %d Creating decomposition...\n", my_rank);
+    if ((ret = PIOc_InitDecomp(iosysid, PIO_FLOAT, 2, &dim_len[1], (PIO_Offset)elements_per_pe,
+			       compdof, &ioid, NULL, NULL, NULL)))
+	ERR(ret);
+    free(compdof);
+
+    /* How many flavors will we be running for? */
+    int num_flavors = 0;
+    int fmtidx = 0;
+#ifdef _PNETCDF
+    num_flavors++;
+    format[fmtidx++] = PIO_IOTYPE_PNETCDF;
+#endif
+#ifdef _NETCDF
+    num_flavors++;
+    format[fmtidx++] = PIO_IOTYPE_NETCDF;
+#endif
+#ifdef _NETCDF4
+    num_flavors += 2;
+    format[fmtidx++] = PIO_IOTYPE_NETCDF4C;
+    format[fmtidx] = PIO_IOTYPE_NETCDF4P;
+#endif
+    
+    /* Use PIO to create the example file in each of the four
+     * available ways. */
+    for (fmt = 0; fmt < num_flavors; fmt++) 
+    {
+	/* Create the netCDF output file. */
+	if (verbose)
+	    printf("rank: %d Creating sample file %s with format %d...\n",
+		   my_rank, filename[fmt], format[fmt]);
+	if ((ret = PIOc_createfile(iosysid, &ncid, &(format[fmt]), filename[fmt],
+				   PIO_CLOBBER)))
+	    ERR(ret);
+
+	/* End define mode. */
+	if ((ret = PIOc_enddef(ncid)))
+	    ERR(ret);
+	
+	/* Close the netCDF file. */
+	if (verbose)
+	    printf("rank: %d Closing the sample data file...\n", my_rank);
+	if ((ret = PIOc_closefile(ncid)))
+	    ERR(ret);
+
+	/* Put a barrier here to make verbose output look better. */
+	if ((ret = MPI_Barrier(MPI_COMM_WORLD)))
+	    MPIERR(ret);
+
+    }
+	
+    /* Free the PIO decomposition. */
+    if (verbose)
+	printf("rank: %d Freeing PIO decomposition...\n", my_rank);
+    if ((ret = PIOc_freedecomp(iosysid, ioid)))
+	ERR(ret);
+	
+    /* Finalize the IO system. */
+    if (verbose)
+	printf("rank: %d Freeing PIO resources...\n", my_rank);
+    if ((ret = PIOc_finalize(iosysid)))
+	ERR(ret);
+
+    /* Finalize the MPI library. */
+    MPI_Finalize();
+
+#ifdef TIMING    
+    /* Finalize the GPTL timing library. */
+    if ((ret = GPTLfinalize ()))
+	return ret;
+#endif    
+    
+
+    return 0;
+}

--- a/tests/unit/test_file.c
+++ b/tests/unit/test_file.c
@@ -249,8 +249,22 @@ main(int argc, char **argv)
 		   my_rank, filename[fmt], format[fmt]);
 	if ((ret = PIOc_create(iosysid, filename[fmt], mode, &ncid)))
 	    ERR(ret);
-	
+
+	/* End define mode. */
 	if ((ret = PIOc_enddef(ncid)))
+	    ERR(ret);
+
+	/* Close the netCDF file. */
+	if (verbose)
+	    printf("rank: %d Closing the sample data file...\n", my_rank);
+	if ((ret = PIOc_closefile(ncid)))
+	    ERR(ret);
+
+	/* Reopen the file. */
+	if (verbose)
+	    printf("rank: %d Re-opening sample file %s with format %d...\n",
+		   my_rank, filename[fmt], format[fmt]);
+	if ((ret = PIOc_open(iosysid, filename[fmt], mode, &ncid)))
 	    ERR(ret);
 
 	/* Close the netCDF file. */

--- a/tests/unit/test_names.c
+++ b/tests/unit/test_names.c
@@ -396,7 +396,8 @@ main(int argc, char **argv)
 	/* Define netCDF dimensions and variable. */
 	if (verbose)
 	    printf("rank: %d Defining netCDF metadata...\n", my_rank);
-	for (d = 0; d < NDIM; d++) {
+	for (d = 0; d < NDIM; d++)
+	{
 	    if (verbose)
 		printf("rank: %d Defining netCDF dimension %s, length %d\n", my_rank,
 		       dim_name[d], dim_len[d]);


### PR DESCRIPTION
Here are the wrappers for nc_open and nc_create. They use the same code behind the scenes as PIOc_openfile() and PIOc_createfile() but with a few twists.

An advantage to using these new wrapper functions is that it transparently enables access to the CDF5 format from Argonne parallel-netcdf, even for netCDF sequential.
