### PR TITLE
Tests for IOSystems with overlapped ranks and some testing infrastructure changes

### DIFF
--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -14,7 +14,8 @@ SET(GENERATED_SRCS pio_file_simple_tests.F90
                    pio_decomp_tests.F90
                    pio_decomp_fillval.F90
                    pio_iosystem_tests.F90
-                   pio_iosystem_tests2.F90)
+                   pio_iosystem_tests2.F90
+                   pio_iosystem_tests3.F90)
 
 foreach (SRC_FILE IN LISTS GENERATED_SRCS)
     add_custom_command (
@@ -347,6 +348,7 @@ else ()
         TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 endif ()
 
+
 #===== pio_iosystems_test2 =====
 add_executable (pio_iosystem_tests2 EXCLUDE_FROM_ALL
     pio_iosystem_tests2.F90
@@ -354,14 +356,33 @@ add_executable (pio_iosystem_tests2 EXCLUDE_FROM_ALL
 target_link_libraries (pio_iosystem_tests2 piof)
 add_dependencies (tests pio_iosystem_tests2)
 
-# if (PIO_USE_MPISERIAL)
-#     add_test(NAME pio_iosystem_tests2
-#         COMMAND pio_iosystem_tests2)
-#     set_tests_properties(pio_iosystem_tests2
-#         PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
-# else ()
-#     add_mpi_test(pio_iosystem_tests2
-#         EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_iosystem_tests2
-#         NUMPROCS 4
-#         TIMEOUT ${DEFAULT_TEST_TIMEOUT})
-# endif ()
+if (PIO_USE_MPISERIAL)
+    add_test(NAME pio_iosystem_tests2
+        COMMAND pio_iosystem_tests2)
+    set_tests_properties(pio_iosystem_tests2
+        PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+else ()
+    add_mpi_test(pio_iosystem_tests2
+        EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_iosystem_tests2
+        NUMPROCS 4
+        TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+endif ()
+
+#===== pio_iosystems_test3 =====
+add_executable (pio_iosystem_tests3 EXCLUDE_FROM_ALL
+    pio_iosystem_tests3.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
+target_link_libraries (pio_iosystem_tests3 piof)
+add_dependencies (tests pio_iosystem_tests3)
+
+if (PIO_USE_MPISERIAL)
+    add_test(NAME pio_iosystem_tests3
+        COMMAND pio_iosystem_tests3)
+    set_tests_properties(pio_iosystem_tests3
+        PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+else ()
+    add_mpi_test(pio_iosystem_tests3
+        EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_iosystem_tests3
+        NUMPROCS 4
+        TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+endif ()

--- a/tests/general/pio_iosystem_tests3.F90.in
+++ b/tests/general/pio_iosystem_tests3.F90.in
@@ -1,0 +1,279 @@
+! Split comm world into two comms (even procs and odd procs) and 
+! rank == overlapped_rank included in both comms
+SUBROUTINE split_world_two_with_overlap(new_comms, new_ranks, new_sizes, overlapped_rank)
+  use mpi
+  use pio_tutil
+  implicit none
+  integer, parameter :: NUM_COMMS = 2
+  integer, dimension(NUM_COMMS), intent(inout) :: new_comms
+  integer, dimension(NUM_COMMS), intent(inout) :: new_ranks
+  integer, dimension(NUM_COMMS), intent(inout) :: new_sizes
+  integer, intent(in) :: overlapped_rank
+
+  integer :: i, ierr
+  integer :: world_group
+  ! first group range (first rank, last rank, stride) for including rank=overlapped_rank
+  ! second group range (first rank, last rank, stride) for other procs
+  !   strided depending on number of comms
+  ! Note: NUM_GROUP_RANGES is always 2, indep of value of NUM_COMMS
+  integer, parameter :: NUM_GROUP_RANGES = 2
+  integer :: nranges
+  integer, dimension(3,NUM_GROUP_RANGES) :: new_group_ranges
+  integer, dimension(NUM_COMMS) :: new_groups
+
+  do i=1,NUM_COMMS
+    new_comms(i) = MPI_COMM_NULL
+    new_ranks(i) = -1
+    new_sizes(i) = 0
+  end do
+
+  call MPI_Comm_group(pio_tf_comm_, world_group, ierr)
+
+  do i=1,NUM_COMMS
+    if(overlapped_rank / NUM_COMMS /= i-1) then
+      nranges = 2
+      ! Include rank == overlapped_rank
+      new_group_ranges(1,1) = overlapped_rank
+      new_group_ranges(2,1) = overlapped_rank
+      new_group_ranges(3,1) = 1
+
+      ! Include other processes split evenly among NUM_COMMS
+      new_group_ranges(1,2) = i-1
+      new_group_ranges(2,2) = i-1 + (pio_tf_world_sz_/NUM_COMMS - 1) * NUM_COMMS
+      new_group_ranges(3,2) = NUM_COMMS
+    else
+      nranges = 1
+      ! Include processes split evenly among NUM_COMMS
+      ! rank == overlapped_rank is already included in this range
+      new_group_ranges(1,1) = i-1
+      new_group_ranges(2,1) = i-1 + (pio_tf_world_sz_/NUM_COMMS - 1) * NUM_COMMS
+      new_group_ranges(3,1) = NUM_COMMS
+    end if
+
+    call MPI_Group_range_incl(world_group, nranges, new_group_ranges,&
+          new_groups(i), ierr)
+  end do
+
+  call MPI_Group_free(world_group, ierr)
+
+  ! Create communicators corresponding to the groups
+  ! All the communicators will have rank == overlapped_rank and are
+  ! disjoint otherwise
+  do i=1,NUM_COMMS
+    call MPI_Comm_create(pio_tf_comm_, new_groups(i), new_comms(i), ierr)
+    call MPI_Group_free(new_groups(i), ierr)
+    if(new_comms(i) /= MPI_COMM_NULL) then
+      call MPI_Comm_rank(new_comms(i), new_ranks(i), ierr)
+      call MPI_Comm_size(new_comms(i), new_sizes(i), ierr)
+    else
+      new_ranks(i) = -1
+      new_sizes(i) = 0
+    end if
+  end do
+
+END SUBROUTINE split_world_two_with_overlap
+
+! Create a file with a global attribute (filename)
+SUBROUTINE create_file(comm, iosys, iotype, fname, attname, dimname, ret)
+    use pio_tutil
+    implicit none
+
+    integer, intent(in) :: comm
+    type(iosystem_desc_t), intent(inout) :: iosys
+    integer, intent(in) :: iotype
+    character(len=*), intent(in) :: fname
+    character(len=*), intent(in) :: attname
+    character(len=*), intent(in) :: dimname
+    integer, intent(inout) :: ret
+
+    type(file_desc_t) :: pio_file
+    integer :: pio_dim
+    type(var_desc_t) :: pio_var
+
+    ret = PIO_createfile(iosys, pio_file, iotype, fname, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed to create dummy file :" // trim(fname))
+
+    ret = PIO_def_dim(pio_file, dimname, PIO_TF_MAX_STR_LEN, pio_dim)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed to define dim "// trim(dimname) // "in file :" // trim(fname))
+
+    ret = PIO_def_var(pio_file, attname, PIO_char, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed to define var " // trim(attname) // " in file :" // trim(fname))
+
+    ret = PIO_put_att(pio_file, pio_var, attname, fname)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed to put att " // trim(attname) // " in file :" // trim(fname))
+
+    call PIO_closefile(pio_file)
+END SUBROUTINE create_file
+
+! Check the contents of file : Check the 
+! global attribute 'filename' (should be equal to the
+! name of the file, fname)
+SUBROUTINE check_file(comm, iosys, iotype, pio_file, fname, attname, dimname, ret)
+    use pio_tutil
+    implicit none
+
+    integer, intent(in) :: comm
+    type(iosystem_desc_t), intent(inout) :: iosys
+    integer, intent(in) :: iotype
+    type(file_desc_t), intent(inout) :: pio_file
+    character(len=*), intent(in) :: fname
+    character(len=*), intent(in) :: attname
+    character(len=*), intent(in) :: dimname
+    integer, intent(inout) :: ret
+
+    integer :: pio_dim
+    type(var_desc_t) :: pio_var
+    character(len=PIO_TF_MAX_STR_LEN) :: val
+
+    ret = PIO_inq_dimid(pio_file, dimname, pio_dim)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed to find dim "// trim(dimname) // "in file :" // trim(fname))
+
+    ret = PIO_inq_varid(pio_file, attname, pio_var)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed to find var " // trim(attname) // " in file :" // trim(fname))
+
+    ret = PIO_get_att(pio_file, pio_var, attname, val)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed to get att " // trim(attname) // " in file :" // trim(fname))
+
+    PRINT *, "val = ", trim(val), ", fname =", trim(fname)
+    PIO_TF_PASSERT(val .eq. fname, comm, "Attribute value is not the expected value")
+END SUBROUTINE check_file
+
+! Open and check the contents of file : open it and check the 
+! global attribute 'filename' (should be equal to the
+! name of the file, fname)
+SUBROUTINE open_and_check_file(comm, iosys, iotype, pio_file, fname, &
+                      attname, dimname, disable_fclose, ret)
+    use pio_tutil
+    implicit none
+
+    integer, intent(in) :: comm
+    type(iosystem_desc_t), intent(inout) :: iosys
+    integer, intent(in) :: iotype
+    type(file_desc_t), intent(inout) :: pio_file
+    character(len=*), intent(in) :: fname
+    character(len=*), intent(in) :: attname
+    character(len=*), intent(in) :: dimname
+    logical, intent(in) :: disable_fclose
+    integer, intent(inout) :: ret
+
+    ret = PIO_openfile(iosys, pio_file, iotype, fname, PIO_write)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed to open:" // fname)
+
+    call check_file(comm, iosys, iotype, pio_file, fname, attname, dimname, ret)
+    PIO_TF_CHECK_ERR(ret, comm, "Checking contents of file failed:" // fname)
+
+    if(.not. disable_fclose) then
+      call PIO_closefile(pio_file)
+    end if
+END SUBROUTINE open_and_check_file
+
+! Create three files with one iosystem - with all procs, and open/read with 
+! two different iosystems - subset (odd/even) of procs
+! The two iosystems created overlap at rank=0 (and are disjoint otherwise)
+PIO_TF_AUTO_TEST_SUB_BEGIN three_files_two_iosystems_with_overlap
+  use mpi
+  implicit none
+
+  character(len=PIO_TF_MAX_STR_LEN), target :: fname0 = "pio_iosys_test_file0.nc"
+  character(len=PIO_TF_MAX_STR_LEN), target :: fname1 = "pio_iosys_test_file1.nc"
+  character(len=PIO_TF_MAX_STR_LEN), target :: fname2 = "pio_iosys_test_file2.nc"
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: attname = "filename"
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: dimname = "filename_dim"
+  character(len=PIO_TF_MAX_STR_LEN), pointer :: fname
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: i, j, num_iotypes = 0
+  type(file_desc_t) :: pio_file0
+  integer, parameter :: NUM_COMMS = 2
+  type(file_desc_t), dimension(NUM_COMMS) :: pio_files
+  integer :: pio_base_rank = 0, pio_num_iotasks = 0
+
+  type(iosystem_desc_t), dimension(NUM_COMMS) :: overlapped_iosys
+  integer, dimension(NUM_COMMS) :: overlapped_comms, overlapped_comm_ranks, overlapped_comm_sizes
+  integer :: ret
+
+  ! Split world to two disjoint comms with overlap only at overlapped_rank=0
+  call split_world_two_with_overlap(overlapped_comms, overlapped_comm_ranks, overlapped_comm_sizes, 0)
+
+  do i=1,NUM_COMMS
+    if(overlapped_comms(i) /= MPI_COMM_NULL) then
+      ! If we have more than 1 proc, make sure that the io tasks start from 1
+      ! since rank=0 is always shared by all the overlapped_comms above
+      if(overlapped_comm_sizes(i) > 1) then
+        pio_base_rank = 1
+        pio_num_iotasks = overlapped_comm_sizes(i) - 1
+      else
+        pio_base_rank = 0
+        pio_num_iotasks = overlapped_comm_sizes(i)
+      end if
+      call PIO_init(overlapped_comm_ranks(i), overlapped_comms(i), &
+                    pio_num_iotasks, &
+                    1, &! Num aggregators
+                    1, &! Stride
+                    PIO_rearr_subset, overlapped_iosys(i), base=pio_base_rank)
+      call PIO_seterrorhandling(overlapped_iosys(i), PIO_BCAST_ERROR)
+    end if
+  end do
+
+  ! Open two different files and close it with two different iosystems
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : ", iotype_descs(i)
+    ! Create three files to be opened later - world - all procs
+    call create_file(pio_tf_comm_, pio_tf_iosystem_, iotypes(i), &
+                      fname0, attname, dimname, ret)
+    PIO_TF_CHECK_ERR(ret, "Failed to create file :" // fname0)
+
+    call create_file(pio_tf_comm_, pio_tf_iosystem_, iotypes(i), &
+                      fname1, attname, dimname, ret)
+    PIO_TF_CHECK_ERR(ret, "Failed to create file :" // fname1)
+
+    call create_file(pio_tf_comm_, pio_tf_iosystem_, iotypes(i), &
+                      fname2, attname, dimname, ret)
+    PIO_TF_CHECK_ERR(ret, "Failed to create file :" // fname2)
+
+    ! Open file0 from all procs - disable close
+    call open_and_check_file(pio_tf_comm_, pio_tf_iosystem_, iotypes(i), &
+                    pio_file0, fname0, attname, dimname, .true., ret)
+    PIO_TF_CHECK_ERR(ret, "Checking contents of file failed :" // fname0)
+
+    fname => fname1
+
+    do j=1,NUM_COMMS
+      ! The two comms operate on different files
+      if(fname == fname1) then
+        fname => fname2
+      else
+        fname => fname1
+      end if
+      if(overlapped_comms(j) /= MPI_COMM_NULL) then
+        call open_and_check_file(overlapped_comms(j), overlapped_iosys(j), iotypes(i), &
+                        pio_files(j), fname, attname, dimname, .true., ret)
+        PIO_TF_CHECK_ERR(ret, overlapped_comms(j), "Checking contents of file failed :" // fname)
+
+        ! Make sure that we can still check the contents of the file
+        call check_file(overlapped_comms(j), overlapped_iosys(j), iotypes(i), &
+                        pio_files(j), fname, attname, dimname, ret)
+        PIO_TF_CHECK_ERR(ret, overlapped_comms(j), "Checking (second) contents of file failed :" // fname)
+      end if
+    end do
+
+    do j=1,NUM_COMMS
+      if(overlapped_comms(j) /= MPI_COMM_NULL) then
+        call PIO_closefile(pio_files(j))
+      end if
+    end do
+    call PIO_closefile(pio_file0)
+  end do
+
+  do i=1,NUM_COMMS
+    if(overlapped_comms(i) /= MPI_COMM_NULL) then
+      call PIO_finalize(overlapped_iosys(i), ret)
+      call MPI_Comm_free(overlapped_comms(i), ret)
+    end if
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+PIO_TF_AUTO_TEST_SUB_END three_files_two_iosystems_with_overlap

--- a/tests/general/util/pio_tf_f90gen.pl
+++ b/tests/general/util/pio_tf_f90gen.pl
@@ -372,7 +372,7 @@ sub transform_src
     $out_line = $out_line . $1 . "END IF";
     $cur_test_case_num += 1;
 }
-  elsif(/^(\s*)PIO_TF_PASSERT\((.+),([a-zA-Z0-9\s]+),([^)]+)\)(.*)$/s){
+  elsif(/^(\s*)PIO_TF_PASSERT\((.+),([^,]+),([^)]+)\)(.*)$/s){
     $out_line = $1 . $5 . "\n";
     $out_line = $out_line . $1 . "IF (.NOT. (PIO_TF_Passert_($2, $3))) THEN\n";
     $out_line = $out_line . $1 . "  pio_tf_retval_utest_ = -1\n";
@@ -409,7 +409,7 @@ sub transform_src
     $out_line = $out_line . $1 . "  RETURN\n";
     $out_line = $out_line . $1 . "END IF";
   }
-  elsif(/^(\s*)PIO_TF_CHECK_ERR\(([^,]+),([a-zA-Z0-9\s]+),(.+)\)(\s*)$/s){
+  elsif(/^(\s*)PIO_TF_CHECK_ERR\(([^,]+),([^,]+),(.+)\)(\s*)$/s){
     $out_line = $1 . $5 . "\n";
     $out_line = $out_line . $1 . "IF (.NOT. (PIO_TF_Passert_(($2) == PIO_NOERR, $3))) THEN\n";
     $out_line = $out_line . $1 . "  pio_tf_retval_utest_ = -1\n";

--- a/tests/general/util/pio_tf_f90gen.pl
+++ b/tests/general/util/pio_tf_f90gen.pl
@@ -375,8 +375,9 @@ sub transform_src
   elsif(/^(\s*)PIO_TF_PASSERT\((.+),([^,]+),([^)]+)\)(.*)$/s){
     $out_line = $1 . $5 . "\n";
     $out_line = $out_line . $1 . "IF (.NOT. (PIO_TF_Passert_($2, $3))) THEN\n";
+    $out_line = $out_line . $1 . "  call MPI_COMM_RANK($3, pio_tf_tmp_comm_rank_, pio_tf_retval_utest_)\n";
     $out_line = $out_line . $1 . "  pio_tf_retval_utest_ = -1\n";
-    $out_line = $out_line . $1 . "  IF (pio_tf_world_rank_ == 0) THEN\n";
+    $out_line = $out_line . $1 . "  IF (pio_tf_tmp_comm_rank_ == 0) THEN\n";
     $out_line = $out_line . $1 . "    PRINT *, \"PIO_TF: Assertion failed :\",&\n";
     $out_line = $out_line . $1 . "      " . $4 . ",&\n";
     $out_line = $out_line . $1 . "       \":\", __FILE__, \":\", __LINE__,&\n";
@@ -412,8 +413,9 @@ sub transform_src
   elsif(/^(\s*)PIO_TF_CHECK_ERR\(([^,]+),([^,]+),(.+)\)(\s*)$/s){
     $out_line = $1 . $5 . "\n";
     $out_line = $out_line . $1 . "IF (.NOT. (PIO_TF_Passert_(($2) == PIO_NOERR, $3))) THEN\n";
+    $out_line = $out_line . $1 . "  call MPI_COMM_RANK($3, pio_tf_tmp_comm_rank_, pio_tf_retval_utest_)\n";
     $out_line = $out_line . $1 . "  pio_tf_retval_utest_ = -1\n";
-    $out_line = $out_line . $1 . "  IF (pio_tf_world_rank_ == 0) THEN\n";
+    $out_line = $out_line . $1 . "  IF (pio_tf_tmp_comm_rank_ == 0) THEN\n";
     $out_line = $out_line . $1 . "    PRINT *, \"PIO_TF: PIO Function failed:\",&\n";
     $out_line = $out_line . $1 . "      " . $4 . ",&\n";
     $out_line = $out_line . $1 . "      \":\", __FILE__, \":\", __LINE__,&\n";


### PR DESCRIPTION
This change brings in the following changes,

* Re-enables pio_iosystem_tests2
* Adds a new test, pio_iosystem_tests3, that performs tests on iosystems with overlapping processes. This test works with pio1 but hangs with master (pio2_0_15-1049-gd3b1b13).
* Some testing infrastructure changes to improve error reporting