### PR TITLE
test fixes for cdash

### DIFF
--- a/tests/unit/pio_tests.h
+++ b/tests/unit/pio_tests.h
@@ -56,7 +56,6 @@ char err_buffer[MPI_MAX_ERROR_STRING];
 int resultlen;
 
 /* Function prototypes. */
-char *flavor_name(int flavor);
 int pio_test_init(int argc, char **argv, int *my_rank, int *ntasks, int target_ntasks, MPI_Comm *test_comm);
 int create_nc_sample(int sample, int iosysid, int format, char *filename, int my_rank, int *ncid);
 int check_nc_sample(int sample, int iosysid, int format, char *filename, int my_rank, int *ncid);

--- a/tests/unit/pio_tests.h
+++ b/tests/unit/pio_tests.h
@@ -67,6 +67,7 @@ int check_nc_sample_1(int iosysid, int format, char *filename, int my_rank, int 
 int create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *ncid);
 int check_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *ncid);
 int get_iotypes(int *num_flavors, int *flavors);
+int get_iotype_name(int iotype, char *name);
 int pio_test_finalize();
 
 #endif /* _PIO_TESTS_H */

--- a/tests/unit/test_async_4proc.c
+++ b/tests/unit/test_async_4proc.c
@@ -2,13 +2,7 @@
  * @file Tests for PIOc_Intercomm. This tests basic asynch I/O capability.
  * @author Ed Hartnett
  *
- * This very simple test runs on 32 ranks. Eight are used for IO, the
- * other 24 for computation. The netCDF sample files are created and
- * checked.
- *
- * To run with valgrind, use this command:
- * <pre>mpiexec -n 4 valgrind -v --leak-check=full --suppressions=../../../tests/unit/valsupp_test.supp
- * --error-exitcode=99 --track-origins=yes ./test_async_8io_24comp</pre>
+ * This very simple test runs on 4 ranks.
  *
  */
 #include <pio.h>
@@ -80,8 +74,12 @@ main(int argc, char **argv)
 
 		for (int sample = 0; sample < NUM_SAMPLES; sample++)
 		{
+		    char iotype_name[NC_MAX_NAME + 1];
+		    
 		    /* Create a filename. */
-		    sprintf(filename, "%s_%s_%d_%d.nc", TEST_NAME, flavor_name(flv), sample, my_comp_idx);
+		    if ((ret = get_iotype_name(flavor[flv], iotype_name)))
+			return ret;
+		    sprintf(filename, "%s_%s_%d_%d.nc", TEST_NAME, iotype_name, sample, my_comp_idx);
 
 		    /* Create sample file. */
 		    printf("%d %s creating file %s\n", my_rank, TEST_NAME, filename);

--- a/tests/unit/test_async_simple.c
+++ b/tests/unit/test_async_simple.c
@@ -39,59 +39,66 @@ main(int argc, char **argv)
     int ret; /* Return code. */
     int num_procs[COMPONENT_COUNT + 1] = {1, 1}; /* Num procs for IO and computation. */
     MPI_Comm test_comm;
+
     /* Initialize test. */
     if ((ret = pio_test_init(argc, argv, &my_rank, &ntasks, TARGET_NTASKS, &test_comm)))
 	ERR(ERR_INIT);
-    if(my_rank < TARGET_NTASKS)
+
+    /* Only do something on TARGET_NTASKS tasks. */
+    if (my_rank < TARGET_NTASKS)
     {
-      /* Figure out iotypes. */
-      if ((ret = get_iotypes(&num_flavors, flavor)))
-	ERR(ret);
+	/* Figure out iotypes. */
+	if ((ret = get_iotypes(&num_flavors, flavor)))
+	    ERR(ret);
 
-      /* Is the current process a computation task? */
-      int comp_task = my_rank < NUM_IO_PROCS ? 0 : 1;
+	/* Is the current process a computation task? */
+	int comp_task = my_rank < NUM_IO_PROCS ? 0 : 1;
 
-      /* Initialize the IO system. */
-      if ((ret = PIOc_Init_Async(test_comm, NUM_IO_PROCS, NULL, COMPONENT_COUNT,
-			       num_procs, NULL, iosysid)))
-	ERR(ERR_INIT);
+	/* Initialize the IO system. */
+	if ((ret = PIOc_Init_Async(test_comm, NUM_IO_PROCS, NULL, COMPONENT_COUNT,
+				   num_procs, NULL, iosysid)))
+	    ERR(ERR_INIT);
 
-      /* All the netCDF calls are only executed on the computation
-       * tasks. The IO tasks have not returned from PIOc_Init_Intercomm,
-       * and when the do, they should go straight to finalize. */
-      if (comp_task)
-      {
-    	for (int flv = 0; flv < num_flavors; flv++)
-    	{
-	    char filename[NC_MAX_NAME + 1]; /* Test filename. */
-	    int my_comp_idx = my_rank - 1; /* Index in iosysid array. */
-
-	    for (int sample = 0; sample < NUM_SAMPLES; sample++)
-	    {
-		/* Create a filename. */
-		sprintf(filename, "%s_%s_%d_%d.nc", TEST_NAME, flavor_name(flv), sample, my_comp_idx);
-
-		/* Create sample file. */
-		printf("%d %s creating file %s\n", my_rank, TEST_NAME, filename);
-		if ((ret = create_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-		    ERR(ret);
-
-		/* Check the file for correctness. */
-		if ((ret = check_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-		    ERR(ret);
-	    }
-    	} /* next netcdf flavor */
-
-	/* Finalize the IO system. Only call this from the computation tasks. */
-	printf("%d %s Freeing PIO resources\n", my_rank, TEST_NAME);
-	for (int c = 0; c < COMPONENT_COUNT; c++)
+	/* All the netCDF calls are only executed on the computation
+	 * tasks. The IO tasks have not returned from PIOc_Init_Intercomm,
+	 * and when the do, they should go straight to finalize. */
+	if (comp_task)
 	{
-	    if ((ret = PIOc_finalize(iosysid[c])))
-		ERR(ret);
-	    printf("%d %s PIOc_finalize completed for iosysid = %d\n", my_rank, TEST_NAME,
-		   iosysid[c]);
-	}
-      } /* endif comp_task */
+	    for (int flv = 0; flv < num_flavors; flv++)
+	    {
+		int my_comp_idx = my_rank - 1; /* Index in iosysid array. */
+
+		for (int sample = 0; sample < NUM_SAMPLES; sample++)
+		{
+		    char filename[NC_MAX_NAME + 1]; /* Test filename. */
+		    char iotype_name[NC_MAX_NAME + 1];
+	    
+		    /* Create a filename. */
+		    if ((ret = get_iotype_name(flavor[flv], iotype_name)))
+			return ret;
+		    sprintf(filename, "%s_%s_%d_%d.nc", TEST_NAME, iotype_name, sample, my_comp_idx);
+
+		    /* Create sample file. */
+		    printf("%d %s creating file %s\n", my_rank, TEST_NAME, filename);
+		    if ((ret = create_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
+			ERR(ret);
+
+		    /* Check the file for correctness. */
+		    if ((ret = check_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
+			ERR(ret);
+		}
+	    } /* next netcdf flavor */
+
+	    /* Finalize the IO system. Only call this from the computation tasks. */
+	    printf("%d %s Freeing PIO resources\n", my_rank, TEST_NAME);
+	    for (int c = 0; c < COMPONENT_COUNT; c++)
+	    {
+		if ((ret = PIOc_finalize(iosysid[c])))
+		    ERR(ret);
+		printf("%d %s PIOc_finalize completed for iosysid = %d\n", my_rank, TEST_NAME,
+		       iosysid[c]);
+	    }
+	} /* endif comp_task */
     } /* endif my_rank < TARGET_NTASKS */
     /* Wait for everyone to catch up. */
     printf("%d %s waiting for all processes!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_intercomm2.c
+++ b/tests/unit/test_intercomm2.c
@@ -22,10 +22,6 @@
 /* Number of computational components to create. */
 #define COMPONENT_COUNT 1
 
-/** The number of possible output netCDF output flavors available to
- * the ParallelIO library. */
-#define NUM_NETCDF_FLAVORS 4
-
 /** The number of dimensions in the test data. */
 #define NDIM 1
 
@@ -54,7 +50,6 @@
 /** Error code for when things go wrong. */
 #define ERR_AWFUL 1111
 #define ERR_WRONG 2222
-
 
 /** Global err buffer for MPI. When there is an MPI error, this buffer
  * is used to store the error message that is associated with the MPI
@@ -264,17 +259,11 @@ main(int argc, char **argv)
     /** Number of processors involved in current execution. */
     int ntasks;
 
-    /** Different output flavors. */
-    int format[NUM_NETCDF_FLAVORS] = {PIO_IOTYPE_PNETCDF,
-				      PIO_IOTYPE_NETCDF,
-				      PIO_IOTYPE_NETCDF4C,
-				      PIO_IOTYPE_NETCDF4P};
+    int num_flavors; /* Number of PIO netCDF flavors in this build. */
+    int flavor[NUM_FLAVORS]; /* iotypes for the supported netCDF IO flavors. */
 
     /** Names for the output files. */
-    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"test_intercomm2_pnetcdf.nc",
-							  "test_intercomm2_classic.nc",
-							  "test_intercomm2_serial4.nc",
-							  "test_intercomm2_parallel4.nc"};
+    char filename[NUM_FLAVORS][NC_MAX_NAME + 1];
 
     /** The ID for the parallel I/O system. */
     int iosysid[COMPONENT_COUNT];
@@ -295,6 +284,11 @@ main(int argc, char **argv)
 
     if ((ret = pio_test_init(argc, argv, &my_rank, &ntasks, TARGET_NTASKS, &test_comm)))
 	ERR(ERR_INIT);
+
+    /* Figure out iotypes. */
+    if ((ret = get_iotypes(&num_flavors, flavor)))
+      ERR(ret);
+
     if(my_rank < TARGET_NTASKS)
     {
       if (verbose)
@@ -334,16 +328,19 @@ main(int argc, char **argv)
        * and when the do, they should go straight to finalize. */
       if (comp_task)
       {
-    	for (int fmt = 1; fmt < NUM_NETCDF_FLAVORS; fmt++)
+    	for (int fmt = 1; fmt < num_flavors; fmt++)
     	{
     	    int ncid, varid, dimid;
     	    PIO_Offset start[NDIM], count[NDIM] = {0};
     	    int data[DIM_LEN];
 
+	    /* Create the filename for this flavor. */
+	    sprintf(filename[fmt], "test_intercomm2_%d.nc", flavor[fmt]);
+
     	    /* Create a netCDF file with one dimension and one variable. */
     	    if (verbose)
     	    	printf("%d test_intercomm2 creating file %s\n", my_rank, filename[fmt]);
-    	    if ((ret = PIOc_createfile(iosysid[my_comp_idx], &ncid, &format[fmt], filename[fmt],
+    	    if ((ret = PIOc_createfile(iosysid[my_comp_idx], &ncid, &flavor[fmt], filename[fmt],
     	    			       NC_CLOBBER)))
     	    	ERR(ret);
     	    if (verbose)
@@ -361,10 +358,10 @@ main(int argc, char **argv)
     	    int myformat;
     	    if ((ret = PIOc_inq_format(ncid, &myformat)))
     	    	ERR(ret);
-    	    if ((format[fmt] == PIO_IOTYPE_PNETCDF || format[fmt] == PIO_IOTYPE_NETCDF) &&
+    	    if ((flavor[fmt] == PIO_IOTYPE_PNETCDF || flavor[fmt] == PIO_IOTYPE_NETCDF) &&
     	    	myformat != 1)
     	    	ERR(ERR_AWFUL);
-    	    else if ((format[fmt] == PIO_IOTYPE_NETCDF4C || format[fmt] == PIO_IOTYPE_NETCDF4P) &&
+    	    else if ((flavor[fmt] == PIO_IOTYPE_NETCDF4C || flavor[fmt] == PIO_IOTYPE_NETCDF4P) &&
     	    	     myformat != 3)
     	    	ERR(ERR_AWFUL);
 
@@ -375,7 +372,7 @@ main(int argc, char **argv)
     	    nc_type xtype[NUM_TYPES] = {NC_CHAR, NC_BYTE, NC_SHORT, NC_INT, NC_FLOAT, NC_DOUBLE,
     	    				NC_UBYTE, NC_USHORT, NC_UINT, NC_INT64, NC_UINT64};
     	    int type_len[NUM_TYPES] = {1, 1, 2, 4, 4, 8, 1, 2, 4, 8, 8};
-    	    int max_type = format[fmt] == PIO_IOTYPE_NETCDF ? NC_DOUBLE : NC_UINT64;
+    	    int max_type = flavor[fmt] == PIO_IOTYPE_NETCDF ? NC_DOUBLE : NC_UINT64;
     	    for (int i = 0; i < max_type; i++)
     	    {
     	    	if ((ret = PIOc_inq_type(ncid, xtype[i], type_name, &type_size)))
@@ -479,17 +476,17 @@ main(int argc, char **argv)
     	    	ERR(ret);
 
     	    /* Check the file for correctness. */
-    	    if ((ret = check_file(iosysid[my_comp_idx], format[fmt], filename[fmt], my_rank, verbose)))
+    	    if ((ret = check_file(iosysid[my_comp_idx], flavor[fmt], filename[fmt], my_rank, verbose)))
     	    	ERR(ret);
 
     	    /* Now delete the file. */
     	    /* if ((ret = PIOc_deletefile(iosysid, filename[fmt]))) */
     	    /* 	ERR(ret); */
-    	    /* if ((ret = PIOc_openfile(iosysid, &ncid, &format[fmt], filename[fmt], */
+    	    /* if ((ret = PIOc_openfile(iosysid, &ncid, &flavor[fmt], filename[fmt], */
     	    /* 			     NC_NOWRITE)) != PIO_ENFILE) */
     	    /* 	ERR(ERR_AWFUL); */
 
-    	} /* next netcdf format flavor */
+    	} /* next netcdf flavor */
 
 	/* Finalize the IO system. Only call this from the computation tasks. */
 	if (verbose)

--- a/tests/unit/test_iosystem2_simple2.c
+++ b/tests/unit/test_iosystem2_simple2.c
@@ -47,85 +47,92 @@ main(int argc, char **argv)
 
     /* Figure out iotypes. */
     if ((ret = get_iotypes(&num_flavors, flavor)))
-      ERR(ret);
+	ERR(ret);
 
-
+    /* Only do something on the first TARGET_NTASKS tasks. */
     if (my_rank < TARGET_NTASKS)
     {
-      /* Split world into odd and even. */
-      MPI_Comm newcomm;
-      int even = my_rank % 2 ? 0 : 1;
-      if ((ret = MPI_Comm_split(test_comm, even, 0, &newcomm)))
-	MPIERR(ret);
-      printf("%d newcomm = %d even = %d\n", my_rank, newcomm, even);
+	/* Split world into odd and even. */
+	MPI_Comm newcomm;
+	int even = my_rank % 2 ? 0 : 1;
+	if ((ret = MPI_Comm_split(test_comm, even, 0, &newcomm)))
+	    MPIERR(ret);
+	printf("%d newcomm = %d even = %d\n", my_rank, newcomm, even);
 
-      /* Get size of new communicator. */
-      int new_size;
-      if ((ret = MPI_Comm_size(newcomm, &new_size)))
-	MPIERR(ret);
+	/* Get size of new communicator. */
+	int new_size;
+	if ((ret = MPI_Comm_size(newcomm, &new_size)))
+	    MPIERR(ret);
 
-      /* Initialize an intracomm for evens/odds. */
-      if ((ret = PIOc_Init_Intracomm(newcomm, new_size, STRIDE, BASE, REARRANGER, &iosysid)))
-	ERR(ret);
+	/* Initialize an intracomm for evens/odds. */
+	if ((ret = PIOc_Init_Intracomm(newcomm, new_size, STRIDE, BASE, REARRANGER, &iosysid)))
+	    ERR(ret);
 
-      /* Initialize an intracomm for all processes. */
-      if ((ret = PIOc_Init_Intracomm(test_comm, TARGET_NTASKS, STRIDE, BASE, REARRANGER,
-				   &iosysid_world)))
-	ERR(ret);
+	/* Initialize an intracomm for all processes. */
+	if ((ret = PIOc_Init_Intracomm(test_comm, TARGET_NTASKS, STRIDE, BASE, REARRANGER,
+				       &iosysid_world)))
+	    ERR(ret);
 
-      int ncid;
-      int ncid2;
-      for (int flv = 0; flv < num_flavors; flv++)
-      {
-	char fn[NUM_FILES][NC_MAX_NAME + 1];
-	char dimname[NC_MAX_NAME + 1];
-	char filename[NUM_SAMPLES][NC_MAX_NAME + 1]; /* Test filename. */
-	int sample_ncid[NUM_SAMPLES];
-
-	for (int sample = 0; sample < NUM_SAMPLES; sample++)
-	{
-	    /* Create a filename. */
-	    sprintf(filename[sample], "%s_%s_%d_%d.nc", TEST_NAME, flavor_name(flv), sample, 0);
-
-	    /* Create sample file. */
-	    printf("%d %s creating file %s\n", my_rank, TEST_NAME, filename[sample]);
-	    if ((ret = create_nc_sample(sample, iosysid_world, flavor[flv], filename[sample], my_rank, NULL)))
-		ERR(ret);
-
-	    /* Check the file for correctness. */
-	    if ((ret = check_nc_sample(sample, iosysid_world, flavor[flv], filename[sample], my_rank, &sample_ncid[sample])))
-		ERR(ret);
-
-	}
-
-	/* Now check the files with the other iosysid. Even and odd
-	 * processes will check different files. */
-	int this_sample = even ? 0 : 1;
-	char *file1 = filename[this_sample];
+	int ncid;
 	int ncid2;
-	if ((ret = check_nc_sample(this_sample, iosysid, flavor[flv], file1, my_rank, &ncid2)))
-	    ERR(ret);
+	for (int flv = 0; flv < num_flavors; flv++)
+	{
+	    char fn[NUM_FILES][NC_MAX_NAME + 1];
+	    char dimname[NC_MAX_NAME + 1];
+	    char filename[NUM_SAMPLES][NC_MAX_NAME + 1]; /* Test filename. */
+	    int sample_ncid[NUM_SAMPLES];
 
-	/* Now close the open files. */
-	for (int sample = 0; sample < NUM_SAMPLES; sample++)
-	    if ((ret = PIOc_closefile(sample_ncid[sample])))
+	    for (int sample = 0; sample < NUM_SAMPLES; sample++)
+	    {
+		char iotype_name[NC_MAX_NAME + 1];
+		
+		/* Create a filename. */
+		if ((ret = get_iotype_name(flavor[flv], iotype_name)))
+		    return ret;
+		sprintf(filename[sample], "%s_%s_%d_%d.nc", TEST_NAME, iotype_name, sample, 0);
+
+		/* Create sample file. */
+		printf("%d %s creating file %s\n", my_rank, TEST_NAME, filename[sample]);
+		if ((ret = create_nc_sample(sample, iosysid_world, flavor[flv], filename[sample], my_rank, NULL)))
+		    ERR(ret);
+
+		/* Check the file for correctness. */
+		if ((ret = check_nc_sample(sample, iosysid_world, flavor[flv], filename[sample], my_rank, &sample_ncid[sample])))
+		    ERR(ret);
+
+	    }
+
+	    /* Now check the files with the other iosysid. Even and odd
+	     * processes will check different files. */
+	    int this_sample = even ? 0 : 1;
+	    char *file1 = filename[this_sample];
+	    int ncid2;
+	    if ((ret = check_nc_sample(this_sample, iosysid, flavor[flv], file1, my_rank, &ncid2)))
 		ERR(ret);
 
-	if ((ret = PIOc_closefile(ncid2)))
+	    /* Now close the open files. */
+	    for (int sample = 0; sample < NUM_SAMPLES; sample++)
+		if ((ret = PIOc_closefile(sample_ncid[sample])))
+		    ERR(ret);
+
+	    if ((ret = PIOc_closefile(ncid2)))
+		ERR(ret);
+
+	} /* next iotype */
+
+	/* Finalize PIO odd/even intracomm. */
+	if ((ret = PIOc_finalize(iosysid)))
 	    ERR(ret);
 
-      } /* next iotype */
-
-      /* Finalize PIO odd/even intracomm. */
-      if ((ret = PIOc_finalize(iosysid)))
-	ERR(ret);
-
-      /* Finalize PIO world intracomm. */
-      if ((ret = PIOc_finalize(iosysid_world)))
-	ERR(ret);
+	/* Finalize PIO world intracomm. */
+	if ((ret = PIOc_finalize(iosysid_world)))
+	    ERR(ret);
 
     }  /* my_rank < TARGET_NTASKS */
+
+    /* Wait for all task before finalizing. */
     MPI_Barrier(MPI_COMM_WORLD);
+    
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
     if ((ret = pio_test_finalize()))


### PR DESCRIPTION
These are some fixes for test code that will (hopefully) make it pass CDash on yellowstone.

In one case the test was not handling the fact that all different iotypes may not be present.

In all other cases the problem had to do with creating the filename of the output test file. The string that provided the iotype name as not being copied correctly and leading to corrupt filenames.

These changes are all to test code - no changes to library code.