### PR TITLE
check params - part 1

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -999,12 +999,10 @@ int PIOc_write_darray_multi(const int ncid, const int *vid, const int ioid,
 
     ierr = PIO_NOERR;
 
-    file = pio_get_file_from_id(ncid);
-    if (file == NULL)
-    {
-	fprintf(stderr,"File handle not found %d %d\n",ncid,__LINE__);
-	return PIO_EBADID;
-    }
+    /* Get the file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
+
     if (! (file->mode & PIO_WRITE))
     {
 	fprintf(stderr,"ERROR:  Attempt to write to read-only file\n");
@@ -1209,12 +1207,11 @@ int PIOc_write_darray(const int ncid, const int vid, const int ioid,
 
     ierr = PIO_NOERR;
     needsflush = 0; // false
-    file = pio_get_file_from_id(ncid);
-    if (file == NULL)
-    {
-	fprintf(stderr,"File handle not found %d %d\n",ncid,__LINE__);
-	return PIO_EBADID;
-    }
+
+    /* Get the file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
+
     if (! (file->mode & PIO_WRITE))
     {
 	fprintf(stderr,"ERROR:  Attempt to write to read-only file\n");
@@ -1832,13 +1829,10 @@ int PIOc_read_darray(const int ncid, const int vid, const int ioid,
     int ierr, tsize;
     MPI_Datatype vtype;
 
-    file = pio_get_file_from_id(ncid);
+    /* Get the file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
 
-    if (file == NULL)
-    {
-	fprintf(stderr,"File handle not found %d %d\n",ncid,__LINE__);
-	return PIO_EBADID;
-    }
     iodesc = pio_get_iodesc_from_id(ioid);
     if (iodesc == NULL)
     {

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -524,8 +524,8 @@ int PIOc_closefile(int ncid)
     LOG((1, "PIOc_closefile ncid = %d", ncid));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
     ios = file->iosystem;
 
     /* Sync changes before closing. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -672,8 +672,8 @@ int PIOc_sync(int ncid)
     wmulti_buffer *wmb, *twmb;
 
     /* Get the file info from the ncid. */
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, send message to IO master tasks. */

--- a/src/clib/pio_get_nc.c
+++ b/src/clib/pio_get_nc.c
@@ -71,8 +71,8 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 	return PIO_EINVAL;
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* Run these on all tasks if async is not in use, but only on
@@ -629,10 +629,11 @@ int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Dataty
     int ibufcnt;
     bool bcast = false;
 
-    file = pio_get_file_from_id(ncid);
-    if(file == NULL)
-	return PIO_EBADID;
+    /* Get the file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
+    
     msg = PIO_MSG_GET_VAR;
     ibufcnt = bufcount;
     ibuftype = buftype;
@@ -701,10 +702,11 @@ int PIOc_get_var1(int ncid, int varid, const PIO_Offset *index, void *buf, PIO_O
     int ibufcnt;
     bool bcast = false;
 
-    file = pio_get_file_from_id(ncid);
-    if(file == NULL)
-	return PIO_EBADID;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
+    
     msg = PIO_MSG_GET_VAR1;
     ibufcnt = bufcount;
     ibuftype = buftype;
@@ -774,10 +776,11 @@ int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
     int ibufcnt;
     bool bcast = false;
 
-    file = pio_get_file_from_id(ncid);
-    if(file == NULL)
-	return PIO_EBADID;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
+    
     msg = PIO_MSG_GET_VARA;
     ibufcnt = bufcount;
     ibuftype = buftype;
@@ -847,10 +850,11 @@ int PIOc_get_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
     int ibufcnt;
     bool bcast = false;
 
-    file = pio_get_file_from_id(ncid);
-    if(file == NULL)
-	return PIO_EBADID;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
+    
     msg = PIO_MSG_GET_VARS;
     ibufcnt = bufcount;
     ibuftype = buftype;

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -78,7 +78,6 @@ extern "C" {
     int pio_delete_iodesc_from_list(int ioid);
     int pio_num_iosystem(int *niosysid);
 
-    file_desc_t *pio_get_file_from_id(int ncid);
     int pio_get_file(int ncid, file_desc_t **filep);
     int pio_delete_file_from_list(int ncid);
     void pio_add_to_file_list(file_desc_t *file);

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -79,7 +79,7 @@ extern "C" {
     int pio_num_iosystem(int *niosysid);
 
     file_desc_t *pio_get_file_from_id(int ncid);
-    int pio_get_file_from_id2(int ncid, file_desc_t **filep);
+    int pio_get_file(int ncid, file_desc_t **filep);
     int pio_delete_file_from_list(int ncid);
     void pio_add_to_file_list(file_desc_t *file);
     void pio_push_request(file_desc_t *file, int request);

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -60,8 +60,7 @@ file_desc_t *pio_get_file_from_id(int ncid)
 }
 
 /** Get a pointer to the file_desc_t using the ncid. */
-int
-pio_get_file(int ncid, file_desc_t **cfile1)
+int pio_get_file(int ncid, file_desc_t **cfile1)
 {
     file_desc_t *cfile = NULL;
 

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -40,31 +40,20 @@ void pio_add_to_file_list(file_desc_t *file)
 }
 
 /** Given ncid, find the file_desc_t data for an open file. The ncid
- * used is the interally generated pio_ncid. */
-/* file_desc_t *pio_get_file_from_id(int ncid) */
-/* { */
-/*     file_desc_t *cfile = NULL; */
-
-/*     /\* Check to see if the current_file is already set to this ncid. *\/ */
-/*     if (current_file && current_file->pio_ncid == ncid) */
-/* 	cfile = current_file; */
-/*     else */
-/* 	for (cfile = pio_file_list; cfile; cfile = cfile->next) */
-/* 	    if (cfile->pio_ncid == ncid) */
-/* 	    { */
-/* 		current_file = cfile; */
-/* 		break; */
-/* 	    } */
-
-/*     return cfile; */
-/* } */
-
-/** Get a pointer to the file_desc_t using the ncid. */
+ * used is the interally generated pio_ncid. 
+ *
+ * @param ncid the PIO assigned ncid of the open file.
+ * @param cfile1 pointer to a pointer to a file_desc_t. The pointer
+ * will get a copy of the pointer to the file info. 
+ *
+ * @returns 0 for success, error code otherwise. 
+ * @internal
+*/
 int pio_get_file(int ncid, file_desc_t **cfile1)
 {
     file_desc_t *cfile = NULL;
 
-    LOG((2, "pio_get_file_from_id2 ncid = %d", ncid));
+    LOG((2, "pio_get_file ncid = %d", ncid));
 
     /* Caller must provide this. */
     if (!cfile1)
@@ -75,13 +64,11 @@ int pio_get_file(int ncid, file_desc_t **cfile1)
 	cfile = current_file;
     else
 	for (cfile = pio_file_list; cfile; cfile=cfile->next)
-	{
 	    if (cfile->pio_ncid == ncid)
 	    {
 		current_file = cfile;
 		break;
 	    }
-	}
 
     /* If not found, return error. */
     if (!cfile)
@@ -90,8 +77,6 @@ int pio_get_file(int ncid, file_desc_t **cfile1)
     /* We depend on every file having a pointer to the iosystem. */
     if (!cfile->iosystem)
 	return PIO_EINVAL;
-
-    LOG((3, "file found!"));
 
     /* Copy pointer to file info. */
     *cfile1 = cfile;

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -61,7 +61,7 @@ file_desc_t *pio_get_file_from_id(int ncid)
 
 /** Get a pointer to the file_desc_t using the ncid. */
 int
-pio_get_file_from_id2(int ncid, file_desc_t **cfile1)
+pio_get_file(int ncid, file_desc_t **cfile1)
 {
     file_desc_t *cfile = NULL;
 

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -41,23 +41,23 @@ void pio_add_to_file_list(file_desc_t *file)
 
 /** Given ncid, find the file_desc_t data for an open file. The ncid
  * used is the interally generated pio_ncid. */
-file_desc_t *pio_get_file_from_id(int ncid)
-{
-    file_desc_t *cfile = NULL;
+/* file_desc_t *pio_get_file_from_id(int ncid) */
+/* { */
+/*     file_desc_t *cfile = NULL; */
 
-    /* Check to see if the current_file is already set to this ncid. */
-    if (current_file && current_file->pio_ncid == ncid)
-	cfile = current_file;
-    else
-	for (cfile = pio_file_list; cfile; cfile = cfile->next)
-	    if (cfile->pio_ncid == ncid)
-	    {
-		current_file = cfile;
-		break;
-	    }
+/*     /\* Check to see if the current_file is already set to this ncid. *\/ */
+/*     if (current_file && current_file->pio_ncid == ncid) */
+/* 	cfile = current_file; */
+/*     else */
+/* 	for (cfile = pio_file_list; cfile; cfile = cfile->next) */
+/* 	    if (cfile->pio_ncid == ncid) */
+/* 	    { */
+/* 		current_file = cfile; */
+/* 		break; */
+/* 	    } */
 
-    return cfile;
-}
+/*     return cfile; */
+/* } */
 
 /** Get a pointer to the file_desc_t using the ncid. */
 int pio_get_file(int ncid, file_desc_t **cfile1)

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -88,6 +88,10 @@ pio_get_file(int ncid, file_desc_t **cfile1)
     if (!cfile)
 	return PIO_EBADID;
 
+    /* We depend on every file having a pointer to the iosystem. */
+    if (!cfile->iosystem)
+	return PIO_EINVAL;
+
     LOG((3, "file found!"));
 
     /* Copy pointer to file info. */

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -45,8 +45,8 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
     LOG((1, "PIOc_inq ncid = %d", ncid));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -251,8 +251,8 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
     LOG((1, "PIOc_inq_type ncid = %d xtype = %d", ncid, xtype));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -339,8 +339,8 @@ int PIOc_inq_format (int ncid, int *formatp)
     LOG((1, "PIOc_inq ncid = %d", ncid));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -643,8 +643,8 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
     LOG((1, "PIOc_inq_var ncid = %d varid = %d", ncid, varid));
 
     /* Get the file info, based on the ncid. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     LOG((2, "got file and iosystem"));
 
@@ -850,8 +850,8 @@ int PIOc_inq_varid (int ncid, const char *name, int *varidp)
         return PIO_EINVAL;
 
     /* Get file info based on ncid. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     LOG((1, "PIOc_inq_varid ncid = %d name = %s", ncid, name));
@@ -944,8 +944,8 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
          ncid, varid, xtypep, lenp));
 
     /* Find file based on ncid. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1061,8 +1061,8 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
          attnum));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1159,8 +1159,8 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
     LOG((1, "PIOc_inq_attid ncid = %d varid = %d name = %s", ncid, varid, name));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1254,8 +1254,8 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
     LOG((1, "PIOc_rename_dim ncid = %d dimid = %d name = %s", ncid, dimid, name));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1342,8 +1342,8 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
     LOG((1, "PIOc_rename_var ncid = %d varid = %d name = %s", ncid, varid, name));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1434,8 +1434,8 @@ int PIOc_rename_att (int ncid, int varid, const char *name,
          ncid, varid, name, newname));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1524,8 +1524,8 @@ int PIOc_del_att(int ncid, int varid, const char *name)
     LOG((1, "PIOc_del_att ncid = %d varid = %d name = %s", ncid, varid, name));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1605,8 +1605,8 @@ int PIOc_set_fill (int ncid, int fillmode, int *old_modep)
          old_modep));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1671,8 +1671,8 @@ int pioc_change_def(int ncid, int is_enddef)
     LOG((2, "pioc_change_def ncid = %d is_enddef = %d", ncid, is_enddef));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1797,8 +1797,8 @@ int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp)
     LOG((1, "PIOc_def_dim ncid = %d name = %s len = %d", ncid, name, len));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1893,11 +1893,8 @@ int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims,
     }
 
     /* Get the file information. */
-    if (!(file = pio_get_file_from_id(ncid)))
-    {
-        check_netcdf(file, PIO_EBADID, __FILE__, __LINE__);     
-        return PIO_EBADID;
-    }
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If using async, and not an IO task, then send parameters. */
@@ -1995,8 +1992,8 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
     LOG((1, "PIOc_inq ncid = %d", ncid));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -2081,8 +2078,8 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
     LOG((1, "PIOc_get_att ncid %d varid %d name %s", ncid, varid, name));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* Run these on all tasks if async is not in use, but only on
@@ -2216,8 +2213,8 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
     LOG((1, "PIOc_put_att ncid = %d varid = %d name = %s", ncid, varid, name));
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-        return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* Run these on all tasks if async is not in use, but only on

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -421,7 +421,7 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
     LOG((1, "PIOc_inq_dim ncid = %d dimid = %d", ncid, dimid));
 
     /* Get the file info, based on the ncid. */
-    if ((ierr = pio_get_file_from_id2(ncid, &file)))
+    if ((ierr = pio_get_file(ncid, &file)))
         return ierr;
     ios = file->iosystem;
 
@@ -552,7 +552,7 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
     LOG((1, "PIOc_inq_dimid ncid = %d name = %s", ncid, name));
 
     /* Get the file info, based on the ncid. */
-    if ((ierr = pio_get_file_from_id2(ncid, &file)))
+    if ((ierr = pio_get_file(ncid, &file)))
 	return ierr;
     ios = file->iosystem;
     LOG((2, "iosysid = %d", ios->iosysid));    

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -41,8 +41,9 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
     errstr = NULL;
     ierr = PIO_NOERR;
 
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    /* Get the file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_DEF_VAR_DEFLATE;
 
@@ -141,8 +142,9 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
     errstr = NULL;
     ierr = PIO_NOERR;
 
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    /* Get the file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_INQ_VAR_DEFLATE;
 
@@ -243,8 +245,8 @@ int PIOc_def_var_chunking(int ncid, int varid, int storage,
     errstr = NULL;
 
     /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -343,8 +345,8 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
     errstr = NULL;
     ierr = PIO_NOERR;
 
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_INQ_VAR_CHUNKING;
 
@@ -448,8 +450,8 @@ int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
     errstr = NULL;
     ierr = PIO_NOERR;
 
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_SET_FILL;
 
@@ -543,8 +545,8 @@ int PIOc_def_var_endian(int ncid, int varid, int endian)
     errstr = NULL;
     ierr = PIO_NOERR;
 
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_DEF_VAR_ENDIAN;
 
@@ -636,8 +638,8 @@ int PIOc_inq_var_endian(int ncid, int varid, int *endianp)
     errstr = NULL;
     ierr = PIO_NOERR;
 
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_INQ_VAR_CHUNKING;
 
@@ -916,8 +918,8 @@ int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset ne
     errstr = NULL;
     ierr = PIO_NOERR;
 
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_SET_VAR_CHUNK_CACHE;
 
@@ -1009,8 +1011,8 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset 
     errstr = NULL;
     ierr = PIO_NOERR;
 
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* Since this is a property of the running HDF5 instance, not the

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -72,9 +72,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     if (!buf)
 	return PIO_EINVAL;
 
-    /* Find the info about this file. */
-    if (!(file = pio_get_file_from_id(ncid)))
-	return PIO_EBADID;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
 
     /* Run these on all tasks if async is not in use, but only on
@@ -711,10 +711,11 @@ int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
 
     ierr = PIO_NOERR;
 
-    file = pio_get_file_from_id(ncid);
-    if(file == NULL)
-	return PIO_EBADID;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
+    
     msg = PIO_MSG_PUT_VAR;
 
     if(ios->async_interface && ! ios->ioproc){
@@ -793,10 +794,11 @@ int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     ierr = PIO_NOERR;
 
-    file = pio_get_file_from_id(ncid);
-    if(file == NULL)
-	return PIO_EBADID;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
+    
     msg = PIO_MSG_PUT_VARS;
 
     if(ios->async_interface && ! ios->ioproc){
@@ -868,10 +870,11 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
 
     ierr = PIO_NOERR;
 
-    file = pio_get_file_from_id(ncid);
-    if(file == NULL)
-	return PIO_EBADID;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
+    
     msg = PIO_MSG_PUT_VAR1;
 
     if(ios->async_interface && ! ios->ioproc){
@@ -941,10 +944,11 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     ierr = PIO_NOERR;
 
-    file = pio_get_file_from_id(ncid);
-    if(file == NULL)
-	return PIO_EBADID;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+	return ierr;
     ios = file->iosystem;
+    
     msg = PIO_MSG_PUT_VARA;
 
     if(ios->async_interface && ! ios->ioproc){

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -22,9 +22,13 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
+
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM;
 
@@ -97,9 +101,9 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_UCHAR;
 
@@ -172,9 +176,9 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_SHORT;
 
@@ -246,9 +250,9 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_TEXT;
 
@@ -323,9 +327,9 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_USHORT;
 
@@ -400,9 +404,9 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_ULONGLONG;
 
@@ -476,9 +480,9 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_INT;
 
@@ -553,9 +557,9 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_FLOAT;
 
@@ -629,9 +633,9 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_LONG;
 
@@ -706,9 +710,9 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_UINT;
 
@@ -783,9 +787,9 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_DOUBLE;
 
@@ -859,9 +863,9 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_SCHAR;
 
@@ -936,9 +940,9 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
 
   ierr = PIO_NOERR;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_PUT_VARM_LONGLONG;
 
@@ -1003,9 +1007,9 @@ int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_UCHAR;
   ibuftype = MPI_UNSIGNED_CHAR;
@@ -1080,9 +1084,9 @@ int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_SCHAR;
   ibuftype = MPI_CHAR;
@@ -1157,9 +1161,9 @@ int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const P
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_DOUBLE;
   ibuftype = MPI_DOUBLE;
@@ -1234,9 +1238,9 @@ int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_TEXT;
   ibuftype = MPI_CHAR;
@@ -1311,9 +1315,9 @@ int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_INT;
   ibuftype = MPI_INT;
@@ -1388,9 +1392,9 @@ int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_UINT;
   ibuftype = MPI_UNSIGNED;
@@ -1465,9 +1469,9 @@ int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM;
   ibufcnt = bufcount;
@@ -1538,9 +1542,9 @@ int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_FLOAT;
   ibuftype = MPI_FLOAT;
@@ -1615,9 +1619,9 @@ int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_LONG;
   ibuftype = MPI_LONG;
@@ -1692,9 +1696,9 @@ int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_USHORT;
   ibuftype = MPI_UNSIGNED_SHORT;
@@ -1769,9 +1773,9 @@ int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_LONGLONG;
   ibuftype = MPI_LONG_LONG;
@@ -1846,9 +1850,9 @@ int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_SHORT;
   ibuftype = MPI_SHORT;
@@ -1923,9 +1927,9 @@ int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
   int ibufcnt;
   bool bcast = false;
 
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  /* Get file info. */
+  if ((ierr = pio_get_file(ncid, &file)))
+      return ierr;
   ios = file->iosystem;
   msg = PIO_MSG_GET_VARM_ULONGLONG;
   ibuftype = MPI_UNSIGNED_LONG_LONG;

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -36,12 +36,13 @@ int PIOc_iosystem_is_active(const int iosysid, bool *active)
 
 int PIOc_File_is_Open(int ncid)
 {
-  file_desc_t *file;
-  file = pio_get_file_from_id(ncid);
-  if(file==NULL)
-    return 0;
-  else
-    return 1;
+    file_desc_t *file;
+
+    /* If get file returns non-zero, then this file is not open. */
+    if (pio_get_file(ncid, &file))
+	return 0;
+    else
+	return 1;
 }
 
 /**

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -69,10 +69,12 @@ int PIOc_Set_File_Error_Handling(int ncid, int method)
 int PIOc_advanceframe(int ncid, int varid)
 {
   file_desc_t *file;
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL)
-    return PIO_EBADID;
+  int ret;
 
+  /* Get the file info. */
+  if ((ret = pio_get_file(ncid, &file)))
+      return ret;
+      
   file->varlist[varid].record++;
 
   return(PIO_NOERR);
@@ -92,14 +94,19 @@ int PIOc_advanceframe(int ncid, int varid)
 int PIOc_setframe(const int ncid, const int varid, const int frame)
 {
   file_desc_t *file;
-  file = pio_get_file_from_id(ncid);
-  if(file == NULL || varid<0 || varid>=PIO_MAX_VARS){
-    return PIO_EBADID;
-  }
+  int ret;
+
+  /* Check inputs. */
+  if (varid < 0 || varid >= PIO_MAX_VARS)
+    return PIO_EINVAL;
+  
+  /* Get file info. */
+  if ((ret = pio_get_file(ncid, &file)))
+      return ret;
 
   file->varlist[varid].record = frame;
 
-  return(PIO_NOERR);
+  return PIO_NOERR;
 }
 
 /**

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -52,10 +52,11 @@ int PIOc_Set_File_Error_Handling(int ncid, int method)
 {
   file_desc_t *file;
   int oldmethod;
+  int ret;
 
   /* Find info for this file. */
-  if (!(file = pio_get_file_from_id(ncid)))
-      return PIO_EBADID;
+  if ((ret = pio_get_file(ncid, &file)))
+      return ret;
   
   oldmethod = file->iosystem->error_handler;
   file->iosystem->error_handler = method;


### PR DESCRIPTION
In the recently rolled-back PR, the following code was being added to check the validity of the iosystem pointer before use.

  if (!(file = pio_get_file_from_id(ncid)))
￼          return PIO_EBADID;		￼         
￼      ios = file->iosystem;		￼   
￼ +    if(ios == NULL){
￼ +      fprintf(stderr, "%s:%d ERROR: File has no iosystem attached to it\n", __FILE__, __LINE__);
￼ +      return PIO_EBADID;
￼ +    }

This change was made in many places. Instead, I have modified the pio_get_file_from_id2() function, to check for this condition. (I also renamed it pio_get_file()). Then I changed the code to use that function, and return any error code.

So now this check (for a valid iosystem) is run within the function. A PIO_EINVAL is returned if the iosystem is NULL, which it should never be.

Since this pull request touches a lot of code I thought I would do the rest of the parameter checking changes in another pull request.