### PR TITLE
reindented, untabified, and deleted trailing whitespace

### DIFF
--- a/src/clib/bget.c
+++ b/src/clib/bget.c
@@ -1,401 +1,401 @@
 /*
 
-			       B G E T
-
-			   Buffer allocator
-
-    Designed and implemented in April of 1972 by John Walker, based on the
-    Case Algol OPRO$ algorithm implemented in 1966.
-
-    Reimplemented in 1975 by John Walker for the Interdata 70.
-    Reimplemented in 1977 by John Walker for the Marinchip 9900.
-    Reimplemented in 1982 by Duff Kurland for the Intel 8080.
-
-    Portable C version implemented in September of 1990 by an older, wiser
-    instance of the original implementor.
-
-    Souped up and/or weighed down  slightly  shortly  thereafter  by  Greg
-    Lutz.
-
-    AMIX  edition, including the new compaction call-back option, prepared
-    by John Walker in July of 1992.
-
-    Bug in built-in test program fixed, ANSI compiler warnings eradicated,
-    buffer pool validator  implemented,  and  guaranteed  repeatable  test
-    added by John Walker in October of 1995.
-
-    This program is in the public domain.
-
-     1. This is the book of the generations of Adam.   In the day that God
-	created man, in the likeness of God made he him;
-     2. Male and female created he them;  and  blessed	them,  and  called
-	their name Adam, in the day when they were created.
-     3. And  Adam  lived  an hundred and thirty years,	and begat a son in
-	his own likeness, and after his image; and called his name Seth:
-     4. And the days of  Adam  after  he  had  begotten  Seth  were  eight
-	hundred years: and he begat sons and daughters:
-     5. And  all  the  days  that Adam lived were nine	hundred and thirty
-	years: and he died.
-     6. And Seth lived an hundred and five years, and begat Enos:
-     7. And Seth lived after he begat Enos eight hundred and seven  years,
-	and begat sons and daughters:
-     8.  And  all the days of Seth were nine hundred and twelve years: and
-	 he died.
-     9. And Enos lived ninety years, and begat Cainan:
-    10. And Enos lived after he begat  Cainan eight  hundred  and  fifteen
-	years, and begat sons and daughters:
-    11. And  all  the days of Enos were nine hundred  and five years:  and
-	he died.
-    12. And Cainan lived seventy years and begat Mahalaleel:
-    13. And Cainan lived  after he  begat  Mahalaleel  eight  hundred  and
-	forty years, and begat sons and daughters:
-    14. And  all the days of Cainan were nine  hundred and ten years:  and
-	he died.
-    15. And Mahalaleel lived sixty and five years, and begat Jared:
-    16. And Mahalaleel lived  after  he  begat	Jared  eight  hundred  and
-	thirty years, and begat sons and daughters:
-    17. And  all  the  days  of Mahalaleel  were eight hundred	ninety and
-	five years: and he died.
-    18. And Jared lived an hundred sixty and  two  years,   and  he  begat
-	Enoch:
-    19. And  Jared  lived  after he begat Enoch  eight hundred years,  and
-	begat sons and daughters:
-    20. And all the days of Jared  were nine hundred sixty and two  years:
-	and he died.
-    21. And Enoch lived sixty and five years, and begat Methuselah:
-    22. And  Enoch  walked   with  God	after  he  begat Methuselah  three
-	hundred years, and begat sons and daughters:
-    23. And all the days of  Enoch  were  three  hundred  sixty  and  five
-	years:
-    24. And Enoch walked with God: and he was not; for God took him.
-    25. And  Methuselah  lived	an  hundred  eighty and  seven years,  and
-	begat Lamech.
-    26. And Methuselah lived after he  begat Lamech seven  hundred  eighty
-	and two years, and begat sons and daughters:
-    27. And  all the days of Methuselah  were nine hundred  sixty and nine
-	years: and he died.
-    28. And Lamech lived an hundred eighty  and two  years,  and  begat  a
-	son:
-    29. And  he called his name Noah, saying,  This same shall	comfort us
-	concerning  our  work and toil of our hands, because of the ground
-	which the LORD hath cursed.
-    30. And  Lamech  lived  after  he begat Noah  five hundred	ninety and
-	five years, and begat sons and daughters:
-    31. And all the days of Lamech were  seven hundred seventy	and  seven
-	years: and he died.
-    32. And  Noah  was five hundred years old:	and Noah begat Shem,  Ham,
-	and Japheth.
-
-    And buffers begat buffers, and links begat	links,	and  buffer  pools
-    begat  links  to chains of buffer pools containing buffers, and lo the
-    buffers and links and pools of buffers and pools of links to chains of
-    pools  of  buffers were fruitful and they multiplied and the Operating
-    System looked down upon them and said that it was Good.
-
-
-    INTRODUCTION
-    ============
-
-    BGET  is a comprehensive memory allocation package which is easily
-    configured to the needs of an application.	BGET is  efficient  in
-    both  the  time  needed to allocate and release buffers and in the
-    memory  overhead  required	for  buffer   pool   management.    It
-    automatically    consolidates   contiguous	 space	 to   minimise
-    fragmentation.  BGET is configured	by  compile-time  definitions,
-    Major options include:
-
-	*   A  built-in  test  program	to  exercise  BGET   and
-	    demonstrate how the various functions are used.
-
-        *   Allocation  by  either the "first fit" or "best fit"
-	    method.
-
-	*   Wiping buffers at release time to catch  code  which
-	    references previously released storage.
-
-	*   Built-in  routines to dump individual buffers or the
-	    entire buffer pool.
-
-	*   Retrieval of allocation and pool size statistics.
-
-	*   Quantisation of buffer sizes to a power  of  two  to
-	    satisfy hardware alignment constraints.
-
-	*   Automatic  pool compaction, growth, and shrinkage by
-	    means of call-backs to user defined functions.
-
-    Applications  of  BGET  can  range	from  storage  management   in
-    ROM-based  embedded programs to providing the framework upon which
-    a  multitasking  system  incorporating   garbage   collection   is
-    constructed.   BGET  incorporates  extensive  internal consistency
-    checking using the <assert.h> mechanism; all these checks  can  be
-    turned off by compiling with NDEBUG defined, yielding a version of
-    BGET with minimal size and maximum speed.
-
-    The  basic	algorithm  underlying  BGET  has withstood the test of
-    time;  more  than  25  years   have   passed   since   the	 first
-    implementation  of	this  code.  And yet, it is substantially more
-    efficient than the native allocation  schemes  of  many  operating
-    systems: the Macintosh and Microsoft Windows to name two, on which
-    programs have obtained substantial speed-ups by layering  BGET  as
-    an application level memory manager atop the underlying system's.
-
-    BGET has been implemented on the largest mainframes and the lowest
-    of	microprocessors.   It  has served as the core for multitasking
-    operating systems, multi-thread applications, embedded software in
-    data  network switching processors, and a host of C programs.  And
-    while it has accreted flexibility and additional options over  the
-    years,  it	remains  fast, memory efficient, portable, and easy to
-    integrate into your program.
-
-
-    BGET IMPLEMENTATION ASSUMPTIONS
-    ===============================
-
-    BGET is written in as portable a dialect of C  as  possible.   The
-    only   fundamental	 assumption   about  the  underlying  hardware
-    architecture is that memory is allocated is a linear  array  which
-    can  be  addressed  as a vector of C "char" objects.  On segmented
-    address space architectures, this generally means that BGET should
-    be used to allocate storage within a single segment (although some
-    compilers	simulate   linear   address   spaces   on    segmented
-    architectures).   On  segmented  architectures,  then, BGET buffer
-    pools  may not be larger than a segment, but since BGET allows any
-    number of separate buffer pools, there is no limit	on  the  total
-    storage  which  can  be  managed,  only  on the largest individual
-    object which can be allocated.  Machines  with  a  linear  address
-    architecture,  such  as  the VAX, 680x0, Sparc, MIPS, or the Intel
-    80386 and above in native mode, may use BGET without restriction.
-
-
-    GETTING STARTED WITH BGET
-    =========================
-
-    Although BGET can be configured in a multitude of fashions,  there
-    are  three	basic  ways  of  working  with	BGET.	The  functions
-    mentioned below are documented in the following  section.	Please
-    excuse  the  forward  references which are made in the interest of
-    providing a roadmap to guide you  to  the  BGET  functions  you're
-    likely to need.
-
-    Embedded Applications
-    ---------------------
-
-    Embedded applications  typically  have  a  fixed  area  of	memory
-    dedicated  to  buffer  allocation (often in a separate RAM address
-    space distinct from the ROM that contains  the  executable	code).
-    To	use  BGET in such an environment, simply call bpool() with the
-    start address and length of the buffer  pool  area	in  RAM,  then
-    allocate  buffers  with  bget()  and  release  them  with  brel().
-    Embedded applications with very limited RAM but abundant CPU speed
-    may  benefit  by configuring BGET for BestFit allocation (which is
-    usually not worth it in other environments).
-
-    Malloc() Emulation
-    ------------------
-
-    If the C library malloc() function is too  slow,  not  present  in
-    your  development environment (for example, an a native Windows or
-    Macintosh program), or otherwise unsuitable, you  can  replace  it
-    with  BGET.  Initially define a buffer pool of an appropriate size
-    with bpool()--usually obtained by making a call to	the  operating
-    system's  low-level  memory allocator.  Then allocate buffers with
-    bget(), bgetz(), and bgetr() (the last two permit  the  allocation
-    of	buffers initialised to zero and [inefficient] re-allocation of
-    existing buffers for  compatibility  with  C  library  functions).
-    Release buffers by calling brel().	If a buffer allocation request
-    fails, obtain more storage from the underlying  operating  system,
-    add it to the buffer pool by another call to bpool(), and continue
-    execution.
-
-    Automatic Storage Management
-    ----------------------------
-
-    You can use BGET as your application's native memory  manager  and
-    implement  automatic  storage  pool  expansion,  contraction,  and
-    optionally application-specific  memory  compaction  by  compiling
-    BGET  with	the  BECtl  variable defined, then calling bectl() and
-    supplying  functions  for  storage	compaction,  acquisition,  and
-    release,  as  well as a standard pool expansion increment.	All of
-    these functions are optional (although it doesn't make much  sense
-    to	provide  a  release  function without an acquisition function,
-    does it?).	Once the call-back functions have  been  defined  with
-    bectl(),  you simply use bget() and brel() to allocate and release
-    storage as before.	You can supply an  initial  buffer  pool  with
-    bpool()  or  rely  on  automatic  allocation to acquire the entire
-    pool.  When a call on  bget()  cannot  be  satisfied,  BGET  first
-    checks  if	a compaction function has been supplied.  If so, it is
-    called (with the space required to satisfy the allocation  request
-    and a sequence number to allow the compaction routine to be called
-    successively without looping).  If the compaction function is able
-    to  free any storage (it needn't know whether the storage it freed
-    was adequate) it should return a  nonzero  value,  whereupon  BGET
-    will retry the allocation request and, if it fails again, call the
-    compaction function again with the next-higher sequence number.
-
-    If	the  compaction  function  returns zero, indicating failure to
-    free space, or no compaction function is defined, BGET next  tests
-    whether  a	non-NULL  allocation function was supplied to bectl().
-    If so, that function is called with  an  argument  indicating  how
-    many  bytes  of  additional  space are required.  This will be the
-    standard pool expansion increment supplied in the call to  bectl()
-    unless  the  original  bget()  call requested a buffer larger than
-    this; buffers larger than the standard pool block can  be  managed
-    "off  the books" by BGET in this mode.  If the allocation function
-    succeeds in obtaining the storage, it returns a pointer to the new
-    block  and	BGET  expands  the  buffer  pool;  if  it  fails,  the
-    allocation request fails and returns NULL to  the  caller.	 If  a
-    non-NULL  release  function  is  supplied,	expansion blocks which
-    become totally empty are released  to  the	global	free  pool  by
-    passing their addresses to the release function.
-
-    Equipped  with  appropriate  allocation,  release,	and compaction
-    functions, BGET can be used as part of very  sophisticated	memory
-    management	 strategies,  including  garbage  collection.	(Note,
-    however, that BGET is *not* a garbage  collector  by  itself,  and
-    that  developing  such a system requires much additional logic and
-    careful design of the application's memory allocation strategy.)
-
-
-    BGET FUNCTION DESCRIPTIONS
-    ==========================
-
-    Functions implemented in this file (some are enabled by certain of
-    the optional settings below):
-
-	    void bpool(void *buffer, bufsize len);
-
-    Create a buffer pool of <len> bytes, using the storage starting at
-    <buffer>.	You  can  call	bpool()  subsequently  to   contribute
-    additional storage to the overall buffer pool.
-
-	    void *bget(bufsize size);
-
-    Allocate  a  buffer of <size> bytes.  The address of the buffer is
-    returned, or NULL if insufficient memory was available to allocate
-    the buffer.
-
-	    void *bgetz(bufsize size);
-
-    Allocate a buffer of <size> bytes and clear it to all zeroes.  The
-    address of the buffer is returned, or NULL if insufficient	memory
-    was available to allocate the buffer.
-
-	    void *bgetr(void *buffer, bufsize newsize);
-
-    Reallocate a buffer previously allocated by bget(),  changing  its
-    size  to  <newsize>  and  preserving  all  existing data.  NULL is
-    returned if insufficient memory is	available  to  reallocate  the
-    buffer, in which case the original buffer remains intact.
-
-	    void brel(void *buf);
-
-    Return  the  buffer  <buf>, previously allocated by bget(), to the
-    free space pool.
-
-	    void bectl(int (*compact)(bufsize sizereq, int sequence),
-		       void *(*acquire)(bufsize size),
-		       void (*release)(void *buf),
-		       bufsize pool_incr);
-
-    Expansion control: specify functions through which the package may
-    compact  storage  (or  take  other	appropriate  action)  when  an
-    allocation	request  fails,  and  optionally automatically acquire
-    storage for expansion blocks  when	necessary,  and  release  such
-    blocks when they become empty.  If <compact> is non-NULL, whenever
-    a buffer allocation request fails, the <compact> function will  be
-    called with arguments specifying the number of bytes (total buffer
-    size,  including  header  overhead)  required   to	 satisfy   the
-    allocation request, and a sequence number indicating the number of
-    consecutive  calls	on  <compact>  attempting  to	satisfy   this
-    allocation	request.   The sequence number is 1 for the first call
-    on <compact> for a given allocation  request,  and	increments  on
-    subsequent	calls,	permitting  the  <compact>  function  to  take
-    increasingly dire measures in an attempt to free up  storage.   If
-    the  <compact>  function  returns  a nonzero value, the allocation
-    attempt is re-tried.  If <compact> returns 0 (as  it  must	if  it
-    isn't  able  to  release  any  space  or add storage to the buffer
-    pool), the allocation request fails, which can  trigger  automatic
-    pool expansion if the <acquire> argument is non-NULL.  At the time
-    the  <compact>  function  is  called,  the	state  of  the	buffer
-    allocator  is  identical  to  that	at  the  moment the allocation
-    request was made; consequently, the <compact>  function  may  call
-    brel(), bpool(), bstats(), and/or directly manipulate  the	buffer
-    pool  in  any  manner which would be valid were the application in
-    control.  This does not, however, relieve the  <compact>  function
-    of the need to ensure that whatever actions it takes do not change
-    things   underneath  the  application  that  made  the  allocation
-    request.  For example, a <compact> function that released a buffer
-    in	the  process  of  being reallocated with bgetr() would lead to
-    disaster.  Implementing a safe and effective  <compact>  mechanism
-    requires  careful  design of an application's memory architecture,
-    and cannot generally be easily retrofitted into existing code.
-
-    If <acquire> is non-NULL, that function will be called whenever an
-    allocation	request  fails.  If the <acquire> function succeeds in
-    allocating the requested space and returns a pointer  to  the  new
-    area,  allocation will proceed using the expanded buffer pool.  If
-    <acquire> cannot obtain the requested space, it should return NULL
-    and   the	entire	allocation  process  will  fail.   <pool_incr>
-    specifies the normal expansion block size.	Providing an <acquire>
-    function will cause subsequent bget()  requests  for  buffers  too
-    large  to  be  managed in the linked-block scheme (in other words,
-    larger than <pool_incr> minus the buffer overhead) to be satisfied
-    directly by calls to the <acquire> function.  Automatic release of
-    empty pool blocks will occur only if all pool blocks in the system
-    are the size given by <pool_incr>.
-
-	    void bstats(bufsize *curalloc, bufsize *totfree,
-			bufsize *maxfree, long *nget, long *nrel);
-
-    The amount	of  space  currently  allocated  is  stored  into  the
-    variable  pointed  to by <curalloc>.  The total free space (sum of
-    all free blocks in the pool) is stored into the  variable  pointed
-    to	by  <totfree>, and the size of the largest single block in the
-    free space	pool  is  stored  into	the  variable  pointed	to  by
-    <maxfree>.	 The  variables  pointed  to  by <nget> and <nrel> are
-    filled, respectively, with	the  number  of  successful  (non-NULL
-    return) bget() calls and the number of brel() calls.
-
-	    void bstatse(bufsize *pool_incr, long *npool,
-			 long *npget, long *nprel,
-			 long *ndget, long *ndrel);
-
-    Extended  statistics: The expansion block size will be stored into
-    the variable pointed to by <pool_incr>, or the negative thereof if
-    automatic  expansion  block  releases are disabled.  The number of
-    currently active pool blocks will  be  stored  into  the  variable
-    pointed  to  by  <npool>.  The variables pointed to by <npget> and
-    <nprel> will be filled with, respectively, the number of expansion
-    block   acquisitions   and	releases  which  have  occurred.   The
-    variables pointed to by <ndget> and <ndrel> will  be  filled  with
-    the  number  of  bget()  and  brel()  calls, respectively, managed
-    through blocks directly allocated by the acquisition  and  release
-    functions.
-
-	    void bufdump(void *buf);
-
-    The buffer pointed to by <buf> is dumped on standard output.
-
-	    void bpoold(void *pool, int dumpalloc, int dumpfree);
-
-    All buffers in the buffer pool <pool>, previously initialised by a
-    call on bpool(), are listed in ascending memory address order.  If
-    <dumpalloc> is nonzero, the  contents  of  allocated  buffers  are
-    dumped;  if <dumpfree> is nonzero, the contents of free blocks are
-    dumped.
-
-	    int bpoolv(void *pool);
-
-    The  named	buffer	pool,  previously  initialised	by  a  call on
-    bpool(), is validated for bad pointers, overwritten data, etc.  If
-    compiled with NDEBUG not defined, any error generates an assertion
-    failure.  Otherwise 1 is returned if the pool is valid,  0	if  an
-    error is found.
-
-
-    BGET CONFIGURATION
-    ==================
+  B G E T
+
+  Buffer allocator
+
+  Designed and implemented in April of 1972 by John Walker, based on the
+  Case Algol OPRO$ algorithm implemented in 1966.
+
+  Reimplemented in 1975 by John Walker for the Interdata 70.
+  Reimplemented in 1977 by John Walker for the Marinchip 9900.
+  Reimplemented in 1982 by Duff Kurland for the Intel 8080.
+
+  Portable C version implemented in September of 1990 by an older, wiser
+  instance of the original implementor.
+
+  Souped up and/or weighed down  slightly  shortly  thereafter  by  Greg
+  Lutz.
+
+  AMIX  edition, including the new compaction call-back option, prepared
+  by John Walker in July of 1992.
+
+  Bug in built-in test program fixed, ANSI compiler warnings eradicated,
+  buffer pool validator  implemented,  and  guaranteed  repeatable  test
+  added by John Walker in October of 1995.
+
+  This program is in the public domain.
+
+  1. This is the book of the generations of Adam.   In the day that God
+  created man, in the likeness of God made he him;
+  2. Male and female created he them;  and  blessed     them,  and  called
+  their name Adam, in the day when they were created.
+  3. And  Adam  lived  an hundred and thirty years,     and begat a son in
+  his own likeness, and after his image; and called his name Seth:
+  4. And the days of  Adam  after  he  had  begotten  Seth  were  eight
+  hundred years: and he begat sons and daughters:
+  5. And  all  the  days  that Adam lived were nine     hundred and thirty
+  years: and he died.
+  6. And Seth lived an hundred and five years, and begat Enos:
+  7. And Seth lived after he begat Enos eight hundred and seven  years,
+  and begat sons and daughters:
+  8.  And  all the days of Seth were nine hundred and twelve years: and
+  he died.
+  9. And Enos lived ninety years, and begat Cainan:
+  10. And Enos lived after he begat  Cainan eight  hundred  and  fifteen
+  years, and begat sons and daughters:
+  11. And  all  the days of Enos were nine hundred  and five years:  and
+  he died.
+  12. And Cainan lived seventy years and begat Mahalaleel:
+  13. And Cainan lived  after he  begat  Mahalaleel  eight  hundred  and
+  forty years, and begat sons and daughters:
+  14. And  all the days of Cainan were nine  hundred and ten years:  and
+  he died.
+  15. And Mahalaleel lived sixty and five years, and begat Jared:
+  16. And Mahalaleel lived  after  he  begat    Jared  eight  hundred  and
+  thirty years, and begat sons and daughters:
+  17. And  all  the  days  of Mahalaleel  were eight hundred    ninety and
+  five years: and he died.
+  18. And Jared lived an hundred sixty and  two  years,   and  he  begat
+  Enoch:
+  19. And  Jared  lived  after he begat Enoch  eight hundred years,  and
+  begat sons and daughters:
+  20. And all the days of Jared  were nine hundred sixty and two  years:
+  and he died.
+  21. And Enoch lived sixty and five years, and begat Methuselah:
+  22. And  Enoch  walked   with  God    after  he  begat Methuselah  three
+  hundred years, and begat sons and daughters:
+  23. And all the days of  Enoch  were  three  hundred  sixty  and  five
+  years:
+  24. And Enoch walked with God: and he was not; for God took him.
+  25. And  Methuselah  lived    an  hundred  eighty and  seven years,  and
+  begat Lamech.
+  26. And Methuselah lived after he  begat Lamech seven  hundred  eighty
+  and two years, and begat sons and daughters:
+  27. And  all the days of Methuselah  were nine hundred  sixty and nine
+  years: and he died.
+  28. And Lamech lived an hundred eighty  and two  years,  and  begat  a
+  son:
+  29. And  he called his name Noah, saying,  This same shall    comfort us
+  concerning  our  work and toil of our hands, because of the ground
+  which the LORD hath cursed.
+  30. And  Lamech  lived  after  he begat Noah  five hundred    ninety and
+  five years, and begat sons and daughters:
+  31. And all the days of Lamech were  seven hundred seventy    and  seven
+  years: and he died.
+  32. And  Noah  was five hundred years old:    and Noah begat Shem,  Ham,
+  and Japheth.
+
+  And buffers begat buffers, and links begat    links,  and  buffer  pools
+  begat  links  to chains of buffer pools containing buffers, and lo the
+  buffers and links and pools of buffers and pools of links to chains of
+  pools  of  buffers were fruitful and they multiplied and the Operating
+  System looked down upon them and said that it was Good.
+
+
+  INTRODUCTION
+  ============
+
+  BGET  is a comprehensive memory allocation package which is easily
+  configured to the needs of an application.    BGET is  efficient  in
+  both  the  time  needed to allocate and release buffers and in the
+  memory  overhead  required    for  buffer   pool   management.    It
+  automatically    consolidates   contiguous     space   to   minimise
+  fragmentation.  BGET is configured    by  compile-time  definitions,
+  Major options include:
+
+  *   A  built-in  test  program        to  exercise  BGET   and
+  demonstrate how the various functions are used.
+
+  *   Allocation  by  either the "first fit" or "best fit"
+  method.
+
+  *   Wiping buffers at release time to catch  code  which
+  references previously released storage.
+
+  *   Built-in  routines to dump individual buffers or the
+  entire buffer pool.
+
+  *   Retrieval of allocation and pool size statistics.
+
+  *   Quantisation of buffer sizes to a power  of  two  to
+  satisfy hardware alignment constraints.
+
+  *   Automatic  pool compaction, growth, and shrinkage by
+  means of call-backs to user defined functions.
+
+  Applications  of  BGET  can  range    from  storage  management   in
+  ROM-based  embedded programs to providing the framework upon which
+  a  multitasking  system  incorporating   garbage   collection   is
+  constructed.   BGET  incorporates  extensive  internal consistency
+  checking using the <assert.h> mechanism; all these checks  can  be
+  turned off by compiling with NDEBUG defined, yielding a version of
+  BGET with minimal size and maximum speed.
+
+  The  basic    algorithm  underlying  BGET  has withstood the test of
+  time;  more  than  25  years   have   passed   since   the     first
+  implementation  of    this  code.  And yet, it is substantially more
+  efficient than the native allocation  schemes  of  many  operating
+  systems: the Macintosh and Microsoft Windows to name two, on which
+  programs have obtained substantial speed-ups by layering  BGET  as
+  an application level memory manager atop the underlying system's.
+
+  BGET has been implemented on the largest mainframes and the lowest
+  of    microprocessors.   It  has served as the core for multitasking
+  operating systems, multi-thread applications, embedded software in
+  data  network switching processors, and a host of C programs.  And
+  while it has accreted flexibility and additional options over  the
+  years,  it    remains  fast, memory efficient, portable, and easy to
+  integrate into your program.
+
+
+  BGET IMPLEMENTATION ASSUMPTIONS
+  ===============================
+
+  BGET is written in as portable a dialect of C  as  possible.   The
+  only   fundamental     assumption   about  the  underlying  hardware
+  architecture is that memory is allocated is a linear  array  which
+  can  be  addressed  as a vector of C "char" objects.  On segmented
+  address space architectures, this generally means that BGET should
+  be used to allocate storage within a single segment (although some
+  compilers     simulate   linear   address   spaces   on    segmented
+  architectures).   On  segmented  architectures,  then, BGET buffer
+  pools  may not be larger than a segment, but since BGET allows any
+  number of separate buffer pools, there is no limit    on  the  total
+  storage  which  can  be  managed,  only  on the largest individual
+  object which can be allocated.  Machines  with  a  linear  address
+  architecture,  such  as  the VAX, 680x0, Sparc, MIPS, or the Intel
+  80386 and above in native mode, may use BGET without restriction.
+
+
+  GETTING STARTED WITH BGET
+  =========================
+
+  Although BGET can be configured in a multitude of fashions,  there
+  are  three    basic  ways  of  working  with  BGET.   The  functions
+  mentioned below are documented in the following  section.     Please
+  excuse  the  forward  references which are made in the interest of
+  providing a roadmap to guide you  to  the  BGET  functions  you're
+  likely to need.
+
+  Embedded Applications
+  ---------------------
+
+  Embedded applications  typically  have  a  fixed  area  of    memory
+  dedicated  to  buffer  allocation (often in a separate RAM address
+  space distinct from the ROM that contains  the  executable    code).
+  To    use  BGET in such an environment, simply call bpool() with the
+  start address and length of the buffer  pool  area    in  RAM,  then
+  allocate  buffers  with  bget()  and  release  them  with  brel().
+  Embedded applications with very limited RAM but abundant CPU speed
+  may  benefit  by configuring BGET for BestFit allocation (which is
+  usually not worth it in other environments).
+
+  Malloc() Emulation
+  ------------------
+
+  If the C library malloc() function is too  slow,  not  present  in
+  your  development environment (for example, an a native Windows or
+  Macintosh program), or otherwise unsuitable, you  can  replace  it
+  with  BGET.  Initially define a buffer pool of an appropriate size
+  with bpool()--usually obtained by making a call to    the  operating
+  system's  low-level  memory allocator.  Then allocate buffers with
+  bget(), bgetz(), and bgetr() (the last two permit  the  allocation
+  of    buffers initialised to zero and [inefficient] re-allocation of
+  existing buffers for  compatibility  with  C  library  functions).
+  Release buffers by calling brel().    If a buffer allocation request
+  fails, obtain more storage from the underlying  operating  system,
+  add it to the buffer pool by another call to bpool(), and continue
+  execution.
+
+  Automatic Storage Management
+  ----------------------------
+
+  You can use BGET as your application's native memory  manager  and
+  implement  automatic  storage  pool  expansion,  contraction,  and
+  optionally application-specific  memory  compaction  by  compiling
+  BGET  with    the  BECtl  variable defined, then calling bectl() and
+  supplying  functions  for  storage    compaction,  acquisition,  and
+  release,  as  well as a standard pool expansion increment.    All of
+  these functions are optional (although it doesn't make much  sense
+  to    provide  a  release  function without an acquisition function,
+  does it?).    Once the call-back functions have  been  defined  with
+  bectl(),  you simply use bget() and brel() to allocate and release
+  storage as before.    You can supply an  initial  buffer  pool  with
+  bpool()  or  rely  on  automatic  allocation to acquire the entire
+  pool.  When a call on  bget()  cannot  be  satisfied,  BGET  first
+  checks  if    a compaction function has been supplied.  If so, it is
+  called (with the space required to satisfy the allocation  request
+  and a sequence number to allow the compaction routine to be called
+  successively without looping).  If the compaction function is able
+  to  free any storage (it needn't know whether the storage it freed
+  was adequate) it should return a  nonzero  value,  whereupon  BGET
+  will retry the allocation request and, if it fails again, call the
+  compaction function again with the next-higher sequence number.
+
+  If    the  compaction  function  returns zero, indicating failure to
+  free space, or no compaction function is defined, BGET next  tests
+  whether  a    non-NULL  allocation function was supplied to bectl().
+  If so, that function is called with  an  argument  indicating  how
+  many  bytes  of  additional  space are required.  This will be the
+  standard pool expansion increment supplied in the call to  bectl()
+  unless  the  original  bget()  call requested a buffer larger than
+  this; buffers larger than the standard pool block can  be  managed
+  "off  the books" by BGET in this mode.  If the allocation function
+  succeeds in obtaining the storage, it returns a pointer to the new
+  block  and    BGET  expands  the  buffer  pool;  if  it  fails,  the
+  allocation request fails and returns NULL to  the  caller.     If  a
+  non-NULL  release  function  is  supplied,    expansion blocks which
+  become totally empty are released  to  the    global  free  pool  by
+  passing their addresses to the release function.
+
+  Equipped  with  appropriate  allocation,  release,    and compaction
+  functions, BGET can be used as part of very  sophisticated    memory
+  management     strategies,  including  garbage  collection.   (Note,
+  however, that BGET is *not* a garbage  collector  by  itself,  and
+  that  developing  such a system requires much additional logic and
+  careful design of the application's memory allocation strategy.)
+
+
+  BGET FUNCTION DESCRIPTIONS
+  ==========================
+
+  Functions implemented in this file (some are enabled by certain of
+  the optional settings below):
+
+  void bpool(void *buffer, bufsize len);
+
+  Create a buffer pool of <len> bytes, using the storage starting at
+  <buffer>.     You  can  call  bpool()  subsequently  to   contribute
+  additional storage to the overall buffer pool.
+
+  void *bget(bufsize size);
+
+  Allocate  a  buffer of <size> bytes.  The address of the buffer is
+  returned, or NULL if insufficient memory was available to allocate
+  the buffer.
+
+  void *bgetz(bufsize size);
+
+  Allocate a buffer of <size> bytes and clear it to all zeroes.  The
+  address of the buffer is returned, or NULL if insufficient    memory
+  was available to allocate the buffer.
+
+  void *bgetr(void *buffer, bufsize newsize);
+
+  Reallocate a buffer previously allocated by bget(),  changing  its
+  size  to  <newsize>  and  preserving  all  existing data.  NULL is
+  returned if insufficient memory is    available  to  reallocate  the
+  buffer, in which case the original buffer remains intact.
+
+  void brel(void *buf);
+
+  Return  the  buffer  <buf>, previously allocated by bget(), to the
+  free space pool.
+
+  void bectl(int (*compact)(bufsize sizereq, int sequence),
+  void *(*acquire)(bufsize size),
+  void (*release)(void *buf),
+  bufsize pool_incr);
+
+  Expansion control: specify functions through which the package may
+  compact  storage  (or  take  other    appropriate  action)  when  an
+  allocation    request  fails,  and  optionally automatically acquire
+  storage for expansion blocks  when    necessary,  and  release  such
+  blocks when they become empty.  If <compact> is non-NULL, whenever
+  a buffer allocation request fails, the <compact> function will  be
+  called with arguments specifying the number of bytes (total buffer
+  size,  including  header  overhead)  required   to     satisfy   the
+  allocation request, and a sequence number indicating the number of
+  consecutive  calls    on  <compact>  attempting  to   satisfy   this
+  allocation    request.   The sequence number is 1 for the first call
+  on <compact> for a given allocation  request,  and    increments  on
+  subsequent    calls,  permitting  the  <compact>  function  to  take
+  increasingly dire measures in an attempt to free up  storage.   If
+  the  <compact>  function  returns  a nonzero value, the allocation
+  attempt is re-tried.  If <compact> returns 0 (as  it  must    if  it
+  isn't  able  to  release  any  space  or add storage to the buffer
+  pool), the allocation request fails, which can  trigger  automatic
+  pool expansion if the <acquire> argument is non-NULL.  At the time
+  the  <compact>  function  is  called,  the    state  of  the  buffer
+  allocator  is  identical  to  that    at  the  moment the allocation
+  request was made; consequently, the <compact>  function  may  call
+  brel(), bpool(), bstats(), and/or directly manipulate  the    buffer
+  pool  in  any  manner which would be valid were the application in
+  control.  This does not, however, relieve the  <compact>  function
+  of the need to ensure that whatever actions it takes do not change
+  things   underneath  the  application  that  made  the  allocation
+  request.  For example, a <compact> function that released a buffer
+  in    the  process  of  being reallocated with bgetr() would lead to
+  disaster.  Implementing a safe and effective  <compact>  mechanism
+  requires  careful  design of an application's memory architecture,
+  and cannot generally be easily retrofitted into existing code.
+
+  If <acquire> is non-NULL, that function will be called whenever an
+  allocation    request  fails.  If the <acquire> function succeeds in
+  allocating the requested space and returns a pointer  to  the  new
+  area,  allocation will proceed using the expanded buffer pool.  If
+  <acquire> cannot obtain the requested space, it should return NULL
+  and   the     entire  allocation  process  will  fail.   <pool_incr>
+  specifies the normal expansion block size.    Providing an <acquire>
+  function will cause subsequent bget()  requests  for  buffers  too
+  large  to  be  managed in the linked-block scheme (in other words,
+  larger than <pool_incr> minus the buffer overhead) to be satisfied
+  directly by calls to the <acquire> function.  Automatic release of
+  empty pool blocks will occur only if all pool blocks in the system
+  are the size given by <pool_incr>.
+
+  void bstats(bufsize *curalloc, bufsize *totfree,
+  bufsize *maxfree, long *nget, long *nrel);
+
+  The amount    of  space  currently  allocated  is  stored  into  the
+  variable  pointed  to by <curalloc>.  The total free space (sum of
+  all free blocks in the pool) is stored into the  variable  pointed
+  to    by  <totfree>, and the size of the largest single block in the
+  free space    pool  is  stored  into  the  variable  pointed  to  by
+  <maxfree>.     The  variables  pointed  to  by <nget> and <nrel> are
+  filled, respectively, with    the  number  of  successful  (non-NULL
+  return) bget() calls and the number of brel() calls.
+
+  void bstatse(bufsize *pool_incr, long *npool,
+  long *npget, long *nprel,
+  long *ndget, long *ndrel);
+
+  Extended  statistics: The expansion block size will be stored into
+  the variable pointed to by <pool_incr>, or the negative thereof if
+  automatic  expansion  block  releases are disabled.  The number of
+  currently active pool blocks will  be  stored  into  the  variable
+  pointed  to  by  <npool>.  The variables pointed to by <npget> and
+  <nprel> will be filled with, respectively, the number of expansion
+  block   acquisitions   and    releases  which  have  occurred.   The
+  variables pointed to by <ndget> and <ndrel> will  be  filled  with
+  the  number  of  bget()  and  brel()  calls, respectively, managed
+  through blocks directly allocated by the acquisition  and  release
+  functions.
+
+  void bufdump(void *buf);
+
+  The buffer pointed to by <buf> is dumped on standard output.
+
+  void bpoold(void *pool, int dumpalloc, int dumpfree);
+
+  All buffers in the buffer pool <pool>, previously initialised by a
+  call on bpool(), are listed in ascending memory address order.  If
+  <dumpalloc> is nonzero, the  contents  of  allocated  buffers  are
+  dumped;  if <dumpfree> is nonzero, the contents of free blocks are
+  dumped.
+
+  int bpoolv(void *pool);
+
+  The  named    buffer  pool,  previously  initialised  by  a  call on
+  bpool(), is validated for bad pointers, overwritten data, etc.  If
+  compiled with NDEBUG not defined, any error generates an assertion
+  failure.  Otherwise 1 is returned if the pool is valid,  0    if  an
+  error is found.
+
+
+  BGET CONFIGURATION
+  ==================
 */
 #include <config.h>
 #include <pio.h>
@@ -404,58 +404,58 @@
 #include <stdlib.h>
 #endif
 
-#define TestProg    20000	      /* Generate built-in test program
-					 if defined.  The value specifies
-					 how many buffer allocation attempts
-					 the test program should make. */
+#define TestProg    20000             /* Generate built-in test program
+                                         if defined.  The value specifies
+                                         how many buffer allocation attempts
+                                         the test program should make. */
 #undef TestProg
 
-#define SizeQuant   4		      /* Buffer allocation size quantum:
-					 all buffers allocated are a
-					 multiple of this size.  This
-					 MUST be a power of two. */
+#define SizeQuant   4                 /* Buffer allocation size quantum:
+                                         all buffers allocated are a
+                                         multiple of this size.  This
+                                         MUST be a power of two. */
 
-#define BufDump     1		      /* Define this symbol to enable the
-					 bpoold() function which dumps the
-					 buffers in a buffer pool. */
+#define BufDump     1                 /* Define this symbol to enable the
+                                         bpoold() function which dumps the
+                                         buffers in a buffer pool. */
 
-#define BufValid    1		      /* Define this symbol to enable the
-					 bpoolv() function for validating
-					 a buffer pool. */ 
+#define BufValid    1                 /* Define this symbol to enable the
+                                         bpoolv() function for validating
+                                         a buffer pool. */
 
-#define DumpData    1		      /* Define this symbol to enable the
-					 bufdump() function which allows
-					 dumping the contents of an allocated
-					 or free buffer. */
+#define DumpData    1                 /* Define this symbol to enable the
+                                         bufdump() function which allows
+                                         dumping the contents of an allocated
+                                         or free buffer. */
 
-#define BufStats    1		      /* Define this symbol to enable the
-					 bstats() function which calculates
-					 the total free space in the buffer
-					 pool, the largest available
-					 buffer, and the total space
-					 currently allocated. */
+#define BufStats    1                 /* Define this symbol to enable the
+                                         bstats() function which calculates
+                                         the total free space in the buffer
+                                         pool, the largest available
+                                         buffer, and the total space
+                                         currently allocated. */
 
-#define FreeWipe    1		      /* Wipe free buffers to a guaranteed
-					 pattern of garbage to trip up
-					 miscreants who attempt to use
-					 pointers into released buffers. */
+#define FreeWipe    1                 /* Wipe free buffers to a guaranteed
+                                         pattern of garbage to trip up
+                                         miscreants who attempt to use
+                                         pointers into released buffers. */
 
 //#define BestFit     1
-#undef BestFit		
-                                       /* Use a best fit algorithm when
-					 searching for space for an
-					 allocation request.  This uses
-					 memory more efficiently, but
-					 allocation will be much slower. */
+#undef BestFit
+/* Use a best fit algorithm when
+   searching for space for an
+   allocation request.  This uses
+   memory more efficiently, but
+   allocation will be much slower. */
 
-#define BECtl	    1		      /* Define this symbol to enable the
-					 bectl() function for automatic
-					 pool space control.  */
+#define BECtl       1                 /* Define this symbol to enable the
+                                         bectl() function for automatic
+                                         pool space control.  */
 
 #include <stdio.h>
 
 #ifdef lint
-#define NDEBUG			      /* Exits in asserts confuse lint */
+#define NDEBUG                        /* Exits in asserts confuse lint */
 /* LINTLIBRARY */                     /* Don't complain about def, no ref */
 extern char *sprintf();               /* Sun includes don't define sprintf */
 #endif
@@ -463,7 +463,7 @@ extern char *sprintf();               /* Sun includes don't define sprintf */
 #include <assert.h>
 #include <memory.h>
 
-#ifdef BufDump			      /* BufDump implies DumpData */
+#ifdef BufDump                        /* BufDump implies DumpData */
 #ifndef DumpData
 #define DumpData    1
 #endif
@@ -478,42 +478,42 @@ extern char *sprintf();               /* Sun includes don't define sprintf */
 
 #include "bget.h"
 
-#define MemSize     size_t	      /* Type for size arguments to memxxx()
-					 functions such as memcmp(). */
+#define MemSize     size_t            /* Type for size arguments to memxxx()
+                                         functions such as memcmp(). */
 
 /* Queue links */
 
 struct qlinks {
-    struct bfhead *flink;	      /* Forward link */
-    struct bfhead *blink;	      /* Backward link */
+    struct bfhead *flink;             /* Forward link */
+    struct bfhead *blink;             /* Backward link */
 };
 
 /* Header in allocated and free buffers */
 
 struct bhead {
-    bufsize prevfree;		      /* Relative link back to previous
-					 free buffer in memory or 0 if
-					 previous buffer is allocated.	*/
-    bufsize bsize;		      /* Buffer size: positive if free,
-					 negative if allocated. */
+    bufsize prevfree;                 /* Relative link back to previous
+                                         free buffer in memory or 0 if
+                                         previous buffer is allocated.  */
+    bufsize bsize;                    /* Buffer size: positive if free,
+                                         negative if allocated. */
 };
-#define BH(p)	((struct bhead *) (p))
+#define BH(p)   ((struct bhead *) (p))
 
 /*  Header in directly allocated buffers (by acqfcn) */
 
 struct bdhead {
-    bufsize tsize;		      /* Total size, including overhead */
-    struct bhead bh;		      /* Common header */
+    bufsize tsize;                    /* Total size, including overhead */
+    struct bhead bh;                  /* Common header */
 };
-#define BDH(p)	((struct bdhead *) (p))
+#define BDH(p)  ((struct bdhead *) (p))
 
 /* Header in free buffers */
 
 struct bfhead {
-    struct bhead bh;		      /* Common allocated/free header */
-    struct qlinks ql;		      /* Links on free list */
+    struct bhead bh;                  /* Common allocated/free header */
+    struct qlinks ql;                 /* Links on free list */
 };
-#define BFH(p)	((struct bfhead *) (p))
+#define BFH(p)  ((struct bfhead *) (p))
 
 static struct bfhead freelist = {     /* List of free buffers */
     {0, 0},
@@ -522,10 +522,10 @@ static struct bfhead freelist = {     /* List of free buffers */
 
 
 #ifdef BufStats
-static bufsize totalloc = 0;	      /* Total space currently allocated */
+static bufsize totalloc = 0;          /* Total space currently allocated */
 static long numget = 0, numrel = 0;   /* Number of bget() and brel() calls */
 #ifdef BECtl
-static long numpblk = 0;	      /* Number of pool blocks */
+static long numpblk = 0;              /* Number of pool blocks */
 static long numpget = 0, numprel = 0; /* Number of block gets and rels */
 static long numdget = 0, numdrel = 0; /* Number of direct gets and rels */
 #endif /* BECtl */
@@ -539,27 +539,27 @@ static int (*compfcn) _((bufsize sizereq, int sequence)) = NULL;
 static void *(*acqfcn) _((bufsize size)) = NULL;
 static void (*relfcn) _((void *buf)) = NULL;
 
-static bufsize exp_incr = 0;	      /* Expansion block size */
-static bufsize pool_len = 0;	      /* 0: no bpool calls have been made
-					 -1: not all pool blocks are
-					     the same size
-					 >0: (common) block size for all
-					     bpool calls made so far
-				      */
+static bufsize exp_incr = 0;          /* Expansion block size */
+static bufsize pool_len = 0;          /* 0: no bpool calls have been made
+                                         -1: not all pool blocks are
+                                         the same size
+                                         >0: (common) block size for all
+                                         bpool calls made so far
+                                      */
 #endif
 
 /*  Minimum allocation quantum: */
 
-#define QLSize	(sizeof(struct qlinks))
-#define SizeQ	((SizeQuant > QLSize) ? SizeQuant : QLSize)
+#define QLSize  (sizeof(struct qlinks))
+#define SizeQ   ((SizeQuant > QLSize) ? SizeQuant : QLSize)
 
-#define V   (void)		      /* To denote unwanted returned values */
+#define V   (void)                    /* To denote unwanted returned values */
 
 /* End sentinel: value placed in bsize field of dummy block delimiting
    end of pool block.  The most negative number which will  fit  in  a
    bufsize, defined in a way that the compiler will accept. */
 
-#define ESent	((bufsize) (-(((1L << (sizeof(bufsize) * 8 - 2)) - 1) * 2) - 2))
+#define ESent   ((bufsize) (-(((1L << (sizeof(bufsize) * 8 - 2)) - 1) * 2) - 2))
 
 static int maxsize=0;
 
@@ -567,33 +567,33 @@ static int maxsize=0;
 void bpoolrelease()
 {
     LOG((2, "bpoolrelease"));
-  freelist.bh.prevfree=0;
-  freelist.bh.bsize=0;
-  freelist.ql.flink=&freelist;
-  freelist.ql.blink=&freelist;
+    freelist.bh.prevfree=0;
+    freelist.bh.bsize=0;
+    freelist.ql.flink=&freelist;
+    freelist.ql.blink=&freelist;
     LOG((2, "bpoolrelease"));
 
 #ifdef BufStats
-  totalloc = 0;	      /* Total space currently allocated */
-  numget = 0;
-  numrel = 0;   /* Number of bget() and brel() calls */
+    totalloc = 0;             /* Total space currently allocated */
+    numget = 0;
+    numrel = 0;   /* Number of bget() and brel() calls */
 #ifdef BECtl
-  numpblk = 0;	      /* Number of pool blocks */
-  numpget = 0;
-  numprel = 0; /* Number of block gets and rels */
-  numdget = 0; 
-  numdrel = 0; /* Number of direct gets and rels */
+    numpblk = 0;              /* Number of pool blocks */
+    numpget = 0;
+    numprel = 0; /* Number of block gets and rels */
+    numdget = 0;
+    numdrel = 0; /* Number of direct gets and rels */
 #endif /* BECtl */
 #endif /* BufStats */
     LOG((2, "bpoolrelease"));
 
 #ifdef BECtl
 /* Automatic expansion block management functions */
-  compfcn = NULL;
-  acqfcn = NULL;
-  relfcn = NULL;
-  exp_incr = 0;	
-  pool_len = 0;
+    compfcn = NULL;
+    acqfcn = NULL;
+    relfcn = NULL;
+    exp_incr = 0;
+    pool_len = 0;
 #endif
     LOG((2, "bpoolrelease"));
 
@@ -604,7 +604,7 @@ void bpoolrelease()
 /*  BGET  --  Allocate a buffer.  */
 
 void *bget(requested_size)
-  bufsize requested_size;
+bufsize requested_size;
 {
     bufsize size = requested_size;
     struct bfhead *b;
@@ -624,16 +624,16 @@ void *bget(requested_size)
     buf = malloc(requested_size);
     //    printf("bget allocate %ld %x\n",requested_size,buf);
     return(buf);
-#endif 
+#endif
 
 
     if(size<=0)
-      print_trace(NULL);
+        print_trace(NULL);
 
     assert(size > 0);
 
-    if (size < SizeQ) { 	      /* Need at least room for the */
-	size = SizeQ;		      /*    queue links.  */
+    if (size < SizeQ) {               /* Need at least room for the */
+        size = SizeQ;                 /*    queue links.  */
     }
 #ifdef SizeQuant
 #if SizeQuant > 1
@@ -642,111 +642,111 @@ void *bget(requested_size)
 #endif
 
     size += sizeof(struct bhead);     /* Add overhead in allocated buffer
-					 to size required. */
+                                         to size required. */
 
 #ifdef BECtl
     /* If a compact function was provided in the call to bectl(), wrap
-       a loop around the allocation process  to  allow	compaction  to
+       a loop around the allocation process  to  allow  compaction  to
        intervene in case we don't find a suitable buffer in the chain. */
 
     while (1) {
 #endif
-	b = freelist.ql.flink;
+        b = freelist.ql.flink;
 #ifdef BestFit
-	best = &freelist;
+        best = &freelist;
 #endif
 
 
-	/* Scan the free list searching for the first buffer big enough
-	   to hold the requested size buffer. */
+        /* Scan the free list searching for the first buffer big enough
+           to hold the requested size buffer. */
 
 #ifdef BestFit
-	while (b != &freelist) {
-	  //	  printf("%s %d %X %X %X %ld \n",__FILE__,__LINE__,b,&freelist,best,b->bh.bsize);
-	    if (b->bh.bsize >= size) {
-		if ((best == &freelist) || (b->bh.bsize < best->bh.bsize)) {
-		    best = b;
-		}
-	    }
-	    b = b->ql.flink;		  /* Link to next buffer */
-	}
-	b = best;
+        while (b != &freelist) {
+            //    printf("%s %d %X %X %X %ld \n",__FILE__,__LINE__,b,&freelist,best,b->bh.bsize);
+            if (b->bh.bsize >= size) {
+                if ((best == &freelist) || (b->bh.bsize < best->bh.bsize)) {
+                    best = b;
+                }
+            }
+            b = b->ql.flink;              /* Link to next buffer */
+        }
+        b = best;
 #endif /* BestFit */
 
-	while (b != &freelist) {
-	    if ((bufsize) b->bh.bsize >= size) {
+        while (b != &freelist) {
+            if ((bufsize) b->bh.bsize >= size) {
 
-		/* Buffer  is big enough to satisfy  the request.  Allocate it
-		   to the caller.  We must decide whether the buffer is  large
-		   enough  to  split  into  the part given to the caller and a
-		   free buffer that remains on the free list, or  whether  the
-		   entire  buffer  should  be  removed	from the free list and
-		   given to the caller in its entirety.   We  only  split  the
-		   buffer if enough room remains for a header plus the minimum
-		   quantum of allocation. */
+                /* Buffer  is big enough to satisfy  the request.  Allocate it
+                   to the caller.  We must decide whether the buffer is  large
+                   enough  to  split  into  the part given to the caller and a
+                   free buffer that remains on the free list, or  whether  the
+                   entire  buffer  should  be  removed  from the free list and
+                   given to the caller in its entirety.   We  only  split  the
+                   buffer if enough room remains for a header plus the minimum
+                   quantum of allocation. */
 
-		if ((b->bh.bsize - size) > (SizeQ + (sizeof(struct bhead)))) {
-		    struct bhead *ba, *bn;
+                if ((b->bh.bsize - size) > (SizeQ + (sizeof(struct bhead)))) {
+                    struct bhead *ba, *bn;
 
-		    ba = BH(((char *) b) + (b->bh.bsize - size));
-		    bn = BH(((char *) ba) + size);
-		    assert(bn->prevfree == b->bh.bsize);
-		    /* Subtract size from length of free block. */
-		    b->bh.bsize -= size;
-		    /* Link allocated buffer to the previous free buffer. */
-		    ba->prevfree = b->bh.bsize;
-		    /* Plug negative size into user buffer. */
-		    ba->bsize = -(bufsize) size;
-		    /* Mark buffer after this one not preceded by free block. */
-		    bn->prevfree = 0;
+                    ba = BH(((char *) b) + (b->bh.bsize - size));
+                    bn = BH(((char *) ba) + size);
+                    assert(bn->prevfree == b->bh.bsize);
+                    /* Subtract size from length of free block. */
+                    b->bh.bsize -= size;
+                    /* Link allocated buffer to the previous free buffer. */
+                    ba->prevfree = b->bh.bsize;
+                    /* Plug negative size into user buffer. */
+                    ba->bsize = -(bufsize) size;
+                    /* Mark buffer after this one not preceded by free block. */
+                    bn->prevfree = 0;
 
 #ifdef BufStats
-		    totalloc += size;
-		    numget++;		  /* Increment number of bget() calls */
+                    totalloc += size;
+                    numget++;             /* Increment number of bget() calls */
 #endif
-		    buf = (void *) ((((char *) ba) + sizeof(struct bhead)));
-		    return buf;
-		} else {
-		    struct bhead *ba;
+                    buf = (void *) ((((char *) ba) + sizeof(struct bhead)));
+                    return buf;
+                } else {
+                    struct bhead *ba;
 
-		    ba = BH(((char *) b) + b->bh.bsize);
-		    assert(ba->prevfree == b->bh.bsize);
+                    ba = BH(((char *) b) + b->bh.bsize);
+                    assert(ba->prevfree == b->bh.bsize);
 
                     /* The buffer isn't big enough to split.  Give  the  whole
-		       shebang to the caller and remove it from the free list. */
+                       shebang to the caller and remove it from the free list. */
 
-		    assert(b->ql.blink->ql.flink == b);
-		    assert(b->ql.flink->ql.blink == b);
-		    b->ql.blink->ql.flink = b->ql.flink;
-		    b->ql.flink->ql.blink = b->ql.blink;
+                    assert(b->ql.blink->ql.flink == b);
+                    assert(b->ql.flink->ql.blink == b);
+                    b->ql.blink->ql.flink = b->ql.flink;
+                    b->ql.flink->ql.blink = b->ql.blink;
 
 #ifdef BufStats
-		    totalloc += b->bh.bsize;
-		    numget++;		  /* Increment number of bget() calls */
+                    totalloc += b->bh.bsize;
+                    numget++;             /* Increment number of bget() calls */
 #endif
-		    /* Negate size to mark buffer allocated. */
-		    b->bh.bsize = -(b->bh.bsize);
+                    /* Negate size to mark buffer allocated. */
+                    b->bh.bsize = -(b->bh.bsize);
 
-		    /* Zero the back pointer in the next buffer in memory
-		       to indicate that this buffer is allocated. */
-		    ba->prevfree = 0;
+                    /* Zero the back pointer in the next buffer in memory
+                       to indicate that this buffer is allocated. */
+                    ba->prevfree = 0;
 
-		    /* Give user buffer starting at queue links. */
-		    buf =  (void *) &(b->ql);
-		    return buf;
-		}
-	    }
-	    b = b->ql.flink;		  /* Link to next buffer */
-	}
+                    /* Give user buffer starting at queue links. */
+                    buf =  (void *) &(b->ql);
+                    return buf;
+                }
+            }
+            b = b->ql.flink;              /* Link to next buffer */
+        }
 #ifdef BECtl
 
         /* We failed to find a buffer.  If there's a compact  function
-	   defined,  notify  it  of the size requested.  If it returns
-	   TRUE, try the allocation again. */
+           defined,  notify  it  of the size requested.  If it returns
+           TRUE, try the allocation again. */
 
-	if ((compfcn == NULL) || (!(*compfcn)(size, ++compactseq))) {
-	    break;
-	}
+        if ((compfcn == NULL) || (!(*compfcn)(size, ++compactseq))) {
+            break;
+        }
     }
 
     /* No buffer available with requested size free. */
@@ -754,52 +754,52 @@ void *bget(requested_size)
     /* Don't give up yet -- look in the reserve supply. */
 
     if (acqfcn != NULL) {
-	if (size > exp_incr - sizeof(struct bhead)) {
+        if (size > exp_incr - sizeof(struct bhead)) {
 
-	    /* Request	is  too  large	to  fit in a single expansion
-	       block.  Try to satisy it by a direct buffer acquisition. */
+            /* Request  is  too  large  to  fit in a single expansion
+               block.  Try to satisy it by a direct buffer acquisition. */
 
-	    struct bdhead *bdh;
+            struct bdhead *bdh;
 
-	    size += sizeof(struct bdhead) - sizeof(struct bhead);
-	    if ((bdh = BDH((*acqfcn)((bufsize) size))) != NULL) {
+            size += sizeof(struct bdhead) - sizeof(struct bhead);
+            if ((bdh = BDH((*acqfcn)((bufsize) size))) != NULL) {
 
-		/*  Mark the buffer special by setting the size field
-		    of its header to zero.  */
-		bdh->bh.bsize = 0;
-		bdh->bh.prevfree = 0;
-		bdh->tsize = size;
+                /*  Mark the buffer special by setting the size field
+                    of its header to zero.  */
+                bdh->bh.bsize = 0;
+                bdh->bh.prevfree = 0;
+                bdh->tsize = size;
 #ifdef BufStats
-		totalloc += size;
-		numget++;	      /* Increment number of bget() calls */
-		numdget++;	      /* Direct bget() call count */
+                totalloc += size;
+                numget++;             /* Increment number of bget() calls */
+                numdget++;            /* Direct bget() call count */
 #endif
-		buf =  (void *) (bdh + 1);
+                buf =  (void *) (bdh + 1);
 
-	    /*only let this happen once */
-		printf("%s %d memory request exceeds block size %d %d %x\n",__FILE__,__LINE__,size,exp_incr,buf);
-	    exp_incr = size+sizeof(struct bhead);
-	    
-		return buf;
-	    }
+                /*only let this happen once */
+                printf("%s %d memory request exceeds block size %d %d %x\n",__FILE__,__LINE__,size,exp_incr,buf);
+                exp_incr = size+sizeof(struct bhead);
 
-	} else {
+                return buf;
+            }
 
-	    /*	Try to obtain a new expansion block */
+        } else {
 
-	    void *newpool;
+            /*  Try to obtain a new expansion block */
 
-	    if ((newpool = (*acqfcn)((bufsize) exp_incr)) != NULL) {
-		bpool(newpool, exp_incr);
+            void *newpool;
+
+            if ((newpool = (*acqfcn)((bufsize) exp_incr)) != NULL) {
+                bpool(newpool, exp_incr);
                 buf =  bget(requested_size);  /* This can't, I say, can't
-						 get into a loop. */
-		//		printf("%s %d new memory block of size %d\n",__FILE__,__LINE__,exp_incr);
-		return buf;
-	    }
-	}
+                                                 get into a loop. */
+                //              printf("%s %d new memory block of size %d\n",__FILE__,__LINE__,exp_incr);
+                return buf;
+            }
+        }
     }
 
-    /*	Still no buffer available */
+    /*  Still no buffer available */
 
 #endif /* BECtl */
 
@@ -807,71 +807,71 @@ void *bget(requested_size)
 }
 
 /*  BGETZ  --  Allocate a buffer and clear its contents to zero.  We clear
-	       the  entire  contents  of  the buffer to zero, not just the
-	       region requested by the caller. */
+    the  entire  contents  of  the buffer to zero, not just the
+    region requested by the caller. */
 
 void *bgetz(size)
-  bufsize size;
+bufsize size;
 {
     char *buf = (char *) bget(size);
 
     if (buf != NULL) {
-	struct bhead *b;
-	bufsize rsize;
+        struct bhead *b;
+        bufsize rsize;
 
-	b = BH(buf - sizeof(struct bhead));
-	rsize = -(b->bsize);
-	if (rsize == 0) {
-	    struct bdhead *bd;
+        b = BH(buf - sizeof(struct bhead));
+        rsize = -(b->bsize);
+        if (rsize == 0) {
+            struct bdhead *bd;
 
-	    bd = BDH(buf - sizeof(struct bdhead));
-	    rsize = bd->tsize - sizeof(struct bdhead);
-	} else {
-	    rsize -= sizeof(struct bhead);
-	}
-	assert(rsize >= size);
-	V memset(buf, 0, (MemSize) rsize);
+            bd = BDH(buf - sizeof(struct bdhead));
+            rsize = bd->tsize - sizeof(struct bdhead);
+        } else {
+            rsize -= sizeof(struct bhead);
+        }
+        assert(rsize >= size);
+        V memset(buf, 0, (MemSize) rsize);
     }
     return ((void *) buf);
 }
 
 /*  BGETR  --  Reallocate a buffer.  This is a minimal implementation,
-	       simply in terms of brel()  and  bget().	 It  could  be
-	       enhanced to allow the buffer to grow into adjacent free
-	       blocks and to avoid moving data unnecessarily.  */
+    simply in terms of brel()  and  bget().      It  could  be
+    enhanced to allow the buffer to grow into adjacent free
+    blocks and to avoid moving data unnecessarily.  */
 
 void *bgetr(buf, size)
-  void *buf;
-  bufsize size;
+void *buf;
+bufsize size;
 {
     void *nbuf;
-    bufsize osize;		      /* Old size of buffer */
+    bufsize osize;                    /* Old size of buffer */
     struct bhead *b;
 
 #ifdef PIO_USE_MALLOC
     return(realloc(buf, size));
 #endif
     if ((nbuf = bget(size)) == NULL) { /* Acquire new buffer */
-	return NULL;
+        return NULL;
     }
     if (buf == NULL) {
-	return nbuf;
+        return nbuf;
     }
     b = BH(((char *) buf) - sizeof(struct bhead));
     osize = -b->bsize;
 #ifdef BECtl
     if (osize == 0) {
-	/*  Buffer acquired directly through acqfcn. */
-	struct bdhead *bd;
+        /*  Buffer acquired directly through acqfcn. */
+        struct bdhead *bd;
 
-	bd = BDH(((char *) buf) - sizeof(struct bdhead));
-	osize = bd->tsize - sizeof(struct bdhead);
+        bd = BDH(((char *) buf) - sizeof(struct bdhead));
+        osize = bd->tsize - sizeof(struct bdhead);
     } else
 #endif
-	osize -= sizeof(struct bhead);
+        osize -= sizeof(struct bhead);
     assert(osize > 0);
     V memcpy((char *) nbuf, (char *) buf, /* Copy the data */
-	     (MemSize) ((size < osize) ? size : osize));
+             (MemSize) ((size < osize) ? size : osize));
     brel(buf);
     return nbuf;
 }
@@ -879,7 +879,7 @@ void *bgetr(buf, size)
 /*  BREL  --  Release a buffer.  */
 
 void brel(buf)
-  void *buf;
+void *buf;
 {
     struct bfhead *b, *bn;
 
@@ -887,35 +887,35 @@ void brel(buf)
     //    printf("bget free %d %x\n",__LINE__,buf);
     free(buf);
     return;
-#endif    
+#endif
 
 
     if(buf==NULL) return;       /* allow for null buffer */
 
     b = BFH(((char *) buf) - sizeof(struct bhead));
 #ifdef BufStats
-    numrel++;			      /* Increment number of brel() calls */
+    numrel++;                         /* Increment number of brel() calls */
 #endif
     assert(buf != NULL);
 
 #ifdef BECtl
-    if (b->bh.bsize == 0) {	      /* Directly-acquired buffer? */
-	struct bdhead *bdh;
+    if (b->bh.bsize == 0) {           /* Directly-acquired buffer? */
+        struct bdhead *bdh;
 
-	bdh = BDH(((char *) buf) - sizeof(struct bdhead));
-	assert(b->bh.prevfree == 0);
+        bdh = BDH(((char *) buf) - sizeof(struct bdhead));
+        assert(b->bh.prevfree == 0);
 #ifdef BufStats
-	totalloc -= bdh->tsize;
-	assert(totalloc >= 0);
-	numdrel++;		      /* Number of direct releases */
+        totalloc -= bdh->tsize;
+        assert(totalloc >= 0);
+        numdrel++;                    /* Number of direct releases */
 #endif /* BufStats */
 #ifdef FreeWipe
-	V memset((char *) buf, 0x55,
-		 (MemSize) (bdh->tsize - sizeof(struct bdhead)));
+        V memset((char *) buf, 0x55,
+                 (MemSize) (bdh->tsize - sizeof(struct bdhead)));
 #endif /* FreeWipe */
-	assert(relfcn != NULL);
-	(*relfcn)((void *) bdh);      /* Release it directly. */
-	return;
+        assert(relfcn != NULL);
+        (*relfcn)((void *) bdh);      /* Release it directly. */
+        return;
     }
 #endif /* BECtl */
 
@@ -923,12 +923,12 @@ void brel(buf)
        allocated. */
 
     if (b->bh.bsize >= 0) {
-	bn = NULL;
+        bn = NULL;
     }
     assert(b->bh.bsize < 0);
 
-    /*	Back pointer in next buffer must be zero, indicating the
-	same thing: */
+    /*  Back pointer in next buffer must be zero, indicating the
+        same thing: */
 
     assert(BH((char *) b - b->bh.bsize)->prevfree == 0);
 
@@ -941,62 +941,62 @@ void brel(buf)
 
     if (b->bh.prevfree != 0) {
 
-	/* The previous buffer is free.  Consolidate this buffer  with	it
-	   by  adding  the  length  of	this  buffer  to the previous free
-	   buffer.  Note that we subtract the size  in	the  buffer  being
+        /* The previous buffer is free.  Consolidate this buffer  with  it
+           by  adding  the  length  of  this  buffer  to the previous free
+           buffer.  Note that we subtract the size  in  the  buffer  being
            released,  since  it's  negative to indicate that the buffer is
-	   allocated. */
+           allocated. */
 
-	register bufsize size = b->bh.bsize;
+        register bufsize size = b->bh.bsize;
 
         /* Make the previous buffer the one we're working on. */
-	assert(BH((char *) b - b->bh.prevfree)->bsize == b->bh.prevfree);
-	b = BFH(((char *) b) - b->bh.prevfree);
-	b->bh.bsize -= size;
+        assert(BH((char *) b - b->bh.prevfree)->bsize == b->bh.prevfree);
+        b = BFH(((char *) b) - b->bh.prevfree);
+        b->bh.bsize -= size;
     } else {
 
         /* The previous buffer isn't allocated.  Insert this buffer
-	   on the free list as an isolated free block. */
+           on the free list as an isolated free block. */
 
-	assert(freelist.ql.blink->ql.flink == &freelist);
-	assert(freelist.ql.flink->ql.blink == &freelist);
-	b->ql.flink = &freelist;
-	b->ql.blink = freelist.ql.blink;
-	freelist.ql.blink = b;
-	b->ql.blink->ql.flink = b;
-	b->bh.bsize = -b->bh.bsize;
+        assert(freelist.ql.blink->ql.flink == &freelist);
+        assert(freelist.ql.flink->ql.blink == &freelist);
+        b->ql.flink = &freelist;
+        b->ql.blink = freelist.ql.blink;
+        freelist.ql.blink = b;
+        b->ql.blink->ql.flink = b;
+        b->bh.bsize = -b->bh.bsize;
     }
 
     /* Now we look at the next buffer in memory, located by advancing from
        the  start  of  this  buffer  by its size, to see if that buffer is
-       free.  If it is, we combine  this  buffer  with	the  next  one	in
+       free.  If it is, we combine  this  buffer  with  the  next  one  in
        memory, dechaining the second buffer from the free list. */
 
     bn =  BFH(((char *) b) + b->bh.bsize);
     if (bn->bh.bsize > 0) {
 
-	/* The buffer is free.	Remove it from the free list and add
-	   its size to that of our buffer. */
+        /* The buffer is free.  Remove it from the free list and add
+           its size to that of our buffer. */
 
-	assert(BH((char *) bn + bn->bh.bsize)->prevfree == bn->bh.bsize);
-	assert(bn->ql.blink->ql.flink == bn);
-	assert(bn->ql.flink->ql.blink == bn);
-	bn->ql.blink->ql.flink = bn->ql.flink;
-	bn->ql.flink->ql.blink = bn->ql.blink;
-	b->bh.bsize += bn->bh.bsize;
+        assert(BH((char *) bn + bn->bh.bsize)->prevfree == bn->bh.bsize);
+        assert(bn->ql.blink->ql.flink == bn);
+        assert(bn->ql.flink->ql.blink == bn);
+        bn->ql.blink->ql.flink = bn->ql.flink;
+        bn->ql.flink->ql.blink = bn->ql.blink;
+        b->bh.bsize += bn->bh.bsize;
 
-	/* Finally,  advance  to   the	buffer	that   follows	the  newly
-	   consolidated free block.  We must set its  backpointer  to  the
-	   head  of  the  consolidated free block.  We know the next block
-	   must be an allocated block because the process of recombination
-	   guarantees  that  two  free	blocks will never be contiguous in
-	   memory.  */
+        /* Finally,  advance  to   the  buffer  that   follows  the  newly
+           consolidated free block.  We must set its  backpointer  to  the
+           head  of  the  consolidated free block.  We know the next block
+           must be an allocated block because the process of recombination
+           guarantees  that  two  free  blocks will never be contiguous in
+           memory.  */
 
-	bn = BFH(((char *) b) + b->bh.bsize);
+        bn = BFH(((char *) b) + b->bh.bsize);
     }
 #ifdef FreeWipe
     V memset(((char *) b) + sizeof(struct bfhead), 0x55,
-	    (MemSize) (b->bh.bsize - sizeof(struct bfhead)));
+             (MemSize) (b->bh.bsize - sizeof(struct bfhead)));
 #endif
     assert(bn->bh.bsize < 0);
 
@@ -1007,27 +1007,27 @@ void brel(buf)
 
 #ifdef BECtl
 
-    /*	If  a  block-release function is defined, and this free buffer
-	constitutes the entire block, release it.  Note that  pool_len
-	is  defined  in  such a way that the test will fail unless all
-	pool blocks are the same size.	*/
+    /*  If  a  block-release function is defined, and this free buffer
+        constitutes the entire block, release it.  Note that  pool_len
+        is  defined  in  such a way that the test will fail unless all
+        pool blocks are the same size.  */
 
     if (relfcn != NULL &&
-	((bufsize) b->bh.bsize) == (pool_len - sizeof(struct bhead))) {
+        ((bufsize) b->bh.bsize) == (pool_len - sizeof(struct bhead))) {
 
-	assert(b->bh.prevfree == 0);
-	assert(BH((char *) b + b->bh.bsize)->bsize == ESent);
-	assert(BH((char *) b + b->bh.bsize)->prevfree == b->bh.bsize);
-	/*  Unlink the buffer from the free list  */
-	b->ql.blink->ql.flink = b->ql.flink;
-	b->ql.flink->ql.blink = b->ql.blink;
-	//	printf("%s %d calling direct release for %x\n",__FILE__,__LINE__,b);
-	(*relfcn)(b);
-	//	printf("%s %d completed direct release \n",__FILE__,__LINE__);
+        assert(b->bh.prevfree == 0);
+        assert(BH((char *) b + b->bh.bsize)->bsize == ESent);
+        assert(BH((char *) b + b->bh.bsize)->prevfree == b->bh.bsize);
+        /*  Unlink the buffer from the free list  */
+        b->ql.blink->ql.flink = b->ql.flink;
+        b->ql.flink->ql.blink = b->ql.blink;
+        //      printf("%s %d calling direct release for %x\n",__FILE__,__LINE__,b);
+        (*relfcn)(b);
+        //      printf("%s %d completed direct release \n",__FILE__,__LINE__);
 #ifdef BufStats
-	numprel++;		      /* Nr of expansion block releases */
-	numpblk--;		      /* Total number of blocks */
-	assert(numpblk == numpget - numprel);
+        numprel++;                    /* Nr of expansion block releases */
+        numpblk--;                    /* Total number of blocks */
+        assert(numpblk == numpget - numprel);
 #endif /* BufStats */
     }
 #endif /* BECtl */
@@ -1038,10 +1038,10 @@ void brel(buf)
 /*  BECTL  --  Establish automatic pool expansion control  */
 
 void bectl(compact, acquire, release, pool_incr)
-  int (*compact) _((bufsize sizereq, int sequence));
-  void *(*acquire) _((bufsize size));
-  void (*release) _((void *buf));
-  bufsize pool_incr;
+    int (*compact) _((bufsize sizereq, int sequence));
+void *(*acquire) _((bufsize size));
+void (*release) _((void *buf));
+bufsize pool_incr;
 {
     compfcn = compact;
     acqfcn = acquire;
@@ -1053,8 +1053,8 @@ void bectl(compact, acquire, release, pool_incr)
 /*  BPOOL  --  Add a region of memory to the buffer pool.  */
 
 void bpool(buf, len)
-  void *buf;
-  bufsize len;
+void *buf;
+bufsize len;
 {
     struct bfhead *b = BFH(buf);
     struct bhead *bn;
@@ -1064,19 +1064,19 @@ void bpool(buf, len)
 #endif
 #ifdef BECtl
     if (pool_len == 0) {
-	pool_len = len;
+        pool_len = len;
     } else if (len != pool_len) {
-	pool_len = -1;
+        pool_len = -1;
     }
 #ifdef BufStats
-    numpget++;			      /* Number of block acquisitions */
-    numpblk++;			      /* Number of blocks total */
+    numpget++;                        /* Number of block acquisitions */
+    numpblk++;                        /* Number of blocks total */
     assert(numpblk == numpget - numprel);
 #endif /* BufStats */
 #endif /* BECtl */
 
     /* Since the block is initially occupied by a single free  buffer,
-       it  had	better	not  be  (much) larger than the largest buffer
+       it  had  better  not  be  (much) larger than the largest buffer
        whose size we can store in bhead.bsize. */
 
     assert(len - sizeof(struct bhead) <= -((bufsize) ESent + 1));
@@ -1096,7 +1096,7 @@ void bpool(buf, len)
     freelist.ql.blink = b;
     b->ql.blink->ql.flink = b;
 
-    /* Create a dummy allocated buffer at the end of the pool.	This dummy
+    /* Create a dummy allocated buffer at the end of the pool.  This dummy
        buffer is seen when a buffer at the end of the pool is released and
        blocks  recombination  of  the last buffer with the dummy buffer at
        the end.  The length in the dummy buffer  is  set  to  the  largest
@@ -1108,7 +1108,7 @@ void bpool(buf, len)
     b->bh.bsize = (bufsize) len;
 #ifdef FreeWipe
     V memset(((char *) b) + sizeof(struct bfhead), 0x55,
-	     (MemSize) (len - sizeof(struct bfhead)));
+             (MemSize) (len - sizeof(struct bfhead)));
 #endif
     bn = BH(((char *) b) + len);
     bn->prevfree = (bufsize) len;
@@ -1121,24 +1121,24 @@ void bpool(buf, len)
 
 void bfreespace(bufsize *totfree, bufsize *maxfree)
 {
-   struct bfhead *b = freelist.ql.flink;
+    struct bfhead *b = freelist.ql.flink;
     *totfree = 0;
     *maxfree = -1;
     while (b != &freelist) {
-	assert(b->bh.bsize > 0);
-	*totfree += b->bh.bsize;
-	if (b->bh.bsize > *maxfree) {
-	    *maxfree = b->bh.bsize;
-	}
-	b = b->ql.flink;	      /* Link to next buffer */
+        assert(b->bh.bsize > 0);
+        *totfree += b->bh.bsize;
+        if (b->bh.bsize > *maxfree) {
+            *maxfree = b->bh.bsize;
+        }
+        b = b->ql.flink;              /* Link to next buffer */
     }
 }
 
-/*  BSTATS  --	Return buffer allocation free space statistics.  */
+/*  BSTATS  --  Return buffer allocation free space statistics.  */
 
 void bstats(curalloc, totfree, maxfree, nget, nrel)
-  bufsize *curalloc, *totfree, *maxfree;
-  long *nget, *nrel;
+    bufsize *curalloc, *totfree, *maxfree;
+long *nget, *nrel;
 {
     *nget = numget;
     *nrel = numrel;
@@ -1151,8 +1151,8 @@ void bstats(curalloc, totfree, maxfree, nget, nrel)
 /*  BSTATSE  --  Return extended statistics  */
 
 void bstatse(pool_incr, npool, npget, nprel, ndget, ndrel)
-  bufsize *pool_incr;
-  long *npool, *npget, *nprel, *ndget, *ndrel;
+bufsize *pool_incr;
+long *npool, *npget, *nprel, *ndget, *ndrel;
 {
     *pool_incr = (pool_len < 0) ? -exp_incr : exp_incr;
     *npool = numpblk;
@@ -1167,11 +1167,11 @@ void bstatse(pool_incr, npool, npget, nprel, ndget, ndrel)
 #ifdef DumpData
 
 /*  BUFDUMP  --  Dump the data in a buffer.  This is called with the  user
-		 data pointer, and backs up to the buffer header.  It will
-		 dump either a free block or an allocated one.	*/
+    data pointer, and backs up to the buffer header.  It will
+    dump either a free block or an allocated one.       */
 
 void bufdump(buf)
-  void *buf;
+void *buf;
 {
     struct bfhead *b;
     unsigned char *bdump;
@@ -1180,96 +1180,96 @@ void bufdump(buf)
     b = BFH(((char *) buf) - sizeof(struct bhead));
     assert(b->bh.bsize != 0);
     if (b->bh.bsize < 0) {
-	bdump = (unsigned char *) buf;
-	bdlen = (-b->bh.bsize) - sizeof(struct bhead);
+        bdump = (unsigned char *) buf;
+        bdlen = (-b->bh.bsize) - sizeof(struct bhead);
     } else {
-	bdump = (unsigned char *) (((char *) b) + sizeof(struct bfhead));
-	bdlen = b->bh.bsize - sizeof(struct bfhead);
+        bdump = (unsigned char *) (((char *) b) + sizeof(struct bfhead));
+        bdlen = b->bh.bsize - sizeof(struct bfhead);
     }
 
     while (bdlen > 0) {
-	int i, dupes = 0;
-	bufsize l = bdlen;
-	char bhex[50], bascii[20];
+        int i, dupes = 0;
+        bufsize l = bdlen;
+        char bhex[50], bascii[20];
 
-	if (l > 16) {
-	    l = 16;
-	}
+        if (l > 16) {
+            l = 16;
+        }
 
-	for (i = 0; i < l; i++) {
+        for (i = 0; i < l; i++) {
             V sprintf(bhex + i * 3, "%02X ", bdump[i]);
             bascii[i] = isprint(bdump[i]) ? bdump[i] : ' ';
-	}
-	bascii[i] = 0;
+        }
+        bascii[i] = 0;
         V printf("%-48s   %s\n", bhex, bascii);
-	bdump += l;
-	bdlen -= l;
-	while ((bdlen > 16) && (memcmp((char *) (bdump - 16),
-				       (char *) bdump, 16) == 0)) {
-	    dupes++;
-	    bdump += 16;
-	    bdlen -= 16;
-	}
-	if (dupes > 1) {
-	    V printf(
+        bdump += l;
+        bdlen -= l;
+        while ((bdlen > 16) && (memcmp((char *) (bdump - 16),
+                                       (char *) bdump, 16) == 0)) {
+            dupes++;
+            bdump += 16;
+            bdlen -= 16;
+        }
+        if (dupes > 1) {
+            V printf(
                 "     (%d lines [%d bytes] identical to above line skipped)\n",
-		dupes, dupes * 16);
-	} else if (dupes == 1) {
-	    bdump -= 16;
-	    bdlen += 16;
-	}
+                dupes, dupes * 16);
+        } else if (dupes == 1) {
+            bdump -= 16;
+            bdlen += 16;
+        }
     }
 }
 #endif
 
 #ifdef BufDump
 
-/*  BPOOLD  --	Dump a buffer pool.  The buffer headers are always listed.
-		If DUMPALLOC is nonzero, the contents of allocated buffers
-		are  dumped.   If  DUMPFREE  is  nonzero,  free blocks are
-		dumped as well.  If FreeWipe  checking	is  enabled,  free
-		blocks	which  have  been clobbered will always be dumped. */
+/*  BPOOLD  --  Dump a buffer pool.  The buffer headers are always listed.
+    If DUMPALLOC is nonzero, the contents of allocated buffers
+    are  dumped.   If  DUMPFREE  is  nonzero,  free blocks are
+    dumped as well.  If FreeWipe  checking      is  enabled,  free
+    blocks      which  have  been clobbered will always be dumped. */
 
 void bpoold(buf, dumpalloc, dumpfree)
-  void *buf;
-  int dumpalloc, dumpfree;
+void *buf;
+int dumpalloc, dumpfree;
 {
     struct bfhead *b = BFH(buf);
 
     while (b->bh.bsize != ESent) {
-	bufsize bs = b->bh.bsize;
+        bufsize bs = b->bh.bsize;
 
-	if (bs < 0) {
-	    bs = -bs;
+        if (bs < 0) {
+            bs = -bs;
             V printf("Allocated buffer: size %6ld bytes.\n", (long) bs);
-	    if (dumpalloc) {
-		bufdump((void *) (((char *) b) + sizeof(struct bhead)));
-	    }
-	} else {
+            if (dumpalloc) {
+                bufdump((void *) (((char *) b) + sizeof(struct bhead)));
+            }
+        } else {
             char *lerr = "";
 
-	    assert(bs > 0);
-	    if ((b->ql.blink->ql.flink != b) ||
-		(b->ql.flink->ql.blink != b)) {
+            assert(bs > 0);
+            if ((b->ql.blink->ql.flink != b) ||
+                (b->ql.flink->ql.blink != b)) {
                 lerr = "  (Bad free list links)";
-	    }
+            }
             V printf("Free block:       size %6ld bytes.%s\n",
-		(long) bs, lerr);
+                     (long) bs, lerr);
 #ifdef FreeWipe
-	    lerr = ((char *) b) + sizeof(struct bfhead);
-	    if ((bs > sizeof(struct bfhead)) && ((*lerr != 0x55) ||
-		(memcmp(lerr, lerr + 1,
-		  (MemSize) (bs - (sizeof(struct bfhead) + 1))) != 0))) {
-		V printf(
+            lerr = ((char *) b) + sizeof(struct bfhead);
+            if ((bs > sizeof(struct bfhead)) && ((*lerr != 0x55) ||
+                                                 (memcmp(lerr, lerr + 1,
+                                                         (MemSize) (bs - (sizeof(struct bfhead) + 1))) != 0))) {
+                V printf(
                     "(Contents of above free block have been overstored.)\n");
-		bufdump((void *) (((char *) b) + sizeof(struct bhead)));
-	    } else
+                bufdump((void *) (((char *) b) + sizeof(struct bhead)));
+            } else
 #endif
-	    if (dumpfree) {
-		bufdump((void *) (((char *) b) + sizeof(struct bhead)));
-	    }
-	}
-	b = BFH(((char *) b) + bs);
+                if (dumpfree) {
+                    bufdump((void *) (((char *) b) + sizeof(struct bhead)));
+                }
+        }
+        b = BFH(((char *) b) + bs);
     }
 }
 #endif /* BufDump */
@@ -1277,79 +1277,79 @@ void bpoold(buf, dumpalloc, dumpfree)
 #ifdef BufValid
 
 /*  BPOOLV  --  Validate a buffer pool.  If NDEBUG isn't defined,
-		any error generates an assertion failure.  */
+    any error generates an assertion failure.  */
 
 int bpoolv(buf)
-  void *buf;
+void *buf;
 {
     struct bfhead *b = BFH(buf);
 
     while (b->bh.bsize != ESent) {
-	bufsize bs = b->bh.bsize;
+        bufsize bs = b->bh.bsize;
 
-	if (bs < 0) {
-	    bs = -bs;
-	} else {
+        if (bs < 0) {
+            bs = -bs;
+        } else {
             char *lerr = "";
 
-	    assert(bs > 0);
-	    if (bs <= 0) {
-		return 0;
-	    }
-	    if ((b->ql.blink->ql.flink != b) ||
-		(b->ql.flink->ql.blink != b)) {
+            assert(bs > 0);
+            if (bs <= 0) {
+                return 0;
+            }
+            if ((b->ql.blink->ql.flink != b) ||
+                (b->ql.flink->ql.blink != b)) {
                 V printf("Free block: size %6ld bytes.  (Bad free list links)\n",
-		     (long) bs);
-		assert(0);
-		return 0;
-	    }
+                         (long) bs);
+                assert(0);
+                return 0;
+            }
 #ifdef FreeWipe
-	    lerr = ((char *) b) + sizeof(struct bfhead);
-	    if ((bs > sizeof(struct bfhead)) && ((*lerr != 0x55) ||
-		(memcmp(lerr, lerr + 1,
-		  (MemSize) (bs - (sizeof(struct bfhead) + 1))) != 0))) {
-		V printf(
+            lerr = ((char *) b) + sizeof(struct bfhead);
+            if ((bs > sizeof(struct bfhead)) && ((*lerr != 0x55) ||
+                                                 (memcmp(lerr, lerr + 1,
+                                                         (MemSize) (bs - (sizeof(struct bfhead) + 1))) != 0))) {
+                V printf(
                     "(Contents of above free block have been overstored.)\n");
-		bufdump((void *) (((char *) b) + sizeof(struct bhead)));
-		assert(0);
-		return 0;
-	    }
+                bufdump((void *) (((char *) b) + sizeof(struct bhead)));
+                assert(0);
+                return 0;
+            }
 #endif
-	}
-	b = BFH(((char *) b) + bs);
+        }
+        b = BFH(((char *) b) + bs);
     }
     return 1;
 }
 #endif /* BufValid */
 
-        /***********************\
-	*			*
-	* Built-in test program *
-	*			*
+/***********************\
+ *                      *
+ * Built-in test program *
+ *                      *
         \***********************/
 
 #ifdef TestProg
 
-#define Repeatable  1		      /* Repeatable pseudorandom sequence */
-				      /* If Repeatable is not defined, a
-					 time-seeded pseudorandom sequence
-					 is generated, exercising BGET with
-					 a different pattern of calls on each
-					 run. */
-#define OUR_RAND		      /* Use our own built-in version of
-					 rand() to guarantee the test is
-					 100% repeatable. */
+#define Repeatable  1                 /* Repeatable pseudorandom sequence */
+                                      /* If Repeatable is not defined, a
+                                         time-seeded pseudorandom sequence
+                                         is generated, exercising BGET with
+                                         a different pattern of calls on each
+                                         run. */
+#define OUR_RAND                      /* Use our own built-in version of
+                                         rand() to guarantee the test is
+                                         100% repeatable. */
 
 #ifdef BECtl
-#define PoolSize    300000	      /* Test buffer pool size */
+#define PoolSize    300000            /* Test buffer pool size */
 #else
-#define PoolSize    50000	      /* Test buffer pool size */
+#define PoolSize    50000             /* Test buffer pool size */
 #endif
-#define ExpIncr     32768	      /* Test expansion block size */
-#define CompactTries 10 	      /* Maximum tries at compacting */
+#define ExpIncr     32768             /* Test expansion block size */
+#define CompactTries 10               /* Maximum tries at compacting */
 
-#define dumpAlloc   0		      /* Dump allocated buffers ? */
-#define dumpFree    0		      /* Dump free buffers ? */
+#define dumpAlloc   0                 /* Dump allocated buffers ? */
+#define dumpFree    0                 /* Dump free buffers ? */
 
 #ifndef Repeatable
 extern long time();
@@ -1358,8 +1358,8 @@ extern long time();
 extern char *malloc();
 extern int free _((char *));
 
-static char *bchain = NULL;	      /* Our private buffer chain */
-static char *bp = NULL; 	      /* Our initial buffer pool */
+static char *bchain = NULL;           /* Our private buffer chain */
+static char *bp = NULL;               /* Our initial buffer pool */
 
 #include <math.h>
 
@@ -1371,23 +1371,23 @@ static unsigned long int next = 1;
 
 int rand()
 {
-	next = next * 1103515245L + 12345;
-	return (unsigned int) (next / 65536L) % 32768L;
+    next = next * 1103515245L + 12345;
+    return (unsigned int) (next / 65536L) % 32768L;
 }
 
 /* Set seed for random generator */
 
 void srand(seed)
-  unsigned int seed;
+unsigned int seed;
 {
-	next = seed;
+    next = seed;
 }
 #endif
 
 /*  STATS  --  Edit statistics returned by bstats() or bstatse().  */
 
 static void stats(when)
-  char *when;
+char *when;
 {
     bufsize cural, totfree, maxfree;
     long nget, nfree;
@@ -1399,24 +1399,24 @@ static void stats(when)
     bstats(&cural, &totfree, &maxfree, &nget, &nfree);
     V printf(
         "%s: %ld gets, %ld releases.  %ld in use, %ld free, largest = %ld\n",
-	when, nget, nfree, (long) cural, (long) totfree, (long) maxfree);
+        when, nget, nfree, (long) cural, (long) totfree, (long) maxfree);
 #ifdef BECtl
     bstatse(&pincr, &totblocks, &npget, &nprel, &ndget, &ndrel);
     V printf(
-         "  Blocks: size = %ld, %ld (%ld bytes) in use, %ld gets, %ld frees\n",
-	 (long)pincr, totblocks, pincr * totblocks, npget, nprel);
+        "  Blocks: size = %ld, %ld (%ld bytes) in use, %ld gets, %ld frees\n",
+        (long)pincr, totblocks, pincr * totblocks, npget, nprel);
     V printf("  %ld direct gets, %ld direct frees\n", ndget, ndrel);
 #endif /* BECtl */
 }
 
 #ifdef BECtl
-static int protect = 0; 	      /* Disable compaction during bgetr() */
+static int protect = 0;               /* Disable compaction during bgetr() */
 
 /*  BCOMPACT  --  Compaction call-back function.  */
 
 static int bcompact(bsize, seq)
-  bufsize bsize;
-  int seq;
+bufsize bsize;
+int seq;
 {
 #ifdef CompactTries
     char *bc = bchain;
@@ -1424,32 +1424,32 @@ static int bcompact(bsize, seq)
 
 #ifdef COMPACTRACE
     V printf("Compaction requested.  %ld bytes needed, sequence %d.\n",
-	(long) bsize, seq);
+             (long) bsize, seq);
 #endif
 
     if (protect || (seq > CompactTries)) {
 #ifdef COMPACTRACE
         V printf("Compaction gave up.\n");
 #endif
-	return 0;
+        return 0;
     }
 
     /* Based on a random cast, release a random buffer in the list
        of allocated buffers. */
 
     while (i > 0 && bc != NULL) {
-	bc = *((char **) bc);
-	i--;
+        bc = *((char **) bc);
+        i--;
     }
     if (bc != NULL) {
-	char *fb;
+        char *fb;
 
-	fb = *((char **) bc);
-	if (fb != NULL) {
-	    *((char **) bc) = *((char **) fb);
-	    brel((void *) fb);
-	    return 1;
-	}
+        fb = *((char **) bc);
+        if (fb != NULL) {
+            *((char **) bc) = *((char **) fb);
+            brel((void *) fb);
+            return 1;
+        }
     }
 
 #ifdef COMPACTRACE
@@ -1462,7 +1462,7 @@ static int bcompact(bsize, seq)
 /*  BEXPAND  --  Expand pool call-back function.  */
 
 static void *bexpand(size)
-  bufsize size;
+bufsize size;
 {
     void *np = NULL;
     bufsize cural, totfree, maxfree;
@@ -1473,11 +1473,11 @@ static void *bexpand(size)
     bstats(&cural, &totfree, &maxfree, &nget, &nfree);
 
     if (cural < PoolSize) {
-	np = (void *) malloc((unsigned) size);
+        np = (void *) malloc((unsigned) size);
     }
 #ifdef EXPTRACE
     V printf("Expand pool by %ld -- %s.\n", (long) size,
-        np == NULL ? "failed" : "succeeded");
+             np == NULL ? "failed" : "succeeded");
 #endif
     return np;
 }
@@ -1485,13 +1485,13 @@ static void *bexpand(size)
 /*  BSHRINK  --  Shrink buffer pool call-back function.  */
 
 static void bshrink(buf)
-  void *buf;
+void *buf;
 {
     if (((char *) buf) == bp) {
 #ifdef EXPTRACE
         V printf("Initial pool released.\n");
 #endif
-	bp = NULL;
+        bp = NULL;
     }
 #ifdef EXPTRACE
     V printf("Shrink pool.\n");
@@ -1505,10 +1505,10 @@ static void bshrink(buf)
     small enough for the CPU architecture.  */
 
 static bufsize blimit(bs)
-  bufsize bs;
+bufsize bs;
 {
     if (bs < sizeof(char *)) {
-	bs = sizeof(char *);
+        bs = sizeof(char *);
     }
 
     /* This is written out in this ugly fashion because the
@@ -1516,13 +1516,13 @@ static bufsize blimit(bs)
        to any length int befuddled some compilers. */
 
     if (sizeof(int) == 2) {
-	if (bs > 32767) {
-	    bs = 32767;
-	}
+        if (bs > 32767) {
+            bs = 32767;
+        }
     } else {
-	if (bs > 200000) {
-	    bs = 200000;
-	}
+        if (bs > 200000) {
+            bs = 200000;
+        }
     }
     return bs;
 }
@@ -1542,9 +1542,9 @@ int main()
     V srand((int) time((long *) NULL));
 #endif
 
-    /*	Compute x such that pow(x, p) ranges between 1 and 4*ExpIncr as
-	p ranges from 0 to ExpIncr-1, with a concentration in the lower
-	numbers.  */
+    /*  Compute x such that pow(x, p) ranges between 1 and 4*ExpIncr as
+        p ranges from 0 to ExpIncr-1, with a concentration in the lower
+        numbers.  */
 
     x = 4.0 * ExpIncr;
     x = log(x);
@@ -1566,110 +1566,110 @@ int main()
     bpoold((void *) bp, dumpAlloc, dumpFree);
 
     for (i = 0; i < TestProg; i++) {
-	char *cb;
-	bufsize bs = pow(x, (double) (rand() & (ExpIncr - 1)));
+        char *cb;
+        bufsize bs = pow(x, (double) (rand() & (ExpIncr - 1)));
 
-	assert(bs <= (((bufsize) 4) * ExpIncr));
-	bs = blimit(bs);
-	if (rand() & 0x400) {
-	    cb = (char *) bgetz(bs);
-	} else {
-	    cb = (char *) bget(bs);
-	}
-	if (cb == NULL) {
+        assert(bs <= (((bufsize) 4) * ExpIncr));
+        bs = blimit(bs);
+        if (rand() & 0x400) {
+            cb = (char *) bgetz(bs);
+        } else {
+            cb = (char *) bget(bs);
+        }
+        if (cb == NULL) {
 #ifdef EasyOut
-	    break;
+            break;
 #else
-	    char *bc = bchain;
+            char *bc = bchain;
 
-	    if (bc != NULL) {
-		char *fb;
+            if (bc != NULL) {
+                char *fb;
 
-		fb = *((char **) bc);
-		if (fb != NULL) {
-		    *((char **) bc) = *((char **) fb);
-		    brel((void *) fb);
-		}
-		continue;
-	    }
+                fb = *((char **) bc);
+                if (fb != NULL) {
+                    *((char **) bc) = *((char **) fb);
+                    brel((void *) fb);
+                }
+                continue;
+            }
 #endif
-	}
-	*((char **) cb) = (char *) bchain;
-	bchain = cb;
+        }
+        *((char **) cb) = (char *) bchain;
+        bchain = cb;
 
-	/* Based on a random cast, release a random buffer in the list
-	   of allocated buffers. */
+        /* Based on a random cast, release a random buffer in the list
+           of allocated buffers. */
 
-	if ((rand() & 0x10) == 0) {
-	    char *bc = bchain;
-	    int i = rand() & 0x3;
+        if ((rand() & 0x10) == 0) {
+            char *bc = bchain;
+            int i = rand() & 0x3;
 
-	    while (i > 0 && bc != NULL) {
-		bc = *((char **) bc);
-		i--;
-	    }
-	    if (bc != NULL) {
-		char *fb;
+            while (i > 0 && bc != NULL) {
+                bc = *((char **) bc);
+                i--;
+            }
+            if (bc != NULL) {
+                char *fb;
 
-		fb = *((char **) bc);
-		if (fb != NULL) {
-		    *((char **) bc) = *((char **) fb);
-		    brel((void *) fb);
-		}
-	    }
-	}
+                fb = *((char **) bc);
+                if (fb != NULL) {
+                    *((char **) bc) = *((char **) fb);
+                    brel((void *) fb);
+                }
+            }
+        }
 
-	/* Based on a random cast, reallocate a random buffer in the list
-	   to a random size */
+        /* Based on a random cast, reallocate a random buffer in the list
+           to a random size */
 
-	if ((rand() & 0x20) == 0) {
-	    char *bc = bchain;
-	    int i = rand() & 0x3;
+        if ((rand() & 0x20) == 0) {
+            char *bc = bchain;
+            int i = rand() & 0x3;
 
-	    while (i > 0 && bc != NULL) {
-		bc = *((char **) bc);
-		i--;
-	    }
-	    if (bc != NULL) {
-		char *fb;
+            while (i > 0 && bc != NULL) {
+                bc = *((char **) bc);
+                i--;
+            }
+            if (bc != NULL) {
+                char *fb;
 
-		fb = *((char **) bc);
-		if (fb != NULL) {
-		    char *newb;
+                fb = *((char **) bc);
+                if (fb != NULL) {
+                    char *newb;
 
-		    bs = pow(x, (double) (rand() & (ExpIncr - 1)));
-		    bs = blimit(bs);
+                    bs = pow(x, (double) (rand() & (ExpIncr - 1)));
+                    bs = blimit(bs);
 #ifdef BECtl
-		    protect = 1;      /* Protect against compaction */
+                    protect = 1;      /* Protect against compaction */
 #endif
-		    newb = (char *) bgetr((void *) fb, bs);
+                    newb = (char *) bgetr((void *) fb, bs);
 #ifdef BECtl
-		    protect = 0;
+                    protect = 0;
 #endif
-		    if (newb != NULL) {
-			*((char **) bc) = newb;
-		    }
-		}
-	    }
-	}
+                    if (newb != NULL) {
+                        *((char **) bc) = newb;
+                    }
+                }
+            }
+        }
     }
     stats("\nAfter allocation");
     if (bp != NULL) {
-	V bpoolv((void *) bp);
-	bpoold((void *) bp, dumpAlloc, dumpFree);
+        V bpoolv((void *) bp);
+        bpoold((void *) bp, dumpAlloc, dumpFree);
     }
 
     while (bchain != NULL) {
-	char *buf = bchain;
+        char *buf = bchain;
 
-	bchain = *((char **) buf);
-	brel((void *) buf);
+        bchain = *((char **) buf);
+        brel((void *) buf);
     }
     stats("\nAfter release");
 #ifndef BECtl
     if (bp != NULL) {
-	V bpoolv((void *) bp);
-	bpoold((void *) bp, dumpAlloc, dumpFree);
+        V bpoolv((void *) bp);
+        bpoold((void *) bp, dumpAlloc, dumpFree);
     }
 #endif
 

--- a/src/clib/bget.h
+++ b/src/clib/bget.h
@@ -1,6 +1,6 @@
 /*
 
-    Interface definitions for bget.c, the memory management package.
+  Interface definitions for bget.c, the memory management package.
 
 */
 /* in PIO we use DEBUG bget uses NDEBUG */
@@ -10,27 +10,27 @@
 
 #ifndef _
 #ifdef PROTOTYPES
-#define  _(x)  x		      /* If compiler knows prototypes */
+#define  _(x)  x                      /* If compiler knows prototypes */
 #else
 #define  _(x)  ()                     /* It it doesn't */
 #endif /* PROTOTYPES */
 #endif
 
 typedef long bufsize;
-void	bpool	    _((void *buffer, bufsize len));
-void   *bget	    _((bufsize size));
-void   *bgetz	    _((bufsize size));
-void   *bgetr	    _((void *buffer, bufsize newsize));
-void	brel	    _((void *buf));
-void	bectl	    _((int (*compact)(bufsize sizereq, int sequence),
-		       void *(*acquire)(bufsize size),
-		       void (*release)(void *buf), bufsize pool_incr));
-void	bstats	    _((bufsize *curalloc, bufsize *totfree, bufsize *maxfree,
-		       long *nget, long *nrel));
-void	bstatse     _((bufsize *pool_incr, long *npool, long *npget,
-		       long *nprel, long *ndget, long *ndrel));
-void	bufdump     _((void *buf));
-void	bpoold	    _((void *pool, int dumpalloc, int dumpfree));
-int	bpoolv	    _((void *pool));
+void    bpool       _((void *buffer, bufsize len));
+void   *bget        _((bufsize size));
+void   *bgetz       _((bufsize size));
+void   *bgetr       _((void *buffer, bufsize newsize));
+void    brel        _((void *buf));
+void    bectl       _((int (*compact)(bufsize sizereq, int sequence),
+                       void *(*acquire)(bufsize size),
+                       void (*release)(void *buf), bufsize pool_incr));
+void    bstats      _((bufsize *curalloc, bufsize *totfree, bufsize *maxfree,
+                       long *nget, long *nrel));
+void    bstatse     _((bufsize *pool_incr, long *npool, long *npget,
+                       long *nprel, long *ndget, long *ndrel));
+void    bufdump     _((void *buf));
+void    bpoold      _((void *pool, int dumpalloc, int dumpfree));
+int     bpoolv      _((void *pool));
 void bpoolrelease  _();
 void bfreespace  _((bufsize *maxfree, bufsize *totfree));

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1,9 +1,9 @@
 /**
- * @file 
+ * @file
  * Public headers for the PIO C interface.
  * @author Jim Edwards
  * @date  2014
- * 
+ *
  * @see http://code.google.com/p/parallelio/
  */
 
@@ -69,9 +69,9 @@ typedef struct var_desc_t
  * IO region structure.
  *
  * Each IO region is a unit of data which can be described using start and count
- * arrays. Each IO task may in general have multiple io regions per variable.  The 
+ * arrays. Each IO task may in general have multiple io regions per variable.  The
  * box rearranger will have at most one io region per variable.
- * 
+ *
  */
 typedef struct io_region
 {
@@ -80,12 +80,12 @@ typedef struct io_region
     PIO_Offset *count;
     struct io_region *next;
 } io_region;
- 
+
 /**
  * IO descriptor structure.
  *
- * This structure defines the mapping for a given variable between 
- * compute and IO decomposition.   
+ * This structure defines the mapping for a given variable between
+ * compute and IO decomposition.
  */
 typedef struct io_desc_t
 {
@@ -101,7 +101,7 @@ typedef struct io_desc_t
     bool needsfill;       // Does this decomp leave holes in the field (true) or write everywhere (false)
 
     /** The maximum number of bytes of this iodesc before flushing. */
-    int maxbytes;        
+    int maxbytes;
     MPI_Datatype basetype;
     PIO_Offset llen;
     int maxiobuflen;
@@ -124,7 +124,7 @@ typedef struct io_desc_t
     bool handshake;
     bool isend;
     int max_requests;
-  
+
     MPI_Comm subset_comm;
 
     /** Pointer to the next io_desc_t in the list. */
@@ -137,7 +137,7 @@ typedef struct io_desc_t
  * This structure contains the general IO subsystem data and MPI
  * structure
  */
-typedef struct iosystem_desc_t 
+typedef struct iosystem_desc_t
 {
     /** The ID of this iosystem_desc_t. This will be obtained by
      * calling PIOc_Init_Intercomm() or PIOc_Init_Intracomm(). */
@@ -166,7 +166,7 @@ typedef struct iosystem_desc_t
     /** This MPI group contains the processors involved in
      * computation. */
     MPI_Group compgroup;
-    
+
     /** This MPI group contains the processors involved in I/O. */
     MPI_Group iogroup;
 
@@ -303,7 +303,7 @@ enum PIO_IOTYPE
     PIO_IOTYPE_NETCDF4C = 3,
 
     /** NetCDF4 (HDF5) parallel */
-    PIO_IOTYPE_NETCDF4P = 4 
+    PIO_IOTYPE_NETCDF4P = 4
 };
 
 /**
@@ -330,7 +330,7 @@ enum PIO_ERROR_HANDLERS
     PIO_BCAST_ERROR = (-52),
 
     /** Errors are returned to caller with no internal action. */
-    PIO_RETURN_ERROR = (-53)  
+    PIO_RETURN_ERROR = (-53)
 };
 
 /** Define the netCDF-based error codes. */
@@ -345,14 +345,14 @@ enum PIO_ERROR_HANDLERS
 #define PIO_NOERR  NC_NOERR
 #define PIO_WRITE  NC_WRITE
 #define PIO_NOWRITE  NC_NOWRITE
-#define PIO_CLOBBER NC_CLOBBER	
-#define PIO_NOCLOBBER NC_NOCLOBBER	
+#define PIO_CLOBBER NC_CLOBBER
+#define PIO_NOCLOBBER NC_NOCLOBBER
 #define PIO_NOFILL NC_NOFILL
 #define PIO_MAX_NAME NC_MAX_NAME
 #define PIO_MAX_VAR_DIMS NC_MAX_VAR_DIMS
 #define PIO_64BIT_OFFSET NC_64BIT_OFFSET
 // NC_64BIT_DATA  This is a problem - need to define directly instead of using include file
-#define PIO_64BIT_DATA 0x0010  
+#define PIO_64BIT_DATA 0x0010
 #define PIO_EBADID NC_EBADID
 #define PIO_ENFILE NC_ENFILE
 #define PIO_EEXIST NC_EEXIST
@@ -436,7 +436,7 @@ enum PIO_ERROR_HANDLERS
 #ifdef _PNETCDF
 #define PIO_EINDEP  NC_EINDEP
 #else  /* _PNETCDF */
-#define PIO_EINDEP  (-203) 
+#define PIO_EINDEP  (-203)
 #endif /* _PNETCDF */
 
 /** Define error codes for PIO. */
@@ -450,15 +450,15 @@ extern "C" {
 #endif
     int PIOc_strerror(int pioerr, char *errstr);
     int PIOc_freedecomp(int iosysid, int ioid);
-    int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep, PIO_Offset *lenp); 
-    int PIOc_inq_format(int ncid, int *formatp); 
-    int PIOc_inq_varid(int ncid, const char *name, int *varidp); 
-    int PIOc_inq_varnatts(int ncid, int varid, int *nattsp); 
+    int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep, PIO_Offset *lenp);
+    int PIOc_inq_format(int ncid, int *formatp);
+    int PIOc_inq_varid(int ncid, const char *name, int *varidp);
+    int PIOc_inq_varnatts(int ncid, int varid, int *nattsp);
     int PIOc_def_var(int ncid, const char *name, nc_type xtype,  int ndims, const int *dimidsp, int *varidp);
     int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
-			     int deflate_level);
+                             int deflate_level);
     int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep, int *deflatep,
-			     int *deflate_levelp);
+                             int *deflate_levelp);
     int PIOc_inq_var_szip(int ncid, int varid, int *options_maskp, int *pixels_per_blockp);
     int PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunksizesp);
     int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizesp);
@@ -469,81 +469,81 @@ extern "C" {
     int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems, float preemption);
     int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset *nelemsp, float *preemptionp);
     int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset nelems,
-				 float preemption);
+                                 float preemption);
     int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nelemsp,
-				 float *preemptionp);
-    int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp, int *nattsp); 
-    int PIOc_inq_varname(int ncid, int varid, char *name); 
-    int PIOc_put_att_double(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const double *op); 
-    int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const int *op); 
-    int PIOc_rename_att(int ncid, int varid, const char *name, const char *newname); 
-    int PIOc_del_att(int ncid, int varid, const char *name); 
-    int PIOc_inq_natts(int ncid, int *ngattsp); 
-    int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp);  
-    int PIOc_get_att_text(int ncid, int varid, const char *name, char *ip); 
-    int PIOc_get_att_short(int ncid, int varid, const char *name, short *ip); 
-    int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long *op); 
-    int PIOc_redef(int ncid); 
-    int PIOc_set_fill(int ncid, int fillmode, int *old_modep); 
-    int PIOc_enddef(int ncid); 
-    int PIOc_rename_var(int ncid, int varid, const char *name); 
-    int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const short *op); 
-    int PIOc_put_att_text(int ncid, int varid, const char *name, PIO_Offset len, const char *op); 
-    int PIOc_inq_attname(int ncid, int varid, int attnum, char *name); 
-    int PIOc_get_att_ulonglong(int ncid, int varid, const char *name, unsigned long long *ip); 
-    int PIOc_get_att_ushort(int ncid, int varid, const char *name, unsigned short *ip); 
-    int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned long long *op); 
-    int PIOc_inq_dimlen(int ncid, int dimid, PIO_Offset *lenp); 
-    int PIOc_get_att_uint(int ncid, int varid, const char *name, unsigned int *ip); 
-    int PIOc_get_att_longlong(int ncid, int varid, const char *name, long long *ip); 
-    int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const signed char *op); 
-    int PIOc_put_att_float(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const float *op); 
-    int PIOc_inq_nvars(int ncid, int *nvarsp); 
-    int PIOc_rename_dim(int ncid, int dimid, const char *name); 
-    int PIOc_inq_varndims(int ncid, int varid, int *ndimsp); 
-    int PIOc_get_att_long(int ncid, int varid, const char *name, long *ip); 
-    int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp); 
-    int PIOc_inq_dimid(int ncid, const char *name, int *idp); 
-    int PIOc_inq_unlimdim(int ncid, int *unlimdimidp); 
-    int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp); 
-    int PIOc_inq_attlen(int ncid, int varid, const char *name, PIO_Offset *lenp); 
-    int PIOc_inq_dimname(int ncid, int dimid, char *name); 
-    int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned short *op); 
-    int PIOc_get_att_float(int ncid, int varid, const char *name, float *ip); 
-    int PIOc_sync(int ncid); 
-    int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long long *op); 
-    int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned int *op); 
-    int PIOc_get_att_schar(int ncid, int varid, const char *name, signed char *ip); 
-    int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp); 
-    int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp); 
-    int PIOc_inq_ndims(int ncid, int *ndimsp); 
-    int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep); 
-    int PIOc_get_att_int(int ncid, int varid, const char *name, int *ip); 
-    int PIOc_get_att_double(int ncid, int varid, const char *name, double *ip); 
-    int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep); 
-    int PIOc_put_att_uchar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op); 
-    int PIOc_get_att_uchar(int ncid, int varid, const char *name, unsigned char *ip);              
-    int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const int dims[], 
-			const int maplen, const PIO_Offset *compmap, int *ioidp, const int *rearr, 
-			const PIO_Offset *iostart,const PIO_Offset *iocount);
-    int PIOc_Init_Intracomm(const MPI_Comm comp_comm, 
-			    const int num_iotasks, const int stride, 
-			    const int base, const int rearr, int *iosysidp);
+                                 float *preemptionp);
+    int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp, int *nattsp);
+    int PIOc_inq_varname(int ncid, int varid, char *name);
+    int PIOc_put_att_double(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const double *op);
+    int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const int *op);
+    int PIOc_rename_att(int ncid, int varid, const char *name, const char *newname);
+    int PIOc_del_att(int ncid, int varid, const char *name);
+    int PIOc_inq_natts(int ncid, int *ngattsp);
+    int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp);
+    int PIOc_get_att_text(int ncid, int varid, const char *name, char *ip);
+    int PIOc_get_att_short(int ncid, int varid, const char *name, short *ip);
+    int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long *op);
+    int PIOc_redef(int ncid);
+    int PIOc_set_fill(int ncid, int fillmode, int *old_modep);
+    int PIOc_enddef(int ncid);
+    int PIOc_rename_var(int ncid, int varid, const char *name);
+    int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const short *op);
+    int PIOc_put_att_text(int ncid, int varid, const char *name, PIO_Offset len, const char *op);
+    int PIOc_inq_attname(int ncid, int varid, int attnum, char *name);
+    int PIOc_get_att_ulonglong(int ncid, int varid, const char *name, unsigned long long *ip);
+    int PIOc_get_att_ushort(int ncid, int varid, const char *name, unsigned short *ip);
+    int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned long long *op);
+    int PIOc_inq_dimlen(int ncid, int dimid, PIO_Offset *lenp);
+    int PIOc_get_att_uint(int ncid, int varid, const char *name, unsigned int *ip);
+    int PIOc_get_att_longlong(int ncid, int varid, const char *name, long long *ip);
+    int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const signed char *op);
+    int PIOc_put_att_float(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const float *op);
+    int PIOc_inq_nvars(int ncid, int *nvarsp);
+    int PIOc_rename_dim(int ncid, int dimid, const char *name);
+    int PIOc_inq_varndims(int ncid, int varid, int *ndimsp);
+    int PIOc_get_att_long(int ncid, int varid, const char *name, long *ip);
+    int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp);
+    int PIOc_inq_dimid(int ncid, const char *name, int *idp);
+    int PIOc_inq_unlimdim(int ncid, int *unlimdimidp);
+    int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp);
+    int PIOc_inq_attlen(int ncid, int varid, const char *name, PIO_Offset *lenp);
+    int PIOc_inq_dimname(int ncid, int dimid, char *name);
+    int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned short *op);
+    int PIOc_get_att_float(int ncid, int varid, const char *name, float *ip);
+    int PIOc_sync(int ncid);
+    int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const long long *op);
+    int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned int *op);
+    int PIOc_get_att_schar(int ncid, int varid, const char *name, signed char *ip);
+    int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp);
+    int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp);
+    int PIOc_inq_ndims(int ncid, int *ndimsp);
+    int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep);
+    int PIOc_get_att_int(int ncid, int varid, const char *name, int *ip);
+    int PIOc_get_att_double(int ncid, int varid, const char *name, double *ip);
+    int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep);
+    int PIOc_put_att_uchar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op);
+    int PIOc_get_att_uchar(int ncid, int varid, const char *name, unsigned char *ip);
+    int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const int dims[],
+                        const int maplen, const PIO_Offset *compmap, int *ioidp, const int *rearr,
+                        const PIO_Offset *iostart,const PIO_Offset *iocount);
+    int PIOc_Init_Intracomm(const MPI_Comm comp_comm,
+                            const int num_iotasks, const int stride,
+                            const int base, const int rearr, int *iosysidp);
     int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
-			int *num_procs_per_comp, int **proc_list, int *iosysidp);
+                        int *num_procs_per_comp, int **proc_list, int *iosysidp);
     int PIOc_Init_Intercomm(int component_count, MPI_Comm peer_comm, MPI_Comm *comp_comms,
-			    MPI_Comm io_comm, int *iosysidp);
+                            MPI_Comm io_comm, int *iosysidp);
     int PIOc_closefile(int ncid);
     int PIOc_createfile(const int iosysid, int *ncidp,  int *iotype,
-			const char *fname, const int mode);
-    int PIOc_create(int iosysid, const char *path, int cmode, int *ncidp);  
+                        const char *fname, const int mode);
+    int PIOc_create(int iosysid, const char *path, int cmode, int *ncidp);
     int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
-		      const char *fname, const int mode);
-    int PIOc_open(const int iosysid, const char *path, int mode, int *ncidp);  
+                      const char *fname, const int mode);
+    int PIOc_open(const int iosysid, const char *path, int mode, int *ncidp);
     int PIOc_write_darray(const int ncid, const int vid, const int ioid, const PIO_Offset arraylen,
-			  void *array, void *fillvalue);
+                          void *array, void *fillvalue);
     int PIOc_write_darray_multi(const int ncid, const int vid[], const int ioid, const int nvars, const PIO_Offset arraylen,
-				void *array, const int frame[], void *fillvalue[], bool flushtodisk);
+                                void *array, const int frame[], void *fillvalue[], bool flushtodisk);
 
     int PIOc_get_att_ubyte(int ncid, int varid, const char *name, unsigned char *ip);
     int PIOc_put_att_ubyte(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const unsigned char *op) ;
@@ -552,7 +552,7 @@ extern "C" {
     int PIOc_readmap_from_f90(const char file[],int *ndims, int *gdims[], PIO_Offset *maplen, PIO_Offset *map[], const int f90_comm);
     int PIOc_writemap(const char file[], const int ndims, const int gdims[], PIO_Offset maplen, PIO_Offset map[], const MPI_Comm comm);
     int PIOc_writemap_from_f90(const char file[], const int ndims, const int gdims[], const PIO_Offset maplen, const PIO_Offset map[], const int f90_comm);
-    int PIOc_deletefile(const int iosysid, const char filename[]); 
+    int PIOc_deletefile(const int iosysid, const char filename[]);
     int PIOc_File_is_Open(int ncid);
     int PIOc_Set_File_Error_Handling(int ncid, int method);
     int PIOc_advanceframe(int ncid, int varid);
@@ -562,9 +562,9 @@ extern "C" {
     int PIOc_get_local_array_size(int ioid);
     int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method);
     int PIOc_set_hint(const int iosysid, char hint[], const char hintval[]);
-    int PIOc_Init_Intracomm(const MPI_Comm comp_comm, 
-			    const int num_iotasks, const int stride, 
-			    const int base,const int rearr, int *iosysidp);
+    int PIOc_Init_Intracomm(const MPI_Comm comp_comm,
+                            const int num_iotasks, const int stride,
+                            const int base,const int rearr, int *iosysidp);
     int PIOc_finalize(const int iosysid);
     int PIOc_iam_iotask(const int iosysid, bool *ioproc);
     int PIOc_iotask_rank(const int iosysid, int *iorank);
@@ -594,122 +594,121 @@ extern "C" {
     int PIOc_get_vara_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], char *buf) ;
     int PIOc_put_vara_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const int *op)  ;
 
-    int PIOc_put_var1_ushort(int ncid, int varid, const PIO_Offset index[], const unsigned short *op); 
-    int PIOc_put_vara_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const char *op);  
-    int PIOc_put_varm_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const char *op);  
-    int PIOc_put_varm_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned short *op); 
-    int PIOc_put_var_ulonglong(int ncid, int varid, const unsigned long long *op); 
-    int PIOc_put_var_int(int ncid, int varid, const int *op); 
-    int PIOc_put_var_longlong(int ncid, int varid, const long long *op); 
-    int PIOc_put_var_schar(int ncid, int varid, const signed char *op); 
-    int PIOc_put_var_uint(int ncid, int varid, const unsigned int *op); 
-    int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
-    int PIOc_put_vara_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned short *op); 
-    int PIOc_put_vars_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const short *op);  
-    int PIOc_put_vara_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned int *op); 
-    int PIOc_put_vara_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const signed char *op);  
-    int PIOc_put_varm_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned long long *op); 
-    int PIOc_put_var1_uchar(int ncid, int varid, const PIO_Offset index[], const unsigned char *op); 
-    int PIOc_put_varm_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const int *op);  
-    int PIOc_put_vars_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const signed char *op);  
-    int PIOc_put_var1(int ncid, int varid, const PIO_Offset index[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_put_vara_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const float *op);  
-    int PIOc_put_var1_float(int ncid, int varid, const PIO_Offset index[], const float *op);  
-    int PIOc_put_varm_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const float *op);  
-    int PIOc_put_var1_text(int ncid, int varid, const PIO_Offset index[], const char *op);  
-    int PIOc_put_vars_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const char *op);  
-    int PIOc_put_varm_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long *op); 
-    int PIOc_put_vars_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const double *op);  
-    int PIOc_put_vara_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const long long *op);  
-    int PIOc_put_var_double(int ncid, int varid, const double *op); 
-    int PIOc_put_var_float(int ncid, int varid, const float *op); 
-    int PIOc_put_var1_ulonglong(int ncid, int varid, const PIO_Offset index[], const unsigned long long *op); 
-    int PIOc_put_varm_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned int *op); 
-    int PIOc_put_var1_uint(int ncid, int varid, const PIO_Offset index[], const unsigned int *op); 
-    int PIOc_put_var1_int(int ncid, int varid, const PIO_Offset index[], const int *op);  
-    int PIOc_put_vars_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const float *op);  
-    int PIOc_put_vara_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const short *op);  
-    int PIOc_put_var1_schar(int ncid, int varid, const PIO_Offset index[], const signed char *op);  
-    int PIOc_put_vara_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned long long *op); 
-    int PIOc_put_varm_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const double *op);  
-    int PIOc_put_vara(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_put_vara_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const long *op); 
-    int PIOc_put_var1_double(int ncid, int varid, const PIO_Offset index[], const double *op);  
-    int PIOc_put_varm_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const signed char *op);  
-    int PIOc_put_var_text(int ncid, int varid, const char *op); 
-    int PIOc_put_vars_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const int *op);  
-    int PIOc_put_var1_short(int ncid, int varid, const PIO_Offset index[], const short *op);  
-    int PIOc_put_vars_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const long long *op);  
-    int PIOc_put_vara_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const double *op);  
-    int PIOc_put_vars(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], nc_type xtype, const void *buf);  
-    int PIOc_put_var_uchar(int ncid, int varid, const unsigned char *op); 
-    int PIOc_put_var_long(int ncid, int varid, const long *op); 
+    int PIOc_put_var1_ushort(int ncid, int varid, const PIO_Offset index[], const unsigned short *op);
+    int PIOc_put_vara_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const char *op);
+    int PIOc_put_varm_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const char *op);
+    int PIOc_put_varm_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned short *op);
+    int PIOc_put_var_ulonglong(int ncid, int varid, const unsigned long long *op);
+    int PIOc_put_var_int(int ncid, int varid, const int *op);
+    int PIOc_put_var_longlong(int ncid, int varid, const long long *op);
+    int PIOc_put_var_schar(int ncid, int varid, const signed char *op);
+    int PIOc_put_var_uint(int ncid, int varid, const unsigned int *op);
+    int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_put_vara_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned short *op);
+    int PIOc_put_vars_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const short *op);
+    int PIOc_put_vara_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned int *op);
+    int PIOc_put_vara_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const signed char *op);
+    int PIOc_put_varm_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned long long *op);
+    int PIOc_put_var1_uchar(int ncid, int varid, const PIO_Offset index[], const unsigned char *op);
+    int PIOc_put_varm_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const int *op);
+    int PIOc_put_vars_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const signed char *op);
+    int PIOc_put_var1(int ncid, int varid, const PIO_Offset index[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_put_vara_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const float *op);
+    int PIOc_put_var1_float(int ncid, int varid, const PIO_Offset index[], const float *op);
+    int PIOc_put_varm_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const float *op);
+    int PIOc_put_var1_text(int ncid, int varid, const PIO_Offset index[], const char *op);
+    int PIOc_put_vars_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const char *op);
+    int PIOc_put_varm_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long *op);
+    int PIOc_put_vars_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const double *op);
+    int PIOc_put_vara_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const long long *op);
+    int PIOc_put_var_double(int ncid, int varid, const double *op);
+    int PIOc_put_var_float(int ncid, int varid, const float *op);
+    int PIOc_put_var1_ulonglong(int ncid, int varid, const PIO_Offset index[], const unsigned long long *op);
+    int PIOc_put_varm_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned int *op);
+    int PIOc_put_var1_uint(int ncid, int varid, const PIO_Offset index[], const unsigned int *op);
+    int PIOc_put_var1_int(int ncid, int varid, const PIO_Offset index[], const int *op);
+    int PIOc_put_vars_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const float *op);
+    int PIOc_put_vara_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const short *op);
+    int PIOc_put_var1_schar(int ncid, int varid, const PIO_Offset index[], const signed char *op);
+    int PIOc_put_vara_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const unsigned long long *op);
+    int PIOc_put_varm_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const double *op);
+    int PIOc_put_vara(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_put_vara_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const long *op);
+    int PIOc_put_var1_double(int ncid, int varid, const PIO_Offset index[], const double *op);
+    int PIOc_put_varm_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const signed char *op);
+    int PIOc_put_var_text(int ncid, int varid, const char *op);
+    int PIOc_put_vars_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const int *op);
+    int PIOc_put_var1_short(int ncid, int varid, const PIO_Offset index[], const short *op);
+    int PIOc_put_vars_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const long long *op);
+    int PIOc_put_vara_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const double *op);
+    int PIOc_put_vars(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], nc_type xtype, const void *buf);
+    int PIOc_put_var_uchar(int ncid, int varid, const unsigned char *op);
+    int PIOc_put_var_long(int ncid, int varid, const long *op);
     int PIOc_put_varm_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long long *op);
     int PIOc_get_vara_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], int *buf);
-    int PIOc_get_var1_float(int ncid, int varid, const PIO_Offset index[], float *buf); 
-    int PIOc_get_var1_short(int ncid, int varid, const PIO_Offset index[], short *buf); 
-    int PIOc_get_vars_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], int *buf);                      
-    int PIOc_get_var_text(int ncid, int varid, char *buf); 
-    int PIOc_get_varm_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], double *buf); 
-    int PIOc_get_vars_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], signed char *buf);  
-    int PIOc_get_vara_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned short *buf); 
-    int PIOc_get_var1_ushort(int ncid, int varid, const PIO_Offset index[], unsigned short *buf); 
-    int PIOc_get_var_float(int ncid, int varid, float *buf); 
-    int PIOc_get_vars_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned char *buf); 
-    int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
-    int PIOc_get_var1_longlong(int ncid, int varid, const PIO_Offset index[], long long *buf); 
-    int PIOc_get_vars_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned short *buf); 
-    int PIOc_get_var_long(int ncid, int varid, long *buf); 
-    int PIOc_get_var1_double(int ncid, int varid, const PIO_Offset index[], double *buf); 
-    int PIOc_get_vara_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned int *buf); 
-    int PIOc_get_vars_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], long long *buf); 
-    int PIOc_get_var_longlong(int ncid, int varid, long long *buf); 
-    int PIOc_get_vara_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], short *buf);  
-    int PIOc_get_vara_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], long *buf); 
-    int PIOc_get_var1_int(int ncid, int varid, const PIO_Offset index[], int *buf); 
-    int PIOc_get_var1_ulonglong(int ncid, int varid, const PIO_Offset index[], unsigned long long *buf); 
-    int PIOc_get_var_uchar(int ncid, int varid, unsigned char *buf); 
-    int PIOc_get_vara_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned char *buf); 
-    int PIOc_get_vars_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], float *buf);  
-    int PIOc_get_vars_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], long *buf); 
-    int PIOc_get_var1(int ncid, int varid, const PIO_Offset index[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
-    int PIOc_get_var_uint(int ncid, int varid, unsigned int *buf); 
-    int PIOc_get_vara(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype); 
-    int PIOc_get_vara_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], signed char *buf); 
-    int PIOc_get_var1_uint(int ncid, int varid, const PIO_Offset index[], unsigned int *buf); 
-    int PIOc_get_vars_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned int *buf); 
-    int PIOc_get_vara_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], float *buf);  
-    int PIOc_get_varm_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], char *buf);  
-    int PIOc_get_var1_text(int ncid, int varid, const PIO_Offset index[], char *buf); 
-    int PIOc_get_varm_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], int *buf);  
-    int PIOc_get_varm_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned int *buf);  
-    int PIOc_get_varm(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_get_vars_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], double *buf); 
-    int PIOc_get_vara_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], long long *buf); 
-    int PIOc_get_var_ulonglong(int ncid, int varid, unsigned long long *buf); 
-    int PIOc_get_vara_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned long long *buf); 
-    int PIOc_get_var_short(int ncid, int varid, short *buf); 
-    int PIOc_get_varm_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], float *buf);  
-    int PIOc_get_var1_long(int ncid, int varid, const PIO_Offset index[], long *buf); 
-    int PIOc_get_varm_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long *buf); 
-    int PIOc_get_varm_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned short *buf);  
-    int PIOc_get_varm_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long long *buf); 
-    int PIOc_get_vars_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], char *buf);  
-    int PIOc_get_var1_uchar(int ncid, int varid, const PIO_Offset index[], unsigned char *buf); 
-    int PIOc_get_vars(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);  
-    int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], nc_type xtype, void *buf);  
-    int PIOc_get_varm_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], short *buf);  
-    int PIOc_get_varm_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned long long *buf);  
-    int PIOc_get_var_schar(int ncid, int varid, signed char *buf); 
+    int PIOc_get_var1_float(int ncid, int varid, const PIO_Offset index[], float *buf);
+    int PIOc_get_var1_short(int ncid, int varid, const PIO_Offset index[], short *buf);
+    int PIOc_get_vars_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], int *buf);
+    int PIOc_get_var_text(int ncid, int varid, char *buf);
+    int PIOc_get_varm_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], double *buf);
+    int PIOc_get_vars_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], signed char *buf);
+    int PIOc_get_vara_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned short *buf);
+    int PIOc_get_var1_ushort(int ncid, int varid, const PIO_Offset index[], unsigned short *buf);
+    int PIOc_get_var_float(int ncid, int varid, float *buf);
+    int PIOc_get_vars_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned char *buf);
+    int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_get_var1_longlong(int ncid, int varid, const PIO_Offset index[], long long *buf);
+    int PIOc_get_vars_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned short *buf);
+    int PIOc_get_var_long(int ncid, int varid, long *buf);
+    int PIOc_get_var1_double(int ncid, int varid, const PIO_Offset index[], double *buf);
+    int PIOc_get_vara_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned int *buf);
+    int PIOc_get_vars_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], long long *buf);
+    int PIOc_get_var_longlong(int ncid, int varid, long long *buf);
+    int PIOc_get_vara_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], short *buf);
+    int PIOc_get_vara_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], long *buf);
+    int PIOc_get_var1_int(int ncid, int varid, const PIO_Offset index[], int *buf);
+    int PIOc_get_var1_ulonglong(int ncid, int varid, const PIO_Offset index[], unsigned long long *buf);
+    int PIOc_get_var_uchar(int ncid, int varid, unsigned char *buf);
+    int PIOc_get_vara_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned char *buf);
+    int PIOc_get_vars_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], float *buf);
+    int PIOc_get_vars_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], long *buf);
+    int PIOc_get_var1(int ncid, int varid, const PIO_Offset index[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_get_var_uint(int ncid, int varid, unsigned int *buf);
+    int PIOc_get_vara(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_get_vara_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], signed char *buf);
+    int PIOc_get_var1_uint(int ncid, int varid, const PIO_Offset index[], unsigned int *buf);
+    int PIOc_get_vars_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], unsigned int *buf);
+    int PIOc_get_vara_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], float *buf);
+    int PIOc_get_varm_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], char *buf);
+    int PIOc_get_var1_text(int ncid, int varid, const PIO_Offset index[], char *buf);
+    int PIOc_get_varm_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], int *buf);
+    int PIOc_get_varm_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned int *buf);
+    int PIOc_get_varm(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_get_vars_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], double *buf);
+    int PIOc_get_vara_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], long long *buf);
+    int PIOc_get_var_ulonglong(int ncid, int varid, unsigned long long *buf);
+    int PIOc_get_vara_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], unsigned long long *buf);
+    int PIOc_get_var_short(int ncid, int varid, short *buf);
+    int PIOc_get_varm_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], float *buf);
+    int PIOc_get_var1_long(int ncid, int varid, const PIO_Offset index[], long *buf);
+    int PIOc_get_varm_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long *buf);
+    int PIOc_get_varm_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned short *buf);
+    int PIOc_get_varm_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long long *buf);
+    int PIOc_get_vars_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], char *buf);
+    int PIOc_get_var1_uchar(int ncid, int varid, const PIO_Offset index[], unsigned char *buf);
+    int PIOc_get_vars(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], nc_type xtype, void *buf);
+    int PIOc_get_varm_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], short *buf);
+    int PIOc_get_varm_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned long long *buf);
+    int PIOc_get_var_schar(int ncid, int varid, signed char *buf);
     int PIOc_iotype_available(const int iotype);
     int PIOc_set_log_level(int level);
     int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const void *op);
     int PIOc_get_att(int ncid, int varid, const char *name, void *ip);
-    int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep);    
+    int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep);
 #if defined(__cplusplus)
 }
 #endif
 
 #endif  // _PIO_H_
-

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -41,7 +41,7 @@ PIO_Offset PIOc_set_buffer_size_limit(const PIO_Offset limit)
     PIO_Offset oldsize;
     oldsize = PIO_BUFFER_SIZE_LIMIT;
     if (limit > 0)
-	PIO_BUFFER_SIZE_LIMIT = limit;
+        PIO_BUFFER_SIZE_LIMIT = limit;
     return oldsize;
 }
 
@@ -59,24 +59,24 @@ void compute_buffer_init(iosystem_desc_t ios)
 
     if (!CN_bpool)
     {
-	if (!(CN_bpool = malloc(PIO_CNBUFFER_LIMIT)))
-	{
-	    char errmsg[180];
-	    sprintf(errmsg,"Unable to allocate a buffer pool of size %d on task %d:"
-		    " try reducing PIO_CNBUFFER_LIMIT\n", PIO_CNBUFFER_LIMIT, ios.comp_rank);
-	    piodie(errmsg, __FILE__, __LINE__);
-	}
+        if (!(CN_bpool = malloc(PIO_CNBUFFER_LIMIT)))
+        {
+            char errmsg[180];
+            sprintf(errmsg,"Unable to allocate a buffer pool of size %d on task %d:"
+                    " try reducing PIO_CNBUFFER_LIMIT\n", PIO_CNBUFFER_LIMIT, ios.comp_rank);
+            piodie(errmsg, __FILE__, __LINE__);
+        }
 
-	bpool(CN_bpool, PIO_CNBUFFER_LIMIT);
-	if (!CN_bpool)
-	{
-	    char errmsg[180];
-	    sprintf(errmsg,"Unable to allocate a buffer pool of size %d on task %d:"
-		    " try reducing PIO_CNBUFFER_LIMIT\n", PIO_CNBUFFER_LIMIT, ios.comp_rank);
-	    piodie(errmsg, __FILE__, __LINE__);
-	}
+        bpool(CN_bpool, PIO_CNBUFFER_LIMIT);
+        if (!CN_bpool)
+        {
+            char errmsg[180];
+            sprintf(errmsg,"Unable to allocate a buffer pool of size %d on task %d:"
+                    " try reducing PIO_CNBUFFER_LIMIT\n", PIO_CNBUFFER_LIMIT, ios.comp_rank);
+            piodie(errmsg, __FILE__, __LINE__);
+        }
 
-	bectl(NULL, malloc, free, PIO_CNBUFFER_LIMIT);
+        bectl(NULL, malloc, free, PIO_CNBUFFER_LIMIT);
     }
 #endif
     LOG((2, "compute_buffer_init CN_bpool = %d", CN_bpool));
@@ -97,7 +97,7 @@ void compute_buffer_init(iosystem_desc_t ios)
  * @ingroup PIO_write_darray
  */
 int pio_write_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid,
-			void *IOBUF, void *fillvalue)
+                        void *IOBUF, void *fillvalue)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;
@@ -120,11 +120,11 @@ int pio_write_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid,
 
     /* Get the IO system info. */
     if (!(ios = file->iosystem))
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     /* Get pointer to variable information. */
     if (!(vdesc = file->varlist + vid))
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     ndims = iodesc->ndims;
 
@@ -134,281 +134,281 @@ int pio_write_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid,
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = 0;
+        if (!ios->ioproc)
+        {
+            int msg = 0;
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->pio_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->pio_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        }
     }
 
     /* If this is an IO task, write the data. */
     if (ios->ioproc)
     {
-	io_region *region;
-	int regioncnt;
-	int rrcnt;
-	void *bufptr;
-	void *tmp_buf = NULL;
-	int tsize;            /* Type size. */
-	size_t start[fndims]; /* Local start array for this task. */
-	size_t count[fndims]; /* Local count array for this task. */
-	int buflen;
-	int j;                /* Loop counter. */
+        io_region *region;
+        int regioncnt;
+        int rrcnt;
+        void *bufptr;
+        void *tmp_buf = NULL;
+        int tsize;            /* Type size. */
+        size_t start[fndims]; /* Local start array for this task. */
+        size_t count[fndims]; /* Local count array for this task. */
+        int buflen;
+        int j;                /* Loop counter. */
 
-	PIO_Offset *startlist[iodesc->maxregions];
-	PIO_Offset *countlist[iodesc->maxregions];
+        PIO_Offset *startlist[iodesc->maxregions];
+        PIO_Offset *countlist[iodesc->maxregions];
 
-	/* Get the type size (again?) */
-	MPI_Type_size(iodesc->basetype, &tsize);
+        /* Get the type size (again?) */
+        MPI_Type_size(iodesc->basetype, &tsize);
 
-	region = iodesc->firstregion;
+        region = iodesc->firstregion;
 
-	/* If this is a var with an unlimited dimension, and the
-	 * iodesc ndims doesn't contain it, then add it to ndims. */
-	if (vdesc->record >= 0 && ndims < fndims)
-	    ndims++;
+        /* If this is a var with an unlimited dimension, and the
+         * iodesc ndims doesn't contain it, then add it to ndims. */
+        if (vdesc->record >= 0 && ndims < fndims)
+            ndims++;
 
 #ifdef _PNETCDF
-	/* Make sure we have room in the buffer. */
-	if (file->iotype == PIO_IOTYPE_PNETCDF)
-	    flush_output_buffer(file, false, tsize * (iodesc->maxiobuflen));
+        /* Make sure we have room in the buffer. */
+        if (file->iotype == PIO_IOTYPE_PNETCDF)
+            flush_output_buffer(file, false, tsize * (iodesc->maxiobuflen));
 #endif
 
-	rrcnt = 0;
-	/* For each region, figure out start/count arrays. */
-	for (regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
-	{
-	    /* Init arrays to zeros. */
-	    for (i = 0; i < ndims; i++)
-	    {
-		start[i] = 0;
-		count[i] = 0;
-	    }
+        rrcnt = 0;
+        /* For each region, figure out start/count arrays. */
+        for (regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
+        {
+            /* Init arrays to zeros. */
+            for (i = 0; i < ndims; i++)
+            {
+                start[i] = 0;
+                count[i] = 0;
+            }
 
-	    if (region)
-	    {
-		bufptr = (void *)((char *)IOBUF + tsize * region->loffset);
-		if (vdesc->record >= 0)
-		{
-		    /* This is a record based multidimensional array. */
+            if (region)
+            {
+                bufptr = (void *)((char *)IOBUF + tsize * region->loffset);
+                if (vdesc->record >= 0)
+                {
+                    /* This is a record based multidimensional array. */
 
-		    /* This does not look correct, but will work if
-		     * unlimited dim is dim 0. */
-		    start[0] = vdesc->record;
+                    /* This does not look correct, but will work if
+                     * unlimited dim is dim 0. */
+                    start[0] = vdesc->record;
 
-		    /* Set the local start and count arrays. */
-		    for (i = 1; i < ndims; i++)
-		    {
-			start[i] = region->start[i - 1];
-			count[i] = region->count[i - 1];
-		    }
+                    /* Set the local start and count arrays. */
+                    for (i = 1; i < ndims; i++)
+                    {
+                        start[i] = region->start[i - 1];
+                        count[i] = region->count[i - 1];
+                    }
 
-		    /* If there is data to be written, write one timestep. */
-		    if (count[1] > 0)
-			count[0] = 1;
-		}
-		else
-		{
-		    /* Array without unlimited dimension. */
-		    for (i = 0; i < ndims; i++)
-		    {
-			start[i] = region->start[i];
-			count[i] = region->count[i];
-		    }
-		}
-	    }
+                    /* If there is data to be written, write one timestep. */
+                    if (count[1] > 0)
+                        count[0] = 1;
+                }
+                else
+                {
+                    /* Array without unlimited dimension. */
+                    for (i = 0; i < ndims; i++)
+                    {
+                        start[i] = region->start[i];
+                        count[i] = region->count[i];
+                    }
+                }
+            }
 
-	    switch(file->iotype)
-	    {
+            switch(file->iotype)
+            {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	    case PIO_IOTYPE_NETCDF4P:
+            case PIO_IOTYPE_NETCDF4P:
 
-		/* Use collective writes with this variable. */
-		ierr = nc_var_par_access(file->fh, vid, NC_COLLECTIVE);
+                /* Use collective writes with this variable. */
+                ierr = nc_var_par_access(file->fh, vid, NC_COLLECTIVE);
 
-		/* Write the data. */
-		if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
-		    ierr = nc_put_vara_double(file->fh, vid, (size_t *)start, (size_t *)count,
-					      (const double *)bufptr);
-		else if (iodesc->basetype == MPI_INTEGER)
-		    ierr = nc_put_vara_int(file->fh, vid, (size_t *)start, (size_t *)count,
-					   (const int *)bufptr);
-		else if (iodesc->basetype == MPI_FLOAT || iodesc->basetype == MPI_REAL4)
-		    ierr = nc_put_vara_float(file->fh, vid, (size_t *)start, (size_t *)count,
-					     (const float *)bufptr);
-		else
-		    fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",
-			    (int)iodesc->basetype);
-		break;
-	    case PIO_IOTYPE_NETCDF4C:
+                /* Write the data. */
+                if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
+                    ierr = nc_put_vara_double(file->fh, vid, (size_t *)start, (size_t *)count,
+                                              (const double *)bufptr);
+                else if (iodesc->basetype == MPI_INTEGER)
+                    ierr = nc_put_vara_int(file->fh, vid, (size_t *)start, (size_t *)count,
+                                           (const int *)bufptr);
+                else if (iodesc->basetype == MPI_FLOAT || iodesc->basetype == MPI_REAL4)
+                    ierr = nc_put_vara_float(file->fh, vid, (size_t *)start, (size_t *)count,
+                                             (const float *)bufptr);
+                else
+                    fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",
+                            (int)iodesc->basetype);
+                break;
+            case PIO_IOTYPE_NETCDF4C:
 #endif /* _NETCDF4 */
-	    case PIO_IOTYPE_NETCDF:
-	    {
-		/* Find the type size (again?) */
-		mpierr = MPI_Type_size(iodesc->basetype, &dsize);
+            case PIO_IOTYPE_NETCDF:
+            {
+                /* Find the type size (again?) */
+                mpierr = MPI_Type_size(iodesc->basetype, &dsize);
 
-		size_t tstart[ndims], tcount[ndims];
+                size_t tstart[ndims], tcount[ndims];
 
-		/* When using the serial netcdf PIO acts like a
-		 * funnel. Data is moved from compute tasks to IO
-		 * tasks then from IO tasks to IO task 0 for
-		 * write. For read data the opposite happens, data is
-		 * read on IO task 0 distributed to all io tasks and
-		 * then to compute tasks. We could optimize these data
-		 * paths but serial netcdf is not the primary mode for
-		 * PIO. */
-		if (ios->io_rank == 0)
-		{
-		    for (i = 0; i < iodesc->num_aiotasks; i++)
-		    {
-			if (i == 0)
-			{
-			    buflen = 1;
-			    for (j = 0; j < ndims; j++)
-			    {
-				tstart[j] =  start[j];
-				tcount[j] =  count[j];
-				buflen *= tcount[j];
-				tmp_buf = bufptr;
-			    }
-			}
-			else
-			{
-			    /* Handshake - tell the sending task I'm ready. */
-			    mpierr = MPI_Send(&ierr, 1, MPI_INT, i, 0, ios->io_comm);
-			    mpierr = MPI_Recv(&buflen, 1, MPI_INT, i, 1, ios->io_comm, &status);
-			    if (buflen > 0)
-			    {
-				mpierr = MPI_Recv(tstart, ndims, MPI_OFFSET, i, ios->num_iotasks+i,
-						  ios->io_comm, &status);
-				mpierr = MPI_Recv(tcount, ndims, MPI_OFFSET, i, 2 * ios->num_iotasks + i,
-						  ios->io_comm, &status);
-				tmp_buf = malloc(buflen * dsize);
-				mpierr = MPI_Recv(tmp_buf, buflen, iodesc->basetype, i, i, ios->io_comm, &status);
-			    }
-			}
+                /* When using the serial netcdf PIO acts like a
+                 * funnel. Data is moved from compute tasks to IO
+                 * tasks then from IO tasks to IO task 0 for
+                 * write. For read data the opposite happens, data is
+                 * read on IO task 0 distributed to all io tasks and
+                 * then to compute tasks. We could optimize these data
+                 * paths but serial netcdf is not the primary mode for
+                 * PIO. */
+                if (ios->io_rank == 0)
+                {
+                    for (i = 0; i < iodesc->num_aiotasks; i++)
+                    {
+                        if (i == 0)
+                        {
+                            buflen = 1;
+                            for (j = 0; j < ndims; j++)
+                            {
+                                tstart[j] =  start[j];
+                                tcount[j] =  count[j];
+                                buflen *= tcount[j];
+                                tmp_buf = bufptr;
+                            }
+                        }
+                        else
+                        {
+                            /* Handshake - tell the sending task I'm ready. */
+                            mpierr = MPI_Send(&ierr, 1, MPI_INT, i, 0, ios->io_comm);
+                            mpierr = MPI_Recv(&buflen, 1, MPI_INT, i, 1, ios->io_comm, &status);
+                            if (buflen > 0)
+                            {
+                                mpierr = MPI_Recv(tstart, ndims, MPI_OFFSET, i, ios->num_iotasks+i,
+                                                  ios->io_comm, &status);
+                                mpierr = MPI_Recv(tcount, ndims, MPI_OFFSET, i, 2 * ios->num_iotasks + i,
+                                                  ios->io_comm, &status);
+                                tmp_buf = malloc(buflen * dsize);
+                                mpierr = MPI_Recv(tmp_buf, buflen, iodesc->basetype, i, i, ios->io_comm, &status);
+                            }
+                        }
 
-			if (buflen > 0)
-			{
-			    /* Write the data. */
-			    if (iodesc->basetype == MPI_INTEGER)
-				ierr = nc_put_vara_int(file->fh, vid, tstart, tcount, (const int *)tmp_buf);
-			    else if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
-				ierr = nc_put_vara_double(file->fh, vid, tstart, tcount, (const double *)tmp_buf);
-			    else if (iodesc->basetype == MPI_FLOAT || iodesc->basetype == MPI_REAL4)
-				ierr = nc_put_vara_float(file->fh, vid, tstart, tcount, (const float *)tmp_buf);
-			    else
-				fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",
-					(int)iodesc->basetype);
+                        if (buflen > 0)
+                        {
+                            /* Write the data. */
+                            if (iodesc->basetype == MPI_INTEGER)
+                                ierr = nc_put_vara_int(file->fh, vid, tstart, tcount, (const int *)tmp_buf);
+                            else if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
+                                ierr = nc_put_vara_double(file->fh, vid, tstart, tcount, (const double *)tmp_buf);
+                            else if (iodesc->basetype == MPI_FLOAT || iodesc->basetype == MPI_REAL4)
+                                ierr = nc_put_vara_float(file->fh, vid, tstart, tcount, (const float *)tmp_buf);
+                            else
+                                fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",
+                                        (int)iodesc->basetype);
 
-			    /* Was there an error from netCDF? */
-			    if (ierr == PIO_EEDGE)
-				for (i = 0; i < ndims; i++)
-				    fprintf(stderr,"dim %d start %ld count %ld\n", i, tstart[i], tcount[i]);
+                            /* Was there an error from netCDF? */
+                            if (ierr == PIO_EEDGE)
+                                for (i = 0; i < ndims; i++)
+                                    fprintf(stderr,"dim %d start %ld count %ld\n", i, tstart[i], tcount[i]);
 
-			    /* Free the temporary buffer, if we don't need it any more. */
-			    if (tmp_buf != bufptr)
-				free(tmp_buf);
-			}
-		    }
-		}
-		else if (ios->io_rank < iodesc->num_aiotasks)
-		{
-		    buflen = 1;
-		    for (i = 0; i < ndims; i++)
-		    {
-			tstart[i] = (size_t) start[i];
-			tcount[i] = (size_t) count[i];
-			buflen *= tcount[i];
-			//               printf("%s %d %d %d %d\n",__FILE__,__LINE__,i,tstart[i],tcount[i]);
-		    }
-		    /*	     printf("%s %d %d %d %d %d %d %d %d %d\n",__FILE__,__LINE__,ios->io_rank,tstart[0],
-			     tstart[1],tcount[0],tcount[1],buflen,ndims,fndims);*/
-		    mpierr = MPI_Recv(&ierr, 1, MPI_INT, 0, 0, ios->io_comm, &status);  // task0 is ready to recieve
-		    mpierr = MPI_Rsend(&buflen, 1, MPI_INT, 0, 1, ios->io_comm);
-		    if (buflen > 0)
-		    {
-			mpierr = MPI_Rsend(tstart, ndims, MPI_OFFSET, 0, ios->num_iotasks+ios->io_rank,
-					    ios->io_comm);
-			mpierr = MPI_Rsend(tcount, ndims, MPI_OFFSET, 0,2*ios->num_iotasks+ios->io_rank,
-					    ios->io_comm);
-			mpierr = MPI_Rsend(bufptr, buflen, iodesc->basetype, 0, ios->io_rank, ios->io_comm);
-		    }
-		}
-		break;
-	    }
-	    break;
+                            /* Free the temporary buffer, if we don't need it any more. */
+                            if (tmp_buf != bufptr)
+                                free(tmp_buf);
+                        }
+                    }
+                }
+                else if (ios->io_rank < iodesc->num_aiotasks)
+                {
+                    buflen = 1;
+                    for (i = 0; i < ndims; i++)
+                    {
+                        tstart[i] = (size_t) start[i];
+                        tcount[i] = (size_t) count[i];
+                        buflen *= tcount[i];
+                        //               printf("%s %d %d %d %d\n",__FILE__,__LINE__,i,tstart[i],tcount[i]);
+                    }
+                    /*       printf("%s %d %d %d %d %d %d %d %d %d\n",__FILE__,__LINE__,ios->io_rank,tstart[0],
+                             tstart[1],tcount[0],tcount[1],buflen,ndims,fndims);*/
+                    mpierr = MPI_Recv(&ierr, 1, MPI_INT, 0, 0, ios->io_comm, &status);  // task0 is ready to recieve
+                    mpierr = MPI_Rsend(&buflen, 1, MPI_INT, 0, 1, ios->io_comm);
+                    if (buflen > 0)
+                    {
+                        mpierr = MPI_Rsend(tstart, ndims, MPI_OFFSET, 0, ios->num_iotasks+ios->io_rank,
+                                           ios->io_comm);
+                        mpierr = MPI_Rsend(tcount, ndims, MPI_OFFSET, 0,2*ios->num_iotasks+ios->io_rank,
+                                           ios->io_comm);
+                        mpierr = MPI_Rsend(bufptr, buflen, iodesc->basetype, 0, ios->io_rank, ios->io_comm);
+                    }
+                }
+                break;
+            }
+            break;
 #endif /* _NETCDF */
 #ifdef _PNETCDF
-	    case PIO_IOTYPE_PNETCDF:
-		for (i = 0, dsize = 1; i < ndims; i++)
-		    dsize *= count[i];
+            case PIO_IOTYPE_PNETCDF:
+                for (i = 0, dsize = 1; i < ndims; i++)
+                    dsize *= count[i];
 
-		tdsize += dsize;
-		//	 if (dsize==1 && ndims==2)
-		//	 printf("%s %d %d\n",__FILE__,__LINE__,iodesc->basetype);
+                tdsize += dsize;
+                //       if (dsize==1 && ndims==2)
+                //       printf("%s %d %d\n",__FILE__,__LINE__,iodesc->basetype);
 
-		if (dsize > 0)
-		{
-		    //	   printf("%s %d %d %d\n",__FILE__,__LINE__,ios->io_rank,dsize);
-		    startlist[rrcnt] = (PIO_Offset *) calloc(fndims, sizeof(PIO_Offset));
-		    countlist[rrcnt] = (PIO_Offset *) calloc(fndims, sizeof(PIO_Offset));
-		    for (i = 0; i < fndims; i++)
-		    {
-			startlist[rrcnt][i] = start[i];
-			countlist[rrcnt][i] = count[i];
-		    }
-		    rrcnt++;
-		}
-		if (regioncnt == iodesc->maxregions - 1)
-		{
-		    // printf("%s %d %d %ld %ld\n",__FILE__,__LINE__,ios->io_rank,iodesc->llen, tdsize);
-		    //	   ierr = ncmpi_put_varn_all(file->fh, vid, iodesc->maxregions, startlist, countlist,
-		    //			     IOBUF, iodesc->llen, iodesc->basetype);
-		    int reqn = 0;
+                if (dsize > 0)
+                {
+                    //     printf("%s %d %d %d\n",__FILE__,__LINE__,ios->io_rank,dsize);
+                    startlist[rrcnt] = (PIO_Offset *) calloc(fndims, sizeof(PIO_Offset));
+                    countlist[rrcnt] = (PIO_Offset *) calloc(fndims, sizeof(PIO_Offset));
+                    for (i = 0; i < fndims; i++)
+                    {
+                        startlist[rrcnt][i] = start[i];
+                        countlist[rrcnt][i] = count[i];
+                    }
+                    rrcnt++;
+                }
+                if (regioncnt == iodesc->maxregions - 1)
+                {
+                    // printf("%s %d %d %ld %ld\n",__FILE__,__LINE__,ios->io_rank,iodesc->llen, tdsize);
+                    //     ierr = ncmpi_put_varn_all(file->fh, vid, iodesc->maxregions, startlist, countlist,
+                    //                       IOBUF, iodesc->llen, iodesc->basetype);
+                    int reqn = 0;
 
-		    if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0 )
-		    {
-			vdesc->request = realloc(vdesc->request,
-						 sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK));
+                    if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0 )
+                    {
+                        vdesc->request = realloc(vdesc->request,
+                                                 sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK));
 
-			for (int i = vdesc->nreqs; i < vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK; i++)
-			    vdesc->request[i] = NC_REQ_NULL;
-			reqn = vdesc->nreqs;
-		    }
-		    else
-			while(vdesc->request[reqn] != NC_REQ_NULL)
-			    reqn++;
+                        for (int i = vdesc->nreqs; i < vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK; i++)
+                            vdesc->request[i] = NC_REQ_NULL;
+                        reqn = vdesc->nreqs;
+                    }
+                    else
+                        while(vdesc->request[reqn] != NC_REQ_NULL)
+                            reqn++;
 
-		    ierr = ncmpi_bput_varn(file->fh, vid, rrcnt, startlist, countlist,
-					   IOBUF, iodesc->llen, iodesc->basetype, vdesc->request+reqn);
-		    if (vdesc->request[reqn] == NC_REQ_NULL)
-			vdesc->request[reqn] = PIO_REQ_NULL;  //keeps wait calls in sync
-		    vdesc->nreqs = reqn;
+                    ierr = ncmpi_bput_varn(file->fh, vid, rrcnt, startlist, countlist,
+                                           IOBUF, iodesc->llen, iodesc->basetype, vdesc->request+reqn);
+                    if (vdesc->request[reqn] == NC_REQ_NULL)
+                        vdesc->request[reqn] = PIO_REQ_NULL;  //keeps wait calls in sync
+                    vdesc->nreqs = reqn;
 
-		    //	   printf("%s %d %X %d\n",__FILE__,__LINE__,IOBUF,request);
-		    for (i=0;i<rrcnt;i++)
-		    {
-			free(startlist[i]);
-			free(countlist[i]);
-		    }
-		}
-		break;
+                    //     printf("%s %d %X %d\n",__FILE__,__LINE__,IOBUF,request);
+                    for (i=0;i<rrcnt;i++)
+                    {
+                        free(startlist[i]);
+                        free(countlist[i]);
+                    }
+                }
+                break;
 #endif /* _PNETCDF */
-	    default:
-		ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	    }
+            default:
+                ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            }
 
-	    /* Move to the next region. */
-	    if (region)
-		region = region->next;
-	} //    for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++){
+            /* Move to the next region. */
+            if (region)
+                region = region->next;
+        } //    for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++){
     } // if (ios->ioproc)
 
     /* Check the error code returned by netCDF. */
@@ -453,10 +453,10 @@ int pio_write_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid,
  * @ingroup PIO_write_darray
  */
 int pio_write_darray_multi_nc(file_desc_t *file, const int nvars, const int *vid,
-			      const int iodesc_ndims, MPI_Datatype basetype, const PIO_Offset *gsize,
-			      const int maxregions, io_region *firstregion, const PIO_Offset llen,
-			      const int maxiobuflen, const int num_aiotasks,
-			      void *IOBUF, const int *frame)
+                              const int iodesc_ndims, MPI_Datatype basetype, const PIO_Offset *gsize,
+                              const int maxregions, io_region *firstregion, const PIO_Offset llen,
+                              const int maxiobuflen, const int num_aiotasks,
+                              void *IOBUF, const int *frame)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;
@@ -481,30 +481,30 @@ int pio_write_darray_multi_nc(file_desc_t *file, const int nvars, const int *vid
     ios = file->iosystem;
     if (ios == NULL)
     {
-	fprintf(stderr,"Failed to find iosystem handle \n");
-	return PIO_EBADID;
+        fprintf(stderr,"Failed to find iosystem handle \n");
+        return PIO_EBADID;
     }
     vdesc = (file->varlist)+vid[0];
     ncid = file->fh;
 
     if (vdesc == NULL)
     {
-	fprintf(stderr,"Failed to find variable handle %d\n",vid[0]);
-	return PIO_EBADID;
+        fprintf(stderr,"Failed to find variable handle %d\n",vid[0]);
+        return PIO_EBADID;
     }
 
     /* If async is in use, send message to IO master task. */
     if (ios->async_interface)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = 0;
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+        if (!ios->ioproc)
+        {
+            int msg = 0;
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->pio_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->pio_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        }
     }
 
     ierr = PIOc_inq_varndims(file->pio_ncid, vid[0], &fndims);
@@ -512,194 +512,194 @@ int pio_write_darray_multi_nc(file_desc_t *file, const int nvars, const int *vid
 
     if (ios->ioproc)
     {
-	io_region *region;
-	int regioncnt;
-	int rrcnt;
-	void *bufptr;
-	int buflen, j;
-	size_t start[fndims];
-	size_t count[fndims];
-	int ndims = iodesc_ndims;
+        io_region *region;
+        int regioncnt;
+        int rrcnt;
+        void *bufptr;
+        int buflen, j;
+        size_t start[fndims];
+        size_t count[fndims];
+        int ndims = iodesc_ndims;
 
-	PIO_Offset *startlist[maxregions];
-	PIO_Offset *countlist[maxregions];
+        PIO_Offset *startlist[maxregions];
+        PIO_Offset *countlist[maxregions];
 
-	ncid = file->fh;
-	region = firstregion;
+        ncid = file->fh;
+        region = firstregion;
 
-	rrcnt = 0;
-	for (regioncnt = 0; regioncnt < maxregions; regioncnt++)
-	{
-	    // printf("%s %d %d %d %d %d %d\n",__FILE__,__LINE__,region->start[0],region->count[0],ndims,fndims,vdesc->record);
-	    for (i = 0; i < fndims; i++)
-	    {
-		start[i] = 0;
-		count[i] = 0;
-	    }
-	    if (region)
-	    {
-		// this is a record based multidimensional array
-		if (vdesc->record >= 0)
-		{
-		    for (i = fndims - ndims; i < fndims; i++)
-		    {
-			start[i] = region->start[i-(fndims-ndims)];
-			count[i] = region->count[i-(fndims-ndims)];
-		    }
+        rrcnt = 0;
+        for (regioncnt = 0; regioncnt < maxregions; regioncnt++)
+        {
+            // printf("%s %d %d %d %d %d %d\n",__FILE__,__LINE__,region->start[0],region->count[0],ndims,fndims,vdesc->record);
+            for (i = 0; i < fndims; i++)
+            {
+                start[i] = 0;
+                count[i] = 0;
+            }
+            if (region)
+            {
+                // this is a record based multidimensional array
+                if (vdesc->record >= 0)
+                {
+                    for (i = fndims - ndims; i < fndims; i++)
+                    {
+                        start[i] = region->start[i-(fndims-ndims)];
+                        count[i] = region->count[i-(fndims-ndims)];
+                    }
 
-		    if (fndims>1 && ndims<fndims && count[1]>0)
-		    {
-			count[0] = 1;
-			start[0] = frame[0];
-		    }
-		    else if (fndims==ndims)
-		    {
-			start[0] += vdesc->record;
-		    }
-		    // Non-time dependent array
-		}
-		else
-		{
-		    for (i = 0; i < ndims; i++)
-		    {
-			start[i] = region->start[i];
-			count[i] = region->count[i];
-		    }
-		}
-	    }
+                    if (fndims>1 && ndims<fndims && count[1]>0)
+                    {
+                        count[0] = 1;
+                        start[0] = frame[0];
+                    }
+                    else if (fndims==ndims)
+                    {
+                        start[0] += vdesc->record;
+                    }
+                    // Non-time dependent array
+                }
+                else
+                {
+                    for (i = 0; i < ndims; i++)
+                    {
+                        start[i] = region->start[i];
+                        count[i] = region->count[i];
+                    }
+                }
+            }
 
-	    switch(file->iotype)
-	    {
+            switch(file->iotype)
+            {
 #ifdef _NETCDF4
-	    case PIO_IOTYPE_NETCDF4P:
-		for (int nv = 0; nv < nvars; nv++)
-		{
-		    if (vdesc->record >= 0 && ndims < fndims)
-		    {
-			start[0] = frame[nv];
-		    }
-		    if (region)
-		    {
-			bufptr = (void *)((char *) IOBUF + tsize*(nv*llen + region->loffset));
-		    }
-		    ierr = nc_var_par_access(ncid, vid[nv], NC_COLLECTIVE);
+            case PIO_IOTYPE_NETCDF4P:
+                for (int nv = 0; nv < nvars; nv++)
+                {
+                    if (vdesc->record >= 0 && ndims < fndims)
+                    {
+                        start[0] = frame[nv];
+                    }
+                    if (region)
+                    {
+                        bufptr = (void *)((char *) IOBUF + tsize*(nv*llen + region->loffset));
+                    }
+                    ierr = nc_var_par_access(ncid, vid[nv], NC_COLLECTIVE);
 
-		    if (basetype == MPI_DOUBLE ||basetype == MPI_REAL8)
-		    {
-			ierr = nc_put_vara_double (ncid, vid[nv],(size_t *) start,(size_t *) count,
-						   (const double *)bufptr);
-		    }
-		    else if (basetype == MPI_INTEGER)
-		    {
-			ierr = nc_put_vara_int (ncid, vid[nv], (size_t *) start, (size_t *) count,
-						(const int *)bufptr);
-		    }
-		    else if (basetype == MPI_FLOAT || basetype == MPI_REAL4)
-		    {
-			ierr = nc_put_vara_float (ncid, vid[nv], (size_t *) start, (size_t *) count,
-						  (const float *)bufptr);
-		    }
-		    else
-		    {
-			fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",
-				(int)basetype);
-		    }
-		}
-		break;
+                    if (basetype == MPI_DOUBLE ||basetype == MPI_REAL8)
+                    {
+                        ierr = nc_put_vara_double (ncid, vid[nv],(size_t *) start,(size_t *) count,
+                                                   (const double *)bufptr);
+                    }
+                    else if (basetype == MPI_INTEGER)
+                    {
+                        ierr = nc_put_vara_int (ncid, vid[nv], (size_t *) start, (size_t *) count,
+                                                (const int *)bufptr);
+                    }
+                    else if (basetype == MPI_FLOAT || basetype == MPI_REAL4)
+                    {
+                        ierr = nc_put_vara_float (ncid, vid[nv], (size_t *) start, (size_t *) count,
+                                                  (const float *)bufptr);
+                    }
+                    else
+                    {
+                        fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",
+                                (int)basetype);
+                    }
+                }
+                break;
 #endif
 #ifdef _PNETCDF
-	    case PIO_IOTYPE_PNETCDF:
-		for (i = 0, dsize = 1; i < fndims; i++)
-		{
-		    dsize *= count[i];
-		}
-		tdsize += dsize;
+            case PIO_IOTYPE_PNETCDF:
+                for (i = 0, dsize = 1; i < fndims; i++)
+                {
+                    dsize *= count[i];
+                }
+                tdsize += dsize;
 
-		if (dsize>0)
-		{
-		    //	   printf("%s %d %d %d\n",__FILE__,__LINE__,ios->io_rank,dsize);
-		    startlist[rrcnt] = (PIO_Offset *) calloc(fndims, sizeof(PIO_Offset));
-		    countlist[rrcnt] = (PIO_Offset *) calloc(fndims, sizeof(PIO_Offset));
-		    for (i = 0; i < fndims; i++)
-		    {
-			startlist[rrcnt][i]=start[i];
-			countlist[rrcnt][i]=count[i];
-		    }
-		    rrcnt++;
-		}
-		if (regioncnt==maxregions-1)
-		{
-		    //printf("%s %d %d %ld %ld\n",__FILE__,__LINE__,ios->io_rank,iodesc->llen, tdsize);
-		    //	   ierr = ncmpi_put_varn_all(ncid, vid, iodesc->maxregions, startlist, countlist,
-		    //			     IOBUF, iodesc->llen, iodesc->basetype);
+                if (dsize>0)
+                {
+                    //     printf("%s %d %d %d\n",__FILE__,__LINE__,ios->io_rank,dsize);
+                    startlist[rrcnt] = (PIO_Offset *) calloc(fndims, sizeof(PIO_Offset));
+                    countlist[rrcnt] = (PIO_Offset *) calloc(fndims, sizeof(PIO_Offset));
+                    for (i = 0; i < fndims; i++)
+                    {
+                        startlist[rrcnt][i]=start[i];
+                        countlist[rrcnt][i]=count[i];
+                    }
+                    rrcnt++;
+                }
+                if (regioncnt==maxregions-1)
+                {
+                    //printf("%s %d %d %ld %ld\n",__FILE__,__LINE__,ios->io_rank,iodesc->llen, tdsize);
+                    //     ierr = ncmpi_put_varn_all(ncid, vid, iodesc->maxregions, startlist, countlist,
+                    //                       IOBUF, iodesc->llen, iodesc->basetype);
 
-		    //printf("%s %d %ld \n",__FILE__,__LINE__,IOBUF);
-		    for (int nv=0; nv<nvars; nv++)
-		    {
-			vdesc = (file->varlist)+vid[nv];
-			if (vdesc->record >= 0 && ndims<fndims)
-			{
-			    for (int rc=0;rc<rrcnt;rc++)
-			    {
-				startlist[rc][0] = frame[nv];
-			    }
-			}
-			bufptr = (void *)((char *) IOBUF + nv*tsize*llen);
+                    //printf("%s %d %ld \n",__FILE__,__LINE__,IOBUF);
+                    for (int nv=0; nv<nvars; nv++)
+                    {
+                        vdesc = (file->varlist)+vid[nv];
+                        if (vdesc->record >= 0 && ndims<fndims)
+                        {
+                            for (int rc=0;rc<rrcnt;rc++)
+                            {
+                                startlist[rc][0] = frame[nv];
+                            }
+                        }
+                        bufptr = (void *)((char *) IOBUF + nv*tsize*llen);
 
-			int reqn=0;
-			if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 )
-			{
-			    vdesc->request = realloc(vdesc->request,
-						     sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+                        int reqn=0;
+                        if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 )
+                        {
+                            vdesc->request = realloc(vdesc->request,
+                                                     sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
 
-			    for (int i=vdesc->nreqs;i<vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK;i++)
-			    {
-				vdesc->request[i]=NC_REQ_NULL;
-			    }
-			    reqn = vdesc->nreqs;
-			}
-			else
-			{
-			    while(vdesc->request[reqn] != NC_REQ_NULL)
-			    {
-				reqn++;
-			    }
-			}
-			ierr = ncmpi_iput_varn(ncid, vid[nv], rrcnt, startlist, countlist,
-					       bufptr, llen, basetype, vdesc->request+reqn);
-			/*
-			  ierr = ncmpi_bput_varn(ncid, vid[nv], rrcnt, startlist, countlist,
-			  bufptr, llen, basetype, &(vdesc->request));
-			*/
-			if (vdesc->request[reqn] == NC_REQ_NULL)
-			{
-			    vdesc->request[reqn] = PIO_REQ_NULL;  //keeps wait calls in sync
-			}
-			vdesc->nreqs += reqn+1;
+                            for (int i=vdesc->nreqs;i<vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK;i++)
+                            {
+                                vdesc->request[i]=NC_REQ_NULL;
+                            }
+                            reqn = vdesc->nreqs;
+                        }
+                        else
+                        {
+                            while(vdesc->request[reqn] != NC_REQ_NULL)
+                            {
+                                reqn++;
+                            }
+                        }
+                        ierr = ncmpi_iput_varn(ncid, vid[nv], rrcnt, startlist, countlist,
+                                               bufptr, llen, basetype, vdesc->request+reqn);
+                        /*
+                          ierr = ncmpi_bput_varn(ncid, vid[nv], rrcnt, startlist, countlist,
+                          bufptr, llen, basetype, &(vdesc->request));
+                        */
+                        if (vdesc->request[reqn] == NC_REQ_NULL)
+                        {
+                            vdesc->request[reqn] = PIO_REQ_NULL;  //keeps wait calls in sync
+                        }
+                        vdesc->nreqs += reqn+1;
 
-			//	     printf("%s %d %d %d\n",__FILE__,__LINE__,vdesc->nreqs,vdesc->request[reqn]);
-		    }
-		    for (i=0;i<rrcnt;i++)
-		    {
-			if (ierr != PIO_NOERR)
-			{
-			    for (j=0;j<fndims;j++)
-			    {
-				printf("pio_darray: %d %d %d %ld %ld \n",__LINE__,i,j,startlist[i][j],countlist[i][j]);
-			    }
-			}
-			free(startlist[i]);
-			free(countlist[i]);
-		    }
-		}
-		break;
+                        //           printf("%s %d %d %d\n",__FILE__,__LINE__,vdesc->nreqs,vdesc->request[reqn]);
+                    }
+                    for (i=0;i<rrcnt;i++)
+                    {
+                        if (ierr != PIO_NOERR)
+                        {
+                            for (j=0;j<fndims;j++)
+                            {
+                                printf("pio_darray: %d %d %d %ld %ld \n",__LINE__,i,j,startlist[i][j],countlist[i][j]);
+                            }
+                        }
+                        free(startlist[i]);
+                        free(countlist[i]);
+                    }
+                }
+                break;
 #endif
-	    default:
-		ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	    }
-	    if (region)
-		region = region->next;
-	} //    for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++){
+            default:
+                ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            }
+            if (region)
+                region = region->next;
+        } //    for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++){
     } // if (ios->ioproc)
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
@@ -744,10 +744,10 @@ int pio_write_darray_multi_nc(file_desc_t *file, const int nvars, const int *vid
  * @ingroup PIO_write_darray
  */
 int pio_write_darray_multi_nc_serial(file_desc_t *file, const int nvars, const int *vid,
-				     const int iodesc_ndims, MPI_Datatype basetype, const PIO_Offset *gsize,
-				     const int maxregions, io_region *firstregion, const PIO_Offset llen,
-				     const int maxiobuflen, const int num_aiotasks,
-				     void *IOBUF, const int *frame)
+                                     const int iodesc_ndims, MPI_Datatype basetype, const PIO_Offset *gsize,
+                                     const int maxregions, io_region *firstregion, const PIO_Offset llen,
+                                     const int maxiobuflen, const int num_aiotasks,
+                                     void *IOBUF, const int *frame)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;
@@ -770,31 +770,31 @@ int pio_write_darray_multi_nc_serial(file_desc_t *file, const int nvars, const i
 
     if (!(ios = file->iosystem))
     {
-	fprintf(stderr,"Failed to find iosystem handle \n");
-	return PIO_EBADID;
+        fprintf(stderr,"Failed to find iosystem handle \n");
+        return PIO_EBADID;
     }
 
     ncid = file->fh;
 
     if (!(vdesc = (file->varlist) + vid[0]))
     {
-	fprintf(stderr,"Failed to find variable handle %d\n",vid[0]);
-	return PIO_EBADID;
+        fprintf(stderr,"Failed to find variable handle %d\n",vid[0]);
+        return PIO_EBADID;
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
-	if (! ios->ioproc)
-	{
-	    int msg = 0;
+        if (! ios->ioproc)
+        {
+            int msg = 0;
 
-	    if (ios->comp_rank==0)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->comp_rank==0)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->pio_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->pio_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        }
     }
 
     ierr = PIOc_inq_varndims(file->pio_ncid, vid[0], &fndims);
@@ -802,153 +802,153 @@ int pio_write_darray_multi_nc_serial(file_desc_t *file, const int nvars, const i
 
     if (ios->ioproc)
     {
-	io_region *region;
-	int regioncnt;
-	int rrcnt;
-	void *bufptr;
-	int buflen, j;
-	size_t tmp_start[fndims*maxregions];
-	size_t tmp_count[fndims*maxregions];
+        io_region *region;
+        int regioncnt;
+        int rrcnt;
+        void *bufptr;
+        int buflen, j;
+        size_t tmp_start[fndims*maxregions];
+        size_t tmp_count[fndims*maxregions];
 
-	int ndims = iodesc_ndims;
+        int ndims = iodesc_ndims;
 
-	ncid = file->fh;
-	region = firstregion;
+        ncid = file->fh;
+        region = firstregion;
 
 
-	rrcnt = 0;
-	for (regioncnt = 0; regioncnt < maxregions; regioncnt++)
-	{
-	    for (i = 0; i < fndims; i++)
-	    {
-		tmp_start[i + regioncnt * fndims] = 0;
-		tmp_count[i + regioncnt * fndims] = 0;
-	    }
-	    if (region)
-	    {
-		// this is a record based multidimensional array
-		if (vdesc->record >= 0)
-		{
-		    for (i = fndims - ndims; i < fndims; i++)
-		    {
-			tmp_start[i + regioncnt * fndims] = region->start[i - (fndims - ndims)];
-			tmp_count[i + regioncnt * fndims] = region->count[i - (fndims - ndims)];
-		    }
-		    // Non-time dependent array
-		}
-		else
-		{
-		    for (i = 0; i < ndims; i++)
-		    {
-			tmp_start[i + regioncnt * fndims] = region->start[i];
-			tmp_count[i + regioncnt * fndims] = region->count[i];
-		    }
-		}
-		region = region->next;
-	    }
-	}
-	if (ios->io_rank > 0)
-	{
-	    mpierr = MPI_Recv(&ierr, 1, MPI_INT, 0, 0, ios->io_comm, &status);  // task0 is ready to recieve
-	    MPI_Send(&llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm);
-	    if (llen>0)
-	    {
-		MPI_Send(&maxregions, 1, MPI_INT, 0, ios->io_rank+ios->num_iotasks, ios->io_comm);
-		MPI_Send(tmp_start, maxregions*fndims, MPI_OFFSET, 0, ios->io_rank+2*ios->num_iotasks, ios->io_comm);
-		MPI_Send(tmp_count, maxregions*fndims, MPI_OFFSET, 0, ios->io_rank+3*ios->num_iotasks, ios->io_comm);
-		//	 printf("%s %d %ld\n",__FILE__,__LINE__,nvars*llen);
-		MPI_Send(IOBUF, nvars*llen, basetype, 0, ios->io_rank+4*ios->num_iotasks, ios->io_comm);
-	    }
-	}
-	else
-	{
-	    size_t rlen;
-	    int rregions;
-	    size_t start[fndims], count[fndims];
-	    size_t loffset;
-	    mpierr = MPI_Type_size(basetype, &dsize);
+        rrcnt = 0;
+        for (regioncnt = 0; regioncnt < maxregions; regioncnt++)
+        {
+            for (i = 0; i < fndims; i++)
+            {
+                tmp_start[i + regioncnt * fndims] = 0;
+                tmp_count[i + regioncnt * fndims] = 0;
+            }
+            if (region)
+            {
+                // this is a record based multidimensional array
+                if (vdesc->record >= 0)
+                {
+                    for (i = fndims - ndims; i < fndims; i++)
+                    {
+                        tmp_start[i + regioncnt * fndims] = region->start[i - (fndims - ndims)];
+                        tmp_count[i + regioncnt * fndims] = region->count[i - (fndims - ndims)];
+                    }
+                    // Non-time dependent array
+                }
+                else
+                {
+                    for (i = 0; i < ndims; i++)
+                    {
+                        tmp_start[i + regioncnt * fndims] = region->start[i];
+                        tmp_count[i + regioncnt * fndims] = region->count[i];
+                    }
+                }
+                region = region->next;
+            }
+        }
+        if (ios->io_rank > 0)
+        {
+            mpierr = MPI_Recv(&ierr, 1, MPI_INT, 0, 0, ios->io_comm, &status);  // task0 is ready to recieve
+            MPI_Send(&llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm);
+            if (llen>0)
+            {
+                MPI_Send(&maxregions, 1, MPI_INT, 0, ios->io_rank+ios->num_iotasks, ios->io_comm);
+                MPI_Send(tmp_start, maxregions*fndims, MPI_OFFSET, 0, ios->io_rank+2*ios->num_iotasks, ios->io_comm);
+                MPI_Send(tmp_count, maxregions*fndims, MPI_OFFSET, 0, ios->io_rank+3*ios->num_iotasks, ios->io_comm);
+                //       printf("%s %d %ld\n",__FILE__,__LINE__,nvars*llen);
+                MPI_Send(IOBUF, nvars*llen, basetype, 0, ios->io_rank+4*ios->num_iotasks, ios->io_comm);
+            }
+        }
+        else
+        {
+            size_t rlen;
+            int rregions;
+            size_t start[fndims], count[fndims];
+            size_t loffset;
+            mpierr = MPI_Type_size(basetype, &dsize);
 
-	    for (int rtask=0; rtask<ios->num_iotasks; rtask++)
-	    {
-		if (rtask>0)
-		{
-		    mpierr = MPI_Send(&ierr, 1, MPI_INT, rtask, 0, ios->io_comm);  // handshake - tell the sending task I'm ready
-		    MPI_Recv(&rlen, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status);
-		    if (rlen>0){
-			MPI_Recv(&rregions, 1, MPI_INT, rtask, rtask+ios->num_iotasks, ios->io_comm, &status);
-			MPI_Recv(tmp_start, rregions*fndims, MPI_OFFSET, rtask, rtask+2*ios->num_iotasks, ios->io_comm, &status);
-			MPI_Recv(tmp_count, rregions*fndims, MPI_OFFSET, rtask, rtask+3*ios->num_iotasks, ios->io_comm, &status);
-			//	     printf("%s %d %d %ld\n",__FILE__,__LINE__,rtask,nvars*rlen);
-			MPI_Recv(IOBUF, nvars*rlen, basetype, rtask, rtask+4*ios->num_iotasks, ios->io_comm, &status);
-		    }
-		}
-		else
-		{
-		    rlen = llen;
-		    rregions = maxregions;
-		}
-		if (rlen>0)
-		{
-		    loffset = 0;
-		    for (regioncnt=0;regioncnt<rregions;regioncnt++)
-		    {
-			for (int i=0;i<fndims;i++)
-			{
-			    start[i] = tmp_start[i+regioncnt*fndims];
-			    count[i] = tmp_count[i+regioncnt*fndims];
-			}
+            for (int rtask=0; rtask<ios->num_iotasks; rtask++)
+            {
+                if (rtask>0)
+                {
+                    mpierr = MPI_Send(&ierr, 1, MPI_INT, rtask, 0, ios->io_comm);  // handshake - tell the sending task I'm ready
+                    MPI_Recv(&rlen, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status);
+                    if (rlen>0){
+                        MPI_Recv(&rregions, 1, MPI_INT, rtask, rtask+ios->num_iotasks, ios->io_comm, &status);
+                        MPI_Recv(tmp_start, rregions*fndims, MPI_OFFSET, rtask, rtask+2*ios->num_iotasks, ios->io_comm, &status);
+                        MPI_Recv(tmp_count, rregions*fndims, MPI_OFFSET, rtask, rtask+3*ios->num_iotasks, ios->io_comm, &status);
+                        //           printf("%s %d %d %ld\n",__FILE__,__LINE__,rtask,nvars*rlen);
+                        MPI_Recv(IOBUF, nvars*rlen, basetype, rtask, rtask+4*ios->num_iotasks, ios->io_comm, &status);
+                    }
+                }
+                else
+                {
+                    rlen = llen;
+                    rregions = maxregions;
+                }
+                if (rlen>0)
+                {
+                    loffset = 0;
+                    for (regioncnt=0;regioncnt<rregions;regioncnt++)
+                    {
+                        for (int i=0;i<fndims;i++)
+                        {
+                            start[i] = tmp_start[i+regioncnt*fndims];
+                            count[i] = tmp_count[i+regioncnt*fndims];
+                        }
 
-			for (int nv=0; nv<nvars; nv++)
-			{
-			    bufptr = (void *)((char *) IOBUF+ tsize*(nv*rlen + loffset));
+                        for (int nv=0; nv<nvars; nv++)
+                        {
+                            bufptr = (void *)((char *) IOBUF+ tsize*(nv*rlen + loffset));
 
-			    if (vdesc->record>=0)
-			    {
-				if (fndims>1 && ndims<fndims && count[1]>0)
-				{
-				    count[0] = 1;
-				    start[0] = frame[nv];
-				}
-				else if (fndims==ndims)
-				{
-				    start[0]+=vdesc->record;
-				}
-			    }
+                            if (vdesc->record>=0)
+                            {
+                                if (fndims>1 && ndims<fndims && count[1]>0)
+                                {
+                                    count[0] = 1;
+                                    start[0] = frame[nv];
+                                }
+                                else if (fndims==ndims)
+                                {
+                                    start[0]+=vdesc->record;
+                                }
+                            }
 
-			    if (basetype == MPI_INTEGER)
-			    {
-				ierr = nc_put_vara_int (ncid, vid[nv], start, count, (const int *) bufptr);
-			    }
-			    else if (basetype == MPI_DOUBLE || basetype == MPI_REAL8)
-			    {
-				ierr = nc_put_vara_double (ncid, vid[nv], start, count, (const double *) bufptr);
-			    }
-			    else if (basetype == MPI_FLOAT || basetype == MPI_REAL4)
-			    {
-				ierr = nc_put_vara_float (ncid,vid[nv], start, count, (const float *) bufptr);
-			    }
-			    else
-			    {
-				fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",(int) basetype);
-			    }
+                            if (basetype == MPI_INTEGER)
+                            {
+                                ierr = nc_put_vara_int (ncid, vid[nv], start, count, (const int *) bufptr);
+                            }
+                            else if (basetype == MPI_DOUBLE || basetype == MPI_REAL8)
+                            {
+                                ierr = nc_put_vara_double (ncid, vid[nv], start, count, (const double *) bufptr);
+                            }
+                            else if (basetype == MPI_FLOAT || basetype == MPI_REAL4)
+                            {
+                                ierr = nc_put_vara_float (ncid,vid[nv], start, count, (const float *) bufptr);
+                            }
+                            else
+                            {
+                                fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",(int) basetype);
+                            }
 
-			    if (ierr != PIO_NOERR){
-				for (i=0;i<fndims;i++)
-				    fprintf(stderr,"vid %d dim %d start %ld count %ld \n",vid[nv],i,start[i],count[i]);
-			    }
-			}
-			size_t tsize;
-			tsize = 1;
-			for (int i=0;i<fndims;i++)
-			{
-			    tsize*=count[i];
-			}
-			loffset += tsize;
-		    }//    for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++){
-		} // if (rlen>0)
-	    } //        for (int rtask=0; rtask<ios->num_iotasks; rtask++){
+                            if (ierr != PIO_NOERR){
+                                for (i=0;i<fndims;i++)
+                                    fprintf(stderr,"vid %d dim %d start %ld count %ld \n",vid[nv],i,start[i],count[i]);
+                            }
+                        }
+                        size_t tsize;
+                        tsize = 1;
+                        for (int i=0;i<fndims;i++)
+                        {
+                            tsize*=count[i];
+                        }
+                        loffset += tsize;
+                    }//    for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++){
+                } // if (rlen>0)
+            } //        for (int rtask=0; rtask<ios->num_iotasks; rtask++){
 
-	}
+        }
     } // if (ios->ioproc)
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
@@ -985,9 +985,9 @@ int pio_write_darray_multi_nc_serial(file_desc_t *file, const int nvars, const i
  * @ingroup PIO_write_darray
  */
 int PIOc_write_darray_multi(const int ncid, const int *vid, const int ioid,
-			    const int nvars, const PIO_Offset arraylen,
-			    void *array, const int *frame, void **fillvalue,
-			    bool flushtodisk)
+                            const int nvars, const PIO_Offset arraylen,
+                            void *array, const int *frame, void **fillvalue,
+                            bool flushtodisk)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;
@@ -1001,20 +1001,20 @@ int PIOc_write_darray_multi(const int ncid, const int *vid, const int ioid,
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
 
     if (! (file->mode & PIO_WRITE))
     {
-	fprintf(stderr,"ERROR:  Attempt to write to read-only file\n");
-	return PIO_EPERM;
+        fprintf(stderr,"ERROR:  Attempt to write to read-only file\n");
+        return PIO_EPERM;
     }
 
     iodesc = pio_get_iodesc_from_id(ioid);
     if (iodesc == NULL)
     {
-	//     print_trace(NULL);
-	//fprintf(stderr,"iodesc handle not found %d %d\n",ioid,__LINE__);
-	return PIO_EBADID;
+        //     print_trace(NULL);
+        //fprintf(stderr,"iodesc handle not found %d %d\n",ioid,__LINE__);
+        return PIO_EBADID;
     }
 
     vdesc0 = file->varlist+vid[0];
@@ -1026,135 +1026,135 @@ int PIOc_write_darray_multi(const int ncid, const int *vid, const int ioid,
     rlen=0;
     if (iodesc->llen>0)
     {
-	rlen = iodesc->maxiobuflen*nvars;
+        rlen = iodesc->maxiobuflen*nvars;
     }
     if (vdesc0->iobuf)
     {
-	piodie("Attempt to overwrite existing io buffer",__FILE__,__LINE__);
+        piodie("Attempt to overwrite existing io buffer",__FILE__,__LINE__);
     }
     if (iodesc->rearranger>0)
     {
-	if (rlen>0)
-	{
-	    MPI_Type_size(iodesc->basetype, &vsize);
-	    //printf("rlen*vsize = %ld\n",rlen*vsize);
+        if (rlen>0)
+        {
+            MPI_Type_size(iodesc->basetype, &vsize);
+            //printf("rlen*vsize = %ld\n",rlen*vsize);
 
-	    vdesc0->iobuf = bget((size_t) vsize* (size_t) rlen);
-	    if (vdesc0->iobuf==NULL)
-	    {
-		printf("%s %d %d %ld\n",__FILE__,__LINE__,nvars,vsize*rlen);
-		piomemerror(*ios,(size_t) rlen*(size_t) vsize, __FILE__,__LINE__);
-	    }
-	    if (iodesc->needsfill && iodesc->rearranger==PIO_REARR_BOX)
-	    {
-		if (vsize==4)
-		{
-		    for (int nv=0;nv < nvars; nv++)
-		    {
-			for (int i=0;i<iodesc->maxiobuflen;i++)
-			{
-			    ((float *) vdesc0->iobuf)[i+nv*(iodesc->maxiobuflen)] = ((float *)fillvalue)[nv];
-			}
-		    }
-		}
-		else if (vsize==8)
-		{
-		    for (int nv=0;nv < nvars; nv++)
-		    {
-			for (int i=0;i<iodesc->maxiobuflen;i++)
-			{
-			    ((double *)vdesc0->iobuf)[i+nv*(iodesc->maxiobuflen)] = ((double *)fillvalue)[nv];
-			}
-		    }
-		}
-	    }
-	}
+            vdesc0->iobuf = bget((size_t) vsize* (size_t) rlen);
+            if (vdesc0->iobuf==NULL)
+            {
+                printf("%s %d %d %ld\n",__FILE__,__LINE__,nvars,vsize*rlen);
+                piomemerror(*ios,(size_t) rlen*(size_t) vsize, __FILE__,__LINE__);
+            }
+            if (iodesc->needsfill && iodesc->rearranger==PIO_REARR_BOX)
+            {
+                if (vsize==4)
+                {
+                    for (int nv=0;nv < nvars; nv++)
+                    {
+                        for (int i=0;i<iodesc->maxiobuflen;i++)
+                        {
+                            ((float *) vdesc0->iobuf)[i+nv*(iodesc->maxiobuflen)] = ((float *)fillvalue)[nv];
+                        }
+                    }
+                }
+                else if (vsize==8)
+                {
+                    for (int nv=0;nv < nvars; nv++)
+                    {
+                        for (int i=0;i<iodesc->maxiobuflen;i++)
+                        {
+                            ((double *)vdesc0->iobuf)[i+nv*(iodesc->maxiobuflen)] = ((double *)fillvalue)[nv];
+                        }
+                    }
+                }
+            }
+        }
 
-	ierr = rearrange_comp2io(*ios, iodesc, array, vdesc0->iobuf, nvars);
+        ierr = rearrange_comp2io(*ios, iodesc, array, vdesc0->iobuf, nvars);
     }/*  this is wrong, need to think about it
-	 else{
-	 vdesc0->iobuf = array;
-	 } */
+         else{
+         vdesc0->iobuf = array;
+         } */
     switch(file->iotype)
     {
     case PIO_IOTYPE_NETCDF4P:
     case PIO_IOTYPE_PNETCDF:
-	ierr = pio_write_darray_multi_nc(file, nvars, vid,
-					 iodesc->ndims, iodesc->basetype, iodesc->gsize,
-					 iodesc->maxregions, iodesc->firstregion, iodesc->llen,
-					 iodesc->maxiobuflen, iodesc->num_aiotasks,
-					 vdesc0->iobuf, frame);
-	break;
+        ierr = pio_write_darray_multi_nc(file, nvars, vid,
+                                         iodesc->ndims, iodesc->basetype, iodesc->gsize,
+                                         iodesc->maxregions, iodesc->firstregion, iodesc->llen,
+                                         iodesc->maxiobuflen, iodesc->num_aiotasks,
+                                         vdesc0->iobuf, frame);
+        break;
     case PIO_IOTYPE_NETCDF4C:
     case PIO_IOTYPE_NETCDF:
-	ierr = pio_write_darray_multi_nc_serial(file, nvars, vid,
-						iodesc->ndims, iodesc->basetype, iodesc->gsize,
-						iodesc->maxregions, iodesc->firstregion, iodesc->llen,
-						iodesc->maxiobuflen, iodesc->num_aiotasks,
-						vdesc0->iobuf, frame);
-	if (vdesc0->iobuf)
-	{
-	    brel(vdesc0->iobuf);
-	    vdesc0->iobuf = NULL;
-	}
-	break;
+        ierr = pio_write_darray_multi_nc_serial(file, nvars, vid,
+                                                iodesc->ndims, iodesc->basetype, iodesc->gsize,
+                                                iodesc->maxregions, iodesc->firstregion, iodesc->llen,
+                                                iodesc->maxiobuflen, iodesc->num_aiotasks,
+                                                vdesc0->iobuf, frame);
+        if (vdesc0->iobuf)
+        {
+            brel(vdesc0->iobuf);
+            vdesc0->iobuf = NULL;
+        }
+        break;
 
     }
 
     if (iodesc->rearranger == PIO_REARR_SUBSET && iodesc->needsfill &&
-       iodesc->holegridsize>0)
+        iodesc->holegridsize>0)
     {
-	if (vdesc0->fillbuf)
-	{
-	    piodie("Attempt to overwrite existing buffer",__FILE__,__LINE__);
-	}
+        if (vdesc0->fillbuf)
+        {
+            piodie("Attempt to overwrite existing buffer",__FILE__,__LINE__);
+        }
 
-	vdesc0->fillbuf = bget(iodesc->holegridsize*vsize*nvars);
-	//printf("%s %d %x\n",__FILE__,__LINE__,vdesc0->fillbuf);
-	if (vsize==4)
-	{
-	    for (int nv=0;nv<nvars;nv++)
-	    {
-		for (int i=0;i<iodesc->holegridsize;i++)
-		{
-		    ((float *) vdesc0->fillbuf)[i+nv*iodesc->holegridsize] = ((float *) fillvalue)[nv];
-		}
-	    }
-	}
-	else if (vsize==8)
-	{
-	    for (int nv=0;nv<nvars;nv++)
-	    {
-		for (int i=0;i<iodesc->holegridsize;i++)
-		{
-		    ((double *) vdesc0->fillbuf)[i+nv*iodesc->holegridsize] = ((double *) fillvalue)[nv];
-		}
-	    }
-	}
-	switch(file->iotype)
-	{
-	case PIO_IOTYPE_PNETCDF:
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = pio_write_darray_multi_nc(file, nvars, vid,
-					     iodesc->ndims, iodesc->basetype, iodesc->gsize,
-					     iodesc->maxfillregions, iodesc->fillregion, iodesc->holegridsize,
-					     iodesc->holegridsize, iodesc->num_aiotasks,
-					     vdesc0->fillbuf, frame);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	case PIO_IOTYPE_NETCDF:
-	  ierr = pio_write_darray_multi_nc_serial(file, nvars, vid,
-		     iodesc->ndims, iodesc->basetype, iodesc->gsize,
-		     iodesc->maxfillregions, iodesc->fillregion, iodesc->holegridsize,
-		     iodesc->holegridsize, iodesc->num_aiotasks,
-		     vdesc0->fillbuf, frame);
-	    break;
-	}
+        vdesc0->fillbuf = bget(iodesc->holegridsize*vsize*nvars);
+        //printf("%s %d %x\n",__FILE__,__LINE__,vdesc0->fillbuf);
+        if (vsize==4)
+        {
+            for (int nv=0;nv<nvars;nv++)
+            {
+                for (int i=0;i<iodesc->holegridsize;i++)
+                {
+                    ((float *) vdesc0->fillbuf)[i+nv*iodesc->holegridsize] = ((float *) fillvalue)[nv];
+                }
+            }
+        }
+        else if (vsize==8)
+        {
+            for (int nv=0;nv<nvars;nv++)
+            {
+                for (int i=0;i<iodesc->holegridsize;i++)
+                {
+                    ((double *) vdesc0->fillbuf)[i+nv*iodesc->holegridsize] = ((double *) fillvalue)[nv];
+                }
+            }
+        }
+        switch(file->iotype)
+        {
+        case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = pio_write_darray_multi_nc(file, nvars, vid,
+                                             iodesc->ndims, iodesc->basetype, iodesc->gsize,
+                                             iodesc->maxfillregions, iodesc->fillregion, iodesc->holegridsize,
+                                             iodesc->holegridsize, iodesc->num_aiotasks,
+                                             vdesc0->fillbuf, frame);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF:
+            ierr = pio_write_darray_multi_nc_serial(file, nvars, vid,
+                                                    iodesc->ndims, iodesc->basetype, iodesc->gsize,
+                                                    iodesc->maxfillregions, iodesc->fillregion, iodesc->holegridsize,
+                                                    iodesc->holegridsize, iodesc->num_aiotasks,
+                                                    vdesc0->fillbuf, frame);
+            break;
+        }
 
-	if (vdesc0->fillbuf != NULL){
-	  brel(vdesc0->fillbuf);
-	  vdesc0->fillbuf = NULL;
-	}
+        if (vdesc0->fillbuf != NULL){
+            brel(vdesc0->fillbuf);
+            vdesc0->fillbuf = NULL;
+        }
 
     }
 
@@ -1186,7 +1186,7 @@ int PIOc_write_darray_multi(const int ncid, const int *vid, const int ioid,
  * @ingroup PIO_write_darray
  */
 int PIOc_write_darray(const int ncid, const int vid, const int ioid,
-		      const PIO_Offset arraylen, void *array, void *fillvalue)
+                      const PIO_Offset arraylen, void *array, void *fillvalue)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;
@@ -1210,84 +1210,84 @@ int PIOc_write_darray(const int ncid, const int vid, const int ioid,
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
 
     if (! (file->mode & PIO_WRITE))
     {
-	fprintf(stderr,"ERROR:  Attempt to write to read-only file\n");
-	return PIO_EPERM;
+        fprintf(stderr,"ERROR:  Attempt to write to read-only file\n");
+        return PIO_EPERM;
     }
 
     iodesc = pio_get_iodesc_from_id(ioid);
     if (iodesc == NULL)
     {
-	fprintf(stderr,"iodesc handle not found %d %d\n",ioid,__LINE__);
-	return PIO_EBADID;
+        fprintf(stderr,"iodesc handle not found %d %d\n",ioid,__LINE__);
+        return PIO_EBADID;
     }
     ios = file->iosystem;
 
     vdesc = (file->varlist)+vid;
     if (vdesc == NULL)
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     /* Is this a record variable? */
     recordvar = vdesc->record >= 0 ? true : false;
 
     if (iodesc->ndof != arraylen)
     {
-	fprintf(stderr,"ndof=%ld, arraylen=%ld\n",iodesc->ndof,arraylen);
-	piodie("ndof != arraylen",__FILE__,__LINE__);
+        fprintf(stderr,"ndof=%ld, arraylen=%ld\n",iodesc->ndof,arraylen);
+        piodie("ndof != arraylen",__FILE__,__LINE__);
     }
     wmb = &(file->buffer);
     if (wmb->ioid == -1)
     {
-	if (recordvar)
-	    wmb->ioid = ioid;
-	else
-	    wmb->ioid = -(ioid);
+        if (recordvar)
+            wmb->ioid = ioid;
+        else
+            wmb->ioid = -(ioid);
     }
     else
     {
-	// separate record and non-record variables
-	if (recordvar)
-	{
-	    while(wmb->next && wmb->ioid!=ioid)
-		if (wmb->next!=NULL)
-		    wmb = wmb->next;
+        // separate record and non-record variables
+        if (recordvar)
+        {
+            while(wmb->next && wmb->ioid!=ioid)
+                if (wmb->next!=NULL)
+                    wmb = wmb->next;
 #ifdef _PNETCDF
-	    /* flush the previous record before starting a new one. this is collective */
-	    //       if (vdesc->request != NULL && (vdesc->request[0] != NC_REQ_NULL) ||
-	    //	  (wmb->frame != NULL && vdesc->record != wmb->frame[0])){
-	    //	 needsflush = 2;  // flush to disk
-	    //  }
+            /* flush the previous record before starting a new one. this is collective */
+            //       if (vdesc->request != NULL && (vdesc->request[0] != NC_REQ_NULL) ||
+            //    (wmb->frame != NULL && vdesc->record != wmb->frame[0])){
+            //   needsflush = 2;  // flush to disk
+            //  }
 #endif
-	}
-	else
-	{
-	    while(wmb->next && wmb->ioid!= -(ioid))
-	    {
-		if (wmb->next!=NULL)
-		    wmb = wmb->next;
-	    }
-	}
+        }
+        else
+        {
+            while(wmb->next && wmb->ioid!= -(ioid))
+            {
+                if (wmb->next!=NULL)
+                    wmb = wmb->next;
+            }
+        }
     }
     if ((recordvar && wmb->ioid != ioid) || (!recordvar && wmb->ioid != -(ioid)))
     {
-	wmb->next = (wmulti_buffer *) bget((bufsize) sizeof(wmulti_buffer));
-	if (wmb->next == NULL)
-	    piomemerror(*ios,sizeof(wmulti_buffer), __FILE__,__LINE__);
-	wmb=wmb->next;
-	wmb->next=NULL;
-	if (recordvar)
-	    wmb->ioid = ioid;
-	else
-	    wmb->ioid = -(ioid);
-	wmb->validvars=0;
-	wmb->arraylen=arraylen;
-	wmb->vid=NULL;
-	wmb->data=NULL;
-	wmb->frame=NULL;
-	wmb->fillvalue=NULL;
+        wmb->next = (wmulti_buffer *) bget((bufsize) sizeof(wmulti_buffer));
+        if (wmb->next == NULL)
+            piomemerror(*ios,sizeof(wmulti_buffer), __FILE__,__LINE__);
+        wmb=wmb->next;
+        wmb->next=NULL;
+        if (recordvar)
+            wmb->ioid = ioid;
+        else
+            wmb->ioid = -(ioid);
+        wmb->validvars=0;
+        wmb->arraylen=arraylen;
+        wmb->vid=NULL;
+        wmb->data=NULL;
+        wmb->frame=NULL;
+        wmb->fillvalue=NULL;
     }
 
     MPI_Type_size(iodesc->basetype, &tsize);
@@ -1297,67 +1297,67 @@ int PIOc_write_darray(const int ncid, const int vid, const int ioid,
     //    cn_buffer_report(*ios, true);
     bfreespace(&totfree, &maxfree);
     if (needsflush == 0)
-	needsflush = (maxfree <= 1.1*(1+wmb->validvars)*arraylen*tsize );
+        needsflush = (maxfree <= 1.1*(1+wmb->validvars)*arraylen*tsize );
     MPI_Allreduce(MPI_IN_PLACE, &needsflush, 1,  MPI_INT,  MPI_MAX, ios->comp_comm);
 
     if (needsflush > 0 )
     {
-	// need to flush first
-	//      printf("%s %d %ld %d %ld %ld\n",__FILE__,__LINE__,maxfree, wmb->validvars, (1+wmb->validvars)*arraylen*tsize,totfree);
-	cn_buffer_report(*ios, true);
+        // need to flush first
+        //      printf("%s %d %ld %d %ld %ld\n",__FILE__,__LINE__,maxfree, wmb->validvars, (1+wmb->validvars)*arraylen*tsize,totfree);
+        cn_buffer_report(*ios, true);
 
-	flush_buffer(ncid, wmb, needsflush == 2);  // if needsflush == 2 flush to disk otherwise just flush to io node
+        flush_buffer(ncid, wmb, needsflush == 2);  // if needsflush == 2 flush to disk otherwise just flush to io node
     }
 
     if (arraylen > 0)
-	if (!(wmb->data = bgetr(wmb->data, (1+wmb->validvars)*arraylen*tsize)))
-	    piomemerror(*ios, (1+wmb->validvars)*arraylen*tsize, __FILE__, __LINE__);
+        if (!(wmb->data = bgetr(wmb->data, (1+wmb->validvars)*arraylen*tsize)))
+            piomemerror(*ios, (1+wmb->validvars)*arraylen*tsize, __FILE__, __LINE__);
 
     if (!(wmb->vid = (int *) bgetr(wmb->vid,sizeof(int)*(1+wmb->validvars))))
-	piomemerror(*ios, (1+wmb->validvars)*sizeof(int), __FILE__, __LINE__);
+        piomemerror(*ios, (1+wmb->validvars)*sizeof(int), __FILE__, __LINE__);
 
     if (vdesc->record >= 0)
-	if (!(wmb->frame = (int *)bgetr(wmb->frame, sizeof(int) * (1 + wmb->validvars))))
-	    piomemerror(*ios, (1+wmb->validvars)*sizeof(int), __FILE__, __LINE__);
+        if (!(wmb->frame = (int *)bgetr(wmb->frame, sizeof(int) * (1 + wmb->validvars))))
+            piomemerror(*ios, (1+wmb->validvars)*sizeof(int), __FILE__, __LINE__);
 
     if (iodesc->needsfill)
-	if (!(wmb->fillvalue = bgetr(wmb->fillvalue,tsize*(1+wmb->validvars))))
-	    piomemerror(*ios, (1+wmb->validvars)*tsize  , __FILE__,__LINE__);
+        if (!(wmb->fillvalue = bgetr(wmb->fillvalue,tsize*(1+wmb->validvars))))
+            piomemerror(*ios, (1+wmb->validvars)*tsize  , __FILE__,__LINE__);
 
     if (iodesc->needsfill)
     {
-	if (fillvalue)
-	{
-	    memcpy((char *) wmb->fillvalue+tsize*wmb->validvars,fillvalue, tsize);
-	}
-	else
-	{
-	    vtype = (MPI_Datatype) iodesc->basetype;
-	    if (vtype == MPI_INTEGER)
-	    {
-		int fill = PIO_FILL_INT;
-		memcpy((char *) wmb->fillvalue+tsize*wmb->validvars, &fill, tsize);
-	    }
-	    else if (vtype == MPI_FLOAT || vtype == MPI_REAL4)
-	    {
-		float fill = PIO_FILL_FLOAT;
-		memcpy((char *) wmb->fillvalue+tsize*wmb->validvars, &fill, tsize);
-	    }
-	    else if (vtype == MPI_DOUBLE || vtype == MPI_REAL8)
-	    {
-		double fill = PIO_FILL_DOUBLE;
-		memcpy((char *) wmb->fillvalue+tsize*wmb->validvars, &fill, tsize);
-	    }
-	    else if (vtype == MPI_CHARACTER)
-	    {
-		char fill = PIO_FILL_CHAR;
-		memcpy((char *) wmb->fillvalue+tsize*wmb->validvars, &fill, tsize);
-	    }
-	    else
-	    {
-		fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",vtype);
-	    }
-	}
+        if (fillvalue)
+        {
+            memcpy((char *) wmb->fillvalue+tsize*wmb->validvars,fillvalue, tsize);
+        }
+        else
+        {
+            vtype = (MPI_Datatype) iodesc->basetype;
+            if (vtype == MPI_INTEGER)
+            {
+                int fill = PIO_FILL_INT;
+                memcpy((char *) wmb->fillvalue+tsize*wmb->validvars, &fill, tsize);
+            }
+            else if (vtype == MPI_FLOAT || vtype == MPI_REAL4)
+            {
+                float fill = PIO_FILL_FLOAT;
+                memcpy((char *) wmb->fillvalue+tsize*wmb->validvars, &fill, tsize);
+            }
+            else if (vtype == MPI_DOUBLE || vtype == MPI_REAL8)
+            {
+                double fill = PIO_FILL_DOUBLE;
+                memcpy((char *) wmb->fillvalue+tsize*wmb->validvars, &fill, tsize);
+            }
+            else if (vtype == MPI_CHARACTER)
+            {
+                char fill = PIO_FILL_CHAR;
+                memcpy((char *) wmb->fillvalue+tsize*wmb->validvars, &fill, tsize);
+            }
+            else
+            {
+                fprintf(stderr,"Type not recognized %d in pioc_write_darray\n",vtype);
+            }
+        }
 
     }
 
@@ -1365,7 +1365,7 @@ int PIOc_write_darray(const int ncid, const int vid, const int ioid,
     wmb->vid[wmb->validvars]=vid;
     bufptr = (void *)((char *) wmb->data + arraylen*tsize*wmb->validvars);
     if (arraylen>0)
-	memcpy(bufptr, array, arraylen*tsize);
+        memcpy(bufptr, array, arraylen*tsize);
     /*
       if (tsize==8){
       double asum=0.0;
@@ -1380,12 +1380,12 @@ int PIOc_write_darray(const int ncid, const int vid, const int ioid,
     //   printf("%s %d %d %d %d %X\n",__FILE__,__LINE__,wmb->validvars,wmb->ioid,vid,bufptr);
 
     if (wmb->frame!=NULL)
-	wmb->frame[wmb->validvars]=vdesc->record;
+        wmb->frame[wmb->validvars]=vdesc->record;
     wmb->validvars++;
 
     //   printf("%s %d %d %d %d %d\n",__FILE__,__LINE__,wmb->validvars,iodesc->maxbytes/tsize, iodesc->ndof, iodesc->llen);
     if (wmb->validvars >= iodesc->maxbytes/tsize)
-	PIOc_sync(ncid);
+        PIOc_sync(ncid);
 
     return ierr;
 }
@@ -1402,7 +1402,7 @@ int PIOc_write_darray(const int ncid, const int vid, const int ioid,
  * @ingroup PIO_read_darray
  */
 int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid,
-		       void *IOBUF)
+                       void *IOBUF)
 {
     int ierr=PIO_NOERR;
     iosystem_desc_t *ios;  /* Pointer to io system information. */
@@ -1417,156 +1417,156 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid,
 #endif
     ios = file->iosystem;
     if (ios == NULL)
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     vdesc = (file->varlist)+vid;
 
     if (vdesc == NULL)
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     ndims = iodesc->ndims;
     ierr = PIOc_inq_varndims(file->pio_ncid, vid, &fndims);
 
     if (fndims==ndims)
-	vdesc->record=-1;
+        vdesc->record=-1;
 
     if (ios->ioproc)
     {
-	io_region *region;
-	size_t start[fndims];
-	size_t count[fndims];
-	size_t tmp_start[fndims];
-	size_t tmp_count[fndims];
-	size_t tmp_bufsize=1;
-	int regioncnt;
-	void *bufptr;
-	int tsize;
+        io_region *region;
+        size_t start[fndims];
+        size_t count[fndims];
+        size_t tmp_start[fndims];
+        size_t tmp_count[fndims];
+        size_t tmp_bufsize=1;
+        int regioncnt;
+        void *bufptr;
+        int tsize;
 
-	int rrlen=0;
-	PIO_Offset *startlist[iodesc->maxregions];
-	PIO_Offset *countlist[iodesc->maxregions];
+        int rrlen=0;
+        PIO_Offset *startlist[iodesc->maxregions];
+        PIO_Offset *countlist[iodesc->maxregions];
 
-	// buffer is incremented by byte and loffset is in terms of the iodessc->basetype
-	// so we need to multiply by the size of the basetype
-	// We can potentially allow for one iodesc to have multiple datatypes by allowing the
-	// calling program to change the basetype.
-	region = iodesc->firstregion;
-	MPI_Type_size(iodesc->basetype, &tsize);
-	if (fndims>ndims)
-	{
-	    ndims++;
-	    if (vdesc->record<0)
-		vdesc->record=0;
-	}
-	for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++)
-	{
-	    //         printf("%s %d %d %ld %d %d\n",__FILE__,__LINE__,regioncnt,region,fndims,ndims);
-	    tmp_bufsize=1;
-	    if (region==NULL || iodesc->llen==0)
-	    {
-		for (i=0;i<fndims;i++)
-		{
-		    start[i] = 0;
-		    count[i] = 0;
-		}
-		bufptr=NULL;
-	    }
-	    else
-	    {
-		if (regioncnt==0 || region==NULL)
-		    bufptr = IOBUF;
-		else
-		    bufptr=(void *)((char *) IOBUF + tsize*region->loffset);
+        // buffer is incremented by byte and loffset is in terms of the iodessc->basetype
+        // so we need to multiply by the size of the basetype
+        // We can potentially allow for one iodesc to have multiple datatypes by allowing the
+        // calling program to change the basetype.
+        region = iodesc->firstregion;
+        MPI_Type_size(iodesc->basetype, &tsize);
+        if (fndims>ndims)
+        {
+            ndims++;
+            if (vdesc->record<0)
+                vdesc->record=0;
+        }
+        for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++)
+        {
+            //         printf("%s %d %d %ld %d %d\n",__FILE__,__LINE__,regioncnt,region,fndims,ndims);
+            tmp_bufsize=1;
+            if (region==NULL || iodesc->llen==0)
+            {
+                for (i=0;i<fndims;i++)
+                {
+                    start[i] = 0;
+                    count[i] = 0;
+                }
+                bufptr=NULL;
+            }
+            else
+            {
+                if (regioncnt==0 || region==NULL)
+                    bufptr = IOBUF;
+                else
+                    bufptr=(void *)((char *) IOBUF + tsize*region->loffset);
 
-		//		printf("%s %d %d %d %d\n",__FILE__,__LINE__,iodesc->llen - region->loffset, iodesc->llen, region->loffset);
+                //              printf("%s %d %d %d %d\n",__FILE__,__LINE__,iodesc->llen - region->loffset, iodesc->llen, region->loffset);
 
-		if (vdesc->record >= 0 && fndims>1)
-		{
-		    start[0] = vdesc->record;
-		    for (i=1;i<ndims;i++)
-		    {
-			start[i] = region->start[i-1];
-			count[i] = region->count[i-1];
-			//	    printf("%s %d %d %ld %ld\n",__FILE__,__LINE__,i,start[i],count[i]);
-		    }
-		    if (count[1] > 0)
-			count[0] = 1;
-		}
-		else
-		{
-		    // Non-time dependent array
-		    for (i=0;i<ndims;i++)
-		    {
-			start[i] = region->start[i];
-			count[i] = region->count[i];
-			// printf("%s %d %d %ld %ld\n",__FILE__,__LINE__,i,start[i],count[i]);
-		    }
-		}
-	    }
+                if (vdesc->record >= 0 && fndims>1)
+                {
+                    start[0] = vdesc->record;
+                    for (i=1;i<ndims;i++)
+                    {
+                        start[i] = region->start[i-1];
+                        count[i] = region->count[i-1];
+                        //          printf("%s %d %d %ld %ld\n",__FILE__,__LINE__,i,start[i],count[i]);
+                    }
+                    if (count[1] > 0)
+                        count[0] = 1;
+                }
+                else
+                {
+                    // Non-time dependent array
+                    for (i=0;i<ndims;i++)
+                    {
+                        start[i] = region->start[i];
+                        count[i] = region->count[i];
+                        // printf("%s %d %d %ld %ld\n",__FILE__,__LINE__,i,start[i],count[i]);
+                    }
+                }
+            }
 
-	    switch(file->iotype)
-	    {
+            switch(file->iotype)
+            {
 #ifdef _NETCDF4
-	    case PIO_IOTYPE_NETCDF4P:
-		if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
-		{
-		    ierr = nc_get_vara_double(file->fh, vid,start,count, bufptr);
-		}
-		else if (iodesc->basetype == MPI_INTEGER)
-		{
-		    ierr = nc_get_vara_int(file->fh, vid, start, count,  bufptr);
-		}
-		else if (iodesc->basetype == MPI_FLOAT || iodesc->basetype == MPI_REAL4)
-		{
-		    ierr = nc_get_vara_float(file->fh, vid, start,  count,  bufptr);
-		}
-		else
-		{
-		    fprintf(stderr,"Type not recognized %d in pioc_read_darray\n",(int) iodesc->basetype);
-		}
-		break;
+            case PIO_IOTYPE_NETCDF4P:
+                if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
+                {
+                    ierr = nc_get_vara_double(file->fh, vid,start,count, bufptr);
+                }
+                else if (iodesc->basetype == MPI_INTEGER)
+                {
+                    ierr = nc_get_vara_int(file->fh, vid, start, count,  bufptr);
+                }
+                else if (iodesc->basetype == MPI_FLOAT || iodesc->basetype == MPI_REAL4)
+                {
+                    ierr = nc_get_vara_float(file->fh, vid, start,  count,  bufptr);
+                }
+                else
+                {
+                    fprintf(stderr,"Type not recognized %d in pioc_read_darray\n",(int) iodesc->basetype);
+                }
+                break;
 #endif
 #ifdef _PNETCDF
-	    case PIO_IOTYPE_PNETCDF:
-	    {
-		tmp_bufsize=1;
-		for (int j = 0; j < fndims; j++)
-		    tmp_bufsize *= count[j];
+            case PIO_IOTYPE_PNETCDF:
+            {
+                tmp_bufsize=1;
+                for (int j = 0; j < fndims; j++)
+                    tmp_bufsize *= count[j];
 
-		if (tmp_bufsize > 0)
-		{
-		    startlist[rrlen] = (PIO_Offset *) bget(fndims * sizeof(PIO_Offset));
-		    countlist[rrlen] = (PIO_Offset *) bget(fndims * sizeof(PIO_Offset));
+                if (tmp_bufsize > 0)
+                {
+                    startlist[rrlen] = (PIO_Offset *) bget(fndims * sizeof(PIO_Offset));
+                    countlist[rrlen] = (PIO_Offset *) bget(fndims * sizeof(PIO_Offset));
 
-		    for (int j = 0; j < fndims; j++)
-		    {
-			startlist[rrlen][j] = start[j];
-			countlist[rrlen][j] = count[j];
-			/*	      printf("%s %d %d %d %d %ld %ld %ld\n",__FILE__,__LINE__,realregioncnt,
-				      iodesc->maxregions, j,start[j],count[j],tmp_bufsize);*/
-		    }
-		    rrlen++;
-		}
-		if (regioncnt==iodesc->maxregions-1)
-		{
-		    ierr = ncmpi_get_varn_all(file->fh, vid, rrlen, startlist,
-					      countlist, IOBUF, iodesc->llen, iodesc->basetype);
-		    for (i=0;i<rrlen;i++)
-		    {
-			brel(startlist[i]);
-			brel(countlist[i]);
-		    }
-		}
-	    }
-	    break;
+                    for (int j = 0; j < fndims; j++)
+                    {
+                        startlist[rrlen][j] = start[j];
+                        countlist[rrlen][j] = count[j];
+                        /*            printf("%s %d %d %d %d %ld %ld %ld\n",__FILE__,__LINE__,realregioncnt,
+                                      iodesc->maxregions, j,start[j],count[j],tmp_bufsize);*/
+                    }
+                    rrlen++;
+                }
+                if (regioncnt==iodesc->maxregions-1)
+                {
+                    ierr = ncmpi_get_varn_all(file->fh, vid, rrlen, startlist,
+                                              countlist, IOBUF, iodesc->llen, iodesc->basetype);
+                    for (i=0;i<rrlen;i++)
+                    {
+                        brel(startlist[i]);
+                        brel(countlist[i]);
+                    }
+                }
+            }
+            break;
 #endif
-	    default:
-		ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            default:
+                ierr = iotype_error(file->iotype,__FILE__,__LINE__);
 
-	    }
-	    if (region)
-		region = region->next;
-	} // for (regioncnt=0;...)
+            }
+            if (region)
+                region = region->next;
+        } // for (regioncnt=0;...)
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
@@ -1591,7 +1591,7 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, const int vid,
  * @ingroup PIO_read_darray
  */
 int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc,
-			      const int vid, void *IOBUF)
+                              const int vid, void *IOBUF)
 {
     int ierr=PIO_NOERR;
     iosystem_desc_t *ios;  /* Pointer to io system information. */
@@ -1606,189 +1606,189 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc,
 #endif
     ios = file->iosystem;
     if (ios == NULL)
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     vdesc = (file->varlist)+vid;
 
     if (vdesc == NULL)
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     ndims = iodesc->ndims;
     ierr = PIOc_inq_varndims(file->pio_ncid, vid, &fndims);
 
     if (fndims==ndims)
-	vdesc->record=-1;
+        vdesc->record=-1;
 
     if (ios->ioproc)
     {
-	io_region *region;
-	size_t start[fndims];
-	size_t count[fndims];
-	size_t tmp_start[fndims * iodesc->maxregions];
-	size_t tmp_count[fndims * iodesc->maxregions];
-	size_t tmp_bufsize;
-	int regioncnt;
-	void *bufptr;
-	int tsize;
+        io_region *region;
+        size_t start[fndims];
+        size_t count[fndims];
+        size_t tmp_start[fndims * iodesc->maxregions];
+        size_t tmp_count[fndims * iodesc->maxregions];
+        size_t tmp_bufsize;
+        int regioncnt;
+        void *bufptr;
+        int tsize;
 
-	int rrlen = 0;
+        int rrlen = 0;
 
-	// buffer is incremented by byte and loffset is in terms of the iodessc->basetype
-	// so we need to multiply by the size of the basetype
-	// We can potentially allow for one iodesc to have multiple datatypes by allowing the
-	// calling program to change the basetype.
-	region = iodesc->firstregion;
-	MPI_Type_size(iodesc->basetype, &tsize);
-	if (fndims>ndims)
-	{
-	    if (vdesc->record < 0)
-		vdesc->record = 0;
-	}
-	for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++)
-	{
-	    if (region==NULL || iodesc->llen==0)
-	    {
-		for (i = 0; i < fndims; i++)
-		{
-		    tmp_start[i + regioncnt * fndims] = 0;
-		    tmp_count[i + regioncnt * fndims] = 0;
-		}
-		bufptr=NULL;
-	    }
-	    else
-	    {
-		if (vdesc->record >= 0 && fndims>1)
-		{
-		    tmp_start[regioncnt*fndims] = vdesc->record;
-		    for (i=1;i<fndims;i++)
-		    {
-			tmp_start[i+regioncnt*fndims] = region->start[i-1];
-			tmp_count[i+regioncnt*fndims] = region->count[i-1];
-		    }
-		    if (tmp_count[1 + regioncnt * fndims] > 0)
-			tmp_count[regioncnt * fndims] = 1;
-		}
-		else
-		{
-		    // Non-time dependent array
-		    for (i = 0; i < fndims; i++)
-		    {
-			tmp_start[i + regioncnt * fndims] = region->start[i];
-			tmp_count[i + regioncnt * fndims] = region->count[i];
-		    }
-		}
-		/*	for (i=0;i<fndims;i++){
-			printf("%d %d %d %ld %ld\n",__LINE__,regioncnt,i,tmp_start[i+regioncnt*fndims],
-			tmp_count[i+regioncnt*fndims]);
-			}*/
+        // buffer is incremented by byte and loffset is in terms of the iodessc->basetype
+        // so we need to multiply by the size of the basetype
+        // We can potentially allow for one iodesc to have multiple datatypes by allowing the
+        // calling program to change the basetype.
+        region = iodesc->firstregion;
+        MPI_Type_size(iodesc->basetype, &tsize);
+        if (fndims>ndims)
+        {
+            if (vdesc->record < 0)
+                vdesc->record = 0;
+        }
+        for (regioncnt=0;regioncnt<iodesc->maxregions;regioncnt++)
+        {
+            if (region==NULL || iodesc->llen==0)
+            {
+                for (i = 0; i < fndims; i++)
+                {
+                    tmp_start[i + regioncnt * fndims] = 0;
+                    tmp_count[i + regioncnt * fndims] = 0;
+                }
+                bufptr=NULL;
+            }
+            else
+            {
+                if (vdesc->record >= 0 && fndims>1)
+                {
+                    tmp_start[regioncnt*fndims] = vdesc->record;
+                    for (i=1;i<fndims;i++)
+                    {
+                        tmp_start[i+regioncnt*fndims] = region->start[i-1];
+                        tmp_count[i+regioncnt*fndims] = region->count[i-1];
+                    }
+                    if (tmp_count[1 + regioncnt * fndims] > 0)
+                        tmp_count[regioncnt * fndims] = 1;
+                }
+                else
+                {
+                    // Non-time dependent array
+                    for (i = 0; i < fndims; i++)
+                    {
+                        tmp_start[i + regioncnt * fndims] = region->start[i];
+                        tmp_count[i + regioncnt * fndims] = region->count[i];
+                    }
+                }
+                /*      for (i=0;i<fndims;i++){
+                        printf("%d %d %d %ld %ld\n",__LINE__,regioncnt,i,tmp_start[i+regioncnt*fndims],
+                        tmp_count[i+regioncnt*fndims]);
+                        }*/
 
-	    }
-	    if (region)
-		region = region->next;
-	} // for (regioncnt=0;...)
+            }
+            if (region)
+                region = region->next;
+        } // for (regioncnt=0;...)
 
-	if (ios->io_rank>0)
-	{
-	    MPI_Send(&(iodesc->llen), 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm);
-	    if (iodesc->llen > 0)
-	    {
-		MPI_Send(&(iodesc->maxregions), 1, MPI_INT, 0,
-			  ios->num_iotasks + ios->io_rank, ios->io_comm);
-		MPI_Send(tmp_count, iodesc->maxregions*fndims, MPI_OFFSET, 0,
-			  2 * ios->num_iotasks + ios->io_rank, ios->io_comm);
-		MPI_Send(tmp_start, iodesc->maxregions*fndims, MPI_OFFSET, 0,
-			  3 * ios->num_iotasks + ios->io_rank, ios->io_comm);
-		MPI_Recv(IOBUF, iodesc->llen, iodesc->basetype, 0,
-			 4 * ios->num_iotasks+ios->io_rank, ios->io_comm, &status);
-	    }
-	}
-	else if (ios->io_rank == 0)
-	{
-	    int maxregions=0;
-	    size_t loffset, regionsize;
-	    size_t this_start[fndims*iodesc->maxregions];
-	    size_t this_count[fndims*iodesc->maxregions];
-	    //      for (i=ios->num_iotasks-1; i>=0; i--){
-	    for (int rtask = 1; rtask <= ios->num_iotasks; rtask++)
-	    {
-		if (rtask<ios->num_iotasks)
-		{
-		    MPI_Recv(&tmp_bufsize, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status);
-		    if (tmp_bufsize>0)
-		    {
-			MPI_Recv(&maxregions, 1, MPI_INT, rtask, ios->num_iotasks+rtask,
-				 ios->io_comm, &status);
-			MPI_Recv(this_count, maxregions*fndims, MPI_OFFSET, rtask,
-				 2 * ios->num_iotasks + rtask, ios->io_comm, &status);
-			MPI_Recv(this_start, maxregions*fndims, MPI_OFFSET, rtask,
-				 3 * ios->num_iotasks + rtask, ios->io_comm, &status);
-		    }
-		}
-		else
-		{
-		    maxregions=iodesc->maxregions;
-		    tmp_bufsize=iodesc->llen;
-		}
-		loffset = 0;
-		for (regioncnt=0;regioncnt<maxregions;regioncnt++)
-		{
-		    bufptr=(void *)((char *) IOBUF + tsize*loffset);
-		    regionsize=1;
-		    if (rtask<ios->num_iotasks)
-		    {
-			for (int m=0; m<fndims; m++)
-			{
-			    start[m] = this_start[m+regioncnt*fndims];
-			    count[m] = this_count[m+regioncnt*fndims];
-			    regionsize*=count[m];
-			}
-		    }
-		    else
-		    {
-			for (int m = 0; m < fndims; m++)
-			{
-			    start[m] = tmp_start[m + regioncnt * fndims];
-			    count[m] = tmp_count[m + regioncnt * fndims];
-			    regionsize *= count[m];
-			}
-		    }
-		    loffset+=regionsize;
+        if (ios->io_rank>0)
+        {
+            MPI_Send(&(iodesc->llen), 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm);
+            if (iodesc->llen > 0)
+            {
+                MPI_Send(&(iodesc->maxregions), 1, MPI_INT, 0,
+                         ios->num_iotasks + ios->io_rank, ios->io_comm);
+                MPI_Send(tmp_count, iodesc->maxregions*fndims, MPI_OFFSET, 0,
+                         2 * ios->num_iotasks + ios->io_rank, ios->io_comm);
+                MPI_Send(tmp_start, iodesc->maxregions*fndims, MPI_OFFSET, 0,
+                         3 * ios->num_iotasks + ios->io_rank, ios->io_comm);
+                MPI_Recv(IOBUF, iodesc->llen, iodesc->basetype, 0,
+                         4 * ios->num_iotasks+ios->io_rank, ios->io_comm, &status);
+            }
+        }
+        else if (ios->io_rank == 0)
+        {
+            int maxregions=0;
+            size_t loffset, regionsize;
+            size_t this_start[fndims*iodesc->maxregions];
+            size_t this_count[fndims*iodesc->maxregions];
+            //      for (i=ios->num_iotasks-1; i>=0; i--){
+            for (int rtask = 1; rtask <= ios->num_iotasks; rtask++)
+            {
+                if (rtask<ios->num_iotasks)
+                {
+                    MPI_Recv(&tmp_bufsize, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status);
+                    if (tmp_bufsize>0)
+                    {
+                        MPI_Recv(&maxregions, 1, MPI_INT, rtask, ios->num_iotasks+rtask,
+                                 ios->io_comm, &status);
+                        MPI_Recv(this_count, maxregions*fndims, MPI_OFFSET, rtask,
+                                 2 * ios->num_iotasks + rtask, ios->io_comm, &status);
+                        MPI_Recv(this_start, maxregions*fndims, MPI_OFFSET, rtask,
+                                 3 * ios->num_iotasks + rtask, ios->io_comm, &status);
+                    }
+                }
+                else
+                {
+                    maxregions=iodesc->maxregions;
+                    tmp_bufsize=iodesc->llen;
+                }
+                loffset = 0;
+                for (regioncnt=0;regioncnt<maxregions;regioncnt++)
+                {
+                    bufptr=(void *)((char *) IOBUF + tsize*loffset);
+                    regionsize=1;
+                    if (rtask<ios->num_iotasks)
+                    {
+                        for (int m=0; m<fndims; m++)
+                        {
+                            start[m] = this_start[m+regioncnt*fndims];
+                            count[m] = this_count[m+regioncnt*fndims];
+                            regionsize*=count[m];
+                        }
+                    }
+                    else
+                    {
+                        for (int m = 0; m < fndims; m++)
+                        {
+                            start[m] = tmp_start[m + regioncnt * fndims];
+                            count[m] = tmp_count[m + regioncnt * fndims];
+                            regionsize *= count[m];
+                        }
+                    }
+                    loffset+=regionsize;
 
 #ifdef _NETCDF
-		    // Cant use switch here because MPI_DATATYPE may not be simple (openmpi)
-		    if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
-		    {
-			ierr = nc_get_vara_double(file->fh, vid,start, count, bufptr);
-		    }
-		    else if (iodesc->basetype == MPI_INTEGER)
-		    {
-			ierr = nc_get_vara_int(file->fh, vid, start, count,  bufptr);
-		    }
-		    else if (iodesc->basetype == MPI_FLOAT || iodesc->basetype == MPI_REAL4)
-		    {
-			ierr = nc_get_vara_float(file->fh, vid, start, count,  bufptr);
-		    }
-		    else
-		    {
-			fprintf(stderr,"Type not recognized %d in pioc_write_darray_nc_serial\n",
-				(int)iodesc->basetype);
-		    }
+                    // Cant use switch here because MPI_DATATYPE may not be simple (openmpi)
+                    if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
+                    {
+                        ierr = nc_get_vara_double(file->fh, vid,start, count, bufptr);
+                    }
+                    else if (iodesc->basetype == MPI_INTEGER)
+                    {
+                        ierr = nc_get_vara_int(file->fh, vid, start, count,  bufptr);
+                    }
+                    else if (iodesc->basetype == MPI_FLOAT || iodesc->basetype == MPI_REAL4)
+                    {
+                        ierr = nc_get_vara_float(file->fh, vid, start, count,  bufptr);
+                    }
+                    else
+                    {
+                        fprintf(stderr,"Type not recognized %d in pioc_write_darray_nc_serial\n",
+                                (int)iodesc->basetype);
+                    }
 
-		    if (ierr != PIO_NOERR)
-		    {
-			for (int i = 0; i < fndims; i++)
-			    fprintf(stderr,"vid %d dim %d start %ld count %ld err %d\n",
-				    vid, i, start[i], count[i], ierr);
+                    if (ierr != PIO_NOERR)
+                    {
+                        for (int i = 0; i < fndims; i++)
+                            fprintf(stderr,"vid %d dim %d start %ld count %ld err %d\n",
+                                    vid, i, start[i], count[i], ierr);
 
-		    }
+                    }
 
 #endif
-		}
-		if (rtask < ios->num_iotasks)
-		    MPI_Send(IOBUF, tmp_bufsize, iodesc->basetype, rtask,
-			     4 * ios->num_iotasks + rtask, ios->io_comm);
-	    }
-	}
+                }
+                if (rtask < ios->num_iotasks)
+                    MPI_Send(IOBUF, tmp_bufsize, iodesc->basetype, rtask,
+                             4 * ios->num_iotasks + rtask, ios->io_comm);
+            }
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__, __LINE__);
@@ -1819,7 +1819,7 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc,
  * @ingroup PIO_read_darray
  */
 int PIOc_read_darray(const int ncid, const int vid, const int ioid,
-		     const PIO_Offset arraylen, void *array)
+                     const PIO_Offset arraylen, void *array)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;
@@ -1831,60 +1831,60 @@ int PIOc_read_darray(const int ncid, const int vid, const int ioid,
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
 
     iodesc = pio_get_iodesc_from_id(ioid);
     if (iodesc == NULL)
     {
-	fprintf(stderr,"iodesc handle not found %d %d\n",ioid,__LINE__);
-	return PIO_EBADID;
+        fprintf(stderr,"iodesc handle not found %d %d\n",ioid,__LINE__);
+        return PIO_EBADID;
     }
     ios = file->iosystem;
     if (ios->iomaster)
     {
-	rlen = iodesc->maxiobuflen;
+        rlen = iodesc->maxiobuflen;
     }
     else
     {
-	rlen = iodesc->llen;
+        rlen = iodesc->llen;
     }
 
     if (iodesc->rearranger > 0)
     {
-	if (ios->ioproc && rlen>0)
-	{
-	    MPI_Type_size(iodesc->basetype, &tsize);
-	    iobuf = bget(((size_t) tsize)*rlen);
-	    if (iobuf==NULL)
-	    {
-		piomemerror(*ios,rlen*((size_t) tsize), __FILE__,__LINE__);
-	    }
-	}
+        if (ios->ioproc && rlen>0)
+        {
+            MPI_Type_size(iodesc->basetype, &tsize);
+            iobuf = bget(((size_t) tsize)*rlen);
+            if (iobuf==NULL)
+            {
+                piomemerror(*ios,rlen*((size_t) tsize), __FILE__,__LINE__);
+            }
+        }
     }
     else
     {
-	iobuf = array;
+        iobuf = array;
     }
 
     switch(file->iotype)
     {
     case PIO_IOTYPE_NETCDF:
     case PIO_IOTYPE_NETCDF4C:
-	ierr = pio_read_darray_nc_serial(file, iodesc, vid, iobuf);
-	break;
+        ierr = pio_read_darray_nc_serial(file, iodesc, vid, iobuf);
+        break;
     case PIO_IOTYPE_PNETCDF:
     case PIO_IOTYPE_NETCDF4P:
-	ierr = pio_read_darray_nc(file, iodesc, vid, iobuf);
-	break;
+        ierr = pio_read_darray_nc(file, iodesc, vid, iobuf);
+        break;
     default:
-	ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        ierr = iotype_error(file->iotype,__FILE__,__LINE__);
     }
     if (iodesc->rearranger > 0)
     {
-	ierr = rearrange_io2comp(*ios, iodesc, iobuf, array);
+        ierr = rearrange_io2comp(*ios, iodesc, iobuf, array);
 
-	if (rlen>0)
-	    brel(iobuf);
+        if (rlen>0)
+            brel(iobuf);
     }
 
     return ierr;
@@ -1913,7 +1913,7 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     PIO_Offset usage = 0;
 
     pioassert(file != NULL, "file pointer not defined", __FILE__,
-	      __LINE__);
+              __LINE__);
 
     /* Find out the buffer usage. */
     ierr = ncmpi_inq_buffer_usage(file->fh, &usage);
@@ -1922,95 +1922,95 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
      * tasks. */
     if (!force && file->iosystem->io_comm != MPI_COMM_NULL)
     {
-	usage += addsize;
-	MPI_Allreduce(MPI_IN_PLACE, &usage, 1,  MPI_OFFSET,  MPI_MAX,
-		      file->iosystem->io_comm);
+        usage += addsize;
+        MPI_Allreduce(MPI_IN_PLACE, &usage, 1,  MPI_OFFSET,  MPI_MAX,
+                      file->iosystem->io_comm);
     }
 
     /* Keep track of the maximum usage. */
     if (usage > maxusage)
-	maxusage = usage;
+        maxusage = usage;
 
     /* If the user forces it, or the buffer has exceeded the size
      * limit, then flush to disk. */
     if (force || usage >= PIO_BUFFER_SIZE_LIMIT)
     {
-	int rcnt;
-	bool prev_dist=false;
-	int prev_record=-1;
-	int prev_type=0;
-	int  maxreq;
-	int reqcnt;
-	maxreq = 0;
-	reqcnt=0;
-	rcnt=0;
-	for (int i = 0; i < PIO_MAX_VARS; i++)
-	{
-	    vdesc = file->varlist + i;
-	    reqcnt += vdesc->nreqs;
-	    if (vdesc->nreqs > 0)
-		maxreq = i;
-	}
-	int request[reqcnt];
-	int status[reqcnt];
+        int rcnt;
+        bool prev_dist=false;
+        int prev_record=-1;
+        int prev_type=0;
+        int  maxreq;
+        int reqcnt;
+        maxreq = 0;
+        reqcnt=0;
+        rcnt=0;
+        for (int i = 0; i < PIO_MAX_VARS; i++)
+        {
+            vdesc = file->varlist + i;
+            reqcnt += vdesc->nreqs;
+            if (vdesc->nreqs > 0)
+                maxreq = i;
+        }
+        int request[reqcnt];
+        int status[reqcnt];
 
-	for (int i = 0; i <= maxreq; i++)
-	{
-	    vdesc = file->varlist + i;
+        for (int i = 0; i <= maxreq; i++)
+        {
+            vdesc = file->varlist + i;
 #ifdef MPIO_ONESIDED
-	    /*onesided optimization requires that all of the requests in a wait_all call represent
-	      a contiguous block of data in the file */
-	    if (rcnt>0 && (prev_record != vdesc->record || vdesc->nreqs==0))
-	    {
-		ierr = ncmpi_wait_all(file->fh, rcnt,  request,status);
-		rcnt=0;
-	    }
-	    prev_record = vdesc->record;
+            /*onesided optimization requires that all of the requests in a wait_all call represent
+              a contiguous block of data in the file */
+            if (rcnt>0 && (prev_record != vdesc->record || vdesc->nreqs==0))
+            {
+                ierr = ncmpi_wait_all(file->fh, rcnt,  request,status);
+                rcnt=0;
+            }
+            prev_record = vdesc->record;
 #endif
-	    //      printf("%s %d %d %d %d \n",__FILE__,__LINE__,i,vdesc->nreqs,vdesc->request);
-	    for (reqcnt=0;reqcnt<vdesc->nreqs;reqcnt++)
-	    {
-		request[rcnt++] = max(vdesc->request[reqcnt],NC_REQ_NULL);
-	    }
-	    if (vdesc->request != NULL)
-	      free(vdesc->request);
-	    vdesc->request = NULL;
-	    vdesc->nreqs = 0;
-	    //      if (file->iosystem->io_rank < 2) printf("%s %d varid=%d\n",__FILE__,__LINE__,i);
+            //      printf("%s %d %d %d %d \n",__FILE__,__LINE__,i,vdesc->nreqs,vdesc->request);
+            for (reqcnt=0;reqcnt<vdesc->nreqs;reqcnt++)
+            {
+                request[rcnt++] = max(vdesc->request[reqcnt],NC_REQ_NULL);
+            }
+            if (vdesc->request != NULL)
+                free(vdesc->request);
+            vdesc->request = NULL;
+            vdesc->nreqs = 0;
+            //      if (file->iosystem->io_rank < 2) printf("%s %d varid=%d\n",__FILE__,__LINE__,i);
 #ifdef FLUSH_EVERY_VAR
-	    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-	    rcnt = 0;
+            ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+            rcnt = 0;
 #endif
-	}
-	//    if (file->iosystem->io_rank==0){
-	//   printf("%s %d %d\n",__FILE__,__LINE__,rcnt);
-	// }
-	if (rcnt > 0)
-	{
-	    /*
-	      if (file->iosystem->io_rank==0){
-	      printf("%s %d %d ",__FILE__,__LINE__,rcnt);
-	      for (int i=0; i<rcnt; i++){
-	      printf("%d ",request[i]);
-	      }
-	      printf("\n");
-	      }*/
-	    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-	}
-	for (int i = 0; i < PIO_MAX_VARS; i++)
-	{
-	    vdesc = file->varlist + i;
-	    if (vdesc->iobuf)
-	    {
-		brel(vdesc->iobuf);
-		vdesc->iobuf=NULL;
-	    }
-	    if (vdesc->fillbuf)
-	    {
-		brel(vdesc->fillbuf);
-		vdesc->fillbuf=NULL;
-	    }
-	}
+        }
+        //    if (file->iosystem->io_rank==0){
+        //   printf("%s %d %d\n",__FILE__,__LINE__,rcnt);
+        // }
+        if (rcnt > 0)
+        {
+            /*
+              if (file->iosystem->io_rank==0){
+              printf("%s %d %d ",__FILE__,__LINE__,rcnt);
+              for (int i=0; i<rcnt; i++){
+              printf("%d ",request[i]);
+              }
+              printf("\n");
+              }*/
+            ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+        }
+        for (int i = 0; i < PIO_MAX_VARS; i++)
+        {
+            vdesc = file->varlist + i;
+            if (vdesc->iobuf)
+            {
+                brel(vdesc->iobuf);
+                vdesc->iobuf=NULL;
+            }
+            if (vdesc->fillbuf)
+            {
+                brel(vdesc->fillbuf);
+                vdesc->fillbuf=NULL;
+            }
+        }
 
     }
 
@@ -2030,48 +2030,48 @@ void cn_buffer_report(iosystem_desc_t ios, bool collective)
 {
 
     LOG((2, "cn_buffer_report ios.iossysid = %d collective = %d CN_bpool = %d",
-	 ios.iosysid, collective, CN_bpool));
+         ios.iosysid, collective, CN_bpool));
     if (CN_bpool)
     {
-	long bget_stats[5];
-	long bget_mins[5];
-	long bget_maxs[5];
+        long bget_stats[5];
+        long bget_mins[5];
+        long bget_maxs[5];
 
-	bstats(bget_stats, bget_stats+1,bget_stats+2,bget_stats+3,bget_stats+4);
-	if (collective)
-	{
-	    LOG((3, "cn_buffer_report calling MPI_Reduce ios.comp_comm = %d", ios.comp_comm));
-	    MPI_Reduce(bget_stats, bget_maxs, 5, MPI_LONG, MPI_MAX, 0, ios.comp_comm);
-	    LOG((3, "cn_buffer_report calling MPI_Reduce"));
-	    MPI_Reduce(bget_stats, bget_mins, 5, MPI_LONG, MPI_MIN, 0, ios.comp_comm);
-	    if (ios.compmaster)
-	    {
-		printf("PIO: Currently allocated buffer space %ld %ld\n",
-		       bget_mins[0], bget_maxs[0]);
-		printf("PIO: Currently available buffer space %ld %ld\n",
-		       bget_mins[1], bget_maxs[1]);
-		printf("PIO: Current largest free block %ld %ld\n",
-		       bget_mins[2], bget_maxs[2]);
-		printf("PIO: Number of successful bget calls %ld %ld\n",
-		       bget_mins[3], bget_maxs[3]);
-		printf("PIO: Number of successful brel calls  %ld %ld\n",
-		       bget_mins[4], bget_maxs[4]);
-		//	print_trace(stdout);
-	    }
-	}
-	else
-	{
-	    printf("%d: PIO: Currently allocated buffer space %ld \n",
-		   ios.union_rank, bget_stats[0]) ;
-	    printf("%d: PIO: Currently available buffer space %ld \n",
-		   ios.union_rank, bget_stats[1]);
-	    printf("%d: PIO: Current largest free block %ld \n",
-		   ios.union_rank, bget_stats[2]);
-	    printf("%d: PIO: Number of successful bget calls %ld \n",
-		   ios.union_rank, bget_stats[3]);
-	    printf("%d: PIO: Number of successful brel calls  %ld \n",
-		   ios.union_rank, bget_stats[4]);
-	}
+        bstats(bget_stats, bget_stats+1,bget_stats+2,bget_stats+3,bget_stats+4);
+        if (collective)
+        {
+            LOG((3, "cn_buffer_report calling MPI_Reduce ios.comp_comm = %d", ios.comp_comm));
+            MPI_Reduce(bget_stats, bget_maxs, 5, MPI_LONG, MPI_MAX, 0, ios.comp_comm);
+            LOG((3, "cn_buffer_report calling MPI_Reduce"));
+            MPI_Reduce(bget_stats, bget_mins, 5, MPI_LONG, MPI_MIN, 0, ios.comp_comm);
+            if (ios.compmaster)
+            {
+                printf("PIO: Currently allocated buffer space %ld %ld\n",
+                       bget_mins[0], bget_maxs[0]);
+                printf("PIO: Currently available buffer space %ld %ld\n",
+                       bget_mins[1], bget_maxs[1]);
+                printf("PIO: Current largest free block %ld %ld\n",
+                       bget_mins[2], bget_maxs[2]);
+                printf("PIO: Number of successful bget calls %ld %ld\n",
+                       bget_mins[3], bget_maxs[3]);
+                printf("PIO: Number of successful brel calls  %ld %ld\n",
+                       bget_mins[4], bget_maxs[4]);
+                //      print_trace(stdout);
+            }
+        }
+        else
+        {
+            printf("%d: PIO: Currently allocated buffer space %ld \n",
+                   ios.union_rank, bget_stats[0]) ;
+            printf("%d: PIO: Currently available buffer space %ld \n",
+                   ios.union_rank, bget_stats[1]);
+            printf("%d: PIO: Current largest free block %ld \n",
+                   ios.union_rank, bget_stats[2]);
+            printf("%d: PIO: Number of successful bget calls %ld \n",
+                   ios.union_rank, bget_stats[3]);
+            printf("%d: PIO: Number of successful brel calls  %ld \n",
+                   ios.union_rank, bget_stats[4]);
+        }
     }
 }
 
@@ -2089,13 +2089,13 @@ void free_cn_buffer_pool(iosystem_desc_t ios)
     LOG((2, "free_cn_buffer_pool CN_bpool = %d", CN_bpool));
     if (CN_bpool)
     {
-	LOG((2, "free_cn_buffer_pool about to call cn_buffer_report"));
-	cn_buffer_report(ios, true);
-	LOG((2, "free_cn_buffer_pool about to call bpoolrelease"));
-	bpoolrelease(CN_bpool);
-	LOG((2, "free_cn_buffer_pool done!"));
-	//    free(CN_bpool);
-	CN_bpool = NULL;
+        LOG((2, "free_cn_buffer_pool about to call cn_buffer_report"));
+        cn_buffer_report(ios, true);
+        LOG((2, "free_cn_buffer_pool about to call bpoolrelease"));
+        bpoolrelease(CN_bpool);
+        LOG((2, "free_cn_buffer_pool done!"));
+        //    free(CN_bpool);
+        CN_bpool = NULL;
     }
 #endif /* !PIO_USE_MALLOC */
 }
@@ -2113,20 +2113,20 @@ void flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
 {
     if (wmb->validvars > 0)
     {
-	PIOc_write_darray_multi(ncid, wmb->vid,  wmb->ioid, wmb->validvars,
-				wmb->arraylen, wmb->data, wmb->frame,
-				wmb->fillvalue, flushtodisk);
-	wmb->validvars = 0;
-	brel(wmb->vid);
-	wmb->vid = NULL;
-	brel(wmb->data);
-	wmb->data = NULL;
-	if (wmb->fillvalue)
-	    brel(wmb->fillvalue);
-	if (wmb->frame)
-	    brel(wmb->frame);
-	wmb->fillvalue = NULL;
-	wmb->frame = NULL;
+        PIOc_write_darray_multi(ncid, wmb->vid,  wmb->ioid, wmb->validvars,
+                                wmb->arraylen, wmb->data, wmb->frame,
+                                wmb->fillvalue, flushtodisk);
+        wmb->validvars = 0;
+        brel(wmb->vid);
+        wmb->vid = NULL;
+        brel(wmb->data);
+        wmb->data = NULL;
+        if (wmb->fillvalue)
+            brel(wmb->fillvalue);
+        if (wmb->frame)
+            brel(wmb->frame);
+        wmb->fillvalue = NULL;
+        wmb->frame = NULL;
     }
 }
 
@@ -2147,10 +2147,10 @@ void compute_maxaggregate_bytes(const iosystem_desc_t ios, io_desc_t *iodesc)
     // printf("%s %d %d %d\n",__FILE__,__LINE__,iodesc->maxiobuflen, iodesc->ndof);
 
     if (ios.ioproc && iodesc->maxiobuflen > 0)
-	maxbytesoniotask = PIO_BUFFER_SIZE_LIMIT / iodesc->maxiobuflen;
+        maxbytesoniotask = PIO_BUFFER_SIZE_LIMIT / iodesc->maxiobuflen;
 
     if (ios.comp_rank >= 0 && iodesc->ndof > 0)
-	maxbytesoncomputetask = PIO_CNBUFFER_LIMIT / iodesc->ndof;
+        maxbytesoncomputetask = PIO_CNBUFFER_LIMIT / iodesc->ndof;
 
     maxbytes = min(maxbytesoniotask, maxbytesoncomputetask);
 

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -3,7 +3,7 @@
 #include <pio_internal.h>
 
 /* start at 16 so that it will be easy for us to notice that it's not
-netcdf (starts at 4), pnetcdf (starts at 0) or netCDF-4/HDF5 (starts at 65xxx). */
+   netcdf (starts at 4), pnetcdf (starts at 0) or netCDF-4/HDF5 (starts at 65xxx). */
 
 int pio_next_ncid = 16;
 
@@ -32,7 +32,7 @@ int pio_next_ncid = 16;
  * @private
  */
 int PIOc_openfile_retry(const int iosysid, int *ncidp, int *iotype,
-			const char *filename, const int mode, int retry)
+                        const char *filename, const int mode, int retry)
 {
     iosystem_desc_t *ios;  /** Pointer to io system information. */
     file_desc_t *file;     /** Pointer to file information. */
@@ -42,23 +42,23 @@ int PIOc_openfile_retry(const int iosysid, int *ncidp, int *iotype,
 
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename)
-	return PIO_EINVAL;
+        return PIO_EINVAL;
     if (*iotype < PIO_IOTYPE_PNETCDF || *iotype > PIO_IOTYPE_NETCDF4P)
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
 
     LOG((2, "PIOc_openfile_retry iosysid = %d iotype = %d filename = %s mode = %d retry = %d",
-	 iosysid, *iotype, filename, mode, retry));
+         iosysid, *iotype, filename, mode, retry));
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
     {
-	LOG((0, "PIOc_openfile got bad iosysid %d",iosysid));
-	return PIO_EBADID;
+        LOG((0, "PIOc_openfile got bad iosysid %d",iosysid));
+        return PIO_EBADID;
     }
 
     /* Allocate space for the file info. */
     if (!(file = (file_desc_t *) malloc(sizeof(*file))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
 
     /* Fill in some file values. */
     file->fh = -1;
@@ -68,14 +68,14 @@ int PIOc_openfile_retry(const int iosysid, int *ncidp, int *iotype,
     file->mode = mode;
     for (int i = 0; i < PIO_MAX_VARS; i++)
     {
-	file->varlist[i].record = -1;
-	file->varlist[i].ndims = -1;
+        file->varlist[i].record = -1;
+        file->varlist[i].ndims = -1;
 #ifdef _PNETCDF
-	file->varlist[i].request = NULL;
-	file->varlist[i].nreqs=0;
+        file->varlist[i].request = NULL;
+        file->varlist[i].nreqs=0;
 #endif
-	file->varlist[i].fillbuf = NULL;
-	file->varlist[i].iobuf = NULL;
+        file->varlist[i].fillbuf = NULL;
+        file->varlist[i].iobuf = NULL;
     }
 
     file->buffer.validvars = 0;
@@ -88,145 +88,145 @@ int PIOc_openfile_retry(const int iosysid, int *ncidp, int *iotype,
     /* Set to true if this task should participate in IO (only true for
      * one task with netcdf serial files. */
     if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
-	ios->io_rank == 0)
-	file->do_io = 1;
+        ios->io_rank == 0)
+        file->do_io = 1;
     else
-	file->do_io = 0;
+        file->do_io = 0;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
-	int msg = PIO_MSG_OPEN_FILE;
-	size_t len = strlen(filename);
+        int msg = PIO_MSG_OPEN_FILE;
+        size_t len = strlen(filename);
 
-	if (!ios->ioproc)
-	{
-	    /* Send the message to the message handler. */
+        if (!ios->ioproc)
+        {
+            /* Send the message to the message handler. */
             if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    /* Send the parameters of the function call. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
+            /* Send the parameters of the function call. */
+            if (!mpierr)
+                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
 
-	case PIO_IOTYPE_NETCDF4P:
+        case PIO_IOTYPE_NETCDF4P:
 #ifdef _MPISERIAL
-	    ierr = nc_open(filename, file->mode, &file->fh);
+            ierr = nc_open(filename, file->mode, &file->fh);
 #else
-	    file->mode = file->mode |  NC_MPIIO;
-	    ierr = nc_open_par(filename, file->mode, ios->io_comm, ios->info, &file->fh);
+            file->mode = file->mode |  NC_MPIIO;
+            ierr = nc_open_par(filename, file->mode, ios->io_comm, ios->info, &file->fh);
 #endif
-	    break;
+            break;
 
-	case PIO_IOTYPE_NETCDF4C:
-	    file->mode = file->mode | NC_NETCDF4;
-	    // *** Note the INTENTIONAL FALLTHROUGH ***
+        case PIO_IOTYPE_NETCDF4C:
+            file->mode = file->mode | NC_NETCDF4;
+            // *** Note the INTENTIONAL FALLTHROUGH ***
 #endif
 
-	case PIO_IOTYPE_NETCDF:
-	    if (ios->io_rank == 0)
-		ierr = nc_open(filename, file->mode, &file->fh);
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if (ios->io_rank == 0)
+                ierr = nc_open(filename, file->mode, &file->fh);
+            break;
 #endif
 
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    ierr = ncmpi_open(ios->io_comm, filename, file->mode, ios->info, &file->fh);
+        case PIO_IOTYPE_PNETCDF:
+            ierr = ncmpi_open(ios->io_comm, filename, file->mode, ios->info, &file->fh);
 
-	    // This should only be done with a file opened to append
-	    if (ierr == PIO_NOERR && (file->mode & PIO_WRITE))
-	    {
-		if (ios->iomaster)
-		    LOG((2, "%d Setting IO buffer %ld", __LINE__, PIO_BUFFER_SIZE_LIMIT));
-		ierr = ncmpi_buffer_attach(file->fh, PIO_BUFFER_SIZE_LIMIT);
-	    }
-	    LOG((2, "ncmpi_open(%s) : fd = %d", filename, file->fh));
-	    break;
+            // This should only be done with a file opened to append
+            if (ierr == PIO_NOERR && (file->mode & PIO_WRITE))
+            {
+                if (ios->iomaster)
+                    LOG((2, "%d Setting IO buffer %ld", __LINE__, PIO_BUFFER_SIZE_LIMIT));
+                ierr = ncmpi_buffer_attach(file->fh, PIO_BUFFER_SIZE_LIMIT);
+            }
+            LOG((2, "ncmpi_open(%s) : fd = %d", filename, file->fh));
+            break;
 #endif
 
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	    break;
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            break;
+        }
 
-	/* If the caller requested a retry, and we failed to open a
-	   file due to an incompatible type of NetCDF, try it once
-	   with just plain old basic NetCDF. */
-	if (retry)
-	{
+        /* If the caller requested a retry, and we failed to open a
+           file due to an incompatible type of NetCDF, try it once
+           with just plain old basic NetCDF. */
+        if (retry)
+        {
 #ifdef _NETCDF
-	    if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
-	    {
-		if (ios->iomaster)
-		    printf("PIO2 pio_file.c retry NETCDF\n");
+            if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
+            {
+                if (ios->iomaster)
+                    printf("PIO2 pio_file.c retry NETCDF\n");
 
-		// reset ierr on all tasks
-		ierr = PIO_NOERR;
+                // reset ierr on all tasks
+                ierr = PIO_NOERR;
 
-		// reset file markers for NETCDF on all tasks
-		file->iotype = PIO_IOTYPE_NETCDF;
+                // reset file markers for NETCDF on all tasks
+                file->iotype = PIO_IOTYPE_NETCDF;
 
-		// open netcdf file serially on main task
-		if (ios->io_rank==0)
-		{
-		    ierr = nc_open(filename, file->mode, &file->fh);
-		}
-	    }
+                // open netcdf file serially on main task
+                if (ios->io_rank==0)
+                {
+                    ierr = nc_open(filename, file->mode, &file->fh);
+                }
+            }
 #endif
-	}
+        }
     }
 
     /* Broadcast and check the return code. */
     LOG((2, "Bcasting error code ierr = %d ios->ioroot = %d ios->my_comm = %d", ierr, ios->ioroot,
-	 ios->my_comm));
+         ios->my_comm));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
     LOG((2, "error code Bcast complete ierr = %d ios->my_comm = %d", ierr, ios->my_comm));
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (!ierr)
     {
-	if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
 
-	/* Create the ncid that the user will see. This is necessary
-	 * because otherwise ncids will be reused if files are opened
-	 * on multiple iosystems. */
-	file->pio_ncid = pio_next_ncid++;
+        /* Create the ncid that the user will see. This is necessary
+         * because otherwise ncids will be reused if files are opened
+         * on multiple iosystems. */
+        file->pio_ncid = pio_next_ncid++;
 
-	/* Return the PIO ncid to the user. */
-	*ncidp = file->pio_ncid;
+        /* Return the PIO ncid to the user. */
+        *ncidp = file->pio_ncid;
 
-	/* Add this file to the list of currently open files. */
-	pio_add_to_file_list(file);
+        /* Add this file to the list of currently open files. */
+        pio_add_to_file_list(file);
     }
 
     LOG((2, "Opened file %s file->pio_ncid = %d file->fh = %d ierr = %d",
-	 filename, file->pio_ncid, file->fh, ierr));
+         filename, file->pio_ncid, file->fh, ierr));
 
     return ierr;
 }
@@ -246,10 +246,10 @@ int PIOc_openfile_retry(const int iosysid, int *ncidp, int *iotype,
  * @ingroup PIO_openfile
  */
 int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
-		  const char *filename, const int mode)
+                  const char *filename, const int mode)
 {
     LOG((1, "PIOc_openfile iosysid = %d iotype = %d filename = %s mode = %d",
-	 iosysid, *iotype, filename, mode));
+         iosysid, *iotype, filename, mode));
 
     return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1);
 }
@@ -274,17 +274,17 @@ PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
     /* Figure out the iotype. */
     if (mode & NC_NETCDF4)
     {
-	if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
-	    iotype = PIO_IOTYPE_NETCDF4P;
-	else
-	    iotype = PIO_IOTYPE_NETCDF4C;
+        if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
+            iotype = PIO_IOTYPE_NETCDF4P;
+        else
+            iotype = PIO_IOTYPE_NETCDF4C;
     }
     else
     {
-	if (mode & NC_PNETCDF || mode & NC_MPIIO)
-	    iotype = PIO_IOTYPE_PNETCDF;
-	else
-	    iotype = PIO_IOTYPE_NETCDF;
+        if (mode & NC_PNETCDF || mode & NC_MPIIO)
+            iotype = PIO_IOTYPE_PNETCDF;
+        else
+            iotype = PIO_IOTYPE_NETCDF;
     }
 
     /* Open the file. If the open fails, do not retry as serial
@@ -306,7 +306,7 @@ PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
  */
 
 int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
-		    const char filename[], const int mode)
+                    const char filename[], const int mode)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -315,18 +315,18 @@ int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
 
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename || strlen(filename) > NC_MAX_NAME)
-	return PIO_EINVAL;
+        return PIO_EINVAL;
 
     LOG((1, "PIOc_createfile iosysid = %d iotype = %d filename = %s mode = %d",
-	 iosysid, *iotype, filename, mode));
+         iosysid, *iotype, filename, mode));
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     /* Allocate space for the file info. */
     if (!(file = (file_desc_t *)malloc(sizeof(file_desc_t))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
 
     /* Fill in some file values. */
     file->next = NULL;
@@ -343,14 +343,14 @@ int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
 
     for(int i = 0; i < PIO_MAX_VARS; i++)
     {
-	file->varlist[i].record = -1;
-	file->varlist[i].ndims = -1;
+        file->varlist[i].record = -1;
+        file->varlist[i].ndims = -1;
 #ifdef _PNETCDF
-	file->varlist[i].request = NULL;
-	file->varlist[i].nreqs=0;
+        file->varlist[i].request = NULL;
+        file->varlist[i].nreqs=0;
 #endif
-	file->varlist[i].fillbuf = NULL;
-	file->varlist[i].iobuf = NULL;
+        file->varlist[i].fillbuf = NULL;
+        file->varlist[i].iobuf = NULL;
     }
 
     file->mode = mode;
@@ -358,116 +358,116 @@ int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
     /* Set to true if this task should participate in IO (only true for
      * one task with netcdf serial files. */
     if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
-	ios->io_rank == 0)
-	file->do_io = 1;
+        ios->io_rank == 0)
+        file->do_io = 1;
     else
-	file->do_io = 0;
+        file->do_io = 0;
     LOG((2, "file->do_io = %d ios->async_interface = %d", file->do_io, ios->async_interface));
 
     /* If async is in use, and this is not an IO task, bcast the
      * parameters. */
     if (ios->async_interface)
     {
-	int msg = PIO_MSG_CREATE_FILE;
-	size_t len = strlen(filename);
+        int msg = PIO_MSG_CREATE_FILE;
+        size_t len = strlen(filename);
 
-	if (!ios->ioproc)
-	{
-	    /* Send the message to the message handler. */
+        if (!ios->ioproc)
+        {
+            /* Send the message to the message handler. */
             if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    /* Send the parameters of the function call. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    LOG((2, "len = %d filename = %s iotype = %d mode = %d", len, filename,
-		 file->iotype, file->mode));
-	}
+            /* Send the parameters of the function call. */
+            if (!mpierr)
+                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            LOG((2, "len = %d filename = %s iotype = %d mode = %d", len, filename,
+                 file->iotype, file->mode));
+        }
 
-	/* Handle MPI errors. */
-	LOG((2, "handling mpi errors mpierr = %d", mpierr));
+        /* Handle MPI errors. */
+        LOG((2, "handling mpi errors mpierr = %d", mpierr));
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this task is in the IO component, do the IO. */
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    file->mode = file->mode |  NC_MPIIO | NC_NETCDF4;
-	    LOG((2, "Calling nc_create_par io_comm = %d mode = %d fh = %d",
-		 ios->io_comm, file->mode, file->fh));
-	    ierr = nc_create_par(filename, file->mode, ios->io_comm, ios->info, &file->fh);
-	    LOG((2, "nc_create_par returned %d file->fh = %d", ierr, file->fh));
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    file->mode = file->mode | NC_NETCDF4;
+        case PIO_IOTYPE_NETCDF4P:
+            file->mode = file->mode |  NC_MPIIO | NC_NETCDF4;
+            LOG((2, "Calling nc_create_par io_comm = %d mode = %d fh = %d",
+                 ios->io_comm, file->mode, file->fh));
+            ierr = nc_create_par(filename, file->mode, ios->io_comm, ios->info, &file->fh);
+            LOG((2, "nc_create_par returned %d file->fh = %d", ierr, file->fh));
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            file->mode = file->mode | NC_NETCDF4;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    if (!ios->io_rank)
-	    {
-		LOG((2, "Calling nc_create mode = %d", file->mode));
-		ierr = nc_create(filename, file->mode, &file->fh);
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if (!ios->io_rank)
+            {
+                LOG((2, "Calling nc_create mode = %d", file->mode));
+                ierr = nc_create(filename, file->mode, &file->fh);
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    LOG((2, "Calling ncmpi_create mode = %d", file->mode));
-	    ierr = ncmpi_create(ios->io_comm, filename, file->mode, ios->info, &file->fh);
-	    if (!ierr)
-		ierr = ncmpi_buffer_attach(file->fh, PIO_BUFFER_SIZE_LIMIT);
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            LOG((2, "Calling ncmpi_create mode = %d", file->mode));
+            ierr = ncmpi_create(ios->io_comm, filename, file->mode, ios->info, &file->fh);
+            if (!ierr)
+                ierr = ncmpi_buffer_attach(file->fh, PIO_BUFFER_SIZE_LIMIT);
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (!ierr)
     {
-	if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
 
-	/* This flag is implied by netcdf create functions but we need
-	   to know if its set. */
-	file->mode = file->mode | PIO_WRITE;
+        /* This flag is implied by netcdf create functions but we need
+           to know if its set. */
+        file->mode = file->mode | PIO_WRITE;
 
-	/* Assign the PIO ncid, necessary because files may be opened
-	 * on mutilple iosystems, causing the underlying library to
-	 * reuse ncids. Hilarious confusion ensues. */
-	file->pio_ncid = pio_next_ncid++;
-	LOG((2, "file->fh = %d file->pio_ncid = %d", file->fh, file->pio_ncid));
+        /* Assign the PIO ncid, necessary because files may be opened
+         * on mutilple iosystems, causing the underlying library to
+         * reuse ncids. Hilarious confusion ensues. */
+        file->pio_ncid = pio_next_ncid++;
+        LOG((2, "file->fh = %d file->pio_ncid = %d", file->fh, file->pio_ncid));
 
-	/* Return the ncid to the caller. */
-	*ncidp = file->pio_ncid;
+        /* Return the ncid to the caller. */
+        *ncidp = file->pio_ncid;
 
-	/* Add the struct with this files info to the global list of
-	 * open files. */
-	pio_add_to_file_list(file);
+        /* Add the struct with this files info to the global list of
+         * open files. */
+        pio_add_to_file_list(file);
     }
 
     LOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
-	 file->fh, file->pio_ncid));
+         file->fh, file->pio_ncid));
 
     return ierr;
 }
@@ -485,25 +485,24 @@ int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
  *
  * @return 0 for success, error code otherwise.
  */
-int
-PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
+int PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
 {
     int iotype;            /* The PIO IO type. */
 
     /* Figure out the iotype. */
     if (cmode & NC_NETCDF4)
     {
-	if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
-	    iotype = PIO_IOTYPE_NETCDF4P;
-	else
-	    iotype = PIO_IOTYPE_NETCDF4C;
+        if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
+            iotype = PIO_IOTYPE_NETCDF4P;
+        else
+            iotype = PIO_IOTYPE_NETCDF4C;
     }
     else
     {
-	if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
-	    iotype = PIO_IOTYPE_PNETCDF;
-	else
-	    iotype = PIO_IOTYPE_NETCDF;
+        if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
+            iotype = PIO_IOTYPE_PNETCDF;
+        else
+            iotype = PIO_IOTYPE_NETCDF;
     }
 
     return PIOc_createfile(iosysid, ncidp, &iotype, filename, cmode);
@@ -530,7 +529,7 @@ int PIOc_closefile(int ncid)
 
     /* Sync changes before closing. */
     if (file->mode & PIO_WRITE)
-	PIOc_sync(ncid);
+        PIOc_sync(ncid);
 
     /* If async is in use and this is a comp tasks, then the compmaster
      * sends a msg to the pio_msg_handler running on the IO master and
@@ -538,59 +537,59 @@ int PIOc_closefile(int ncid)
      * to the IO tasks. */
     if (ios->async_interface)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = PIO_MSG_CLOSE_FILE;
+        if (!ios->ioproc)
+        {
+            int msg = PIO_MSG_CLOSE_FILE;
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_close(file->fh);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_close(file->fh);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    if (ios->io_rank == 0)
-		ierr = nc_close(file->fh);
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if (ios->io_rank == 0)
+                ierr = nc_close(file->fh);
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    if ((file->mode & PIO_WRITE)){
-		ierr = ncmpi_buffer_detach(file->fh);
-	    }
-	    ierr = ncmpi_close(file->fh);
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            if ((file->mode & PIO_WRITE)){
+                ierr = ncmpi_buffer_detach(file->fh);
+            }
+            ierr = ncmpi_close(file->fh);
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Delete file from our list of open files. */
     pio_delete_file_from_list(ncid);
@@ -615,38 +614,38 @@ int PIOc_deletefile(const int iosysid, const char filename[])
 
     /* Get the IO system info from the id. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     /* If async is in use, send message to IO master task. */
     if (ios->async_interface)
     {
-	if (!ios->ioproc)
-	{
-	    if (ios->comp_rank==0)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        if (!ios->ioproc)
+        {
+            if (ios->comp_rank==0)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    len = strlen(filename);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	}
+            len = strlen(filename);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+        }
     }
 
     /* If this is an IO task, then call the netCDF function. The
      * barriers are needed to assure that no task is trying to operate
      * on the file while it is being deleted. */
     if (ios->ioproc){
-	MPI_Barrier(ios->io_comm);
+        MPI_Barrier(ios->io_comm);
 #ifdef _NETCDF
-	if (ios->io_rank==0)
-	    ierr = nc_delete(filename);
+        if (ios->io_rank==0)
+            ierr = nc_delete(filename);
 #else
 #ifdef _PNETCDF
-	ierr = ncmpi_delete(filename, ios->info);
+        ierr = ncmpi_delete(filename, ios->info);
 #endif
 #endif
-	MPI_Barrier(ios->io_comm);
+        MPI_Barrier(ios->io_comm);
     }
 
     //   Special case - always broadcast the return from the
@@ -673,69 +672,69 @@ int PIOc_sync(int ncid)
 
     /* Get the file info from the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, send message to IO master tasks. */
     if (ios->async_interface)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = PIO_MSG_SYNC;
+        if (!ios->ioproc)
+        {
+            int msg = PIO_MSG_SYNC;
 
-	    if (ios->comp_rank == 0)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->comp_rank == 0)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
+            mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        }
     }
 
     if (file->mode & PIO_WRITE)
     {
-	//  cn_buffer_report( *ios, true);
-	wmb = &(file->buffer);
-	while(wmb != NULL){
-	    //    printf("%s %d %d %d\n",__FILE__,__LINE__,wmb->ioid, wmb->validvars);
-	    if (wmb->validvars>0){
-		flush_buffer(ncid, wmb, true);
-	    }
-	    twmb = wmb;
-	    wmb = wmb->next;
-	    if (twmb == &(file->buffer)){
-		twmb->ioid=-1;
-		twmb->next=NULL;
-	    }else{
-		brel(twmb);
-	    }
-	}
-	flush_output_buffer(file, true, 0);
+        //  cn_buffer_report( *ios, true);
+        wmb = &(file->buffer);
+        while(wmb != NULL){
+            //    printf("%s %d %d %d\n",__FILE__,__LINE__,wmb->ioid, wmb->validvars);
+            if (wmb->validvars>0){
+                flush_buffer(ncid, wmb, true);
+            }
+            twmb = wmb;
+            wmb = wmb->next;
+            if (twmb == &(file->buffer)){
+                twmb->ioid=-1;
+                twmb->next=NULL;
+            }else{
+                brel(twmb);
+            }
+        }
+        flush_output_buffer(file, true, 0);
 
-	if (ios->ioproc){
-	    switch(file->iotype){
+        if (ios->ioproc){
+            switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	    case PIO_IOTYPE_NETCDF4P:
-		ierr = nc_sync(file->fh);;
-		break;
-	    case PIO_IOTYPE_NETCDF4C:
+            case PIO_IOTYPE_NETCDF4P:
+                ierr = nc_sync(file->fh);;
+                break;
+            case PIO_IOTYPE_NETCDF4C:
 #endif
-	    case PIO_IOTYPE_NETCDF:
-		if (ios->io_rank==0){
-		    ierr = nc_sync(file->fh);;
-		}
-		break;
+            case PIO_IOTYPE_NETCDF:
+                if (ios->io_rank==0){
+                    ierr = nc_sync(file->fh);;
+                }
+                break;
 #endif
 #ifdef _PNETCDF
-	    case PIO_IOTYPE_PNETCDF:
-		ierr = ncmpi_sync(file->fh);;
-		break;
+            case PIO_IOTYPE_PNETCDF:
+                ierr = ncmpi_sync(file->fh);;
+                break;
 #endif
-	    default:
-		ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	    }
-	}
+            default:
+                ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            }
+        }
 
-	ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+        ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
     }
     return ierr;
 }

--- a/src/clib/pio_get_nc.c
+++ b/src/clib/pio_get_nc.c
@@ -4,7 +4,7 @@
  *
  * @author Ed Hartnett
  * @date  2016
- * 
+ *
  * @see http://code.google.com/p/parallelio/
  */
 
@@ -12,7 +12,7 @@
 #include <pio.h>
 #include <pio_internal.h>
 
-/** 
+/**
  * Internal PIO function which provides a type-neutral interface to
  * nc_get_vars.
  *
@@ -51,7 +51,7 @@
  * @return PIO_NOERR on success, error code otherwise.
  */
 int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		     const PIO_Offset *stride, nc_type xtype, void *buf)
+                     const PIO_Offset *stride, nc_type xtype, void *buf)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -64,414 +64,414 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     int bcast = false;
 
     LOG((1, "PIOc_get_vars_tc ncid = %d varid = %d start = %d count = %d "
-    	 "stride = %d xtype = %d", ncid, varid, start, count, stride, xtype));
+         "stride = %d xtype = %d", ncid, varid, start, count, stride, xtype));
 
     /* User must provide a place to put some data. */
     if (!buf)
-	return PIO_EINVAL;
+        return PIO_EINVAL;
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* Run these on all tasks if async is not in use, but only on
      * non-IO tasks if async is in use. */
     if (!ios->async_interface || !ios->ioproc)
     {
-	/* Get the length of the data type. */
-	if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
-	    return check_netcdf(file, ierr, __FILE__, __LINE__);
+        /* Get the length of the data type. */
+        if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
+            return check_netcdf(file, ierr, __FILE__, __LINE__);
 
-	/* Get the number of dims for this var. */
-	if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
-	    return check_netcdf(file, ierr, __FILE__, __LINE__);
+        /* Get the number of dims for this var. */
+        if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
+            return check_netcdf(file, ierr, __FILE__, __LINE__);
 
-	PIO_Offset dimlen[ndims];
+        PIO_Offset dimlen[ndims];
 
-	/* If no count array was passed, we need to know the dimlens
-	 * so we can calculate how many data elements are in the
-	 * buf. */
-	if (!count)
-	{
-	    int dimid[ndims];
+        /* If no count array was passed, we need to know the dimlens
+         * so we can calculate how many data elements are in the
+         * buf. */
+        if (!count)
+        {
+            int dimid[ndims];
 
-	    /* Get the dimids for this var. */
-	    if ((ierr = PIOc_inq_vardimid(ncid, varid, dimid)))
-		return check_netcdf(file, ierr, __FILE__, __LINE__);
+            /* Get the dimids for this var. */
+            if ((ierr = PIOc_inq_vardimid(ncid, varid, dimid)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
 
-	    /* Get the length of each dimension. */
-	    for (int vd = 0; vd < ndims; vd++)
-		if ((ierr = PIOc_inq_dimlen(ncid, dimid[vd], &dimlen[vd])))
-		    return check_netcdf(file, ierr, __FILE__, __LINE__);
-	}
+            /* Get the length of each dimension. */
+            for (int vd = 0; vd < ndims; vd++)
+                if ((ierr = PIOc_inq_dimlen(ncid, dimid[vd], &dimlen[vd])))
+                    return check_netcdf(file, ierr, __FILE__, __LINE__);
+        }
 
-	/* Figure out the real start, count, and stride arrays. (The
-	 * user may have passed in NULLs.) */
-	PIO_Offset rstart[ndims], rcount[ndims], rstride[ndims];
-	for (int vd = 0; vd < ndims; vd++)
-	{
-	    rstart[vd] = start ? start[vd] : 0;
-	    rcount[vd] = count ? count[vd] : dimlen[vd];
-	    rstride[vd] = stride ? stride[vd] : 1;
-	}
+        /* Figure out the real start, count, and stride arrays. (The
+         * user may have passed in NULLs.) */
+        PIO_Offset rstart[ndims], rcount[ndims], rstride[ndims];
+        for (int vd = 0; vd < ndims; vd++)
+        {
+            rstart[vd] = start ? start[vd] : 0;
+            rcount[vd] = count ? count[vd] : dimlen[vd];
+            rstride[vd] = stride ? stride[vd] : 1;
+        }
 
-	/* How many elements in buf? */
-	for (int vd = 0; vd < ndims; vd++)
-	    num_elem *= (rcount[vd] - rstart[vd])/rstride[vd];
-	LOG((2, "PIOc_get_vars_tc num_elem = %d", num_elem));
+        /* How many elements in buf? */
+        for (int vd = 0; vd < ndims; vd++)
+            num_elem *= (rcount[vd] - rstart[vd])/rstride[vd];
+        LOG((2, "PIOc_get_vars_tc num_elem = %d", num_elem));
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = PIO_MSG_GET_VARS;
-	    char start_present = start ? true : false;
-	    char count_present = count ? true : false;
-	    char stride_present = stride ? true : false;
+        if (!ios->ioproc)
+        {
+            int msg = PIO_MSG_GET_VARS;
+            char start_present = start ? true : false;
+            char count_present = count ? true : false;
+            char stride_present = stride ? true : false;
 
-	    if(ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if(ios->compmaster)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    /* Send the function parameters and associated informaiton
-	     * to the msg handler. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&varid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&start_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr && start_present)
-		mpierr = MPI_Bcast((PIO_Offset *)start, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&count_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr && count_present)
-		mpierr = MPI_Bcast((PIO_Offset *)count, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&stride_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr && stride_present)
-		mpierr = MPI_Bcast((PIO_Offset *)stride, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    LOG((2, "PIOc_get_vars_tc ncid = %d varid = %d ndims = %d start_present = %d "
-		 "count_present = %d stride_present = %d xtype = %d num_elem = %d", ncid, varid,
-		 ndims, start_present, count_present, stride_present, xtype, num_elem));
-	}
+            /* Send the function parameters and associated informaiton
+             * to the msg handler. */
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&varid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&start_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr && start_present)
+                mpierr = MPI_Bcast((PIO_Offset *)start, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&count_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr && count_present)
+                mpierr = MPI_Bcast((PIO_Offset *)count, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&stride_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr && stride_present)
+                mpierr = MPI_Bcast((PIO_Offset *)stride, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            LOG((2, "PIOc_get_vars_tc ncid = %d varid = %d ndims = %d start_present = %d "
+                 "count_present = %d stride_present = %d xtype = %d num_elem = %d", ncid, varid,
+                 ndims, start_present, count_present, stride_present, xtype, num_elem));
+        }
 
-	/* Handle MPI errors. */
-	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        /* Handle MPI errors. */
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(file, mpierr2, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
 
-	/* Broadcast values currently only known on computation tasks to IO tasks. */
-	if ((mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
-	    check_mpi(file, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
-	    check_mpi(file, mpierr, __FILE__, __LINE__);
+        /* Broadcast values currently only known on computation tasks to IO tasks. */
+        if ((mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
+            check_mpi(file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
+            check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
 #ifdef _PNETCDF
-	if (file->iotype == PIO_IOTYPE_PNETCDF)
-	{
+        if (file->iotype == PIO_IOTYPE_PNETCDF)
+        {
 #ifdef PNET_READ_AND_BCAST
-	    LOG((1, "PNET_READ_AND_BCAST"));
-	    ncmpi_begin_indep_data(file->fh);
+            LOG((1, "PNET_READ_AND_BCAST"));
+            ncmpi_begin_indep_data(file->fh);
 
-	    /* Only the IO master does the IO, so we are not really
-	     * getting parallel IO here. */
-	    if (ios->iomaster)
-	    {
-		switch(xtype)
-		{
-		case NC_BYTE:
-		    ierr = ncmpi_get_vars_schar(file->fh, varid, start, count, stride, buf);
-		    break;
-		case NC_CHAR:
-		    ierr = ncmpi_get_vars_text(file->fh, varid, start, count, stride, buf);
-		    break;
-		case NC_SHORT:
-		    ierr = ncmpi_get_vars_short(file->fh, varid, start, count, stride, buf);
-		    break;
-		case NC_INT:
-		    ierr = ncmpi_get_vars_int(file->fh, varid, start, count, stride, buf);
-		    break;
-		case NC_FLOAT:
-		    ierr = ncmpi_get_vars_float(file->fh, varid, start, count, stride, buf);
-		    break;
-		case NC_DOUBLE:
-		    ierr = ncmpi_get_vars_double(file->fh, varid, start, count, stride, buf);
-		    break;
-		case NC_INT64:
-		    ierr = ncmpi_get_vars_longlong(file->fh, varid, start, count, stride, buf);
-		    break;
-		default:
-		    LOG((0, "Unknown type for pnetcdf file! xtype = %d", xtype));
-		}
-	    };
-	    ncmpi_end_indep_data(file->fh);
-	    bcast=true;
+            /* Only the IO master does the IO, so we are not really
+             * getting parallel IO here. */
+            if (ios->iomaster)
+            {
+                switch(xtype)
+                {
+                case NC_BYTE:
+                    ierr = ncmpi_get_vars_schar(file->fh, varid, start, count, stride, buf);
+                    break;
+                case NC_CHAR:
+                    ierr = ncmpi_get_vars_text(file->fh, varid, start, count, stride, buf);
+                    break;
+                case NC_SHORT:
+                    ierr = ncmpi_get_vars_short(file->fh, varid, start, count, stride, buf);
+                    break;
+                case NC_INT:
+                    ierr = ncmpi_get_vars_int(file->fh, varid, start, count, stride, buf);
+                    break;
+                case NC_FLOAT:
+                    ierr = ncmpi_get_vars_float(file->fh, varid, start, count, stride, buf);
+                    break;
+                case NC_DOUBLE:
+                    ierr = ncmpi_get_vars_double(file->fh, varid, start, count, stride, buf);
+                    break;
+                case NC_INT64:
+                    ierr = ncmpi_get_vars_longlong(file->fh, varid, start, count, stride, buf);
+                    break;
+                default:
+                    LOG((0, "Unknown type for pnetcdf file! xtype = %d", xtype));
+                }
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else /* PNET_READ_AND_BCAST */
-	    LOG((1, "not PNET_READ_AND_BCAST"));
-	    switch(xtype)
-	    {
-	    case NC_BYTE:
-		ierr = ncmpi_get_vars_schar_all(file->fh, varid, start, count, stride, buf);
-		break;
-	    case NC_CHAR:
-		ierr = ncmpi_get_vars_text_all(file->fh, varid, start, count, stride, buf);
-		break;
-	    case NC_SHORT:
-		ierr = ncmpi_get_vars_short_all(file->fh, varid, start, count, stride, buf);
-		break;
-	    case NC_INT:
-		ierr = ncmpi_get_vars_int_all(file->fh, varid, start, count, stride, buf);
-		for (int i = 0; i < 4; i++)
-		    LOG((2, "((int *)buf)[%d] = %d", i, ((int *)buf)[0]));
-		break;
-	    case NC_FLOAT:
-		ierr = ncmpi_get_vars_float_all(file->fh, varid, start, count, stride, buf);
-		break;
-	    case NC_DOUBLE:
-		ierr = ncmpi_get_vars_double_all(file->fh, varid, start, count, stride, buf);
-		break;
-	    case NC_INT64:
-		ierr = ncmpi_get_vars_longlong_all(file->fh, varid, start, count, stride, buf);
-		break;
-	    default:
-		LOG((0, "Unknown type for pnetcdf file! xtype = %d", xtype));
-	    }
+            LOG((1, "not PNET_READ_AND_BCAST"));
+            switch(xtype)
+            {
+            case NC_BYTE:
+                ierr = ncmpi_get_vars_schar_all(file->fh, varid, start, count, stride, buf);
+                break;
+            case NC_CHAR:
+                ierr = ncmpi_get_vars_text_all(file->fh, varid, start, count, stride, buf);
+                break;
+            case NC_SHORT:
+                ierr = ncmpi_get_vars_short_all(file->fh, varid, start, count, stride, buf);
+                break;
+            case NC_INT:
+                ierr = ncmpi_get_vars_int_all(file->fh, varid, start, count, stride, buf);
+                for (int i = 0; i < 4; i++)
+                    LOG((2, "((int *)buf)[%d] = %d", i, ((int *)buf)[0]));
+                break;
+            case NC_FLOAT:
+                ierr = ncmpi_get_vars_float_all(file->fh, varid, start, count, stride, buf);
+                break;
+            case NC_DOUBLE:
+                ierr = ncmpi_get_vars_double_all(file->fh, varid, start, count, stride, buf);
+                break;
+            case NC_INT64:
+                ierr = ncmpi_get_vars_longlong_all(file->fh, varid, start, count, stride, buf);
+                break;
+            default:
+                LOG((0, "Unknown type for pnetcdf file! xtype = %d", xtype));
+            }
 #endif /* PNET_READ_AND_BCAST */
-	}
+        }
 #endif /* _PNETCDF */
 #ifdef _NETCDF
-	if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
-	    switch(xtype)
-	    {
-	    case NC_BYTE:
-		ierr = nc_get_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_CHAR:
-		ierr = nc_get_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_SHORT:
-		ierr = nc_get_vars_short(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_INT:
-		ierr = nc_get_vars_int(file->fh, varid, (size_t *)start, (size_t *)count,
-				       (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_FLOAT:
-		ierr = nc_get_vars_float(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_DOUBLE:
-		ierr = nc_get_vars_double(file->fh, varid, (size_t *)start, (size_t *)count,
-					  (ptrdiff_t *)stride, buf);
-		break;
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
+            switch(xtype)
+            {
+            case NC_BYTE:
+                ierr = nc_get_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_CHAR:
+                ierr = nc_get_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_SHORT:
+                ierr = nc_get_vars_short(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_INT:
+                ierr = nc_get_vars_int(file->fh, varid, (size_t *)start, (size_t *)count,
+                                       (ptrdiff_t *)stride, buf);
+                break;
+            case NC_FLOAT:
+                ierr = nc_get_vars_float(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_DOUBLE:
+                ierr = nc_get_vars_double(file->fh, varid, (size_t *)start, (size_t *)count,
+                                          (ptrdiff_t *)stride, buf);
+                break;
 #ifdef _NETCDF4
-	    case NC_UBYTE:
-		ierr = nc_get_vars_uchar(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_USHORT:
-		ierr = nc_get_vars_ushort(file->fh, varid, (size_t *)start, (size_t *)count,
-					  (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_UINT:
-		ierr = nc_get_vars_uint(file->fh, varid, (size_t *)start, (size_t *)count,
-					(ptrdiff_t *)stride, buf);
-		break;
-	    case NC_INT64:
-		ierr = nc_get_vars_longlong(file->fh, varid, (size_t *)start, (size_t *)count,
-					    (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_UINT64:
-		ierr = nc_get_vars_ulonglong(file->fh, varid, (size_t *)start, (size_t *)count,
-					     (ptrdiff_t *)stride, buf);
-		break;
-		/* case NC_STRING: */
-		/* 	ierr = nc_get_vars_string(file->fh, varid, (size_t *)start, (size_t *)count, */
-		/* 				  (ptrdiff_t *)stride, (void *)buf); */
-		/* 	break; */
-	    default:
-		ierr = nc_get_vars(file->fh, varid, (size_t *)start, (size_t *)count,
-				   (ptrdiff_t *)stride, buf);
+            case NC_UBYTE:
+                ierr = nc_get_vars_uchar(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_USHORT:
+                ierr = nc_get_vars_ushort(file->fh, varid, (size_t *)start, (size_t *)count,
+                                          (ptrdiff_t *)stride, buf);
+                break;
+            case NC_UINT:
+                ierr = nc_get_vars_uint(file->fh, varid, (size_t *)start, (size_t *)count,
+                                        (ptrdiff_t *)stride, buf);
+                break;
+            case NC_INT64:
+                ierr = nc_get_vars_longlong(file->fh, varid, (size_t *)start, (size_t *)count,
+                                            (ptrdiff_t *)stride, buf);
+                break;
+            case NC_UINT64:
+                ierr = nc_get_vars_ulonglong(file->fh, varid, (size_t *)start, (size_t *)count,
+                                             (ptrdiff_t *)stride, buf);
+                break;
+                /* case NC_STRING: */
+                /*      ierr = nc_get_vars_string(file->fh, varid, (size_t *)start, (size_t *)count, */
+                /*                                (ptrdiff_t *)stride, (void *)buf); */
+                /*      break; */
+            default:
+                ierr = nc_get_vars(file->fh, varid, (size_t *)start, (size_t *)count,
+                                   (ptrdiff_t *)stride, buf);
 #endif /* _NETCDF4 */
-	    }
+            }
 #endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	return check_mpi(file, mpierr, __FILE__, __LINE__);
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Send the data. */
     LOG((2, "PIOc_get_vars_tc bcasting data num_elem = %d typelen = %d", num_elem,
-	 typelen));
+         typelen));
     if (!mpierr)
-	mpierr = MPI_Bcast((void *)buf, num_elem * typelen, MPI_BYTE, ios->ioroot,
-			   ios->my_comm);
+        mpierr = MPI_Bcast((void *)buf, num_elem * typelen, MPI_BYTE, ios->ioroot,
+                           ios->my_comm);
     return ierr;
 }
 
 int PIOc_get_vars_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			const PIO_Offset *stride, char *buf)
+                       const PIO_Offset *stride, char *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_CHAR, buf);
 }
 
 int PIOc_get_vars_uchar(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const PIO_Offset *stride, unsigned char *buf)
+                        const PIO_Offset *count, const PIO_Offset *stride, unsigned char *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_UBYTE, buf);
 }
 
 int PIOc_get_vars_schar(int ncid, int varid, const PIO_Offset *start,
-			 const PIO_Offset *count, const PIO_Offset *stride, signed char *buf)
+                        const PIO_Offset *count, const PIO_Offset *stride, signed char *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_BYTE, buf);
 }
 
 int PIOc_get_vars_ushort(int ncid, int varid, const PIO_Offset *start,
-			 const PIO_Offset *count, const PIO_Offset *stride, unsigned short *buf)
+                         const PIO_Offset *count, const PIO_Offset *stride, unsigned short *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_USHORT, buf);
 }
 
 int PIOc_get_vars_short(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const PIO_Offset *stride, short *buf)
+                        const PIO_Offset *count, const PIO_Offset *stride, short *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_SHORT, buf);
 }
 
 int PIOc_get_vars_uint(int ncid, int varid, const PIO_Offset *start,
-		       const PIO_Offset *count, const PIO_Offset *stride, unsigned int *buf)
+                       const PIO_Offset *count, const PIO_Offset *stride, unsigned int *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_UINT, buf);
 }
 
 int PIOc_get_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		      const PIO_Offset *stride, int *buf)
+                      const PIO_Offset *stride, int *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_INT, buf);
 }
 
 int PIOc_get_vars_long(int ncid, int varid, const PIO_Offset *start,
-		       const PIO_Offset *count, const PIO_Offset *stride, long *buf)
+                       const PIO_Offset *count, const PIO_Offset *stride, long *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_LONG, buf);
 }
 
 int PIOc_get_vars_float(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const PIO_Offset *stride, float *buf)
+                        const PIO_Offset *count, const PIO_Offset *stride, float *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_FLOAT, buf);
 }
 
 int PIOc_get_vars_double(int ncid, int varid, const PIO_Offset *start,
-			 const PIO_Offset *count, const PIO_Offset *stride, double *buf)
+                         const PIO_Offset *count, const PIO_Offset *stride, double *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_DOUBLE, buf);
 }
 
 int PIOc_get_vars_ulonglong(int ncid, int varid, const PIO_Offset *start,
-			    const PIO_Offset *count, const PIO_Offset *stride,
-			    unsigned long long *buf)
+                            const PIO_Offset *count, const PIO_Offset *stride,
+                            unsigned long long *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_UINT64, buf);
 }
 
 int PIOc_get_vars_longlong(int ncid, int varid, const PIO_Offset *start,
-			    const PIO_Offset *count, const PIO_Offset *stride, long long *buf)
+                           const PIO_Offset *count, const PIO_Offset *stride, long long *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_UINT64, buf);
 }
 
 int PIOc_get_vara_text(int ncid, int varid, const PIO_Offset *start,
-		       const PIO_Offset *count, char *buf)
+                       const PIO_Offset *count, char *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_CHAR, buf);
 }
 
 int PIOc_get_vara_uchar(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, unsigned char *buf)
+                        const PIO_Offset *count, unsigned char *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_UBYTE, buf);
 }
 
 int PIOc_get_vara_schar(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, signed char *buf)
+                        const PIO_Offset *count, signed char *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_BYTE, buf);
 }
 
 int PIOc_get_vara_ushort(int ncid, int varid, const PIO_Offset *start,
-			 const PIO_Offset *count, unsigned short *buf)
+                         const PIO_Offset *count, unsigned short *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_USHORT, buf);
 }
 
 int PIOc_get_vara_short(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, short *buf)
+                        const PIO_Offset *count, short *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_SHORT, buf);
 }
 
 int PIOc_get_vara_long(int ncid, int varid, const PIO_Offset *start,
-		       const PIO_Offset *count, long *buf)
+                       const PIO_Offset *count, long *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_LONG, buf);
 }
 
 int PIOc_get_vara_uint(int ncid, int varid, const PIO_Offset *start,
-		       const PIO_Offset *count, unsigned int *buf)
+                       const PIO_Offset *count, unsigned int *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_UINT, buf);
 }
 
 int PIOc_get_vara_int(int ncid, int varid, const PIO_Offset *start,
-		      const PIO_Offset *count, int *buf)
+                      const PIO_Offset *count, int *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_INT, buf);
 }
 
 int PIOc_get_vara_float(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, float *buf)
+                        const PIO_Offset *count, float *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_FLOAT, buf);
 }
 
 int PIOc_get_vara_double(int ncid, int varid, const PIO_Offset *start,
-			 const PIO_Offset *count, double *buf)
+                         const PIO_Offset *count, double *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_DOUBLE, buf);
 }
 
 int PIOc_get_vara_ulonglong(int ncid, int varid, const PIO_Offset *start,
-			    const PIO_Offset *count, unsigned long long *buf)
+                            const PIO_Offset *count, unsigned long long *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_UINT64, buf);
 }
 
 int PIOc_get_vara_longlong(int ncid, int varid, const PIO_Offset *start,
-			   const PIO_Offset *count, long long *buf)
+                           const PIO_Offset *count, long long *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_INT64, buf);
 }
@@ -530,26 +530,26 @@ int PIOc_get_var_ulonglong(int ncid, int varid, unsigned long long *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, NULL, NULL, NULL, NC_UINT64, buf);
 }
-    
+
 int PIOc_get_var_longlong(int ncid, int varid, long long *buf)
 {
     return PIOc_get_vars_tc(ncid, varid, NULL, NULL, NULL, NC_INT64, buf);
 }
 
 int PIOc_get_var1_tc(int ncid, int varid, const PIO_Offset *index, nc_type xtype,
-		     void *buf)
+                     void *buf)
 {
     int ndims;
     int ierr;
 
     /* Find the number of dimensions. */
     if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
-	return ierr;
+        return ierr;
 
     /* Set up count array. */
     PIO_Offset count[ndims];
     for (int c = 0; c < ndims; c++)
-	count[c] = 1;
+        count[c] = 1;
 
     return PIOc_get_vars_tc(ncid, varid, index, count, NULL, xtype, buf);
 }
@@ -571,52 +571,52 @@ int PIOc_get_var1_schar(int ncid, int varid, const PIO_Offset *index, signed cha
 
 int PIOc_get_var1_ushort(int ncid, int varid, const PIO_Offset *index, unsigned short *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_USHORT, buf);            
+    return PIOc_get_var1_tc(ncid, varid, index, NC_USHORT, buf);
 }
 
 int PIOc_get_var1_short(int ncid, int varid, const PIO_Offset *index, short *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_SHORT, buf);        
+    return PIOc_get_var1_tc(ncid, varid, index, NC_SHORT, buf);
 }
 
 int PIOc_get_var1_uint(int ncid, int varid, const PIO_Offset *index, unsigned int *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_UINT, buf);    
+    return PIOc_get_var1_tc(ncid, varid, index, NC_UINT, buf);
 }
 
 int PIOc_get_var1_long (int ncid, int varid, const PIO_Offset *index, long *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_LONG, buf);    
+    return PIOc_get_var1_tc(ncid, varid, index, NC_LONG, buf);
 }
 
 int PIOc_get_var1_int(int ncid, int varid, const PIO_Offset *index, int *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_INT, buf);    
+    return PIOc_get_var1_tc(ncid, varid, index, NC_INT, buf);
 }
 
 int PIOc_get_var1_float(int ncid, int varid, const PIO_Offset *index, float *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_FLOAT, buf);    
+    return PIOc_get_var1_tc(ncid, varid, index, NC_FLOAT, buf);
 }
 
 int PIOc_get_var1_double (int ncid, int varid, const PIO_Offset *index, double *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_DOUBLE, buf);    
+    return PIOc_get_var1_tc(ncid, varid, index, NC_DOUBLE, buf);
 }
 
 int PIOc_get_var1_ulonglong (int ncid, int varid, const PIO_Offset *index,
-			     unsigned long long *buf)
+                             unsigned long long *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_INT64, buf);    
+    return PIOc_get_var1_tc(ncid, varid, index, NC_INT64, buf);
 }
-    
+
 
 int PIOc_get_var1_longlong(int ncid, int varid, const PIO_Offset *index,
-			   long long *buf)
+                           long long *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_INT64, buf);    
+    return PIOc_get_var1_tc(ncid, varid, index, NC_INT64, buf);
 }
-    
+
 int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Datatype buftype)
 {
     int ierr;
@@ -631,60 +631,60 @@ int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Dataty
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     msg = PIO_MSG_GET_VAR;
     ibufcnt = bufcount;
     ibuftype = buftype;
     ierr = PIO_NOERR;
 
     if(ios->async_interface && ! ios->ioproc){
-	if(ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
     if(ios->ioproc){
-	switch(file->iotype){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_get_var(file->fh, varid,   buf);;
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_var(file->fh, varid,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    bcast = true;
-	    if(ios->iomaster){
-		ierr = nc_get_var(file->fh, varid,   buf);;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_var(file->fh, varid,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-	    ncmpi_begin_indep_data(file->fh);
-	    if(ios->iomaster){
-		ierr = ncmpi_get_var(file->fh, varid, buf, bufcount, buftype);;
-	    };
-	    ncmpi_end_indep_data(file->fh);
-	    bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_var(file->fh, varid, buf, bufcount, buftype);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-	    ierr = ncmpi_get_var_all(file->fh, varid, buf, bufcount, buftype);;
+            ierr = ncmpi_get_var_all(file->fh, varid, buf, bufcount, buftype);;
 #endif
-	    break;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
-	MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
     }
 
     return ierr;
@@ -704,61 +704,61 @@ int PIOc_get_var1(int ncid, int varid, const PIO_Offset *index, void *buf, PIO_O
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     msg = PIO_MSG_GET_VAR1;
     ibufcnt = bufcount;
     ibuftype = buftype;
     ierr = PIO_NOERR;
 
     if(ios->async_interface && ! ios->ioproc){
-	if(ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
 
     if(ios->ioproc){
-	switch(file->iotype){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_get_var1(file->fh, varid, (size_t *) index,   buf);;
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_var1(file->fh, varid, (size_t *) index,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    bcast = true;
-	    if(ios->iomaster){
-		ierr = nc_get_var1(file->fh, varid, (size_t *) index,   buf);;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_var1(file->fh, varid, (size_t *) index,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-	    ncmpi_begin_indep_data(file->fh);
-	    if(ios->iomaster){
-		ierr = ncmpi_get_var1(file->fh, varid, index, buf, bufcount, buftype);;
-	    };
-	    ncmpi_end_indep_data(file->fh);
-	    bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_var1(file->fh, varid, index, buf, bufcount, buftype);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-	    ierr = ncmpi_get_var1_all(file->fh, varid, index, buf, bufcount, buftype);;
+            ierr = ncmpi_get_var1_all(file->fh, varid, index, buf, bufcount, buftype);;
 #endif
-	    break;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
-	MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
     }
 
     return ierr;
@@ -778,61 +778,61 @@ int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     msg = PIO_MSG_GET_VARA;
     ibufcnt = bufcount;
     ibuftype = buftype;
     ierr = PIO_NOERR;
 
     if(ios->async_interface && ! ios->ioproc){
-	if(ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
 
     if(ios->ioproc){
-	switch(file->iotype){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_get_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    bcast = true;
-	    if(ios->iomaster){
-		ierr = nc_get_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-	    ncmpi_begin_indep_data(file->fh);
-	    if(ios->iomaster){
-		ierr = ncmpi_get_vara(file->fh, varid, start, count, buf, bufcount, buftype);;
-	    };
-	    ncmpi_end_indep_data(file->fh);
-	    bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_vara(file->fh, varid, start, count, buf, bufcount, buftype);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-	    ierr = ncmpi_get_vara_all(file->fh, varid, start, count, buf, bufcount, buftype);;
+            ierr = ncmpi_get_vara_all(file->fh, varid, start, count, buf, bufcount, buftype);;
 #endif
-	    break;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
-	MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
     }
 
     return ierr;
@@ -852,63 +852,62 @@ int PIOc_get_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     msg = PIO_MSG_GET_VARS;
     ibufcnt = bufcount;
     ibuftype = buftype;
     ierr = PIO_NOERR;
 
     if(ios->async_interface && ! ios->ioproc){
-	if(ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
 
     if(ios->ioproc){
-	switch(file->iotype){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_get_vars(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride,   buf);;
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_vars(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    bcast = true;
-	    if(ios->iomaster){
-		ierr = nc_get_vars(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride,   buf);;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_vars(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-	    ncmpi_begin_indep_data(file->fh);
-	    if(ios->iomaster){
-		ierr = ncmpi_get_vars(file->fh, varid, start, count, stride, buf, bufcount, buftype);;
-	    };
-	    ncmpi_end_indep_data(file->fh);
-	    bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_vars(file->fh, varid, start, count, stride, buf, bufcount, buftype);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-	    ierr = ncmpi_get_vars_all(file->fh, varid, start, count, stride, buf, bufcount, buftype);;
+            ierr = ncmpi_get_vars_all(file->fh, varid, start, count, stride, buf, bufcount, buftype);;
 #endif
-	    break;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
-	MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
     }
 
     return ierr;
 }
-

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -1,9 +1,9 @@
 /**
- * @file 
+ * @file
  * Private headers and defines for the PIO C interface.
  * @author Jim Edwards
  * @date  2014
- * 
+ *
  * @see http://code.google.com/p/parallelio/
  */
 
@@ -36,15 +36,15 @@ void pio_log(int severity, const char *fmt, ...);
 #define LOG(e)
 #endif /* PIO_ENABLE_LOGGING */
 
-#define max(a,b)				\
-    ({ __typeof__ (a) _a = (a);			\
-	__typeof__ (b) _b = (b);		\
-	_a > _b ? _a : _b; })
+#define max(a,b)                                \
+    ({ __typeof__ (a) _a = (a);                 \
+        __typeof__ (b) _b = (b);                \
+        _a > _b ? _a : _b; })
 
-#define min(a,b)				\
-    ({ __typeof__ (a) _a = (a);			\
-	__typeof__ (b) _b = (b);		\
-	_a < _b ? _a : _b; })
+#define min(a,b)                                \
+    ({ __typeof__ (a) _a = (a);                 \
+        __typeof__ (b) _b = (b);                \
+        _a < _b ? _a : _b; })
 
 #define MAX_GATHER_BLOCK_SIZE 0
 #define PIO_REQUEST_ALLOC_CHUNK 16
@@ -59,17 +59,17 @@ extern "C" {
     /** Used to sort map points in the subset rearranger. */
     typedef struct mapsort
     {
-	int rfrom;
-	PIO_Offset soffset;
-	PIO_Offset iomap;
+        int rfrom;
+        PIO_Offset soffset;
+        PIO_Offset iomap;
     } mapsort;
 
     /** swapm defaults. */
     typedef struct pio_swapm_defaults
     {
-	int nreqs;
-	bool handshake;
-	bool isend;
+        int nreqs;
+        bool handshake;
+        bool isend;
     } pio_swapm_defaults;
 
     void pio_get_env(void);
@@ -85,55 +85,55 @@ extern "C" {
 
     iosystem_desc_t *pio_get_iosystem_from_id(int iosysid);
     int pio_add_to_iosystem_list(iosystem_desc_t *ios);
-  
+
     int check_netcdf(file_desc_t *file,const int status, const char *fname, const int line);
     int iotype_error(const int iotype, const char *fname, const int line);
     void piodie(const char *msg,const char *fname, const int line);
     void pioassert(bool exp, const char *msg,const char *fname, const int line);
     int CalcStartandCount(const int basetype, const int ndims, const int *gdims, const int num_io_procs,
-			  const int myiorank, PIO_Offset *start, PIO_Offset *kount);
+                          const int myiorank, PIO_Offset *start, PIO_Offset *kount);
     void CheckMPIReturn(const int ierr,const char file[],const int line);
     int pio_fc_gather( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype,
-		       void *recvbuf, const int recvcnt, const MPI_Datatype recvtype, const int root, 
-		       MPI_Comm comm, const int flow_cntl);
+                       void *recvbuf, const int recvcnt, const MPI_Datatype recvtype, const int root,
+                       MPI_Comm comm, const int flow_cntl);
     int pio_fc_gatherv( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype,
-			void *recvbuf, const int recvcnts[], const int recvdispl[], const MPI_Datatype recvtype, const int root, 
-			MPI_Comm comm, const int flow_cntl);
-  
+                        void *recvbuf, const int recvcnts[], const int recvdispl[], const MPI_Datatype recvtype, const int root,
+                        MPI_Comm comm, const int flow_cntl);
+
     int pio_fc_gatherv( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype,
-			void *recvbuf, const int recvcnts[], const int rdispls[], const MPI_Datatype recvtype, const int root, 
-			MPI_Comm comm, const int flow_cntl);
-  
-    int pio_swapm(void *sndbuf, int sndlths[], int sdispls[], MPI_Datatype stypes[], 
-		  void *rcvbuf, int rcvlths[], int rdispls[], MPI_Datatype rtypes[], 
-		  MPI_Comm comm, const bool handshake, bool isend, const int max_requests);
-  
+                        void *recvbuf, const int recvcnts[], const int rdispls[], const MPI_Datatype recvtype, const int root,
+                        MPI_Comm comm, const int flow_cntl);
+
+    int pio_swapm(void *sndbuf, int sndlths[], int sdispls[], MPI_Datatype stypes[],
+                  void *rcvbuf, int rcvlths[], int rdispls[], MPI_Datatype rtypes[],
+                  MPI_Comm comm, const bool handshake, bool isend, const int max_requests);
+
     long long lgcd_array(int nain, long long*ain);
-  
+
     void PIO_Offset_size(MPI_Datatype *dtype, int *tsize);
     PIO_Offset GCDblocksize(const int arrlen, const PIO_Offset arr_in[]);
-  
+
     int subset_rearrange_create(const iosystem_desc_t ios,const int maplen, PIO_Offset compmap[], const int gsize[],
-				const int ndim, io_desc_t *iodesc);
-  
+                                const int ndim, io_desc_t *iodesc);
+
 
     int box_rearrange_create(const iosystem_desc_t ios,const int maplen, const PIO_Offset compmap[], const int gsize[],
-			     const int ndim, io_desc_t *iodesc);
-  
+                             const int ndim, io_desc_t *iodesc);
+
 
     int rearrange_io2comp(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
-			  void *rbuf);
+                          void *rbuf);
     int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
-			  void *rbuf, const int nvars);
+                          void *rbuf, const int nvars);
     int calcdisplace(const int bsize, const int numblocks,const PIO_Offset map[],int displace[]);
     io_desc_t *malloc_iodesc(const int piotype, const int ndims);
     void performance_tune_rearranger(iosystem_desc_t ios, io_desc_t *iodesc);
-  
+
     int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize);
     void compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc);
     io_region *alloc_region(const int ndims);
     int pio_delete_iosystem_from_list(int piosysid);
-    int gcd(int a, int b); 
+    int gcd(int a, int b);
     long long lgcd (long long a,long long b );
     int gcd_array(int nain, int *ain);
     void free_region_list(io_region *top);
@@ -144,12 +144,12 @@ extern "C" {
     int pair(const int np, const int p, const int k);
     int define_iodesc_datatypes(const iosystem_desc_t ios, io_desc_t *iodesc);
 
-    int create_mpi_datatypes(const MPI_Datatype basetype,const int msgcnt,const PIO_Offset dlen, 
-			     const PIO_Offset mindex[],const int mcount[],int *mfrom, MPI_Datatype mtype[]);
+    int create_mpi_datatypes(const MPI_Datatype basetype,const int msgcnt,const PIO_Offset dlen,
+                             const PIO_Offset mindex[],const int mcount[],int *mfrom, MPI_Datatype mtype[]);
     int compare_offsets(const void *a,const void *b) ;
 
-    int subset_rearrange_create(const iosystem_desc_t ios, int maplen, PIO_Offset compmap[], 
-				const int gsize[], const int ndims, io_desc_t *iodesc);
+    int subset_rearrange_create(const iosystem_desc_t ios, int maplen, PIO_Offset compmap[],
+                                const int gsize[], const int ndims, io_desc_t *iodesc);
     void print_trace (FILE *fp);
     void cn_buffer_report(iosystem_desc_t ios, bool collective);
     void compute_buffer_init(iosystem_desc_t ios);
@@ -158,12 +158,12 @@ extern "C" {
     void piomemerror(iosystem_desc_t ios, size_t req, char *fname, const int line);
     void compute_maxaggregate_bytes(const iosystem_desc_t ios, io_desc_t *iodesc);
     int check_mpi(file_desc_t *file, const int mpierr, const char *filename,
-		  const int line);
+                  const int line);
 
 #ifdef BGQ
     void identity(MPI_Comm comm, int *iotask);
-    void determineiotasks(const MPI_Comm comm, int *numiotasks,int *base, int *stride, int *rearr, 
-			  bool *iamIOtask);
+    void determineiotasks(const MPI_Comm comm, int *numiotasks,int *base, int *stride, int *rearr,
+                          bool *iamIOtask);
 
 #endif
 

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -13,42 +13,42 @@ static file_desc_t *current_file=NULL;
 /** Add a new entry to the global list of open files.
  *
  * @param file pointer to the file_desc_t struct for the new file.
-*/
+ */
 void pio_add_to_file_list(file_desc_t *file)
 {
-  file_desc_t *cfile;
+    file_desc_t *cfile;
 
-  /* This file will be at the end of the list, and have no next. */
-  file->next = NULL;
+    /* This file will be at the end of the list, and have no next. */
+    file->next = NULL;
 
-  /* Get a pointer to the global list of files. */
-  cfile = pio_file_list;
+    /* Get a pointer to the global list of files. */
+    cfile = pio_file_list;
 
-  /* Keep a global pointer to the current file. */
-  current_file = file;
+    /* Keep a global pointer to the current file. */
+    current_file = file;
 
-  /* If there is nothing in the list, then file will be the first
-   * entry. Otherwise, move to end of the list. */
-  if (!cfile)
-      pio_file_list = file;
-  else
-  {
-      while (cfile->next)
-	  cfile = cfile->next;
-      cfile->next = file;
-  }
+    /* If there is nothing in the list, then file will be the first
+     * entry. Otherwise, move to end of the list. */
+    if (!cfile)
+        pio_file_list = file;
+    else
+    {
+        while (cfile->next)
+            cfile = cfile->next;
+        cfile->next = file;
+    }
 }
 
 /** Given ncid, find the file_desc_t data for an open file. The ncid
- * used is the interally generated pio_ncid. 
+ * used is the interally generated pio_ncid.
  *
  * @param ncid the PIO assigned ncid of the open file.
  * @param cfile1 pointer to a pointer to a file_desc_t. The pointer
- * will get a copy of the pointer to the file info. 
+ * will get a copy of the pointer to the file info.
  *
- * @returns 0 for success, error code otherwise. 
+ * @returns 0 for success, error code otherwise.
  * @internal
-*/
+ */
 int pio_get_file(int ncid, file_desc_t **cfile1)
 {
     file_desc_t *cfile = NULL;
@@ -57,26 +57,26 @@ int pio_get_file(int ncid, file_desc_t **cfile1)
 
     /* Caller must provide this. */
     if (!cfile1)
-	return PIO_EINVAL;
+        return PIO_EINVAL;
 
     /* Find the file pointer. */
     if (current_file && current_file->pio_ncid == ncid)
-	cfile = current_file;
+        cfile = current_file;
     else
-	for (cfile = pio_file_list; cfile; cfile=cfile->next)
-	    if (cfile->pio_ncid == ncid)
-	    {
-		current_file = cfile;
-		break;
-	    }
+        for (cfile = pio_file_list; cfile; cfile=cfile->next)
+            if (cfile->pio_ncid == ncid)
+            {
+                current_file = cfile;
+                break;
+            }
 
     /* If not found, return error. */
     if (!cfile)
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     /* We depend on every file having a pointer to the iosystem. */
     if (!cfile->iosystem)
-	return PIO_EINVAL;
+        return PIO_EINVAL;
 
     /* Copy pointer to file info. */
     *cfile1 = cfile;
@@ -93,21 +93,21 @@ int pio_delete_file_from_list(int ncid)
     /* Look through list of open files. */
     for (cfile = pio_file_list; cfile; cfile = cfile->next)
     {
-	if (cfile->pio_ncid == ncid)
-	{
-	    if (!pfile)
-		pio_file_list = cfile->next;
-	    else
-		pfile->next = cfile->next;
+        if (cfile->pio_ncid == ncid)
+        {
+            if (!pfile)
+                pio_file_list = cfile->next;
+            else
+                pfile->next = cfile->next;
 
-	    if (current_file == cfile)
-		current_file = pfile;
+            if (current_file == cfile)
+                current_file = pfile;
 
-	    /* Free the memory used for this file. */
-	    free(cfile);
-	    return PIO_NOERR;
-	}
-	pfile = cfile;
+            /* Free the memory used for this file. */
+            free(cfile);
+            return PIO_NOERR;
+        }
+        pfile = cfile;
     }
 
     /* No file was found. */
@@ -121,59 +121,59 @@ int pio_delete_iosystem_from_list(int piosysid)
     piosystem = NULL;
 
     for (ciosystem = pio_iosystem_list; ciosystem; ciosystem = ciosystem->next)
-	LOG((2, "iosysid = %d union_comm = %d io_comm = %d my_comm = %d intercomm = %d comproot = %d"
-	     " next = %d",
-	     ciosystem->iosysid, ciosystem->union_comm, ciosystem->io_comm, ciosystem->my_comm,
-	     ciosystem->intercomm, ciosystem->comproot, ciosystem->next));
+        LOG((2, "iosysid = %d union_comm = %d io_comm = %d my_comm = %d intercomm = %d comproot = %d"
+             " next = %d",
+             ciosystem->iosysid, ciosystem->union_comm, ciosystem->io_comm, ciosystem->my_comm,
+             ciosystem->intercomm, ciosystem->comproot, ciosystem->next));
 
     LOG((1, "pio_delete_iosystem_from_list piosysid = %d", piosysid));
     for (ciosystem = pio_iosystem_list; ciosystem; ciosystem = ciosystem->next)
     {
-	LOG((3, "iosysid = %d union_comm = %d io_comm = %d my_comm = %d intercomm = %d comproot = %d",
-	     ciosystem->iosysid, ciosystem->union_comm, ciosystem->io_comm, ciosystem->my_comm,
-	     ciosystem->intercomm, ciosystem->comproot));
-	if (ciosystem->iosysid == piosysid)
-	{
-	    if (piosystem == NULL)
-	    {
-		LOG((3, "start of list"));
-		pio_iosystem_list = ciosystem->next;
-	    }
-	    else
-	    {
-		LOG((3, "setting next"));
-		piosystem->next = ciosystem->next;
-	    }
-	    free(ciosystem);
-	    return PIO_NOERR;
-	}
-	piosystem = ciosystem;
+        LOG((3, "iosysid = %d union_comm = %d io_comm = %d my_comm = %d intercomm = %d comproot = %d",
+             ciosystem->iosysid, ciosystem->union_comm, ciosystem->io_comm, ciosystem->my_comm,
+             ciosystem->intercomm, ciosystem->comproot));
+        if (ciosystem->iosysid == piosysid)
+        {
+            if (piosystem == NULL)
+            {
+                LOG((3, "start of list"));
+                pio_iosystem_list = ciosystem->next;
+            }
+            else
+            {
+                LOG((3, "setting next"));
+                piosystem->next = ciosystem->next;
+            }
+            free(ciosystem);
+            return PIO_NOERR;
+        }
+        piosystem = ciosystem;
     }
     return PIO_EBADID;
 }
 
 int pio_add_to_iosystem_list(iosystem_desc_t *ios)
 {
-  iosystem_desc_t *cios;
-  int i=1;
+    iosystem_desc_t *cios;
+    int i=1;
 
-  //assert(ios != NULL);
-  ios->next = NULL;
-  cios = pio_iosystem_list;
-  if(cios==NULL)
-    pio_iosystem_list = ios;
-  else{
-    i++;
-    while(cios->next != NULL){
-      cios = cios->next;
-      i++;
+    //assert(ios != NULL);
+    ios->next = NULL;
+    cios = pio_iosystem_list;
+    if(cios==NULL)
+        pio_iosystem_list = ios;
+    else{
+        i++;
+        while(cios->next != NULL){
+            cios = cios->next;
+            i++;
+        }
+        cios->next = ios;
     }
-    cios->next = ios;
-  }
-  ios->iosysid = i << 16;
-  //  ios->iosysid = i ;
-  //  printf(" ios = %ld %d %ld\n",ios, ios->iosysid,ios->next);
-  return ios->iosysid;
+    ios->iosysid = i << 16;
+    //  ios->iosysid = i ;
+    //  printf(" ios = %ld %d %ld\n",ios, ios->iosysid,ios->next);
+    return ios->iosysid;
 }
 
 iosystem_desc_t *pio_get_iosystem_from_id(int iosysid)
@@ -183,14 +183,14 @@ iosystem_desc_t *pio_get_iosystem_from_id(int iosysid)
     LOG((2, "pio_get_iosystem_from_id iosysid = %d", iosysid));
 
     for (ciosystem = pio_iosystem_list; ciosystem; ciosystem = ciosystem->next)
-	if (ciosystem->iosysid == iosysid)
-	{
-	    LOG((3, "FOUND! iosysid = %d union_comm = %d comp_comm = %d io_comm = %d my_comm = %d "
-		 "intercomm = %d comproot = %d next = %d",
-		 ciosystem->iosysid, ciosystem->union_comm, ciosystem->comp_comm, ciosystem->io_comm,
-		 ciosystem->my_comm, ciosystem->intercomm, ciosystem->comproot, ciosystem->next));
-	    return ciosystem;
-	}
+        if (ciosystem->iosysid == iosysid)
+        {
+            LOG((3, "FOUND! iosysid = %d union_comm = %d comp_comm = %d io_comm = %d my_comm = %d "
+                 "intercomm = %d comproot = %d next = %d",
+                 ciosystem->iosysid, ciosystem->union_comm, ciosystem->comp_comm, ciosystem->io_comm,
+                 ciosystem->my_comm, ciosystem->intercomm, ciosystem->comproot, ciosystem->next));
+            return ciosystem;
+        }
 
 
     return NULL;
@@ -205,80 +205,80 @@ pio_num_iosystem(int *niosysid)
 
     /* Count the elements in the list. */
     for (iosystem_desc_t *c = pio_iosystem_list; c; c = c->next)
-	count++;
+        count++;
 
     /* Return count to caller via pointer. */
     if (niosysid)
-	*niosysid = count;
+        *niosysid = count;
 
     return PIO_NOERR;
 }
 
 int pio_add_to_iodesc_list(io_desc_t *iodesc)
 {
-  io_desc_t *ciodesc;
-  int imax=512;
+    io_desc_t *ciodesc;
+    int imax=512;
 
-  iodesc->next = NULL;
-  if(pio_iodesc_list == NULL)
-    pio_iodesc_list = iodesc;
-  else{
-    imax++;
-    for(ciodesc = pio_iodesc_list; ciodesc->next != NULL; ciodesc=ciodesc->next, imax=ciodesc->ioid+1);
-    ciodesc->next = iodesc;
-  }
-  iodesc->ioid = imax;
-  current_iodesc = iodesc;
-  //  printf("In add to list %d\n",iodesc->ioid);
-  return iodesc->ioid;
+    iodesc->next = NULL;
+    if(pio_iodesc_list == NULL)
+        pio_iodesc_list = iodesc;
+    else{
+        imax++;
+        for(ciodesc = pio_iodesc_list; ciodesc->next != NULL; ciodesc=ciodesc->next, imax=ciodesc->ioid+1);
+        ciodesc->next = iodesc;
+    }
+    iodesc->ioid = imax;
+    current_iodesc = iodesc;
+    //  printf("In add to list %d\n",iodesc->ioid);
+    return iodesc->ioid;
 }
 
 
 io_desc_t *pio_get_iodesc_from_id(int ioid)
 {
-  io_desc_t *ciodesc;
+    io_desc_t *ciodesc;
 
-  ciodesc = NULL;
+    ciodesc = NULL;
 
-  if(current_iodesc != NULL && current_iodesc->ioid == abs(ioid))
-    ciodesc=current_iodesc;
-  for(ciodesc=pio_iodesc_list; ciodesc != NULL; ciodesc=ciodesc->next){
-    if(ciodesc->ioid == abs(ioid)){
-      current_iodesc = ciodesc;
-      break;
-    }
-  }
-  /*
-  if(ciodesc==NULL){
+    if(current_iodesc != NULL && current_iodesc->ioid == abs(ioid))
+        ciodesc=current_iodesc;
     for(ciodesc=pio_iodesc_list; ciodesc != NULL; ciodesc=ciodesc->next){
-      printf("%s %d %d %d\n",__FILE__,__LINE__,ioid,ciodesc->ioid);
+        if(ciodesc->ioid == abs(ioid)){
+            current_iodesc = ciodesc;
+            break;
+        }
     }
-  }
-  */
+    /*
+      if(ciodesc==NULL){
+      for(ciodesc=pio_iodesc_list; ciodesc != NULL; ciodesc=ciodesc->next){
+      printf("%s %d %d %d\n",__FILE__,__LINE__,ioid,ciodesc->ioid);
+      }
+      }
+    */
 
-  return ciodesc;
+    return ciodesc;
 }
 
 int pio_delete_iodesc_from_list(int ioid)
 {
 
-  io_desc_t *ciodesc, *piodesc;
+    io_desc_t *ciodesc, *piodesc;
 
-  piodesc = NULL;
-  //  if(abs(ioid)==518) printf("In delete from list %d\n", ioid);
-  for(ciodesc=pio_iodesc_list; ciodesc != NULL; ciodesc=ciodesc->next){
-    if(ciodesc->ioid == ioid){
-      if(piodesc == NULL){
-	pio_iodesc_list = ciodesc->next;
-      }else{
-	piodesc->next = ciodesc->next;
-      }
-      if(current_iodesc==ciodesc)
-	current_iodesc=pio_iodesc_list;
-      brel(ciodesc);
-      return PIO_NOERR;
+    piodesc = NULL;
+    //  if(abs(ioid)==518) printf("In delete from list %d\n", ioid);
+    for(ciodesc=pio_iodesc_list; ciodesc != NULL; ciodesc=ciodesc->next){
+        if(ciodesc->ioid == ioid){
+            if(piodesc == NULL){
+                pio_iodesc_list = ciodesc->next;
+            }else{
+                piodesc->next = ciodesc->next;
+            }
+            if(current_iodesc==ciodesc)
+                current_iodesc=pio_iodesc_list;
+            brel(ciodesc);
+            return PIO_NOERR;
+        }
+        piodesc = ciodesc;
     }
-    piodesc = ciodesc;
-  }
-  return PIO_EBADID;
+    return PIO_EBADID;
 }

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -34,23 +34,23 @@ int inq_type_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, 0, ios->intercomm)))
-    	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&name_present, 1, MPI_CHAR, 0, ios->intercomm)))
-    	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&size_present, 1, MPI_CHAR, 0, ios->intercomm)))
-    	return PIO_EIO;
+        return PIO_EIO;
 
     /* Handle null pointer issues. */
     if (name_present)
-	namep = name;
+        namep = name;
     if (size_present)
-	sizep = &size;
+        sizep = &size;
 
     /* Call the function. */
     if ((ret = PIOc_inq_type(ncid, xtype, namep, sizep)))
-	return ret;
+        return ret;
 
     LOG((1, "inq_type_handler succeeded!"));
     return PIO_NOERR;
@@ -71,22 +71,22 @@ int inq_format_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&format_present, 1, MPI_CHAR, 0, ios->intercomm)))
-    	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "inq_format_handler got parameters ncid = %d format_present = %d",
-	 ncid, format_present));
+         ncid, format_present));
 
     /* Manage NULL pointers. */
     if (format_present)
-	formatp = &format;
+        formatp = &format;
 
     /* Call the function. */
     if ((ret = PIOc_inq_format(ncid, formatp)))
-	return ret;
+        return ret;
 
     if (formatp)
-	LOG((2, "inq_format_handler format = %d", *formatp));
+        LOG((2, "inq_format_handler format = %d", *formatp));
     LOG((1, "inq_format_handler succeeded!"));
 
     return PIO_NOERR;
@@ -108,24 +108,24 @@ int create_file_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&len, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "create_file_handler got parameter len = %d\n", len));
     if (!(filename = malloc(len + 1 * sizeof(char))))
-    	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, 0,
-    			    ios->intercomm)))
-    	return PIO_EIO;
+                            ios->intercomm)))
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&iotype, 1, MPI_INT, 0, ios->intercomm)))
-    	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&mode, 1, MPI_INT, 0, ios->intercomm)))
-    	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "create_file_handler got parameters len = %d "
-    	   "filename = %s iotype = %d mode = %d\n",
-	 len, filename, iotype, mode));
+         "filename = %s iotype = %d mode = %d\n",
+         len, filename, iotype, mode));
 
     /* Call the create file function. */
     if ((ret = PIOc_createfile(ios->iosysid, &ncid, &iotype, filename, mode)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(filename);
@@ -139,7 +139,7 @@ int create_file_handler(iosystem_desc_t *ios)
  *
  * @param ios pointer to the iosystem_desc_t.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int close_file_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -153,12 +153,12 @@ int close_file_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "create_file_handler got parameter ncid = %d", ncid));
 
     /* Call the close file function. */
     if ((ret = PIOc_closefile(ncid)))
-	return ret;
+        return ret;
 
     LOG((1, "close_file_handler succeeded!"));
     return PIO_NOERR;
@@ -169,7 +169,7 @@ int close_file_handler(iosystem_desc_t *ios)
  *
  * @param ios pointer to the iosystem_desc_t.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int inq_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -186,33 +186,33 @@ int inq_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&ndims_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&nvars_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&ngatts_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&unlimdimid_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "inq_handler ndims_present = %d nvars_present = %d ngatts_present = %d unlimdimid_present = %d\n",
-	 ndims_present, nvars_present, ngatts_present, unlimdimid_present));
+         ndims_present, nvars_present, ngatts_present, unlimdimid_present));
 
     /* NULLs passed in to any of the pointers in the original call
      * need to be matched with NULLs here. Assign pointers where
      * non-NULL pointers were passed in. */
     if (ndims_present)
-	ndimsp = &ndims;
+        ndimsp = &ndims;
     if (nvars_present)
-	nvarsp = &nvars;
+        nvarsp = &nvars;
     if (ngatts_present)
-	ngattsp = &ngatts;
+        ngattsp = &ngatts;
     if (unlimdimid_present)
-	unlimdimidp = &unlimdimid;
+        unlimdimidp = &unlimdimid;
 
     /* Call the inq function to get the values. */
     if ((ret = PIOc_inq(ncid, ndimsp, nvarsp, ngattsp, unlimdimidp)))
-	return ret;
+        return ret;
 
     return PIO_NOERR;
 }
@@ -223,7 +223,7 @@ int inq_handler(iosystem_desc_t *ios)
  * @param ios pointer to the iosystem_desc_t.
  * @param msg the message sent my the comp root task.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int inq_dim_handler(iosystem_desc_t *ios, int msg)
 {
     int ncid;
@@ -242,25 +242,25 @@ int inq_dim_handler(iosystem_desc_t *ios, int msg)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&dimid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&name_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&len_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "inq_handler name_present = %d len_present = %d", name_present,
-	 len_present));
+         len_present));
 
     /* Set the non-null pointers. */
     if (name_present)
-	dimnamep = dimname;
+        dimnamep = dimname;
     if (len_present)
-	dimlenp = &dimlen;
+        dimlenp = &dimlen;
 
     /* Call the inq function to get the values. */
     if ((ret = PIOc_inq_dim(ncid, dimid, dimnamep, dimlenp)))
-	return ret;
+        return ret;
 
     return PIO_NOERR;
 }
@@ -270,7 +270,7 @@ int inq_dim_handler(iosystem_desc_t *ios, int msg)
  *
  * @param ios pointer to the iosystem_desc_t.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int inq_dimid_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -286,25 +286,25 @@ int inq_dimid_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&id_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "inq_dimid_handler ncid = %d namelen = %d name = %s id_present = %d",
-	 ncid, namelen, name, id_present));
+         ncid, namelen, name, id_present));
 
     /* Set non-null pointer. */
     if (id_present)
-	dimidp = &dimid;
+        dimidp = &dimid;
 
     /* Call the inq_dimid function. */
     if ((ret = PIOc_inq_dimid(ncid, name, dimidp)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -318,7 +318,7 @@ int inq_dimid_handler(iosystem_desc_t *ios)
  * @param ios pointer to the iosystem_desc_t.
  * @param msg the message sent my the comp root task.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int inq_att_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -337,30 +337,30 @@ int inq_att_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT,  ios->compmaster, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, ios->compmaster,
-			    ios->intercomm)))
-	return PIO_ENOMEM;
+                            ios->intercomm)))
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast(&xtype_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&len_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
 
     /* Match NULLs in collective function call. */
     if (xtype_present)
-	xtypep = &xtype;
+        xtypep = &xtype;
     if (len_present)
-	lenp = &len;
+        lenp = &len;
 
     /* Call the function to learn about the attribute. */
     if ((ret = PIOc_inq_att(ncid, varid, name, xtypep, lenp)))
-	return ret;
+        return ret;
 
     /* Free memory. */
     free(name);
@@ -374,7 +374,7 @@ int inq_att_handler(iosystem_desc_t *ios)
  * @param ios pointer to the iosystem_desc_t.
  * @param msg the message sent my the comp root task.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int inq_attname_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -390,23 +390,23 @@ int inq_attname_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&attnum, 1, MPI_INT,  ios->compmaster, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&name_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "inq_attname_handler got ncid = %d varid = %d attnum = %d name_present = %d",
-	 ncid, varid, attnum, name_present));
+         ncid, varid, attnum, name_present));
 
     /* Match NULLs in collective function call. */
     if (name_present)
-	namep = name;
+        namep = name;
 
     /* Call the function to learn about the attribute. */
     if ((ret = PIOc_inq_attname(ncid, varid, attnum, namep)))
-	return ret;
+        return ret;
 
     return PIO_NOERR;
 }
@@ -417,7 +417,7 @@ int inq_attname_handler(iosystem_desc_t *ios)
  * @param ios pointer to the iosystem_desc_t.
  * @param msg the message sent my the comp root task.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int inq_attid_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -435,27 +435,27 @@ int inq_attid_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT,  ios->compmaster, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast(name, namelen + 1, MPI_CHAR,  ios->compmaster, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&id_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "inq_attid_handler got ncid = %d varid = %d attnum = %d id_present = %d",
-	 ncid, varid, attnum, id_present));
+         ncid, varid, attnum, id_present));
 
     /* Match NULLs in collective function call. */
     if (id_present)
-	idp = &id;
+        idp = &id;
 
     /* Call the function to learn about the attribute. */
     if ((ret = PIOc_inq_attid(ncid, varid, name, idp)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -468,7 +468,7 @@ int inq_attid_handler(iosystem_desc_t *ios)
  * @param ios pointer to the iosystem_desc_t.
  * @param msg the message sent my the comp root task.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int att_put_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -487,31 +487,31 @@ int att_put_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     mpierr = MPI_Bcast(&namelen, 1, MPI_INT,  ios->compmaster, ios->intercomm);
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, ios->compmaster,
-		       ios->intercomm);
+                       ios->intercomm);
     if ((mpierr = MPI_Bcast(&atttype, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&attlen, 1, MPI_OFFSET, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(op = malloc(attlen * typelen)))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)op, attlen * typelen, MPI_BYTE, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "att_put_handler ncid = %d varid = %d namelen = %d name = %s iotype = %d"
-	 "atttype = %d attlen = %d typelen = %d",
-	 ncid, varid, namelen, name, iotype, atttype, attlen, typelen));
+         "atttype = %d attlen = %d typelen = %d",
+         ncid, varid, namelen, name, iotype, atttype, attlen, typelen));
 
     /* Call the function to read the attribute. */
     if ((ierr = PIOc_put_att(ncid, varid, name, atttype, attlen, op)))
-	return ierr;
+        return ierr;
     LOG((2, "put_handler called PIOc_put_att, ierr = %d", ierr));
 
     /* Free resources. */
@@ -527,7 +527,7 @@ int att_put_handler(iosystem_desc_t *ios)
  * @param ios pointer to the iosystem_desc_t.
  * @param msg the message sent my the comp root task.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int att_get_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -546,33 +546,33 @@ int att_get_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     mpierr = MPI_Bcast(&namelen, 1, MPI_INT,  ios->compmaster, ios->intercomm);
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, ios->compmaster,
-		       ios->intercomm);
+                       ios->intercomm);
     if ((mpierr = MPI_Bcast(&iotype, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&atttype, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&attlen, 1, MPI_OFFSET, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "att_get_handler ncid = %d varid = %d namelen = %d name = %s iotype = %d"
-	 "atttype = %d attlen = %d typelen = %d",
-	 ncid, varid, namelen, name, iotype, atttype, attlen, typelen));
+         "atttype = %d attlen = %d typelen = %d",
+         ncid, varid, namelen, name, iotype, atttype, attlen, typelen));
 
     /* Allocate space for the attribute data. */
     if (!(ip = malloc(attlen * typelen)))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
 
     /* Call the function to read the attribute. */
     if ((ierr = PIOc_get_att(ncid, varid, name, ip)))
-	return ierr;
+        return ierr;
 
     /* Free resources. */
     free(name);
@@ -585,7 +585,7 @@ int att_get_handler(iosystem_desc_t *ios)
  *
  * @param ios pointer to the iosystem_desc_t.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int put_vars_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -607,125 +607,125 @@ int put_vars_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
 
     /* Now we know how big to make these arrays. */
     PIO_Offset start[ndims], count[ndims], stride[ndims];
 
     if ((mpierr = MPI_Bcast(&start_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!mpierr && start_present)
     {
-	if ((mpierr = MPI_Bcast(start, ndims, MPI_OFFSET, 0, ios->intercomm)))
-	    return PIO_EIO;
-	LOG((1, "put_vars_handler getting start[0] = %d ndims = %d", start[0], ndims));
+        if ((mpierr = MPI_Bcast(start, ndims, MPI_OFFSET, 0, ios->intercomm)))
+            return PIO_EIO;
+        LOG((1, "put_vars_handler getting start[0] = %d ndims = %d", start[0], ndims));
     }
     if ((mpierr = MPI_Bcast(&count_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!mpierr && count_present)
-	if ((mpierr = MPI_Bcast(count, ndims, MPI_OFFSET, 0, ios->intercomm)))
-	    return PIO_EIO;
+        if ((mpierr = MPI_Bcast(count, ndims, MPI_OFFSET, 0, ios->intercomm)))
+            return PIO_EIO;
     if ((mpierr = MPI_Bcast(&stride_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!mpierr && stride_present)
-	if ((mpierr = MPI_Bcast(stride, ndims, MPI_OFFSET, 0, ios->intercomm)))
-	    return PIO_EIO;
+        if ((mpierr = MPI_Bcast(stride, ndims, MPI_OFFSET, 0, ios->intercomm)))
+            return PIO_EIO;
     if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "put_vars_handler ncid = %d varid = %d ndims = %d start_present = %d "
-	 "count_present = %d stride_present = %d xtype = %d num_elem = %d typelen = %d",
-	 ncid, varid, ndims, start_present, count_present, stride_present, xtype,
-	 num_elem, typelen));
+         "count_present = %d stride_present = %d xtype = %d num_elem = %d typelen = %d",
+         ncid, varid, ndims, start_present, count_present, stride_present, xtype,
+         num_elem, typelen));
 
     for (int d = 0; d < ndims; d++)
     {
-	if (start_present)
-	    LOG((2, "start[%d] = %d\n", d, start[d]));
-	if (count_present)
-	    LOG((2, "count[%d] = %d\n", d, count[d]));
-	if (stride_present)
-	    LOG((2, "stride[%d] = %d\n", d, stride[d]));
+        if (start_present)
+            LOG((2, "start[%d] = %d\n", d, start[d]));
+        if (count_present)
+            LOG((2, "count[%d] = %d\n", d, count[d]));
+        if (stride_present)
+            LOG((2, "stride[%d] = %d\n", d, stride[d]));
     }
 
     /* Allocate room for our data. */
     if (!(buf = malloc(num_elem * typelen)))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
 
     /* Get the data. */
     if ((mpierr = MPI_Bcast(buf, num_elem * typelen, MPI_BYTE, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
 
     /* for (int e = 0; e < num_elem; e++) */
-    /* 	LOG((2, "element %d = %d", e, ((int *)buf)[e])); */
+    /*  LOG((2, "element %d = %d", e, ((int *)buf)[e])); */
 
     /* Set the non-NULL pointers. */
     if (start_present)
-	startp = start;
+        startp = start;
     if (count_present)
-	countp = count;
+        countp = count;
     if (stride_present)
-	stridep = stride;
+        stridep = stride;
 
     /* Call the function to write the data. */
     switch(xtype)
     {
     case NC_BYTE:
-	ierr = PIOc_put_vars_schar(ncid, varid, startp, countp, stridep, buf);
-	break;
+        ierr = PIOc_put_vars_schar(ncid, varid, startp, countp, stridep, buf);
+        break;
     case NC_CHAR:
-	ierr = PIOc_put_vars_schar(ncid, varid, startp, countp, stridep, buf);
-	break;
+        ierr = PIOc_put_vars_schar(ncid, varid, startp, countp, stridep, buf);
+        break;
     case NC_SHORT:
-	ierr = PIOc_put_vars_short(ncid, varid, startp, countp, stridep, buf);
-	break;
+        ierr = PIOc_put_vars_short(ncid, varid, startp, countp, stridep, buf);
+        break;
     case NC_INT:
-	ierr = PIOc_put_vars_int(ncid, varid, startp, countp,
-				 stridep, buf);
-	break;
+        ierr = PIOc_put_vars_int(ncid, varid, startp, countp,
+                                 stridep, buf);
+        break;
     case NC_FLOAT:
-	ierr = PIOc_put_vars_float(ncid, varid, startp, countp,
-				   stridep, buf);
-	break;
+        ierr = PIOc_put_vars_float(ncid, varid, startp, countp,
+                                   stridep, buf);
+        break;
     case NC_DOUBLE:
-	ierr = PIOc_put_vars_double(ncid, varid, startp, countp,
-				    stridep, buf);
-	break;
+        ierr = PIOc_put_vars_double(ncid, varid, startp, countp,
+                                    stridep, buf);
+        break;
 #ifdef _NETCDF4
     case NC_UBYTE:
-	ierr = PIOc_put_vars_uchar(ncid, varid, startp, countp,
-				   stridep, buf);
-	break;
+        ierr = PIOc_put_vars_uchar(ncid, varid, startp, countp,
+                                   stridep, buf);
+        break;
     case NC_USHORT:
-	ierr = PIOc_put_vars_ushort(ncid, varid, startp, countp,
-				    stridep, buf);
-	break;
+        ierr = PIOc_put_vars_ushort(ncid, varid, startp, countp,
+                                    stridep, buf);
+        break;
     case NC_UINT:
-	ierr = PIOc_put_vars_uint(ncid, varid, startp, countp,
-				  stridep, buf);
-	break;
+        ierr = PIOc_put_vars_uint(ncid, varid, startp, countp,
+                                  stridep, buf);
+        break;
     case NC_INT64:
-	ierr = PIOc_put_vars_longlong(ncid, varid, startp, countp,
-				      stridep, buf);
-	break;
+        ierr = PIOc_put_vars_longlong(ncid, varid, startp, countp,
+                                      stridep, buf);
+        break;
     case NC_UINT64:
-	ierr = PIOc_put_vars_ulonglong(ncid, varid, startp, countp,
-				       stridep, buf);
-	break;
-	/* case NC_STRING: */
-	/* 	ierr = PIOc_put_vars_string(ncid, varid, startp, countp, */
-	/* 				  stridep, (void *)buf); */
-	/* 	break; */
-	/*    default:*/
-	/* ierr = PIOc_put_vars(ncid, varid, startp, countp, */
-	/* 		     stridep, buf); */
+        ierr = PIOc_put_vars_ulonglong(ncid, varid, startp, countp,
+                                       stridep, buf);
+        break;
+        /* case NC_STRING: */
+        /*      ierr = PIOc_put_vars_string(ncid, varid, startp, countp, */
+        /*                                stridep, (void *)buf); */
+        /*      break; */
+        /*    default:*/
+        /* ierr = PIOc_put_vars(ncid, varid, startp, countp, */
+        /*                   stridep, buf); */
 #endif /* _NETCDF4 */
     }
 
@@ -738,7 +738,7 @@ int put_vars_handler(iosystem_desc_t *ios)
  *
  * @param ios pointer to the iosystem_desc_t.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int get_vars_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -760,121 +760,121 @@ int get_vars_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
 
     /* Now we know how big to make these arrays. */
     PIO_Offset start[ndims], count[ndims], stride[ndims];
 
     if ((mpierr = MPI_Bcast(&start_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!mpierr && start_present)
     {
-	if ((mpierr = MPI_Bcast(start, ndims, MPI_OFFSET, 0, ios->intercomm)))
-	    return PIO_EIO;
-	LOG((1, "put_vars_handler getting start[0] = %d ndims = %d", start[0], ndims));
+        if ((mpierr = MPI_Bcast(start, ndims, MPI_OFFSET, 0, ios->intercomm)))
+            return PIO_EIO;
+        LOG((1, "put_vars_handler getting start[0] = %d ndims = %d", start[0], ndims));
     }
     if ((mpierr = MPI_Bcast(&count_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!mpierr && count_present)
-	if ((mpierr = MPI_Bcast(count, ndims, MPI_OFFSET, 0, ios->intercomm)))
-	    return PIO_EIO;
+        if ((mpierr = MPI_Bcast(count, ndims, MPI_OFFSET, 0, ios->intercomm)))
+            return PIO_EIO;
     if ((mpierr = MPI_Bcast(&stride_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!mpierr && stride_present)
-	if ((mpierr = MPI_Bcast(stride, ndims, MPI_OFFSET, 0, ios->intercomm)))
-	    return PIO_EIO;
+        if ((mpierr = MPI_Bcast(stride, ndims, MPI_OFFSET, 0, ios->intercomm)))
+            return PIO_EIO;
     if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "get_vars_handler ncid = %d varid = %d ndims = %d start_present = %d "
-	 "count_present = %d stride_present = %d xtype = %d num_elem = %d typelen = %d",
-	 ncid, varid, ndims, start_present, count_present, stride_present, xtype,
-	 num_elem, typelen));
+         "count_present = %d stride_present = %d xtype = %d num_elem = %d typelen = %d",
+         ncid, varid, ndims, start_present, count_present, stride_present, xtype,
+         num_elem, typelen));
 
     for (int d = 0; d < ndims; d++)
     {
-	if (start_present)
-	    LOG((2, "start[%d] = %d\n", d, start[d]));
-	if (count_present)
-	    LOG((2, "count[%d] = %d\n", d, count[d]));
-	if (stride_present)
-	    LOG((2, "stride[%d] = %d\n", d, stride[d]));
+        if (start_present)
+            LOG((2, "start[%d] = %d\n", d, start[d]));
+        if (count_present)
+            LOG((2, "count[%d] = %d\n", d, count[d]));
+        if (stride_present)
+            LOG((2, "stride[%d] = %d\n", d, stride[d]));
     }
 
     /* Allocate room for our data. */
     if (!(buf = malloc(num_elem * typelen)))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
 
     /* Set the non-NULL pointers. */
     if (start_present)
-	startp = start;
+        startp = start;
     if (count_present)
-	countp = count;
+        countp = count;
     if (stride_present)
-	stridep = stride;
+        stridep = stride;
 
     /* Call the function to read the data. */
     switch(xtype)
     {
     case NC_BYTE:
-	ierr = PIOc_get_vars_schar(ncid, varid, startp, countp,
-				   stridep, buf);
-	break;
+        ierr = PIOc_get_vars_schar(ncid, varid, startp, countp,
+                                   stridep, buf);
+        break;
     case NC_CHAR:
-	ierr = PIOc_get_vars_schar(ncid, varid, startp, countp,
-				   stridep, buf);
-	break;
+        ierr = PIOc_get_vars_schar(ncid, varid, startp, countp,
+                                   stridep, buf);
+        break;
     case NC_SHORT:
-	ierr = PIOc_get_vars_short(ncid, varid, startp, countp,
-				   stridep, buf);
-	break;
+        ierr = PIOc_get_vars_short(ncid, varid, startp, countp,
+                                   stridep, buf);
+        break;
     case NC_INT:
-	ierr = PIOc_get_vars_int(ncid, varid, startp, countp,
-				 stridep, buf);
-	break;
+        ierr = PIOc_get_vars_int(ncid, varid, startp, countp,
+                                 stridep, buf);
+        break;
     case NC_FLOAT:
-	ierr = PIOc_get_vars_float(ncid, varid, startp, countp,
-				   stridep, buf);
-	break;
+        ierr = PIOc_get_vars_float(ncid, varid, startp, countp,
+                                   stridep, buf);
+        break;
     case NC_DOUBLE:
-	ierr = PIOc_get_vars_double(ncid, varid, startp, countp,
-				    stridep, buf);
-	break;
+        ierr = PIOc_get_vars_double(ncid, varid, startp, countp,
+                                    stridep, buf);
+        break;
 #ifdef _NETCDF4
     case NC_UBYTE:
-	ierr = PIOc_get_vars_uchar(ncid, varid, startp, countp,
-				   stridep, buf);
-	break;
+        ierr = PIOc_get_vars_uchar(ncid, varid, startp, countp,
+                                   stridep, buf);
+        break;
     case NC_USHORT:
-	ierr = PIOc_get_vars_ushort(ncid, varid, startp, countp,
-				    stridep, buf);
-	break;
+        ierr = PIOc_get_vars_ushort(ncid, varid, startp, countp,
+                                    stridep, buf);
+        break;
     case NC_UINT:
-	ierr = PIOc_get_vars_uint(ncid, varid, startp, countp,
-				  stridep, buf);
-	break;
+        ierr = PIOc_get_vars_uint(ncid, varid, startp, countp,
+                                  stridep, buf);
+        break;
     case NC_INT64:
-	ierr = PIOc_get_vars_longlong(ncid, varid, startp, countp,
-				      stridep, buf);
-	break;
+        ierr = PIOc_get_vars_longlong(ncid, varid, startp, countp,
+                                      stridep, buf);
+        break;
     case NC_UINT64:
-	ierr = PIOc_get_vars_ulonglong(ncid, varid, startp, countp,
-				       stridep, buf);
-	break;
-	/* case NC_STRING: */
-	/* 	ierr = PIOc_get_vars_string(ncid, varid, startp, countp, */
-	/* 				  stridep, (void *)buf); */
-	/* 	break; */
-	/*    default:*/
-	/* ierr = PIOc_get_vars(ncid, varid, startp, countp, */
-	/* 		     stridep, buf); */
+        ierr = PIOc_get_vars_ulonglong(ncid, varid, startp, countp,
+                                       stridep, buf);
+        break;
+        /* case NC_STRING: */
+        /*      ierr = PIOc_get_vars_string(ncid, varid, startp, countp, */
+        /*                                stridep, (void *)buf); */
+        /*      break; */
+        /*    default:*/
+        /* ierr = PIOc_get_vars(ncid, varid, startp, countp, */
+        /*                   stridep, buf); */
 #endif /* _NETCDF4 */
     }
 
@@ -889,7 +889,7 @@ int get_vars_handler(iosystem_desc_t *ios)
  * @param ios pointer to the iosystem_desc_t.
  * @param msg the message sent my the comp root task.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int inq_var_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -907,41 +907,41 @@ int inq_var_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&name_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&xtype_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&ndims_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&dimids_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&natts_present, 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2,"inq_var_handler ncid = %d varid = %d name_present = %d xtype_present = %d ndims_present = %d "
-	 "dimids_present = %d natts_present = %d\n",
-	 ncid, varid, name_present, xtype_present, ndims_present, dimids_present, natts_present));
+         "dimids_present = %d natts_present = %d\n",
+         ncid, varid, name_present, xtype_present, ndims_present, dimids_present, natts_present));
 
     /* Set the non-NULL pointers. */
     if (name_present)
-	namep = name;
+        namep = name;
     if (xtype_present)
-	xtypep = &xtype;
+        xtypep = &xtype;
     if (ndims_present)
-	ndimsp = &ndims;
+        ndimsp = &ndims;
     if (dimids_present)
-	dimidsp = dimids;
+        dimidsp = dimids;
     if (natts_present)
-	nattsp = &natts;
+        nattsp = &natts;
 
     /* Call the inq function to get the values. */
     if ((ret = PIOc_inq_var(ncid, varid, namep, xtypep, ndimsp, dimidsp, nattsp)))
-	return ret;
+        return ret;
 
     if (ndims_present)
-	LOG((2, "inq_var_handler ndims = %d", ndims));
+        LOG((2, "inq_var_handler ndims = %d", ndims));
 
     return PIO_NOERR;
 }
@@ -951,7 +951,7 @@ int inq_var_handler(iosystem_desc_t *ios)
  *
  * @param ios pointer to the iosystem_desc_t.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int inq_varid_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -964,17 +964,17 @@ int inq_varid_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
 
     /* Call the inq_dimid function. */
     if ((ret = PIOc_inq_varid(ncid, name, &varid)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -986,7 +986,7 @@ int inq_varid_handler(iosystem_desc_t *ios)
  *
  * @param ios pointer to the iosystem_desc_t.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int sync_file_handler(iosystem_desc_t *ios)
 {
     int ncid;
@@ -998,12 +998,12 @@ int sync_file_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "sync_file_handler got parameter ncid = %d", ncid));
 
     /* Call the sync file function. */
     if ((ret = PIOc_sync(ncid)))
-	return ret;
+        return ret;
 
     LOG((2, "sync_file_handler succeeded!"));
     return PIO_NOERR;
@@ -1013,7 +1013,7 @@ int sync_file_handler(iosystem_desc_t *ios)
  *
  * @param ios pointer to the iosystem_desc_t.
  * @return PIO_NOERR for success, error code otherwise.
-*/
+ */
 int change_def_file_handler(iosystem_desc_t *ios, int msg)
 {
     int ncid;
@@ -1025,7 +1025,7 @@ int change_def_file_handler(iosystem_desc_t *ios, int msg)
     /* Get the parameters for this function that the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
 
     /* Call the function. */
     ret = (msg == PIO_MSG_ENDDEF) ? PIOc_enddef(ncid) : PIOc_redef(ncid);
@@ -1057,28 +1057,28 @@ int def_var_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc(namelen + 1 * sizeof(char))))
-    	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, 0,
-    			    ios->intercomm)))
-    	return PIO_EIO;
+                            ios->intercomm)))
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(dimids = malloc(ndims * sizeof(int))))
-    	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast(dimids, ndims, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "def_var_handler got parameters namelen = %d "
-    	   "name = %s len = %d ncid = %d\n", namelen, name, len, ncid));
+         "name = %s len = %d ncid = %d\n", namelen, name, len, ncid));
 
     /* Call the create file function. */
     if ((ret = PIOc_def_var(ncid, name, xtype, ndims, dimids, &varid)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -1108,22 +1108,22 @@ int def_dim_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc(namelen + 1 * sizeof(char))))
-    	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, 0,
-    			    ios->intercomm)))
-    	return PIO_EIO;
+                            ios->intercomm)))
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&len, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "def_dim_handler got parameters namelen = %d "
-	 "name = %s len = %d ncid = %d", namelen, name, len, ncid));
+         "name = %s len = %d ncid = %d", namelen, name, len, ncid));
 
     /* Call the create file function. */
     if ((ret = PIOc_def_dim(ncid, name, len, &dimid)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -1151,21 +1151,21 @@ int rename_dim_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&dimid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "rename_dim_handler got parameters namelen = %d "
-	 "name = %s ncid = %d dimid = %d", namelen, name, ncid, dimid));
+         "name = %s ncid = %d dimid = %d", namelen, name, ncid, dimid));
 
     /* Call the create file function. */
     if ((ret = PIOc_rename_dim(ncid, dimid, name)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -1193,21 +1193,21 @@ int rename_var_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "rename_var_handler got parameters namelen = %d "
-	 "name = %s ncid = %d varid = %d", namelen, name, ncid, varid));
+         "name = %s ncid = %d varid = %d", namelen, name, ncid, varid));
 
     /* Call the create file function. */
     if ((ret = PIOc_rename_var(ncid, varid, name)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -1232,27 +1232,27 @@ int rename_att_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast(name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&newnamelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(newname = malloc((newnamelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast(newname, newnamelen + 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "rename_att_handler got parameters namelen = %d name = %s ncid = %d varid = %d "
-	 "newnamelen = %d newname = %s", namelen, name, ncid, varid, newnamelen, newname));
+         "newnamelen = %d newname = %s", namelen, name, ncid, varid, newnamelen, newname));
 
     /* Call the create file function. */
     if ((ret = PIOc_rename_att(ncid, varid, name, newname)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -1278,21 +1278,21 @@ int delete_att_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(name = malloc((namelen + 1) * sizeof(char))))
-	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast(name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "delete_att_handler namelen = %d name = %s ncid = %d varid = %d ",
-	 namelen, name, ncid, varid));
+         namelen, name, ncid, varid));
 
     /* Call the create file function. */
     if ((ret = PIOc_del_att(ncid, varid, name)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(name);
@@ -1323,23 +1323,23 @@ int open_file_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&len, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "open_file_handler got parameter len = %d", len));
     if (!(filename = malloc(len + 1 * sizeof(char))))
-    	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, 0,
-    			    ios->intercomm)))
-    	return PIO_EIO;
+                            ios->intercomm)))
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&iotype, 1, MPI_INT, 0, ios->intercomm)))
-    	return PIO_EIO;
+        return PIO_EIO;
     if ((mpierr = MPI_Bcast(&mode, 1, MPI_INT, 0, ios->intercomm)))
-    	return PIO_EIO;
+        return PIO_EIO;
     LOG((2, "open_file_handler got parameters len = %d filename = %s iotype = %d mode = %d\n",
-	 len, filename, iotype, mode));
+         len, filename, iotype, mode));
 
     /* Call the open file function. */
     if ((ret = PIOc_openfile(ios->iosysid, &ncid, &iotype, filename, mode)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(filename);
@@ -1368,18 +1368,18 @@ int delete_file_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&len, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     if (!(filename = malloc(len + 1 * sizeof(char))))
-    	return PIO_ENOMEM;
+        return PIO_ENOMEM;
     if ((mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, 0,
-    			    ios->intercomm)))
-    	return PIO_EIO;
+                            ios->intercomm)))
+        return PIO_EIO;
     LOG((1, "delete_file_handler got parameters len = %d filename = %s\n",
-	 len, filename));
+         len, filename));
 
     /* Call the delete file function. */
     if ((ret = PIOc_deletefile(ios->iosysid, filename)))
-	return ret;
+        return ret;
 
     /* Free resources. */
     free(filename);
@@ -1428,9 +1428,9 @@ int PIOc_noop_finalize(const int iosysid)
 
     /* Find the IO system information. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return PIO_EBADID;
+        return PIO_EBADID;
     LOG((3, "found iosystem info comproot = %d union_comm = %d", ios->comproot,
-	 ios->union_comm));
+         ios->union_comm));
 
     /* If asynch IO is in use, send the PIO_MSG_EXIT message from the
      * comp master to the IO processes. This may be called by
@@ -1438,32 +1438,32 @@ int PIOc_noop_finalize(const int iosysid)
      * there is a valid union_comm. */
     if (ios->async_interface)
     {
-	int msg = PIO_MSG_EXIT;
-	LOG((3, "async"));
+        int msg = PIO_MSG_EXIT;
+        LOG((3, "async"));
 
-	if (!ios->ioproc)
-	{
-	    LOG((2, "sending msg = %d ioroot = %d union_comm = %d", msg,
-		 ios->ioroot, ios->union_comm));
+        if (!ios->ioproc)
+        {
+            LOG((2, "sending msg = %d ioroot = %d union_comm = %d", msg,
+                 ios->ioroot, ios->union_comm));
 
-	    /* Send the message to the message handler. */
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+            /* Send the message to the message handler. */
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    LOG((2, "sending iosysid = %d", iosysid));
+            LOG((2, "sending iosysid = %d", iosysid));
 
-	    /* Send the parameters of the function call. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast((int *)&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
+            /* Send the parameters of the function call. */
+            if (!mpierr)
+                mpierr = MPI_Bcast((int *)&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        }
 
-	/* Handle MPI errors. */
-	LOG((3, "handling async errors mpierr = %d my_comm = %d", mpierr, ios->my_comm));
-	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    return check_mpi(NULL, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(NULL, mpierr, __FILE__, __LINE__);
-	LOG((3, "async errors bcast"));
+        /* Handle MPI errors. */
+        LOG((3, "handling async errors mpierr = %d my_comm = %d", mpierr, ios->my_comm));
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(NULL, mpierr2, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+        LOG((3, "async errors bcast"));
     }
 
     return ierr;
@@ -1483,14 +1483,14 @@ int finalize_handler(iosystem_desc_t *ios, int index)
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, 0, ios->intercomm)))
-	return PIO_EIO;
+        return PIO_EIO;
     LOG((1, "finalize_handler got parameter iosysid = %d", iosysid));
 
     /* Call the close file function. */
     LOG((2, "finalize_handler calling PIOc_finalize for iosysid = %d",
-	 iosysid));
+         iosysid));
     if ((ret = PIOc_finalize(iosysid)))
-	return ret;
+        return ret;
 
     LOG((1, "finalize_handler succeeded!"));
     return PIO_NOERR;
@@ -1502,7 +1502,7 @@ int pio_callback_handler(iosystem_desc_t *ios, int msg)
 }
 
 /** This function is called by the IO tasks.  This function will not
- return, unless there is an error. */
+    return, unless there is an error. */
 int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys, MPI_Comm io_comm)
 {
     iosystem_desc_t *my_iosys;
@@ -1522,187 +1522,187 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys, 
      * (non-blocking) for a message from each of the comproots. */
     if (!io_rank)
     {
-	for (int cmp = 0; cmp < component_count; cmp++)
-	{
-	    my_iosys = iosys[cmp];
-	    LOG((1, "about to call MPI_Irecv union_comm = %d", my_iosys->union_comm));
-	    mpierr = MPI_Irecv(&msg, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG,
-			       my_iosys->union_comm, &req[cmp]);
-	    CheckMPIReturn(mpierr, __FILE__, __LINE__);
-	    LOG((1, "MPI_Irecv req[%d] = %d", cmp, req[cmp]));
-	}
+        for (int cmp = 0; cmp < component_count; cmp++)
+        {
+            my_iosys = iosys[cmp];
+            LOG((1, "about to call MPI_Irecv union_comm = %d", my_iosys->union_comm));
+            mpierr = MPI_Irecv(&msg, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG,
+                               my_iosys->union_comm, &req[cmp]);
+            CheckMPIReturn(mpierr, __FILE__, __LINE__);
+            LOG((1, "MPI_Irecv req[%d] = %d", cmp, req[cmp]));
+        }
     }
 
     /* If the message is not -1, keep processing messages. */
     while (msg != -1)
     {
-	LOG((3, "pio_msg_handler2 at top of loop"));
+        LOG((3, "pio_msg_handler2 at top of loop"));
 
-	/* Wait until any one of the requests are complete. Once it
-	 * returns, the Waitany function automatically sets the
-	 * appropriate member of the req array to MPI_REQUEST_NULL. */
-	if (!io_rank)
-	{
-	    LOG((1, "about to call MPI_Waitany req[0] = %d MPI_REQUEST_NULL = %d\n",
-		 req[0], MPI_REQUEST_NULL));
-	    for (int c = 0; c < component_count; c++)
-		LOG((2, "req[%d] = %d", c, req[c]));
-	    mpierr = MPI_Waitany(component_count, req, &index, &status);
-	    CheckMPIReturn(mpierr, __FILE__, __LINE__);
-	    LOG((3, "Waitany returned index = %d req[%d] = %d", index, index, req[index]));
-	}
+        /* Wait until any one of the requests are complete. Once it
+         * returns, the Waitany function automatically sets the
+         * appropriate member of the req array to MPI_REQUEST_NULL. */
+        if (!io_rank)
+        {
+            LOG((1, "about to call MPI_Waitany req[0] = %d MPI_REQUEST_NULL = %d\n",
+                 req[0], MPI_REQUEST_NULL));
+            for (int c = 0; c < component_count; c++)
+                LOG((2, "req[%d] = %d", c, req[c]));
+            mpierr = MPI_Waitany(component_count, req, &index, &status);
+            CheckMPIReturn(mpierr, __FILE__, __LINE__);
+            LOG((3, "Waitany returned index = %d req[%d] = %d", index, index, req[index]));
+        }
 
-	/* Broadcast the index of the computational component that
-	 * originated the request to the rest of the IO tasks. */
-	LOG((3, "About to do Bcast of index = %d io_comm = %d", index, io_comm));
-	mpierr = MPI_Bcast(&index, 1, MPI_INT, 0, io_comm);
-	CheckMPIReturn(mpierr, __FILE__, __LINE__);
-	LOG((3, "index MPI_Bcast complete index = %d", index));
+        /* Broadcast the index of the computational component that
+         * originated the request to the rest of the IO tasks. */
+        LOG((3, "About to do Bcast of index = %d io_comm = %d", index, io_comm));
+        mpierr = MPI_Bcast(&index, 1, MPI_INT, 0, io_comm);
+        CheckMPIReturn(mpierr, __FILE__, __LINE__);
+        LOG((3, "index MPI_Bcast complete index = %d", index));
 
-	/* Set the correct iosys depending on the index. */
-	my_iosys = iosys[index];
+        /* Set the correct iosys depending on the index. */
+        my_iosys = iosys[index];
 
-	/* Broadcast the msg value to the rest of the IO tasks. */
-	LOG((3, "about to call msg MPI_Bcast my_iosys->io_comm = %d", my_iosys->io_comm));
-	mpierr = MPI_Bcast(&msg, 1, MPI_INT, 0, my_iosys->io_comm);
-	CheckMPIReturn(mpierr, __FILE__, __LINE__);
-	LOG((1, "pio_msg_handler2 msg MPI_Bcast complete msg = %d", msg));
+        /* Broadcast the msg value to the rest of the IO tasks. */
+        LOG((3, "about to call msg MPI_Bcast my_iosys->io_comm = %d", my_iosys->io_comm));
+        mpierr = MPI_Bcast(&msg, 1, MPI_INT, 0, my_iosys->io_comm);
+        CheckMPIReturn(mpierr, __FILE__, __LINE__);
+        LOG((1, "pio_msg_handler2 msg MPI_Bcast complete msg = %d", msg));
 
-	/* Handle the message. This code is run on all IO tasks. */
-	switch (msg)
-	{
-	case PIO_MSG_INQ_TYPE:
-	    inq_type_handler(my_iosys);
-	    break;
-	case PIO_MSG_INQ_FORMAT:
-	    inq_format_handler(my_iosys);
-	    break;
-	case PIO_MSG_CREATE_FILE:
-	    create_file_handler(my_iosys);
-	    LOG((2, "returned from create_file_handler"));
-	    break;
-	case PIO_MSG_SYNC:
-	    sync_file_handler(my_iosys);
-	    break;
-	case PIO_MSG_ENDDEF:
-	case PIO_MSG_REDEF:
-	    LOG((2, "calling change_def_file_handler"));
-	    change_def_file_handler(my_iosys, msg);
-	    LOG((2, "returned from change_def_file_handler"));
-	    break;
-	case PIO_MSG_OPEN_FILE:
-	    open_file_handler(my_iosys);
-	    break;
-	case PIO_MSG_CLOSE_FILE:
-	    close_file_handler(my_iosys);
-	    break;
-	case PIO_MSG_DELETE_FILE:
-	    delete_file_handler(my_iosys);
-	    break;
-	case PIO_MSG_RENAME_DIM:
-	    rename_dim_handler(my_iosys);
-	    break;
-	case PIO_MSG_RENAME_VAR:
-	    rename_var_handler(my_iosys);
-	    break;
-	case PIO_MSG_RENAME_ATT:
-	    rename_att_handler(my_iosys);
-	    break;
-	case PIO_MSG_DEL_ATT:
-	    delete_att_handler(my_iosys);
-	    break;
-	case PIO_MSG_DEF_DIM:
-	    def_dim_handler(my_iosys);
-	    break;
-	case PIO_MSG_DEF_VAR:
-	    def_var_handler(my_iosys);
-	    break;
-	case PIO_MSG_INQ:
-	    inq_handler(my_iosys);
-	    break;
-	case PIO_MSG_INQ_DIM:
-	    inq_dim_handler(my_iosys, msg);
-	    break;
-	case PIO_MSG_INQ_DIMID:
-	    inq_dimid_handler(my_iosys);
-	    break;
-	case PIO_MSG_INQ_VAR:
-	    inq_var_handler(my_iosys);
-	    break;
-	case PIO_MSG_GET_ATT:
-	    ret = att_get_handler(my_iosys);
-	    break;
-	case PIO_MSG_PUT_ATT:
-	    ret = att_put_handler(my_iosys);
-	    break;
-	case PIO_MSG_INQ_VARID:
-	    inq_varid_handler(my_iosys);
-	    break;
-	case PIO_MSG_INQ_ATT:
-	    inq_att_handler(my_iosys);
-	    break;
-	case PIO_MSG_INQ_ATTNAME:
-	    inq_attname_handler(my_iosys);
-	    break;
-	case PIO_MSG_INQ_ATTID:
-	    inq_attid_handler(my_iosys);
-	    break;
-	case PIO_MSG_GET_VARS:
-	    get_vars_handler(my_iosys);
-	    break;
-	case PIO_MSG_PUT_VARS:
-	    put_vars_handler(my_iosys);
-	    break;
-	case PIO_MSG_INITDECOMP_DOF:
-	    initdecomp_dof_handler(my_iosys);
-	    break;
-	case PIO_MSG_WRITEDARRAY:
-	    writedarray_handler(my_iosys);
-	    break;
-	case PIO_MSG_READDARRAY:
-	    readdarray_handler(my_iosys);
-	    break;
-	case PIO_MSG_SETERRORHANDLING:
-	    seterrorhandling_handler(my_iosys);
-	    break;
-	case PIO_MSG_FREEDECOMP:
-	    freedecomp_handler(my_iosys);
-	    break;
-	case PIO_MSG_EXIT:
-	    finalize_handler(my_iosys, index);
-	    msg = -1;
-	    break;
-	default:
-	    pio_callback_handler(my_iosys, msg);
-	}
+        /* Handle the message. This code is run on all IO tasks. */
+        switch (msg)
+        {
+        case PIO_MSG_INQ_TYPE:
+            inq_type_handler(my_iosys);
+            break;
+        case PIO_MSG_INQ_FORMAT:
+            inq_format_handler(my_iosys);
+            break;
+        case PIO_MSG_CREATE_FILE:
+            create_file_handler(my_iosys);
+            LOG((2, "returned from create_file_handler"));
+            break;
+        case PIO_MSG_SYNC:
+            sync_file_handler(my_iosys);
+            break;
+        case PIO_MSG_ENDDEF:
+        case PIO_MSG_REDEF:
+            LOG((2, "calling change_def_file_handler"));
+            change_def_file_handler(my_iosys, msg);
+            LOG((2, "returned from change_def_file_handler"));
+            break;
+        case PIO_MSG_OPEN_FILE:
+            open_file_handler(my_iosys);
+            break;
+        case PIO_MSG_CLOSE_FILE:
+            close_file_handler(my_iosys);
+            break;
+        case PIO_MSG_DELETE_FILE:
+            delete_file_handler(my_iosys);
+            break;
+        case PIO_MSG_RENAME_DIM:
+            rename_dim_handler(my_iosys);
+            break;
+        case PIO_MSG_RENAME_VAR:
+            rename_var_handler(my_iosys);
+            break;
+        case PIO_MSG_RENAME_ATT:
+            rename_att_handler(my_iosys);
+            break;
+        case PIO_MSG_DEL_ATT:
+            delete_att_handler(my_iosys);
+            break;
+        case PIO_MSG_DEF_DIM:
+            def_dim_handler(my_iosys);
+            break;
+        case PIO_MSG_DEF_VAR:
+            def_var_handler(my_iosys);
+            break;
+        case PIO_MSG_INQ:
+            inq_handler(my_iosys);
+            break;
+        case PIO_MSG_INQ_DIM:
+            inq_dim_handler(my_iosys, msg);
+            break;
+        case PIO_MSG_INQ_DIMID:
+            inq_dimid_handler(my_iosys);
+            break;
+        case PIO_MSG_INQ_VAR:
+            inq_var_handler(my_iosys);
+            break;
+        case PIO_MSG_GET_ATT:
+            ret = att_get_handler(my_iosys);
+            break;
+        case PIO_MSG_PUT_ATT:
+            ret = att_put_handler(my_iosys);
+            break;
+        case PIO_MSG_INQ_VARID:
+            inq_varid_handler(my_iosys);
+            break;
+        case PIO_MSG_INQ_ATT:
+            inq_att_handler(my_iosys);
+            break;
+        case PIO_MSG_INQ_ATTNAME:
+            inq_attname_handler(my_iosys);
+            break;
+        case PIO_MSG_INQ_ATTID:
+            inq_attid_handler(my_iosys);
+            break;
+        case PIO_MSG_GET_VARS:
+            get_vars_handler(my_iosys);
+            break;
+        case PIO_MSG_PUT_VARS:
+            put_vars_handler(my_iosys);
+            break;
+        case PIO_MSG_INITDECOMP_DOF:
+            initdecomp_dof_handler(my_iosys);
+            break;
+        case PIO_MSG_WRITEDARRAY:
+            writedarray_handler(my_iosys);
+            break;
+        case PIO_MSG_READDARRAY:
+            readdarray_handler(my_iosys);
+            break;
+        case PIO_MSG_SETERRORHANDLING:
+            seterrorhandling_handler(my_iosys);
+            break;
+        case PIO_MSG_FREEDECOMP:
+            freedecomp_handler(my_iosys);
+            break;
+        case PIO_MSG_EXIT:
+            finalize_handler(my_iosys, index);
+            msg = -1;
+            break;
+        default:
+            pio_callback_handler(my_iosys, msg);
+        }
 
-	/* If an error was returned by the handler, do something! */
-	LOG((3, "pio_msg_handler2 checking error ret = %d", ret));
-	if (ret)
-	    MPI_Finalize();
+        /* If an error was returned by the handler, do something! */
+        LOG((3, "pio_msg_handler2 checking error ret = %d", ret));
+        if (ret)
+            MPI_Finalize();
 
-	LOG((3, "pio_msg_handler2 getting ready to listen"));
+        LOG((3, "pio_msg_handler2 getting ready to listen"));
 
-	/* Unless finalize was called, listen for another msg from the
-	 * component whose message we just handled. */
-	if (!io_rank && msg != -1)
-	{
-	    my_iosys = iosys[index];
-	    LOG((3, "pio_msg_handler2 about to Irecv index = %d comproot = %d union_comm = %d",
-		 index, my_iosys->comproot, my_iosys->union_comm));
-	    mpierr = MPI_Irecv(&msg, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
-			       &req[index]);
-	    LOG((3, "pio_msg_handler2 called MPI_Irecv req[%d] = %d\n", index, req[index]));
-	    CheckMPIReturn(mpierr, __FILE__, __LINE__);
-	}
+        /* Unless finalize was called, listen for another msg from the
+         * component whose message we just handled. */
+        if (!io_rank && msg != -1)
+        {
+            my_iosys = iosys[index];
+            LOG((3, "pio_msg_handler2 about to Irecv index = %d comproot = %d union_comm = %d",
+                 index, my_iosys->comproot, my_iosys->union_comm));
+            mpierr = MPI_Irecv(&msg, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
+                               &req[index]);
+            LOG((3, "pio_msg_handler2 called MPI_Irecv req[%d] = %d\n", index, req[index]));
+            CheckMPIReturn(mpierr, __FILE__, __LINE__);
+        }
 
-	LOG((3, "pio_msg_handler2 done msg = %d open_components = %d",
-	     msg, open_components));
+        LOG((3, "pio_msg_handler2 done msg = %d open_components = %d",
+             msg, open_components));
 
-	/* If there are no more open components, exit. */
-	if (msg == -1)
-	    if (--open_components)
-		msg = PIO_MSG_EXIT;
+        /* If there are no more open components, exit. */
+        if (msg == -1)
+            if (--open_components)
+                msg = PIO_MSG_EXIT;
     }
 
     LOG((3, "returning from pio_msg_handler2"));
@@ -1774,8 +1774,8 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys, 
  */
 int
 PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
-		int component_count, int *num_procs_per_comp, int **proc_list,
-		int *iosysidp)
+                int component_count, int *num_procs_per_comp, int **proc_list,
+                int *iosysidp)
 {
     int my_rank;
     MPI_Comm newcomm;
@@ -1785,12 +1785,12 @@ PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
 
     /* Check input parameters. */
     if (num_io_procs < 1 || component_count < 1 || !num_procs_per_comp ||
-	!iosysidp)
-	return PIO_EINVAL;
+        !iosysidp)
+        return PIO_EINVAL;
 
     /* Temporarily limit to one computational component. */
     if (component_count > 1)
-	return PIO_EINVAL;
+        return PIO_EINVAL;
 
     LOG((1, "PIOc_init_io component_count = %d", component_count));
 
@@ -1798,54 +1798,54 @@ PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
      * IO, create it. */
     if (!io_proc_list)
     {
-	if (!(my_io_proc_list = malloc(num_io_procs * sizeof(int))))
-	    return PIO_ENOMEM;
-	for (int p = 0; p < num_io_procs; p++)
-	    my_io_proc_list[p] = p;
+        if (!(my_io_proc_list = malloc(num_io_procs * sizeof(int))))
+            return PIO_ENOMEM;
+        for (int p = 0; p < num_io_procs; p++)
+            my_io_proc_list[p] = p;
     }
     else
-	my_io_proc_list = io_proc_list;
+        my_io_proc_list = io_proc_list;
 
     /* If the user did not provide a list of processes for each
      * component, create one. */
     if (!proc_list)
     {
-	int last_proc = 0;
+        int last_proc = 0;
 
-	/* Allocate space for array of arrays. */
-	if (!(my_proc_list = malloc((component_count + 1) * sizeof(int *))))
-	    return PIO_ENOMEM;
+        /* Allocate space for array of arrays. */
+        if (!(my_proc_list = malloc((component_count + 1) * sizeof(int *))))
+            return PIO_ENOMEM;
 
-	/* Fill the array of arrays. */
-	for (int cmp = 0; cmp < component_count + 1; cmp++)
-	{
-	    LOG((3, "calculating processors for component %d", cmp));
+        /* Fill the array of arrays. */
+        for (int cmp = 0; cmp < component_count + 1; cmp++)
+        {
+            LOG((3, "calculating processors for component %d", cmp));
 
-	    /* Allocate space for each array. */
-	    if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
-		return PIO_ENOMEM;
+            /* Allocate space for each array. */
+            if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
+                return PIO_ENOMEM;
 
-	    int proc;
-	    for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
-	    {
-		my_proc_list[cmp][proc - last_proc] = proc;
-		LOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
-	    }
-	    last_proc = proc;
-	}
+            int proc;
+            for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
+            {
+                my_proc_list[cmp][proc - last_proc] = proc;
+                LOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
+            }
+            last_proc = proc;
+        }
     }
     else
-	my_proc_list = proc_list;
+        my_proc_list = proc_list;
 
     /* Get rank of this task. */
     if ((ret = MPI_Comm_rank(world, &my_rank)))
-	return check_mpi(NULL, ret, __FILE__, __LINE__);
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
 
     /* Is this process in the IO component? */
     int pidx;
     for (pidx = 0; pidx < num_procs_per_comp[0]; pidx++)
-	if (my_rank == my_proc_list[0][pidx])
-	    break;
+        if (my_rank == my_proc_list[0][pidx])
+            break;
     int in_io = (pidx == num_procs_per_comp[0]) ? 0 : 1;
     LOG((3, "in_io = %d", in_io));
 
@@ -1853,13 +1853,13 @@ PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
     /* Allocate struct to hold io system info for each component. */
     iosystem_desc_t *iosys[component_count], *my_iosys;
     for (int cmp1 = 0; cmp1 < component_count; cmp1++)
-	if (!(iosys[cmp1] = (iosystem_desc_t *)calloc(1, sizeof(iosystem_desc_t))))
-	    return PIO_ENOMEM;
+        if (!(iosys[cmp1] = (iosystem_desc_t *)calloc(1, sizeof(iosystem_desc_t))))
+            return PIO_ENOMEM;
 
     /* Create group for world. */
     MPI_Group world_group;
     if ((ret = MPI_Comm_group(world, &world_group)))
-	return check_mpi(NULL, ret, __FILE__, __LINE__);
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
     LOG((3, "world group created\n"));
 
     /* We will create a group for the IO component. */
@@ -1877,26 +1877,26 @@ PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
 
     /* Create a group for the IO component. */
     if ((ret = MPI_Group_incl(world_group, num_io_procs, my_io_proc_list, &io_group)))
-	return check_mpi(NULL, ret, __FILE__, __LINE__);
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
     LOG((3, "created IO group - io_group = %d group empty is %d", io_group, MPI_GROUP_EMPTY));
     for (int p = 0; p < num_io_procs; p++)
-	LOG((3, "my_io_proc_list[%d] = %d", p, my_io_proc_list[p]));
+        LOG((3, "my_io_proc_list[%d] = %d", p, my_io_proc_list[p]));
 
     /* There is one shared IO comm. Create it. */
     if ((ret = MPI_Comm_create(world, io_group, &io_comm)))
-	return check_mpi(NULL, ret, __FILE__, __LINE__);
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
     LOG((3, "created io comm io_comm = %d", io_comm));
 
     /* For processes in the IO component, get their rank within the IO
      * communicator. */
     if (in_io)
     {
-	LOG((3, "about to get io rank"));
-	if ((ret = MPI_Comm_rank(io_comm, &io_rank)))
-	    return check_mpi(NULL, ret, __FILE__, __LINE__);
-	iomaster = !io_rank ? MPI_ROOT : MPI_PROC_NULL;
-	LOG((3, "intracomm created for io_comm = %d io_rank = %d IO %s",
-	     io_comm, io_rank, iomaster == MPI_ROOT ? "MASTER" : "SERVANT"));
+        LOG((3, "about to get io rank"));
+        if ((ret = MPI_Comm_rank(io_comm, &io_rank)))
+            return check_mpi(NULL, ret, __FILE__, __LINE__);
+        iomaster = !io_rank ? MPI_ROOT : MPI_PROC_NULL;
+        LOG((3, "intracomm created for io_comm = %d io_rank = %d IO %s",
+             io_comm, io_rank, iomaster == MPI_ROOT ? "MASTER" : "SERVANT"));
     }
 
     /* We will create a group for each component. */
@@ -1910,216 +1910,216 @@ PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
     /* For each component, starting with the IO component. */
     for (int cmp = 0; cmp < component_count + 1; cmp++)
     {
-	LOG((3, "processing component %d", cmp));
+        LOG((3, "processing component %d", cmp));
 
-	/* Don't start initing iosys until after IO component. */
-	if (cmp)
-	{
-	    /* Get pointer to current iosys. */
-	    my_iosys = iosys[cmp - 1];
-
-	    /* Initialize some values. */
-	    my_iosys->io_comm = MPI_COMM_NULL;
-	    my_iosys->comp_comm = MPI_COMM_NULL;
-	    my_iosys->union_comm = MPI_COMM_NULL;
-	    my_iosys->intercomm = MPI_COMM_NULL;
-	    my_iosys->my_comm = MPI_COMM_NULL;
-	    my_iosys->async_interface = 1;
-	    my_iosys->error_handler = PIO_INTERNAL_ERROR;
-	    my_iosys->num_comptasks = num_procs_per_comp[cmp];
-	    my_iosys->num_iotasks = num_procs_per_comp[0];
-	    my_iosys->compgroup = MPI_GROUP_NULL;
-	    my_iosys->iogroup = MPI_GROUP_NULL;
-
-	    /* The rank of the computation leader in the union comm. */
-	    my_iosys->comproot = num_procs_per_comp[0];
-	    LOG((3, "my_iosys->comproot = %d", my_iosys->comproot));
-
-	    /* Create an MPI info object. */
-	    if ((ret = MPI_Info_create(&my_iosys->info)))
-		return check_mpi(NULL, ret, __FILE__, __LINE__);
-	}
-
-	/* Create a group for this component. */
-	if ((ret = MPI_Group_incl(world_group, num_procs_per_comp[cmp], my_proc_list[cmp],
-				  &group[cmp])))
-	    return check_mpi(NULL, ret, __FILE__, __LINE__);
-	LOG((3, "created component MPI group - group[%d] = %d", cmp, group[cmp]));
-
-	/* For all the computation components (i.e. cmp != 0), create
-	 * a union group with their processors and the processors of
-	 * the (shared) IO component. */
-	if (cmp)
-	{
-	    /* How many processors in the union comm? */
-	    int nprocs_union = num_procs_per_comp[0] + num_procs_per_comp[cmp];
-
-	    /* This will hold proc numbers from both computation and IO
-	     * components. */
-	    int proc_list_union[nprocs_union];
-
-	    /* Add proc numbers from IO. */
-	    for (int p = 0; p < num_procs_per_comp[0]; p++)
-		proc_list_union[p] = my_proc_list[0][p];
-
-	    /* Add proc numbers from computation component. */
-	    for (int p = 0; p < num_procs_per_comp[cmp]; p++)
-		proc_list_union[p + num_procs_per_comp[0]] = my_proc_list[cmp][p];
-
-	    /* Create the union group. */
-	    if ((ret = MPI_Group_incl(world_group, nprocs_union, proc_list_union,
-				      &union_group[cmp - 1])))
-		return check_mpi(NULL, ret, __FILE__, __LINE__);
-	    LOG((3, "created union MPI_group - union_group[%d] = %d with %d procs", cmp, union_group[cmp-1], nprocs_union));
-	}
-
-	/* Remember whether this process is in the IO component. */
-	if (cmp)
-	    my_iosys->ioproc = in_io;
-
-	/* Is this process in this computation component (which is the
-	 * IO component if cmp == 0)? */
-	int in_cmp = 0;
-	for (pidx = 0; pidx < num_procs_per_comp[cmp]; pidx++)
-	    if (my_rank == my_proc_list[cmp][pidx])
-		break;
-	in_cmp = (pidx == num_procs_per_comp[cmp]) ? 0 : 1;
-	LOG((3, "pidx = %d num_procs_per_comp[%d] = %d in_cmp = %d",
-	     pidx, cmp, num_procs_per_comp[cmp], in_cmp));
-
-	/* Create an intracomm for this component. Only processes in
-	 * the component need to participate in the intracomm create
-	 * call. */
-	/* Create the intracomm from the group. */
-	LOG((3, "creating intracomm cmp = %d from group[%d] = %d", cmp, cmp, group[cmp]));
-
-	/* We handle the IO comm differently (cmp == 0). */
-	if (!cmp)
+        /* Don't start initing iosys until after IO component. */
+        if (cmp)
         {
-	  /* LOG((3, "about to create io comm")); */
-	  /* if ((ret = MPI_Comm_create_group(world, group[cmp], cmp, &io_comm))) */
-	  /*     return check_mpi(NULL, ret, __FILE__, __LINE__); */
-	  /* LOG((3, "about to get io rank"));		 */
-	  /* if ((ret = MPI_Comm_rank(io_comm, &io_rank))) */
-	  /*     return check_mpi(NULL, ret, __FILE__, __LINE__); */
-	  /* iomaster = !io_rank ? MPI_ROOT : MPI_PROC_NULL; */
-	  /* LOG((3, "intracomm created for cmp = %d io_comm = %d io_rank = %d IO %s", */
-	  /*      cmp, io_comm, io_rank, iomaster == MPI_ROOT ? "MASTER" : "SERVANT")); */
-	}
-	else
-	{
-	  if ((ret = MPI_Comm_create(world, group[cmp], &my_iosys->comp_comm)))
-	    return check_mpi(NULL, ret, __FILE__, __LINE__);
-	  if (in_cmp)
-	  {
-	    if ((ret = MPI_Comm_rank(my_iosys->comp_comm, &my_iosys->comp_rank)))
-	      return check_mpi(NULL, ret, __FILE__, __LINE__);
-	    my_iosys->compmaster = my_iosys->comp_rank ? MPI_PROC_NULL : MPI_ROOT;
-	    LOG((3, "intracomm created for cmp = %d comp_comm = %d comp_rank = %d comp %s",
-		 cmp, my_iosys->comp_comm, my_iosys->comp_rank,
-		 my_iosys->compmaster == MPI_ROOT ? "MASTER" : "SERVANT"));
-	  }
-	}
+            /* Get pointer to current iosys. */
+            my_iosys = iosys[cmp - 1];
+
+            /* Initialize some values. */
+            my_iosys->io_comm = MPI_COMM_NULL;
+            my_iosys->comp_comm = MPI_COMM_NULL;
+            my_iosys->union_comm = MPI_COMM_NULL;
+            my_iosys->intercomm = MPI_COMM_NULL;
+            my_iosys->my_comm = MPI_COMM_NULL;
+            my_iosys->async_interface = 1;
+            my_iosys->error_handler = PIO_INTERNAL_ERROR;
+            my_iosys->num_comptasks = num_procs_per_comp[cmp];
+            my_iosys->num_iotasks = num_procs_per_comp[0];
+            my_iosys->compgroup = MPI_GROUP_NULL;
+            my_iosys->iogroup = MPI_GROUP_NULL;
+
+            /* The rank of the computation leader in the union comm. */
+            my_iosys->comproot = num_procs_per_comp[0];
+            LOG((3, "my_iosys->comproot = %d", my_iosys->comproot));
+
+            /* Create an MPI info object. */
+            if ((ret = MPI_Info_create(&my_iosys->info)))
+                return check_mpi(NULL, ret, __FILE__, __LINE__);
+        }
+
+        /* Create a group for this component. */
+        if ((ret = MPI_Group_incl(world_group, num_procs_per_comp[cmp], my_proc_list[cmp],
+                                  &group[cmp])))
+            return check_mpi(NULL, ret, __FILE__, __LINE__);
+        LOG((3, "created component MPI group - group[%d] = %d", cmp, group[cmp]));
+
+        /* For all the computation components (i.e. cmp != 0), create
+         * a union group with their processors and the processors of
+         * the (shared) IO component. */
+        if (cmp)
+        {
+            /* How many processors in the union comm? */
+            int nprocs_union = num_procs_per_comp[0] + num_procs_per_comp[cmp];
+
+            /* This will hold proc numbers from both computation and IO
+             * components. */
+            int proc_list_union[nprocs_union];
+
+            /* Add proc numbers from IO. */
+            for (int p = 0; p < num_procs_per_comp[0]; p++)
+                proc_list_union[p] = my_proc_list[0][p];
+
+            /* Add proc numbers from computation component. */
+            for (int p = 0; p < num_procs_per_comp[cmp]; p++)
+                proc_list_union[p + num_procs_per_comp[0]] = my_proc_list[cmp][p];
+
+            /* Create the union group. */
+            if ((ret = MPI_Group_incl(world_group, nprocs_union, proc_list_union,
+                                      &union_group[cmp - 1])))
+                return check_mpi(NULL, ret, __FILE__, __LINE__);
+            LOG((3, "created union MPI_group - union_group[%d] = %d with %d procs", cmp, union_group[cmp-1], nprocs_union));
+        }
+
+        /* Remember whether this process is in the IO component. */
+        if (cmp)
+            my_iosys->ioproc = in_io;
+
+        /* Is this process in this computation component (which is the
+         * IO component if cmp == 0)? */
+        int in_cmp = 0;
+        for (pidx = 0; pidx < num_procs_per_comp[cmp]; pidx++)
+            if (my_rank == my_proc_list[cmp][pidx])
+                break;
+        in_cmp = (pidx == num_procs_per_comp[cmp]) ? 0 : 1;
+        LOG((3, "pidx = %d num_procs_per_comp[%d] = %d in_cmp = %d",
+             pidx, cmp, num_procs_per_comp[cmp], in_cmp));
+
+        /* Create an intracomm for this component. Only processes in
+         * the component need to participate in the intracomm create
+         * call. */
+        /* Create the intracomm from the group. */
+        LOG((3, "creating intracomm cmp = %d from group[%d] = %d", cmp, cmp, group[cmp]));
+
+        /* We handle the IO comm differently (cmp == 0). */
+        if (!cmp)
+        {
+            /* LOG((3, "about to create io comm")); */
+            /* if ((ret = MPI_Comm_create_group(world, group[cmp], cmp, &io_comm))) */
+            /*     return check_mpi(NULL, ret, __FILE__, __LINE__); */
+            /* LOG((3, "about to get io rank"));                 */
+            /* if ((ret = MPI_Comm_rank(io_comm, &io_rank))) */
+            /*     return check_mpi(NULL, ret, __FILE__, __LINE__); */
+            /* iomaster = !io_rank ? MPI_ROOT : MPI_PROC_NULL; */
+            /* LOG((3, "intracomm created for cmp = %d io_comm = %d io_rank = %d IO %s", */
+            /*      cmp, io_comm, io_rank, iomaster == MPI_ROOT ? "MASTER" : "SERVANT")); */
+        }
+        else
+        {
+            if ((ret = MPI_Comm_create(world, group[cmp], &my_iosys->comp_comm)))
+                return check_mpi(NULL, ret, __FILE__, __LINE__);
+            if (in_cmp)
+            {
+                if ((ret = MPI_Comm_rank(my_iosys->comp_comm, &my_iosys->comp_rank)))
+                    return check_mpi(NULL, ret, __FILE__, __LINE__);
+                my_iosys->compmaster = my_iosys->comp_rank ? MPI_PROC_NULL : MPI_ROOT;
+                LOG((3, "intracomm created for cmp = %d comp_comm = %d comp_rank = %d comp %s",
+                     cmp, my_iosys->comp_comm, my_iosys->comp_rank,
+                     my_iosys->compmaster == MPI_ROOT ? "MASTER" : "SERVANT"));
+            }
+        }
 
 
-	/* If this is the IO component, remember the
-	 * comm. Otherwise make a copy of the comm for each
-	 * component. */
-	if (in_io)
-	    if (cmp)
-	    {
-		LOG((3, "making a dup of io_comm = %d io_rank = %d", io_comm, io_rank));
-		if ((ret = MPI_Comm_dup(io_comm, &my_iosys->io_comm)))
-		    return check_mpi(NULL, ret, __FILE__, __LINE__);
-		LOG((3, "dup of io_comm = %d io_rank = %d", my_iosys->io_comm, io_rank));
-		my_iosys->iomaster = iomaster;
-		my_iosys->io_rank = io_rank;
-		my_iosys->ioroot = 0;
-		my_iosys->comp_idx = cmp - 1;
-	    }
+        /* If this is the IO component, remember the
+         * comm. Otherwise make a copy of the comm for each
+         * component. */
+        if (in_io)
+            if (cmp)
+            {
+                LOG((3, "making a dup of io_comm = %d io_rank = %d", io_comm, io_rank));
+                if ((ret = MPI_Comm_dup(io_comm, &my_iosys->io_comm)))
+                    return check_mpi(NULL, ret, __FILE__, __LINE__);
+                LOG((3, "dup of io_comm = %d io_rank = %d", my_iosys->io_comm, io_rank));
+                my_iosys->iomaster = iomaster;
+                my_iosys->io_rank = io_rank;
+                my_iosys->ioroot = 0;
+                my_iosys->comp_idx = cmp - 1;
+            }
 
-	/* All the processes in this component, and the IO component,
-	 * are part of the union_comm. */
-	if (cmp)
-	{
-	    if (in_io || in_cmp)
-	    {
-	      LOG((3, "my_iosys->io_comm = %d group = %d", my_iosys->io_comm, union_group[cmp-1]));
-		/* Create a group for the union of the IO component
-		 * and one of the computation components. */
-		if ((ret = MPI_Comm_create(world, union_group[cmp - 1],
-						 &my_iosys->union_comm)))
-		    return check_mpi(NULL, ret, __FILE__, __LINE__);
+        /* All the processes in this component, and the IO component,
+         * are part of the union_comm. */
+        if (cmp)
+        {
+            if (in_io || in_cmp)
+            {
+                LOG((3, "my_iosys->io_comm = %d group = %d", my_iosys->io_comm, union_group[cmp-1]));
+                /* Create a group for the union of the IO component
+                 * and one of the computation components. */
+                if ((ret = MPI_Comm_create(world, union_group[cmp - 1],
+                                           &my_iosys->union_comm)))
+                    return check_mpi(NULL, ret, __FILE__, __LINE__);
 
-		if ((ret = MPI_Comm_rank(my_iosys->union_comm, &my_iosys->union_rank)))
-		    return check_mpi(NULL, ret, __FILE__, __LINE__);
+                if ((ret = MPI_Comm_rank(my_iosys->union_comm, &my_iosys->union_rank)))
+                    return check_mpi(NULL, ret, __FILE__, __LINE__);
 
-		/* Set my_comm to union_comm for async. */
-		my_iosys->my_comm = my_iosys->union_comm;
-		LOG((3, "intracomm created for union cmp = %d union_rank = %d union_comm = %d",
-		     cmp, my_iosys->union_rank, my_iosys->union_comm));
+                /* Set my_comm to union_comm for async. */
+                my_iosys->my_comm = my_iosys->union_comm;
+                LOG((3, "intracomm created for union cmp = %d union_rank = %d union_comm = %d",
+                     cmp, my_iosys->union_rank, my_iosys->union_comm));
 
-		if (in_io)
-		{
-		    LOG((3, "my_iosys->io_comm = %d", my_iosys->io_comm));
-		    /* Create the intercomm from IO to computation component. */
-		    LOG((3, "about to create intercomm for IO component to cmp = %d "
-			 "my_iosys->io_comm = %d", cmp, my_iosys->io_comm));
-		    if ((ret = MPI_Intercomm_create(my_iosys->io_comm, 0, my_iosys->union_comm,
-						    num_procs_per_comp[0], my_rank,
-						    &my_iosys->intercomm)))
-			return check_mpi(NULL, ret, __FILE__, __LINE__);
-		}
-		else
-		{
-		    /* Create the intercomm from computation component to IO component. */
-		    LOG((3, "about to create intercomm for cmp = %d my_iosys->comp_comm = %d", cmp,
-			 my_iosys->comp_comm));
-		    if ((ret = MPI_Intercomm_create(my_iosys->comp_comm, 0, my_iosys->union_comm, 0,
-						    my_rank, &my_iosys->intercomm)))
-			return check_mpi(NULL, ret, __FILE__, __LINE__);
-		}
-		LOG((3, "intercomm created for cmp = %d", cmp));
-	    }
+                if (in_io)
+                {
+                    LOG((3, "my_iosys->io_comm = %d", my_iosys->io_comm));
+                    /* Create the intercomm from IO to computation component. */
+                    LOG((3, "about to create intercomm for IO component to cmp = %d "
+                         "my_iosys->io_comm = %d", cmp, my_iosys->io_comm));
+                    if ((ret = MPI_Intercomm_create(my_iosys->io_comm, 0, my_iosys->union_comm,
+                                                    num_procs_per_comp[0], my_rank,
+                                                    &my_iosys->intercomm)))
+                        return check_mpi(NULL, ret, __FILE__, __LINE__);
+                }
+                else
+                {
+                    /* Create the intercomm from computation component to IO component. */
+                    LOG((3, "about to create intercomm for cmp = %d my_iosys->comp_comm = %d", cmp,
+                         my_iosys->comp_comm));
+                    if ((ret = MPI_Intercomm_create(my_iosys->comp_comm, 0, my_iosys->union_comm, 0,
+                                                    my_rank, &my_iosys->intercomm)))
+                        return check_mpi(NULL, ret, __FILE__, __LINE__);
+                }
+                LOG((3, "intercomm created for cmp = %d", cmp));
+            }
 
-	    /* Add this id to the list of PIO iosystem ids. */
-	    iosysidp[cmp - 1] = pio_add_to_iosystem_list(my_iosys);
-	    LOG((2, "new iosys ID added to iosystem_list iosysid = %d\n", iosysidp[cmp - 1]));
-	}
+            /* Add this id to the list of PIO iosystem ids. */
+            iosysidp[cmp - 1] = pio_add_to_iosystem_list(my_iosys);
+            LOG((2, "new iosys ID added to iosystem_list iosysid = %d\n", iosysidp[cmp - 1]));
+        }
     }
 
     /* Now call the function from which the IO tasks will not return
      * until the PIO_MSG_EXIT message is sent. This will handle all
      * components. */
     if (in_io)
-	if ((ret = pio_msg_handler2(io_rank, component_count, iosys, io_comm)))
-	    return ret;
+        if ((ret = pio_msg_handler2(io_rank, component_count, iosys, io_comm)))
+            return ret;
 
     /* Free resources if needed. */
     LOG((2, "about to free io_proc_list"));
     if (!io_proc_list)
-	free(my_io_proc_list);
+        free(my_io_proc_list);
 
     LOG((2, "about to free proc_list"));
     if (!proc_list)
     {
-	for (int cmp = 0; cmp < component_count + 1; cmp++)
-	    free(my_proc_list[cmp]);
-	free(my_proc_list);
+        for (int cmp = 0; cmp < component_count + 1; cmp++)
+            free(my_proc_list[cmp]);
+        free(my_proc_list);
     }
 
     /* Free MPI groups. */
     LOG((2, "about to free MPI groups"));
     if ((ret = MPI_Group_free(&io_group)))
-	return check_mpi(NULL, ret, __FILE__, __LINE__);
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
 
     for (int cmp = 0; cmp < component_count + 1; cmp++)
     {
-	if ((ret = MPI_Group_free(&group[cmp])))
-	    return check_mpi(NULL, ret, __FILE__, __LINE__);
-	if (cmp)
-	    if ((ret = MPI_Group_free(&union_group[cmp - 1])))
-		return check_mpi(NULL, ret, __FILE__, __LINE__);
+        if ((ret = MPI_Group_free(&group[cmp])))
+            return check_mpi(NULL, ret, __FILE__, __LINE__);
+        if (cmp)
+            if ((ret = MPI_Group_free(&union_group[cmp - 1])))
+                return check_mpi(NULL, ret, __FILE__, __LINE__);
     }
 
     LOG((2, "successfully done with PIO_Init_Async"));

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -1,5 +1,5 @@
 /**
- * @file   
+ * @file
  * PIO interfaces to
  * [NetCDF](http://www.unidata.ucar.edu/software/netcdf/docs/modules.html)
  * support functions
@@ -10,7 +10,7 @@
  *  pnetcdf or netcdf4 functions from the appropriate subset of mpi
  *  tasks (io_comm). Each routine must be called collectively from
  *  union_comm.
- *  
+ *
  * @author Jim Edwards (jedwards@ucar.edu), Ed Hartnett
  * @date     Feburary 2014, April 2016
  */
@@ -19,7 +19,7 @@
 #include <pio.h>
 #include <pio_internal.h>
 
-/** 
+/**
  * @ingroup PIOc_inq
  * The PIO-C interface for the NetCDF function nc_inq.
  *
@@ -35,7 +35,7 @@
  * @return PIO_NOERR for success, error code otherwise. See
  * PIOc_Set_File_Error_Handling
  */
-int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp) 
+int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -46,7 +46,7 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -59,10 +59,10 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
             char nvars_present = nvarsp ? true : false;
             char ngatts_present = ngattsp ? true : false;
             char unlimdimid_present = unlimdimidp ? true : false;
-            
-            if (ios->compmaster) 
+
+            if (ios->compmaster)
                 mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-            
+
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
@@ -73,43 +73,43 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
                 mpierr = MPI_Bcast(&ngatts_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&unlimdimid_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    LOG((2, "PIOc_inq ncid = %d ndims_present = %d nvars_present = %d ngatts_present = %d unlimdimid_present = %d",
-		 ncid, ndims_present, nvars_present, ngatts_present, unlimdimid_present));
+            LOG((2, "PIOc_inq ncid = %d ndims_present = %d nvars_present = %d ngatts_present = %d unlimdimid_present = %d",
+                 ncid, ndims_present, nvars_present, ngatts_present, unlimdimid_present));
         }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
-	{
-	    LOG((2, "PIOc_inq calling ncmpi_inq unlimdimidp = %d", unlimdimidp));
+        {
+            LOG((2, "PIOc_inq calling ncmpi_inq unlimdimidp = %d", unlimdimidp));
             ierr = ncmpi_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);
-	    LOG((2, "PIOc_inq called ncmpi_inq"));
-	    if (unlimdimidp)
-		LOG((2, "PIOc_inq returned from ncmpi_inq unlimdimid = %d", *unlimdimidp));		
-	}
+            LOG((2, "PIOc_inq called ncmpi_inq"));
+            if (unlimdimidp)
+                LOG((2, "PIOc_inq returned from ncmpi_inq unlimdimid = %d", *unlimdimidp));
+        }
 #endif /* _PNETCDF */
 #ifdef _NETCDF
         if (file->iotype == PIO_IOTYPE_NETCDF && file->do_io)
         {
-	    LOG((2, "PIOc_inq calling classic nc_inq"));
+            LOG((2, "PIOc_inq calling classic nc_inq"));
             /* Should not be necessary to do this - nc_inq should
              * handle null pointers. This has been reported as a bug
              * to netCDF developers. */
             int tmp_ndims, tmp_nvars, tmp_ngatts, tmp_unlimdimid;
-	    LOG((2, "PIOc_inq calling classic nc_inq"));
+            LOG((2, "PIOc_inq calling classic nc_inq"));
             ierr = nc_inq(file->fh, &tmp_ndims, &tmp_nvars, &tmp_ngatts, &tmp_unlimdimid);
-	    LOG((2, "PIOc_inq calling classic nc_inq"));
-	    if (unlimdimidp)
-		LOG((2, "classic tmp_unlimdimid = %d", tmp_unlimdimid));
+            LOG((2, "PIOc_inq calling classic nc_inq"));
+            if (unlimdimidp)
+                LOG((2, "classic tmp_unlimdimid = %d", tmp_unlimdimid));
             if (ndimsp)
                 *ndimsp = tmp_ndims;
             if (nvarsp)
@@ -118,14 +118,14 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
                 *ngattsp = tmp_ngatts;
             if (unlimdimidp)
                 *unlimdimidp = tmp_unlimdimid;
-	    if (unlimdimidp)
-		LOG((2, "classic unlimdimid = %d", *unlimdimidp));
+            if (unlimdimidp)
+                LOG((2, "classic unlimdimid = %d", *unlimdimidp));
         }
-	else if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
-	{
-	    LOG((2, "PIOc_inq calling netcdf-4 nc_inq"));	    
+        else if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
+        {
+            LOG((2, "PIOc_inq calling netcdf-4 nc_inq"));
             ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);
-	}
+        }
 #endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
@@ -134,64 +134,64 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
+
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (!ierr)
     {
         if (ndimsp)
             if ((mpierr = MPI_Bcast(ndimsp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
-        
+
         if (nvarsp)
             if ((mpierr = MPI_Bcast(nvarsp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
-        
+
         if (ngattsp)
             if ((mpierr = MPI_Bcast(ngattsp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
-        
+
         if (unlimdimidp)
             if ((mpierr = MPI_Bcast(unlimdimidp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_ndims
  * The PIO-C interface for the NetCDF function nc_inq_ndims.
  */
-int PIOc_inq_ndims (int ncid, int *ndimsp) 
+int PIOc_inq_ndims (int ncid, int *ndimsp)
 {
     LOG((1, "PIOc_inq_ndims"));
     return PIOc_inq(ncid, ndimsp, NULL, NULL, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_nvars
  * The PIO-C interface for the NetCDF function nc_inq_nvars.
  */
-int PIOc_inq_nvars(int ncid, int *nvarsp) 
+int PIOc_inq_nvars(int ncid, int *nvarsp)
 {
     return PIOc_inq(ncid, NULL, nvarsp, NULL, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_natts
  * The PIO-C interface for the NetCDF function nc_inq_natts.
  */
-int PIOc_inq_natts(int ncid, int *ngattsp) 
+int PIOc_inq_natts(int ncid, int *ngattsp)
 {
     return PIOc_inq(ncid, NULL, NULL, ngattsp, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_unlimdim
  * The PIO-C interface for the NetCDF function nc_inq_unlimdim.
  */
-int PIOc_inq_unlimdim(int ncid, int *unlimdimidp) 
+int PIOc_inq_unlimdim(int ncid, int *unlimdimidp)
 {
     LOG((1, "PIOc_inq_unlimdim ncid = %d unlimdimidp = %d", ncid, unlimdimidp));
     return PIOc_inq(ncid, NULL, NULL, NULL, unlimdimidp);
@@ -203,7 +203,7 @@ int pioc_pnetcdf_inq_type(int ncid, nc_type xtype, char *name,
 {
     int typelen;
     char typename[NC_MAX_NAME + 1];
-    
+
     switch (xtype)
     {
     case NC_UBYTE:
@@ -236,7 +236,7 @@ int pioc_pnetcdf_inq_type(int ncid, nc_type xtype, char *name,
     return PIO_NOERR;
 }
 
-/** 
+/**
  * @ingroup PIOc_typelen
  * The PIO-C interface for the NetCDF function nctypelen.
  */
@@ -252,7 +252,7 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -261,12 +261,12 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
         if (!ios->ioproc)
         {
             int msg = PIO_MSG_INQ_TYPE; /* Message for async notification. */
-            char name_present = name ? true : false;    
+            char name_present = name ? true : false;
             char size_present = sizep ? true : false;
-            
-            if (ios->compmaster) 
+
+            if (ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-            
+
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
@@ -279,17 +279,17 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            return check_mpi(file, mpierr2, __FILE__, __LINE__);            
+            return check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
-            ierr = pioc_pnetcdf_inq_type(ncid, xtype, name, sizep);         
+            ierr = pioc_pnetcdf_inq_type(ncid, xtype, name, sizep);
 #endif /* _PNETCDF */
 #ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
@@ -300,36 +300,36 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);             
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
     check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (!ierr)
     {
         if (name)
-        { 
+        {
             int slen;
             if (ios->iomaster)
                 slen = strlen(name);
             if ((mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
-	    if (!mpierr)
-		if ((mpierr = MPI_Bcast((void *)name, slen + 1, MPI_CHAR, ios->ioroot, ios->my_comm)))
-		    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            if (!mpierr)
+                if ((mpierr = MPI_Bcast((void *)name, slen + 1, MPI_CHAR, ios->ioroot, ios->my_comm)))
+                    return check_mpi(file, mpierr, __FILE__, __LINE__);
         }
         if (sizep)
             if ((mpierr = MPI_Bcast(sizep , 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
-                return check_mpi(file, mpierr, __FILE__, __LINE__);         
+                return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_format
  * The PIO-C interface for the NetCDF function nc_inq_format.
  */
-int PIOc_inq_format (int ncid, int *formatp) 
+int PIOc_inq_format (int ncid, int *formatp)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -340,7 +340,7 @@ int PIOc_inq_format (int ncid, int *formatp)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -350,8 +350,8 @@ int PIOc_inq_format (int ncid, int *formatp)
         {
             int msg = PIO_MSG_INQ_FORMAT;
             char format_present = formatp ? true : false;
-        
-            if(ios->compmaster) 
+
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -363,8 +363,8 @@ int PIOc_inq_format (int ncid, int *formatp)
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -383,9 +383,9 @@ int PIOc_inq_format (int ncid, int *formatp)
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);             
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
     check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (!ierr)
     {
@@ -393,25 +393,25 @@ int PIOc_inq_format (int ncid, int *formatp)
             if ((mpierr = MPI_Bcast(formatp , 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_dim
  * The PIO-C interface for the NetCDF function nc_inq_dim.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
- * @param lenp a pointer that will get the number of values 
+ * @param lenp a pointer that will get the number of values
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp) 
+int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -431,12 +431,12 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
         if (!ios->ioproc)
         {
             int msg = PIO_MSG_INQ_DIM;
-            char name_present = name ? true : false;    
+            char name_present = name ? true : false;
             char len_present = lenp ? true : false;
-            
-            if(ios->compmaster) 
+
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-            
+
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
@@ -448,12 +448,12 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
                 mpierr = MPI_Bcast(&len_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             LOG((2, "PIOc_inq netcdf Bcast len_present = %d", len_present));
         }
-        
+
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            return check_mpi(file, mpierr2, __FILE__, __LINE__);            
+            return check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -461,33 +461,33 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
     {
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
-	{
-	    LOG((2, "calling ncmpi_inq_dim"));
+        {
+            LOG((2, "calling ncmpi_inq_dim"));
             ierr = ncmpi_inq_dim(file->fh, dimid, name, lenp);;
-	}
+        }
 #endif /* _PNETCDF */
 #ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
-	{
-	    LOG((2, "calling nc_inq_dim"));
+        {
+            LOG((2, "calling nc_inq_dim"));
             ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
-	}
+        }
 #endif /* _NETCDF */
-	LOG((2, "ierr = %d", ierr));
+        LOG((2, "ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);             
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
     check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (!ierr)
     {
         if (name)
-        { 
+        {
             int slen;
-	    LOG((2, "bcasting results my_comm = %d", ios->my_comm));
+            LOG((2, "bcasting results my_comm = %d", ios->my_comm));
             if (ios->iomaster)
                 slen = strlen(name);
             if ((mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm)))
@@ -495,42 +495,42 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
             if ((mpierr = MPI_Bcast((void *)name, slen + 1, MPI_CHAR, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
         }
-        
+
         if (lenp)
             if ((mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
-                return check_mpi(file, mpierr, __FILE__, __LINE__);         
+                return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     LOG((2, "done with PIOc_inq_dim"));
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_dimname
  * The PIO-C interface for the NetCDF function nc_inq_dimname.
  */
-int PIOc_inq_dimname(int ncid, int dimid, char *name) 
+int PIOc_inq_dimname(int ncid, int dimid, char *name)
 {
     LOG((1, "PIOc_inq_dimname ncid = %d dimid = %d", ncid, dimid));
     return PIOc_inq_dim(ncid, dimid, name, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_dimlen
  * The PIO-C interface for the NetCDF function nc_inq_dimlen.
  */
-int PIOc_inq_dimlen(int ncid, int dimid, PIO_Offset *lenp) 
+int PIOc_inq_dimlen(int ncid, int dimid, PIO_Offset *lenp)
 {
     return PIOc_inq_dim(ncid, dimid, NULL, lenp);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_dimid
  * The PIO-C interface for the NetCDF function nc_inq_dimid.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -538,7 +538,7 @@ int PIOc_inq_dimlen(int ncid, int dimid, PIO_Offset *lenp)
  * @param idp a pointer that will get the id of the variable or attribute.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_dimid(int ncid, const char *name, int *idp) 
+int PIOc_inq_dimid(int ncid, const char *name, int *idp)
 {
     iosystem_desc_t *ios;
     file_desc_t *file;
@@ -548,14 +548,14 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
     /* Name must be provided. */
     if (!name)
         return PIO_EINVAL;
-    
+
     LOG((1, "PIOc_inq_dimid ncid = %d name = %s", ncid, name));
 
     /* Get the file info, based on the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    LOG((2, "iosysid = %d", ios->iosysid));    
+    LOG((2, "iosysid = %d", ios->iosysid));
 
     /* If using async, and not an IO task, then send parameters. */
     if (ios->async_interface)
@@ -564,10 +564,10 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
         {
             int msg = PIO_MSG_INQ_DIMID;
             char id_present = idp ? true : false;
-            
-            if(ios->compmaster) 
+
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-            
+
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
             int namelen = strlen(name);
@@ -581,9 +581,9 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            return check_mpi(file, mpierr2, __FILE__, __LINE__);            
+            return check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* IO tasks call the netCDF functions. */
@@ -602,7 +602,7 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);             
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
     check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results. */
@@ -611,28 +611,28 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
             if ((mpierr = MPI_Bcast(idp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
     LOG((3, "id = %d", *idp));
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_var
  * The PIO-C interface for the NetCDF function nc_inq_var.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
  * @param xtypep a pointer that will get the type of the attribute.
- * @param nattsp a pointer that will get the number of attributes 
+ * @param nattsp a pointer that will get the number of attributes
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
 int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
-                 int *dimidsp, int *nattsp) 
+                 int *dimidsp, int *nattsp)
 {
     iosystem_desc_t *ios;
     file_desc_t *file;
@@ -644,7 +644,7 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
 
     /* Get the file info, based on the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
     LOG((2, "got file and iosystem"));
 
@@ -654,13 +654,13 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
         if (!ios->ioproc)
         {
             int msg = PIO_MSG_INQ_VAR;
-	    char name_present = name ? true : false;
-	    char xtype_present = xtypep ? true : false;
-	    char ndims_present = ndimsp ? true : false;
-	    char dimids_present = dimidsp ? true : false;
-	    char natts_present = nattsp ? true : false;
+            char name_present = name ? true : false;
+            char xtype_present = xtypep ? true : false;
+            char ndims_present = ndimsp ? true : false;
+            char dimids_present = dimidsp ? true : false;
+            char natts_present = nattsp ? true : false;
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -677,27 +677,27 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
                 mpierr = MPI_Bcast(&dimids_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&natts_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    LOG((2, "PIOc_inq_var name_present = %d xtype_present = %d ndims_present = %d "
-		 "dimids_present = %d, natts_present = %d nattsp = %d",
-		 name_present, xtype_present, ndims_present, dimids_present, natts_present, nattsp));
+            LOG((2, "PIOc_inq_var name_present = %d xtype_present = %d ndims_present = %d "
+                 "dimids_present = %d, natts_present = %d nattsp = %d",
+                 name_present, xtype_present, ndims_present, dimids_present, natts_present, nattsp));
         }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-        
+
     /* Call the netCDF layer. */
     if (ios->ioproc)
     {
-	LOG((2, "Calling the netCDF layer"));
+        LOG((2, "Calling the netCDF layer"));
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
             ierr = ncmpi_inq_varndims(file->fh, varid, &ndims);
-	    LOG((2, "from pnetcdf ndims = %d", ndims));
+            LOG((2, "from pnetcdf ndims = %d", ndims));
             if (!ierr)
                 ierr = ncmpi_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);
         }
@@ -706,42 +706,42 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             ierr = nc_inq_varndims(file->fh, varid, &ndims);
-	    char my_name[NC_MAX_NAME + 1];
-	    nc_type my_xtype;
-	    int my_ndims, my_dimids[ndims], my_natts;
-	    LOG((2, "file->fh = %d varid = %d xtypep = %d ndimsp = %d dimidsp = %d nattsp = %d",
-		 file->fh, varid, xtypep, ndimsp, dimidsp, nattsp));	    
+            char my_name[NC_MAX_NAME + 1];
+            nc_type my_xtype;
+            int my_ndims, my_dimids[ndims], my_natts;
+            LOG((2, "file->fh = %d varid = %d xtypep = %d ndimsp = %d dimidsp = %d nattsp = %d",
+                 file->fh, varid, xtypep, ndimsp, dimidsp, nattsp));
             if (!ierr)
                 ierr = nc_inq_var(file->fh, varid, my_name, &my_xtype, &my_ndims, my_dimids, &my_natts);
-	    LOG((3, "my_name = %s my_xtype = %d my_ndims = %d my_natts = %d",  my_name, my_xtype, my_ndims, my_natts));
-	    if (name)
-		strcpy(name, my_name);
-	    if (xtypep)
-		*xtypep = my_xtype;
-	    if (ndimsp)
-		*ndimsp = my_ndims;
-	    if (dimidsp)
-		for (int d = 0; d < ndims; d++)
-		    dimidsp[d] = my_dimids[d];
-	    if (nattsp)
-		*nattsp = my_natts;
-        }           
+            LOG((3, "my_name = %s my_xtype = %d my_ndims = %d my_natts = %d",  my_name, my_xtype, my_ndims, my_natts));
+            if (name)
+                strcpy(name, my_name);
+            if (xtypep)
+                *xtypep = my_xtype;
+            if (ndimsp)
+                *ndimsp = my_ndims;
+            if (dimidsp)
+                for (int d = 0; d < ndims; d++)
+                    dimidsp[d] = my_dimids[d];
+            if (nattsp)
+                *nattsp = my_natts;
+        }
 #endif /* _NETCDF */
-	if (ndimsp)
-	    LOG((2, "PIOc_inq_var ndims = %d ierr = %d", *ndimsp, ierr));
+        if (ndimsp)
+            LOG((2, "PIOc_inq_var ndims = %d ierr = %d", *ndimsp, ierr));
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);             
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Broadcast the results for non-null pointers. */
     if (!ierr)
     {
         if (name)
-        { 
+        {
             int slen;
             if(ios->iomaster)
                 slen = strlen(name);
@@ -753,15 +753,15 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
         if (xtypep)
             if ((mpierr = MPI_Bcast(xtypep, 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 return check_mpi(file, mpierr, __FILE__, __LINE__);
-        
+
         if (ndimsp)
         {
-	    if (ios->ioroot)
-		LOG((2, "PIOc_inq_var about to Bcast ndims = %d ios->ioroot = %d", *ndimsp, ios->ioroot));
+            if (ios->ioroot)
+                LOG((2, "PIOc_inq_var about to Bcast ndims = %d ios->ioroot = %d", *ndimsp, ios->ioroot));
             if ((mpierr = MPI_Bcast(ndimsp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-                return check_mpi(file, mpierr, __FILE__, __LINE__);         
+                return check_mpi(file, mpierr, __FILE__, __LINE__);
             file->varlist[varid].ndims = *ndimsp;
-	    LOG((2, "PIOc_inq_var Bcast ndims = %d", *ndimsp));
+            LOG((2, "PIOc_inq_var Bcast ndims = %d", *ndimsp));
         }
         if (dimidsp)
         {
@@ -778,67 +778,67 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_varname
  * The PIO-C interface for the NetCDF function nc_inq_varname.
  */
-int PIOc_inq_varname (int ncid, int varid, char *name) 
+int PIOc_inq_varname (int ncid, int varid, char *name)
 {
     return PIOc_inq_var(ncid, varid, name, NULL, NULL, NULL, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_vartype
  * The PIO-C interface for the NetCDF function nc_inq_vartype.
  */
-int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep) 
+int PIOc_inq_vartype (int ncid, int varid, nc_type *xtypep)
 {
     return PIOc_inq_var(ncid, varid, NULL, xtypep, NULL, NULL, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_varndims
  * The PIO-C interface for the NetCDF function nc_inq_varndims.
  */
-int PIOc_inq_varndims (int ncid, int varid, int *ndimsp) 
+int PIOc_inq_varndims (int ncid, int varid, int *ndimsp)
 {
     return PIOc_inq_var(ncid, varid, NULL, NULL, ndimsp, NULL, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_vardimid
  * The PIO-C interface for the NetCDF function nc_inq_vardimid.
  */
-int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp) 
+int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp)
 {
     return PIOc_inq_var(ncid, varid, NULL, NULL, NULL, dimidsp, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_varnatts
  * The PIO-C interface for the NetCDF function nc_inq_varnatts.
  */
-int PIOc_inq_varnatts (int ncid, int varid, int *nattsp) 
+int PIOc_inq_varnatts (int ncid, int varid, int *nattsp)
 {
     return PIOc_inq_var(ncid, varid, NULL, NULL, NULL, NULL, nattsp);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_varid
  * The PIO-C interface for the NetCDF function nc_inq_varid.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
- * @param varidp a pointer that will get the variable id 
+ * @param varidp a pointer that will get the variable id
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_varid (int ncid, const char *name, int *varidp) 
+int PIOc_inq_varid (int ncid, const char *name, int *varidp)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -851,7 +851,7 @@ int PIOc_inq_varid (int ncid, const char *name, int *varidp)
 
     /* Get file info based on ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     LOG((1, "PIOc_inq_varid ncid = %d name = %s", ncid, name));
@@ -861,10 +861,10 @@ int PIOc_inq_varid (int ncid, const char *name, int *varidp)
         if (!ios->ioproc)
         {
             int msg = PIO_MSG_INQ_VARID;
-            
-            if(ios->compmaster) 
+
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-            
+
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
             int namelen;
@@ -877,9 +877,9 @@ int PIOc_inq_varid (int ncid, const char *name, int *varidp)
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -887,7 +887,7 @@ int PIOc_inq_varid (int ncid, const char *name, int *varidp)
     {
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
-            ierr = ncmpi_inq_varid(file->fh, name, varidp);        
+            ierr = ncmpi_inq_varid(file->fh, name, varidp);
 #endif /* _PNETCDF */
 #ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
@@ -898,7 +898,7 @@ int PIOc_inq_varid (int ncid, const char *name, int *varidp)
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
@@ -911,24 +911,24 @@ int PIOc_inq_varid (int ncid, const char *name, int *varidp)
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_att
  * The PIO-C interface for the NetCDF function nc_inq_att.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
  * @param xtypep a pointer that will get the type of the attribute.
- * @param lenp a pointer that will get the number of values 
+ * @param lenp a pointer that will get the number of values
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
 int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
-                 PIO_Offset *lenp) 
+                 PIO_Offset *lenp)
 {
     int msg = PIO_MSG_INQ_ATT;
     iosystem_desc_t *ios;
@@ -945,7 +945,7 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
 
     /* Find file based on ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -956,8 +956,8 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
             char xtype_present = xtypep ? true : false;
             char len_present = lenp ? true : false;
             int namelen = strlen(name);
-            
-            if(ios->compmaster) 
+
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -977,10 +977,10 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
@@ -998,11 +998,11 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+
     /* Broadcast results. */
     if (!ierr)
     {
@@ -1013,35 +1013,35 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
             if ((mpierr = MPI_Bcast(lenp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
                 check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_attlen
  * The PIO-C interface for the NetCDF function nc_inq_attlen.
  */
-int PIOc_inq_attlen (int ncid, int varid, const char *name, PIO_Offset *lenp) 
+int PIOc_inq_attlen (int ncid, int varid, const char *name, PIO_Offset *lenp)
 {
     return PIOc_inq_att(ncid, varid, name, NULL, lenp);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_atttype
  * The PIO-C interface for the NetCDF function nc_inq_atttype.
  */
-int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep) 
+int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep)
 {
     return PIOc_inq_att(ncid, varid, name, xtypep, NULL);
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_attname
  * The PIO-C interface for the NetCDF function nc_inq_attname.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -1050,7 +1050,7 @@ int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep)
  * @param attnum the attribute ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_attname(int ncid, int varid, int attnum, char *name) 
+int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1062,7 +1062,7 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1073,9 +1073,9 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
             int msg = PIO_MSG_INQ_ATTNAME;
             char name_present = name ? true : false;
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-            
+
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
@@ -1089,8 +1089,8 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -1110,11 +1110,11 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (!ierr)
         if (name)
@@ -1130,13 +1130,13 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_attid
  * The PIO-C interface for the NetCDF function nc_inq_attid.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -1145,7 +1145,7 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
  * @param idp a pointer that will get the id of the variable or attribute.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp) 
+int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1155,12 +1155,12 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
     /* User must provide name shorter than NC_MAX_NAME +1. */
     if (!name || strlen(name) > NC_MAX_NAME)
         return PIO_EINVAL;
-    
+
     LOG((1, "PIOc_inq_attid ncid = %d varid = %d name = %s", ncid, varid, name));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1171,8 +1171,8 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
             int msg = PIO_MSG_INQ_ATTID;
             int namelen = strlen(name);
             char id_present = idp ? true : false;
-            
-            if(ios->compmaster) 
+
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -1190,8 +1190,8 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -1211,36 +1211,36 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+
     /* Broadcast results. */
     if (!ierr)
     {
         if (idp)
             if ((mpierr = MPI_Bcast(idp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-                check_mpi(file, mpierr, __FILE__, __LINE__);    
+                check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_rename_dim
  * The PIO-C interface for the NetCDF function nc_rename_dim.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_rename_dim(int ncid, int dimid, const char *name) 
+int PIOc_rename_dim(int ncid, int dimid, const char *name)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1255,7 +1255,7 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1266,7 +1266,7 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
             int msg = PIO_MSG_RENAME_DIM; /* Message for async notification. */
             int namelen = strlen(name);
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -1283,12 +1283,12 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
-    
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
@@ -1306,21 +1306,21 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_rename_var
  * The PIO-C interface for the NetCDF function nc_rename_var.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -1328,7 +1328,7 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_rename_var(int ncid, int varid, const char *name) 
+int PIOc_rename_var(int ncid, int varid, const char *name)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1343,7 +1343,7 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1354,7 +1354,7 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
             int msg = PIO_MSG_RENAME_VAR; /* Message for async notification. */
             int namelen = strlen(name);
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -1371,12 +1371,12 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
-    
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
@@ -1394,21 +1394,21 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_rename_att
  * The PIO-C interface for the NetCDF function nc_rename_att.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -1418,7 +1418,7 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
  * PIOc_Set_File_Error_Handling
  */
 int PIOc_rename_att (int ncid, int varid, const char *name,
-                     const char *newname) 
+                     const char *newname)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1435,7 +1435,7 @@ int PIOc_rename_att (int ncid, int varid, const char *name,
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1447,7 +1447,7 @@ int PIOc_rename_att (int ncid, int varid, const char *name,
             int namelen = strlen(name);
             int newnamelen = strlen(newname);
 
-            if (ios->compmaster) 
+            if (ios->compmaster)
                 mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -1466,11 +1466,11 @@ int PIOc_rename_att (int ncid, int varid, const char *name,
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
@@ -1487,22 +1487,22 @@ int PIOc_rename_att (int ncid, int varid, const char *name,
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
 
-    LOG((2, "PIOc_rename_att succeeded"));        
+    LOG((2, "PIOc_rename_att succeeded"));
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_del_att
  * The PIO-C interface for the NetCDF function nc_del_att.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -1510,7 +1510,7 @@ int PIOc_rename_att (int ncid, int varid, const char *name,
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_del_att(int ncid, int varid, const char *name) 
+int PIOc_del_att(int ncid, int varid, const char *name)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1525,7 +1525,7 @@ int PIOc_del_att(int ncid, int varid, const char *name)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1536,7 +1536,7 @@ int PIOc_del_att(int ncid, int varid, const char *name)
             int msg = PIO_MSG_DEL_ATT;
             int namelen = strlen(name); /* Length of name string. */
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -1552,8 +1552,8 @@ int PIOc_del_att(int ncid, int varid, const char *name)
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -1572,29 +1572,29 @@ int PIOc_del_att(int ncid, int varid, const char *name)
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
 
-    LOG((2, "PIOc_del_att succeeded"));        
+    LOG((2, "PIOc_del_att succeeded"));
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_set_fill
  * The PIO-C interface for the NetCDF function nc_set_fill.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_set_fill (int ncid, int fillmode, int *old_modep) 
+int PIOc_set_fill (int ncid, int fillmode, int *old_modep)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1606,7 +1606,7 @@ int PIOc_set_fill (int ncid, int fillmode, int *old_modep)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1616,18 +1616,18 @@ int PIOc_set_fill (int ncid, int fillmode, int *old_modep)
         {
             int msg = PIO_MSG_SET_FILL;
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-            
+
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
         }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
 
@@ -1647,19 +1647,19 @@ int PIOc_set_fill (int ncid, int fillmode, int *old_modep)
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
 
-    LOG((2, "PIOc_set_fill succeeded"));        
+    LOG((2, "PIOc_set_fill succeeded"));
     return ierr;
 }
 
 /** This is an internal function that handles both PIOc_enddef and
- * PIOc_redef. 
+ * PIOc_redef.
  * @param ncid the ncid of the file to enddef or redef
- * @param is_enddef set to non-zero for enddef, 0 for redef. 
+ * @param is_enddef set to non-zero for enddef, 0 for redef.
  * @returns PIO_NOERR on success, error code on failure. */
 int pioc_change_def(int ncid, int is_enddef)
 {
@@ -1672,37 +1672,37 @@ int pioc_change_def(int ncid, int is_enddef)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
         if (!ios->ioproc)
         {
             int msg = is_enddef ? PIO_MSG_ENDDEF : PIO_MSG_REDEF;
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-            if (!mpierr)            
+            if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    LOG((3, "pioc_change_def ncid = %d mpierr = %d", ncid, mpierr));
+            LOG((3, "pioc_change_def ncid = %d mpierr = %d", ncid, mpierr));
         }
 
         /* Handle MPI errors. */
-	LOG((3, "pioc_change_def handling MPI errors"));	
+        LOG((3, "pioc_change_def handling MPI errors"));
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
-    LOG((3, "pioc_change_def ios->ioproc = %d", ios->ioproc));    
+    LOG((3, "pioc_change_def ios->ioproc = %d", ios->ioproc));
     if (ios->ioproc)
     {
-	LOG((3, "pioc_change_def calling netcdf function file->fh = %d file->do_io = %d",
-	     file->fh, file->do_io));
+        LOG((3, "pioc_change_def calling netcdf function file->fh = %d file->do_io = %d",
+             file->fh, file->do_io));
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             if (is_enddef)
@@ -1713,10 +1713,10 @@ int pioc_change_def(int ncid, int is_enddef)
 #ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             if (is_enddef)
-	    {
-		LOG((3, "pioc_change_def calling nc_enddef file->fh = %d", file->fh));
-		ierr = nc_enddef(file->fh);
-	    }
+            {
+                LOG((3, "pioc_change_def calling nc_enddef file->fh = %d", file->fh));
+                ierr = nc_enddef(file->fh);
+            }
             else
                 ierr = nc_redef(file->fh);
 #endif /* _NETCDF */
@@ -1725,57 +1725,57 @@ int pioc_change_def(int ncid, int is_enddef)
     /* Broadcast and check the return code. */
     LOG((3, "pioc_change_def bcasting return code ierr = %d", ierr));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);            
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
     LOG((3, "pioc_change_def succeeded"));
 
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_enddef
  * The PIO-C interface for the NetCDF function nc_enddef.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_enddef(int ncid) 
+int PIOc_enddef(int ncid)
 {
     return pioc_change_def(ncid, 1);
 }
 
-/** 
+/**
  * @ingroup PIOc_redef
  * The PIO-C interface for the NetCDF function nc_redef.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__datasets.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_redef(int ncid) 
+int PIOc_redef(int ncid)
 {
-    return pioc_change_def(ncid, 0);    
+    return pioc_change_def(ncid, 0);
 }
 
-/** 
+/**
  * @ingroup PIOc_def_dim
  * The PIO-C interface for the NetCDF function nc_def_dim.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__dimensions.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -1783,7 +1783,7 @@ int PIOc_redef(int ncid)
  * @param idp a pointer that will get the id of the variable or attribute.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp) 
+int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1798,7 +1798,7 @@ int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -1809,7 +1809,7 @@ int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp)
             int msg = PIO_MSG_DEF_DIM;
             int namelen = strlen(name);
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -1826,28 +1826,28 @@ int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp)
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
-            ierr = ncmpi_def_dim(file->fh, name, len, idp);        
+            ierr = ncmpi_def_dim(file->fh, name, len, idp);
 #endif /* _PNETCDF */
 #ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
-            ierr = nc_def_dim(file->fh, name, (size_t)len, idp);            
+            ierr = nc_def_dim(file->fh, name, (size_t)len, idp);
 #endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr2, __FILE__, __LINE__);           
+        check_mpi(file, mpierr2, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
@@ -1856,29 +1856,29 @@ int PIOc_def_dim (int ncid, const char *name, PIO_Offset len, int *idp)
     if (!ierr)
         if (idp)
             if ((mpierr = MPI_Bcast(idp , 1, MPI_INT, ios->ioroot, ios->my_comm)))
-                check_mpi(file, mpierr, __FILE__, __LINE__);            
+                check_mpi(file, mpierr, __FILE__, __LINE__);
 
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_def_var
  * The PIO-C interface for the NetCDF function nc_def_var.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
  *
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
- * @param varidp a pointer that will get the variable id 
+ * @param varidp a pointer that will get the variable id
  * @return PIO_NOERR for success, error code otherwise. See
  * PIOc_Set_File_Error_Handling
  */
 int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims,
-                  const int *dimidsp, int *varidp) 
+                  const int *dimidsp, int *varidp)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1888,13 +1888,13 @@ int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims,
     /* User must provide name and storage for varid. */
     if (!name || !varidp || strlen(name) > NC_MAX_NAME)
     {
-        check_netcdf(file, PIO_EINVAL, __FILE__, __LINE__);     
+        check_netcdf(file, PIO_EINVAL, __FILE__, __LINE__);
         return PIO_EINVAL;
     }
 
     /* Get the file information. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If using async, and not an IO task, then send parameters. */
@@ -1904,10 +1904,10 @@ int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims,
         {
             int msg = PIO_MSG_DEF_VAR;
             int namelen = strlen(name);
-            
-            if(ios->compmaster) 
+
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-            
+
             if (!mpierr)
                 mpierr = MPI_Bcast(&(ncid), 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
@@ -1924,9 +1924,9 @@ int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims,
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -1954,7 +1954,7 @@ int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims,
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
@@ -1964,17 +1964,17 @@ int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims,
         if (varidp)
             if ((mpierr = MPI_Bcast(varidp , 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 check_mpi(file, mpierr, __FILE__, __LINE__);
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_inq_var_fill
  * The PIO-C interface for the NetCDF function nc_inq_var_fill.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -1982,7 +1982,7 @@ int PIOc_def_var (int ncid, const char *name, nc_type xtype, int ndims,
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
-int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep) 
+int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1993,7 +1993,7 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -2003,7 +2003,7 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
         {
             int msg = PIO_MSG_INQ_VAR_FILL;
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -2012,9 +2012,9 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -2033,27 +2033,27 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
 
-    /* Broadcast results to all tasks. Ignore NULL parameters. */    
+    /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (!ierr)
         if (fill_valuep)
             if ((mpierr = MPI_Bcast(fill_valuep, 1, MPI_INT, ios->ioroot, ios->my_comm)))
                 check_mpi(file, mpierr, __FILE__, __LINE__);
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att
  * The PIO-C interface for the NetCDF function nc_get_att.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -2062,7 +2062,7 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
  * @return PIO_NOERR for success, error code otherwise. See
  * PIOc_Set_File_Error_Handling
  */
-int PIOc_get_att(int ncid, int varid, const char *name, void *ip) 
+int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -2079,7 +2079,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* Run these on all tasks if async is not in use, but only on
@@ -2092,7 +2092,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
             check_netcdf(file, ierr, __FILE__, __LINE__);
             return ierr;
         }
-	LOG((2, "atttype = %d attlen = %d", atttype, attlen));
+        LOG((2, "atttype = %d attlen = %d", atttype, attlen));
 
         /* Get the length (in bytes) of the type. */
         if ((ierr = PIOc_inq_type(ncid, atttype, NULL, &typelen)))
@@ -2100,7 +2100,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
             check_netcdf(file, ierr, __FILE__, __LINE__);
             return ierr;
         }
-	LOG((2, "typelen = %d", typelen));
+        LOG((2, "typelen = %d", typelen));
     }
     LOG((2, "again typelen = %d", typelen));
 
@@ -2111,10 +2111,10 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
         if (!ios->ioproc)
         {
             int msg = PIO_MSG_GET_ATT;
-	    LOG((2, "sending parameters"));
+            LOG((2, "sending parameters"));
 
             /* Send the message to IO master. */
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             /* Send the function parameters. */
@@ -2135,18 +2135,18 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
                 mpierr = MPI_Bcast(&attlen, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    LOG((2, "Bcast complete ncid = %d varid = %d namelen = %d name = %s iotype = %d "
-		 "atttype = %d attlen = %d typelen = %d", ncid, varid, namelen, name, file->iotype,
-		 atttype, attlen, typelen));
+            LOG((2, "Bcast complete ncid = %d varid = %d namelen = %d name = %s iotype = %d "
+                 "atttype = %d attlen = %d typelen = %d", ncid, varid, namelen, name, file->iotype,
+                 atttype, attlen, typelen));
         }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
-	LOG((2, "mpi errors handled"));
-        
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
+        LOG((2, "mpi errors handled"));
+
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         LOG((2, "PIOc_get_att bcast from comproot = %d attlen = %d typelen = %d", ios->comproot, attlen, typelen));
         if ((mpierr = MPI_Bcast(&attlen, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
@@ -2155,11 +2155,11 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
             return check_mpi(file, mpierr, __FILE__, __LINE__);
         LOG((2, "PIOc_get_att bcast complete attlen = %d typelen = %d", attlen, typelen));
     }
-        
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-	LOG((2, "calling pnetcdf/netcdf"));
+        LOG((2, "calling pnetcdf/netcdf"));
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_get_att(file->fh, varid, name, ip);
@@ -2175,25 +2175,25 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. */
     if (!ierr)
         if ((mpierr = MPI_Bcast(ip, (int)attlen * typelen, MPI_BYTE, ios->ioroot,
                                 ios->my_comm)))
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
 
-    LOG((2, "get_att data bcast complete"));    
+    LOG((2, "get_att data bcast complete"));
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att
  * The PIO-C interface for the NetCDF function nc_put_att.
  *
- * This routine is called collectively by all tasks in the communicator 
+ * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
- * please read about this function in the NetCDF documentation at: 
+ * please read about this function in the NetCDF documentation at:
  * http://www.unidata.ucar.edu/software/netcdf/docs/group__attributes.html
  *
  * @param ncid the ncid of the open file, obtained from
@@ -2202,7 +2202,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
  */
 int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
-                 PIO_Offset len, const void *op) 
+                 PIO_Offset len, const void *op)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -2214,7 +2214,7 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* Run these on all tasks if async is not in use, but only on
@@ -2229,7 +2229,7 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
         }
         LOG((2, "PIOc_put_att typelen = %d", ncid, typelen));
     }
-    
+
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
@@ -2237,7 +2237,7 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
         {
             int msg = PIO_MSG_PUT_ATT;
 
-            if(ios->compmaster) 
+            if(ios->compmaster)
                 mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
             if (!mpierr)
@@ -2264,16 +2264,16 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(file, mpierr2, __FILE__, __LINE__);           
+            check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         LOG((2, "PIOc_put_att bcast from comproot = %d typelen = %d", ios->comproot, typelen));
         if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
             check_mpi(file, mpierr, __FILE__, __LINE__);
     }
-    
+
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
@@ -2290,259 +2290,257 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
     {
-        check_mpi(file, mpierr, __FILE__, __LINE__);            
+        check_mpi(file, mpierr, __FILE__, __LINE__);
         return PIO_EIO;
     }
     check_netcdf(file, ierr, __FILE__, __LINE__);
-    
+
     return ierr;
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_double
  * The PIO-C interface for the NetCDF function nc_get_att_double.
  */
-int PIOc_get_att_double(int ncid, int varid, const char *name, double *ip) 
+int PIOc_get_att_double(int ncid, int varid, const char *name, double *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_uchar
  * The PIO-C interface for the NetCDF function nc_get_att_uchar.
  */
-int PIOc_get_att_uchar (int ncid, int varid, const char *name, unsigned char *ip) 
+int PIOc_get_att_uchar (int ncid, int varid, const char *name, unsigned char *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_ushort
  * The PIO-C interface for the NetCDF function nc_get_att_ushort.
  */
-int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *ip) 
+int PIOc_get_att_ushort (int ncid, int varid, const char *name, unsigned short *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_uint
  * The PIO-C interface for the NetCDF function nc_get_att_uint.
  */
-int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip) 
+int PIOc_get_att_uint (int ncid, int varid, const char *name, unsigned int *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_long
  * The PIO-C interface for the NetCDF function nc_get_att_long.
  */
-int PIOc_get_att_long (int ncid, int varid, const char *name, long *ip) 
+int PIOc_get_att_long (int ncid, int varid, const char *name, long *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_ubyte
  * The PIO-C interface for the NetCDF function nc_get_att_ubyte.
  */
-int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip) 
+int PIOc_get_att_ubyte (int ncid, int varid, const char *name, unsigned char *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_text
  * The PIO-C interface for the NetCDF function nc_get_att_text.
  */
-int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip) 
+int PIOc_get_att_text (int ncid, int varid, const char *name, char *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_schar
  * The PIO-C interface for the NetCDF function nc_get_att_schar.
  */
-int PIOc_get_att_schar (int ncid, int varid, const char *name, signed char *ip) 
+int PIOc_get_att_schar (int ncid, int varid, const char *name, signed char *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_ulonglong
  * The PIO-C interface for the NetCDF function nc_get_att_ulonglong.
  */
-int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long long *ip) 
+int PIOc_get_att_ulonglong (int ncid, int varid, const char *name, unsigned long long *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_short
  * The PIO-C interface for the NetCDF function nc_get_att_short.
  */
-int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip) 
+int PIOc_get_att_short (int ncid, int varid, const char *name, short *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_int
  * The PIO-C interface for the NetCDF function nc_get_att_int.
  */
-int PIOc_get_att_int(int ncid, int varid, const char *name, int *ip) 
+int PIOc_get_att_int(int ncid, int varid, const char *name, int *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_longlong
  * The PIO-C interface for the NetCDF function nc_get_att_longlong.
  */
-int PIOc_get_att_longlong(int ncid, int varid, const char *name, long long *ip) 
+int PIOc_get_att_longlong(int ncid, int varid, const char *name, long long *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_get_att_float
  * The PIO-C interface for the NetCDF function nc_get_att_float.
  */
-int PIOc_get_att_float (int ncid, int varid, const char *name, float *ip) 
+int PIOc_get_att_float (int ncid, int varid, const char *name, float *ip)
 {
     return PIOc_get_att(ncid, varid, name, (void *)ip);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_schar
  * The PIO-C interface for the NetCDF function nc_put_att_schar.
  */
 int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype,
-                       PIO_Offset len, const signed char *op) 
+                       PIO_Offset len, const signed char *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_long
  * The PIO-C interface for the NetCDF function nc_put_att_long.
  */
 int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype,
-                      PIO_Offset len, const long *op) 
+                      PIO_Offset len, const long *op)
 {
     return PIOc_put_att(ncid, varid, name, NC_CHAR, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_int
  * The PIO-C interface for the NetCDF function nc_put_att_int.
  */
 int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype,
-                     PIO_Offset len, const int *op) 
+                     PIO_Offset len, const int *op)
 {
-    return PIOc_put_att(ncid, varid, name, xtype, len, op);    
+    return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_uchar
  * The PIO-C interface for the NetCDF function nc_put_att_uchar.
  */
 int PIOc_put_att_uchar(int ncid, int varid, const char *name, nc_type xtype,
-                       PIO_Offset len, const unsigned char *op) 
+                       PIO_Offset len, const unsigned char *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_longlong
  * The PIO-C interface for the NetCDF function nc_put_att_longlong.
  */
 int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype,
-                          PIO_Offset len, const long long *op) 
+                          PIO_Offset len, const long long *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_uint
  * The PIO-C interface for the NetCDF function nc_put_att_uint.
  */
 int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype,
-                      PIO_Offset len, const unsigned int *op) 
+                      PIO_Offset len, const unsigned int *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_ubyte
  * The PIO-C interface for the NetCDF function nc_put_att_ubyte.
  */
 int PIOc_put_att_ubyte(int ncid, int varid, const char *name, nc_type xtype,
-                       PIO_Offset len, const unsigned char *op) 
+                       PIO_Offset len, const unsigned char *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_float
  * The PIO-C interface for the NetCDF function nc_put_att_float.
  */
 int PIOc_put_att_float(int ncid, int varid, const char *name, nc_type xtype,
-                       PIO_Offset len, const float *op) 
+                       PIO_Offset len, const float *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_ulonglong
  * The PIO-C interface for the NetCDF function nc_put_att_ulonglong.
  */
 int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype,
-                           PIO_Offset len, const unsigned long long *op) 
+                           PIO_Offset len, const unsigned long long *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_ushort
  * The PIO-C interface for the NetCDF function nc_put_att_ushort.
  */
 int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype,
-                        PIO_Offset len, const unsigned short *op) 
+                        PIO_Offset len, const unsigned short *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_text
  * The PIO-C interface for the NetCDF function nc_put_att_text.
  */
 int PIOc_put_att_text(int ncid, int varid, const char *name,
-                      PIO_Offset len, const char *op) 
+                      PIO_Offset len, const char *op)
 {
     return PIOc_put_att(ncid, varid, name, NC_CHAR, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_short
  * The PIO-C interface for the NetCDF function nc_put_att_short.
  */
 int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype,
-                       PIO_Offset len, const short *op) 
+                       PIO_Offset len, const short *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
 
-/** 
+/**
  * @ingroup PIOc_put_att_double
  * The PIO-C interface for the NetCDF function nc_put_att_double.
  */
 int PIOc_put_att_double(int ncid, int varid, const char *name, nc_type xtype,
-                        PIO_Offset len, const double *op) 
+                        PIO_Offset len, const double *op)
 {
     return PIOc_put_att(ncid, varid, name, xtype, len, op);
 }
-
-

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -29,7 +29,7 @@
  * @return PIO_NOERR for success, otherwise an error code.
  */
 int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
-			 int deflate_level)
+                         int deflate_level)
 {
     int ierr;
     int msg;
@@ -43,55 +43,55 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_DEF_VAR_DEFLATE;
 
     if (ios->async_interface && ! ios->ioproc)
     {
-	if (ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    /* Versions of netCDF 4.4 and earlier do not return an
-	     * error when attempting to turn on deflation with
-	     * parallel I.O. But this is not allowed by HDF5. So
-	     * return the correct error code. */
-	    ierr = NC_EINVAL;
-	    //ierr = nc_def_var_deflate(file->fh, varid, shuffle, deflate, deflate_level);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (!ios->io_rank)
-		ierr = nc_def_var_deflate(file->fh, varid, shuffle, deflate, deflate_level);
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            /* Versions of netCDF 4.4 and earlier do not return an
+             * error when attempting to turn on deflation with
+             * parallel I.O. But this is not allowed by HDF5. So
+             * return the correct error code. */
+            ierr = NC_EINVAL;
+            //ierr = nc_def_var_deflate(file->fh, varid, shuffle, deflate, deflate_level);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (!ios->io_rank)
+                ierr = nc_def_var_deflate(file->fh, varid, shuffle, deflate, deflate_level);
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* If there is an error, allocate space for the error string. */
     if (ierr != PIO_NOERR)
     {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
+        errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+        sprintf(errstr,"in file %s",__FILE__);
     }
 
     /* Check the netCDF return code, and broadcast it to all tasks. */
@@ -99,7 +99,7 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
 
     /* Free the error string if it was allocated. */
     if (errstr != NULL)
-	free(errstr);
+        free(errstr);
 
     return ierr;
 }
@@ -129,7 +129,7 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
  * @return PIO_NOERR for success, otherwise an error code.
  */
 int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
-			 int *deflatep, int *deflate_levelp)
+                         int *deflatep, int *deflate_levelp)
 {
     int ierr;
     int msg;
@@ -144,50 +144,50 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_INQ_VAR_DEFLATE;
 
     if (ios->async_interface && ! ios->ioproc)
     {
-	if (ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_inq_var_deflate(file->fh, varid, shufflep, deflatep, deflate_levelp);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (ios->io_rank == 0)
-		ierr = nc_inq_var_deflate(file->fh, varid, shufflep, deflatep, deflate_levelp);
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_inq_var_deflate(file->fh, varid, shufflep, deflatep, deflate_levelp);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (ios->io_rank == 0)
+                ierr = nc_inq_var_deflate(file->fh, varid, shufflep, deflatep, deflate_levelp);
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* If there is an error, allocate space for the error string. */
     if (ierr != PIO_NOERR)
     {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
+        errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+        sprintf(errstr,"in file %s",__FILE__);
     }
 
     /* Check the netCDF return code, and broadcast it to all tasks. */
@@ -195,17 +195,17 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
 
     /* Free the error string if it was allocated. */
     if (errstr != NULL)
-	free(errstr);
+        free(errstr);
 
     /* Broadcast results to all tasks. */
     if (ierr == PIO_NOERR)
     {
-	if (shufflep)
-	    ierr = MPI_Bcast(shufflep, 1, MPI_INT, ios->ioroot, ios->my_comm);
-	if (deflatep)
-	    ierr = MPI_Bcast(deflatep, 1, MPI_INT, ios->ioroot, ios->my_comm);
-	if (deflate_levelp)
-	    ierr = MPI_Bcast(deflate_levelp, 1, MPI_INT, ios->ioroot, ios->my_comm);
+        if (shufflep)
+            ierr = MPI_Bcast(shufflep, 1, MPI_INT, ios->ioroot, ios->my_comm);
+        if (deflatep)
+            ierr = MPI_Bcast(deflatep, 1, MPI_INT, ios->ioroot, ios->my_comm);
+        if (deflate_levelp)
+            ierr = MPI_Bcast(deflate_levelp, 1, MPI_INT, ios->ioroot, ios->my_comm);
     }
     return ierr;
 }
@@ -235,7 +235,7 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
  * @return PIO_NOERR for success, otherwise an error code.
  */
 int PIOc_def_var_chunking(int ncid, int varid, int storage,
-			  const PIO_Offset *chunksizesp)
+                          const PIO_Offset *chunksizesp)
 {
     iosystem_desc_t *ios;  /** Pointer to io system information. */
     file_desc_t *file;     /** Pointer to file information. */
@@ -246,66 +246,66 @@ int PIOc_def_var_chunking(int ncid, int varid, int storage,
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = PIO_MSG_DEF_VAR_CHUNKING;
+        if (!ios->ioproc)
+        {
+            int msg = PIO_MSG_DEF_VAR_CHUNKING;
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_def_var_chunking(file->fh, varid, storage, chunksizesp);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (ios->io_rank==0)
-	    {
-		ierr = nc_def_var_chunking(file->fh, varid, storage, chunksizesp);
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_def_var_chunking(file->fh, varid, storage, chunksizesp);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (ios->io_rank==0)
+            {
+                ierr = nc_def_var_chunking(file->fh, varid, storage, chunksizesp);
+            }
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    return PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            return PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    return PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            return PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -346,55 +346,55 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
     ierr = PIO_NOERR;
 
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_INQ_VAR_CHUNKING;
 
     if (ios->async_interface && ! ios->ioproc)
     {
-	if (ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_inq_var_chunking(file->fh, varid, storagep, chunksizesp);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (ios->io_rank == 0)
-	    {
-		if ((ierr = nc_inq_var_chunking(file->fh, varid, storagep, chunksizesp)))
-		    return ierr;
-		if ((ierr = nc_inq_varndims(file->fh, varid, &ndims)))
-		    return ierr;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_inq_var_chunking(file->fh, varid, storagep, chunksizesp);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (ios->io_rank == 0)
+            {
+                if ((ierr = nc_inq_var_chunking(file->fh, varid, storagep, chunksizesp)))
+                    return ierr;
+                if ((ierr = nc_inq_varndims(file->fh, varid, &ndims)))
+                    return ierr;
+            }
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    return PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            return PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    return PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            return PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* If there is an error, allocate space for the error string. */
     if (ierr != PIO_NOERR)
     {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
+        errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+        sprintf(errstr,"in file %s",__FILE__);
     }
 
     /* Check the netCDF return code, and broadcast it to all tasks. */
@@ -402,14 +402,14 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
 
     /* Free the error stringif it was allocated. */
     if (errstr != NULL)
-	free(errstr);
+        free(errstr);
 
     /* Broadcast results to all tasks. */
     ierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->ioroot, ios->my_comm);
     if (storagep)
-	ierr = MPI_Bcast(storagep, 1, MPI_INT, ios->ioroot, ios->my_comm);
+        ierr = MPI_Bcast(storagep, 1, MPI_INT, ios->ioroot, ios->my_comm);
     if (chunksizesp)
-	ierr = MPI_Bcast(chunksizesp, ndims, MPI_OFFSET, ios->ioroot, ios->my_comm);
+        ierr = MPI_Bcast(chunksizesp, ndims, MPI_OFFSET, ios->ioroot, ios->my_comm);
 
     return ierr;
 }
@@ -451,52 +451,52 @@ int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
     ierr = PIO_NOERR;
 
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_SET_FILL;
 
     if (ios->async_interface && ! ios->ioproc)
     {
-	if (ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_def_var_fill(file->fh, varid, no_fill, fill_value);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (ios->io_rank==0)
-	    {
-		ierr = nc_def_var_fill(file->fh, varid, no_fill, fill_value);
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_def_var_fill(file->fh, varid, no_fill, fill_value);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (ios->io_rank==0)
+            {
+                ierr = nc_def_var_fill(file->fh, varid, no_fill, fill_value);
+            }
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    return PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            return PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    return PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            return PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* Allocate an error string if needed. */
     if (ierr != PIO_NOERR)
     {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
+        errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+        sprintf(errstr,"in file %s",__FILE__);
     }
 
     /* Check for netCDF error. */
@@ -504,7 +504,7 @@ int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
 
     /* Free the error string if it was allocated. */
     if (errstr != NULL)
-	free(errstr);
+        free(errstr);
 
     return ierr;
 }
@@ -546,52 +546,52 @@ int PIOc_def_var_endian(int ncid, int varid, int endian)
     ierr = PIO_NOERR;
 
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_DEF_VAR_ENDIAN;
 
     if (ios->async_interface && ! ios->ioproc)
     {
-	if (ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_def_var_endian(file->fh, varid, endian);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (ios->io_rank==0)
-	    {
-		ierr = nc_def_var_endian(file->fh, varid, endian);
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_def_var_endian(file->fh, varid, endian);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (ios->io_rank==0)
+            {
+                ierr = nc_def_var_endian(file->fh, varid, endian);
+            }
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* Allocate an error string if needed. */
     if (ierr != PIO_NOERR)
     {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
+        errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+        sprintf(errstr,"in file %s",__FILE__);
     }
 
     /* Check for netCDF error. */
@@ -599,7 +599,7 @@ int PIOc_def_var_endian(int ncid, int varid, int endian)
 
     /* Free the error string if it was allocated. */
     if (errstr != NULL)
-	free(errstr);
+        free(errstr);
 
     return ierr;
 }
@@ -639,50 +639,50 @@ int PIOc_inq_var_endian(int ncid, int varid, int *endianp)
     ierr = PIO_NOERR;
 
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_INQ_VAR_CHUNKING;
 
     if (ios->async_interface && ! ios->ioproc)
     {
-	if (ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_inq_var_endian(file->fh, varid, endianp);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (!ios->io_rank)
-		ierr = nc_inq_var_endian(file->fh, varid, endianp);
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_inq_var_endian(file->fh, varid, endianp);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (!ios->io_rank)
+                ierr = nc_inq_var_endian(file->fh, varid, endianp);
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* If there is an error, allocate space for the error string. */
     if (ierr != PIO_NOERR)
     {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
+        errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+        sprintf(errstr,"in file %s",__FILE__);
     }
 
     /* Check the netCDF return code, and broadcast it to all tasks. */
@@ -690,11 +690,11 @@ int PIOc_inq_var_endian(int ncid, int varid, int *endianp)
 
     /* Free the error string if it was allocated. */
     if (errstr != NULL)
-	free(errstr);
+        free(errstr);
 
     /* Broadcast results to all tasks. */
     if (endianp)
-	ierr = MPI_Bcast(endianp, 1, MPI_INT, ios->ioroot, ios->my_comm);
+        ierr = MPI_Bcast(endianp, 1, MPI_INT, ios->ioroot, ios->my_comm);
 
     return ierr;
 }
@@ -726,7 +726,7 @@ int PIOc_inq_var_endian(int ncid, int varid, int *endianp)
  * @return PIO_NOERR for success, otherwise an error code.
  */
 int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size,
-			 PIO_Offset nelems, float preemption)
+                         PIO_Offset nelems, float preemption)
 {
     int ierr;
     int msg;
@@ -741,12 +741,12 @@ int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size,
 
     ios = pio_get_iosystem_from_id(iosysid);
     if(ios == NULL)
-	return PIO_EBADID;
+        return PIO_EBADID;
 
-  /* if (ios->async_interface && ! ios->ioproc){ */
-    /* 	if (ios->compmaster) */
-    /* 	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm); */
-    /* 	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm); */
+    /* if (ios->async_interface && ! ios->ioproc){ */
+    /*  if (ios->compmaster) */
+    /*      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm); */
+    /*  mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm); */
     /* } */
 
     switch (iotype)
@@ -754,24 +754,24 @@ int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size,
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-	ierr = nc_set_chunk_cache(size, nelems, preemption);
-	break;
+        ierr = nc_set_chunk_cache(size, nelems, preemption);
+        break;
     case PIO_IOTYPE_NETCDF4C:
-	if (!ios->io_rank)
-	    ierr = nc_set_chunk_cache(size, nelems, preemption);
-	break;
+        if (!ios->io_rank)
+            ierr = nc_set_chunk_cache(size, nelems, preemption);
+        break;
 #endif
     case PIO_IOTYPE_NETCDF:
-	ierr = PIO_ENOTNC4;
-	break;
+        ierr = PIO_ENOTNC4;
+        break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-	ierr = PIO_ENOTNC4;
-	break;
+        ierr = PIO_ENOTNC4;
+        break;
 #endif
     default:
-	ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        ierr = iotype_error(file->iotype,__FILE__,__LINE__);
     }
 
     /* Propogate error code to all processes. */
@@ -811,7 +811,7 @@ int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size,
  * @return PIO_NOERR for success, otherwise an error code.
  */
 int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep,
-			 PIO_Offset *nelemsp, float *preemptionp)
+                         PIO_Offset *nelemsp, float *preemptionp)
 {
     int ierr;
     int msg;
@@ -824,7 +824,7 @@ int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep,
 
     ios = pio_get_iosystem_from_id(iosysid);
     if(ios == NULL)
-	return PIO_EBADID;
+        return PIO_EBADID;
 
     /* Since this is a property of the running HDF5 instance, not the
      * file, it's not clear if this message passing will apply. For
@@ -832,9 +832,9 @@ int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep,
     /* msg = PIO_MSG_INQ_VAR_FLETCHER32; */
 
     /* if (ios->async_interface && ! ios->ioproc){ */
-    /* 	if (ios->compmaster)  */
-    /* 	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm); */
-    /* 	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm); */
+    /*  if (ios->compmaster)  */
+    /*      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm); */
+    /*  mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm); */
     /* } */
 
     switch (iotype)
@@ -842,24 +842,24 @@ int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep,
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
-	ierr = nc_get_chunk_cache((size_t *)sizep, (size_t *)nelemsp, preemptionp);
-	break;
+        ierr = nc_get_chunk_cache((size_t *)sizep, (size_t *)nelemsp, preemptionp);
+        break;
     case PIO_IOTYPE_NETCDF4C:
-	if (!ios->io_rank)
-	    ierr = nc_get_chunk_cache((size_t *)sizep, (size_t *)nelemsp, preemptionp);
-	break;
+        if (!ios->io_rank)
+            ierr = nc_get_chunk_cache((size_t *)sizep, (size_t *)nelemsp, preemptionp);
+        break;
 #endif
     case PIO_IOTYPE_NETCDF:
-	ierr = PIO_ENOTNC4;
-	break;
+        ierr = PIO_ENOTNC4;
+        break;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-	ierr = PIO_ENOTNC4;
-	break;
+        ierr = PIO_ENOTNC4;
+        break;
 #endif
     default:
-	ierr = iotype_error(iotype,__FILE__,__LINE__);
+        ierr = iotype_error(iotype,__FILE__,__LINE__);
     }
 
 
@@ -867,15 +867,15 @@ int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep,
     MPI_Bcast(&ierr, 1, MPI_INTEGER, ios->ioroot, ios->my_comm);
     if (!ierr)
     {
-	if (sizep)
-	    if ((ierr = MPI_Bcast(sizep, 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
-		ierr = PIO_EIO;
-	if (nelemsp && !ierr)
-	    if ((ierr = MPI_Bcast(nelemsp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
-		ierr = PIO_EIO;
-	if (preemptionp && !ierr)
-	    if ((ierr = MPI_Bcast(preemptionp, 1, MPI_FLOAT, ios->ioroot, ios->my_comm)))
-		ierr = PIO_EIO;
+        if (sizep)
+            if ((ierr = MPI_Bcast(sizep, 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
+                ierr = PIO_EIO;
+        if (nelemsp && !ierr)
+            if ((ierr = MPI_Bcast(nelemsp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
+                ierr = PIO_EIO;
+        if (preemptionp && !ierr)
+            if ((ierr = MPI_Bcast(preemptionp, 1, MPI_FLOAT, ios->ioroot, ios->my_comm)))
+                ierr = PIO_EIO;
     }
 
     return ierr;
@@ -906,7 +906,7 @@ int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep,
  * @return PIO_NOERR for success, otherwise an error code.
  */
 int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset nelems,
-			     float preemption)
+                             float preemption)
 {
     int ierr;
     int msg;
@@ -919,50 +919,50 @@ int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset ne
     ierr = PIO_NOERR;
 
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
     msg = PIO_MSG_SET_VAR_CHUNK_CACHE;
 
     if (ios->async_interface && ! ios->ioproc)
     {
-	if (ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
     }
 
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_set_var_chunk_cache(file->fh, varid, size, nelems, preemption);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (!ios->io_rank)
-		ierr = nc_set_var_chunk_cache(file->fh, varid, size, nelems, preemption);
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_set_var_chunk_cache(file->fh, varid, size, nelems, preemption);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (!ios->io_rank)
+                ierr = nc_set_var_chunk_cache(file->fh, varid, size, nelems, preemption);
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* Allocate an error string if needed. */
     if (ierr != PIO_NOERR)
     {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
+        errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+        sprintf(errstr,"in file %s",__FILE__);
     }
 
     /* Check for netCDF error. */
@@ -970,7 +970,7 @@ int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset ne
 
     /* Free the error string if it was allocated. */
     if (errstr != NULL)
-	free(errstr);
+        free(errstr);
 
     return ierr;
 }
@@ -999,7 +999,7 @@ int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset ne
  * @return PIO_NOERR for success, otherwise an error code.
  */
 int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nelemsp,
-			     float *preemptionp)
+                             float *preemptionp)
 {
     int ierr;
     int msg;
@@ -1012,7 +1012,7 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset 
     ierr = PIO_NOERR;
 
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* Since this is a property of the running HDF5 instance, not the
@@ -1021,46 +1021,46 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset 
     /* msg = PIO_MSG_INQ_VAR_FLETCHER32; */
 
     /* if (ios->async_interface && ! ios->ioproc){ */
-    /* 	if (ios->compmaster)  */
-    /* 	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm); */
-    /* 	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm); */
+    /*  if (ios->compmaster)  */
+    /*      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm); */
+    /*  mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm); */
     /* } */
 
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_get_var_chunk_cache(file->fh, varid,  (size_t *)sizep, (size_t *)nelemsp,
-					  preemptionp);
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    if (ios->io_rank == 0)
-		ierr = nc_get_var_chunk_cache(file->fh, varid,  (size_t *)sizep, (size_t *)nelemsp,
-					      preemptionp);
-	    break;
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_var_chunk_cache(file->fh, varid,  (size_t *)sizep, (size_t *)nelemsp,
+                                          preemptionp);
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (ios->io_rank == 0)
+                ierr = nc_get_var_chunk_cache(file->fh, varid,  (size_t *)sizep, (size_t *)nelemsp,
+                                              preemptionp);
+            break;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    ierr = PIO_ENOTNC4;
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            ierr = PIO_ENOTNC4;
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     /* If there is an error, allocate space for the error string. */
     if (ierr != PIO_NOERR)
     {
-	errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
-	sprintf(errstr,"in file %s",__FILE__);
+        errstr = (char *) malloc((strlen(__FILE__) + 20)* sizeof(char));
+        sprintf(errstr,"in file %s",__FILE__);
     }
 
     /* Check the netCDF return code, and broadcast it to all tasks. */
@@ -1068,15 +1068,15 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset 
 
     /* Free the error string if it was allocated. */
     if (errstr != NULL)
-	free(errstr);
+        free(errstr);
 
     /* Broadcast results to all tasks. */
     if (sizep && !ierr)
-	ierr = MPI_Bcast(sizep, 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
+        ierr = MPI_Bcast(sizep, 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
     if (nelemsp && !ierr)
-    	ierr = MPI_Bcast(nelemsp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
+        ierr = MPI_Bcast(nelemsp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
     if (preemptionp && !ierr)
-    	ierr = MPI_Bcast(preemptionp, 1, MPI_FLOAT, ios->ioroot, ios->my_comm);
+        ierr = MPI_Bcast(preemptionp, 1, MPI_FLOAT, ios->ioroot, ios->my_comm);
 
     return ierr;
 }

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * PIO functions to write data. 
+ * PIO functions to write data.
  *
  * @author Ed Hartnett
  * @date  2016
@@ -47,7 +47,7 @@
  * @private
  */
 int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		     const PIO_Offset *stride, nc_type xtype, const void *buf)
+                     const PIO_Offset *stride, nc_type xtype, const void *buf)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -66,291 +66,291 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     int *request;
 
     LOG((1, "PIOc_put_vars_tc ncid = %d varid = %d start = %d count = %d "
-    	 "stride = %d xtype = %d", ncid, varid, start, count, stride, xtype));
+         "stride = %d xtype = %d", ncid, varid, start, count, stride, xtype));
 
     /* User must provide some data. */
     if (!buf)
-	return PIO_EINVAL;
+        return PIO_EINVAL;
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
 
     /* Run these on all tasks if async is not in use, but only on
      * non-IO tasks if async is in use. */
     if (!ios->async_interface || !ios->ioproc)
     {
-	/* Get the number of dims for this var. */
-	if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
-	    return check_netcdf(file, ierr, __FILE__, __LINE__);
+        /* Get the number of dims for this var. */
+        if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
+            return check_netcdf(file, ierr, __FILE__, __LINE__);
 
-	/* Get the length of the data type. */
-	if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
-	    return check_netcdf(file, ierr, __FILE__, __LINE__);
+        /* Get the length of the data type. */
+        if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
+            return check_netcdf(file, ierr, __FILE__, __LINE__);
 
-	LOG((2, "ndims = %d typelen = %d", ndims, typelen));
+        LOG((2, "ndims = %d typelen = %d", ndims, typelen));
 
-	PIO_Offset dimlen[ndims];
+        PIO_Offset dimlen[ndims];
 
-	/* If no count array was passed, we need to know the dimlens
-	 * so we can calculate how many data elements are in the
-	 * buf. */
-	if (!count)
-	{
-	    int dimid[ndims];
+        /* If no count array was passed, we need to know the dimlens
+         * so we can calculate how many data elements are in the
+         * buf. */
+        if (!count)
+        {
+            int dimid[ndims];
 
-	    /* Get the dimids for this var. */
-	    if ((ierr = PIOc_inq_vardimid(ncid, varid, dimid)))
-		return check_netcdf(file, ierr, __FILE__, __LINE__);
+            /* Get the dimids for this var. */
+            if ((ierr = PIOc_inq_vardimid(ncid, varid, dimid)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
 
-	    /* Get the length of each dimension. */
-	    for (int vd = 0; vd < ndims; vd++)
-	    {
-		if ((ierr = PIOc_inq_dimlen(ncid, dimid[vd], &dimlen[vd])))
-		    return check_netcdf(file, ierr, __FILE__, __LINE__);
-		LOG((3, "dimlen[%d] = %d", vd, dimlen[vd]));
-	    }
-	}
+            /* Get the length of each dimension. */
+            for (int vd = 0; vd < ndims; vd++)
+            {
+                if ((ierr = PIOc_inq_dimlen(ncid, dimid[vd], &dimlen[vd])))
+                    return check_netcdf(file, ierr, __FILE__, __LINE__);
+                LOG((3, "dimlen[%d] = %d", vd, dimlen[vd]));
+            }
+        }
 
-	/* Allocate memory for these arrays, now that we know ndims. */
-	if (!(rstart = malloc(ndims * sizeof(PIO_Offset))))
-	    return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
-	if (!(rcount = malloc(ndims * sizeof(PIO_Offset))))
-	    return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
-	if (!(rstride = malloc(ndims * sizeof(PIO_Offset))))
-	    return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
+        /* Allocate memory for these arrays, now that we know ndims. */
+        if (!(rstart = malloc(ndims * sizeof(PIO_Offset))))
+            return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(rcount = malloc(ndims * sizeof(PIO_Offset))))
+            return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(rstride = malloc(ndims * sizeof(PIO_Offset))))
+            return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
 
-	/* Figure out the real start, count, and stride arrays. (The
-	 * user may have passed in NULLs.) */
-	for (int vd = 0; vd < ndims; vd++)
-	{
-	    rstart[vd] = start ? start[vd] : 0;
-	    rcount[vd] = count ? count[vd] : dimlen[vd];
-	    rstride[vd] = stride ? stride[vd] : 1;
-	    LOG((3, "rstart[%d] = %d rcount[%d] = %d rstride[%d] = %d", vd,
-		 rstart[vd], vd, rcount[vd], vd, rstride[vd]));
-	}
+        /* Figure out the real start, count, and stride arrays. (The
+         * user may have passed in NULLs.) */
+        for (int vd = 0; vd < ndims; vd++)
+        {
+            rstart[vd] = start ? start[vd] : 0;
+            rcount[vd] = count ? count[vd] : dimlen[vd];
+            rstride[vd] = stride ? stride[vd] : 1;
+            LOG((3, "rstart[%d] = %d rcount[%d] = %d rstride[%d] = %d", vd,
+                 rstart[vd], vd, rcount[vd], vd, rstride[vd]));
+        }
 
-	/* How many elements in buf? */
-	for (int vd = 0; vd < ndims; vd++)
-	    num_elem *= (rcount[vd] - rstart[vd])/rstride[vd];
-	LOG((2, "PIOc_put_vars_tc num_elem = %d", num_elem));
+        /* How many elements in buf? */
+        for (int vd = 0; vd < ndims; vd++)
+            num_elem *= (rcount[vd] - rstart[vd])/rstride[vd];
+        LOG((2, "PIOc_put_vars_tc num_elem = %d", num_elem));
 
-	/* Free resources. */
-	free(rstart);
-	free(rcount);
-	free(rstride);
+        /* Free resources. */
+        free(rstart);
+        free(rcount);
+        free(rstride);
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = PIO_MSG_PUT_VARS;
+        if (!ios->ioproc)
+        {
+            int msg = PIO_MSG_PUT_VARS;
 
-	    if(ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if(ios->compmaster)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    /* Send the function parameters and associated informaiton
-	     * to the msg handler. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&varid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&start_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr && start_present)
-		mpierr = MPI_Bcast((PIO_Offset *)start, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&count_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr && count_present)
-		mpierr = MPI_Bcast((PIO_Offset *)count, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&stride_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr && stride_present)
-		mpierr = MPI_Bcast((PIO_Offset *)stride, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
-	    LOG((2, "PIOc_put_vars_tc ncid = %d varid = %d ndims = %d start_present = %d "
-		 "count_present = %d stride_present = %d xtype = %d num_elem = %d", ncid, varid,
-		 ndims, start_present, count_present, stride_present, xtype, num_elem));
+            /* Send the function parameters and associated informaiton
+             * to the msg handler. */
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&varid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&start_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr && start_present)
+                mpierr = MPI_Bcast((PIO_Offset *)start, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&count_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr && count_present)
+                mpierr = MPI_Bcast((PIO_Offset *)count, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&stride_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr && stride_present)
+                mpierr = MPI_Bcast((PIO_Offset *)stride, ndims, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
+            LOG((2, "PIOc_put_vars_tc ncid = %d varid = %d ndims = %d start_present = %d "
+                 "count_present = %d stride_present = %d xtype = %d num_elem = %d", ncid, varid,
+                 ndims, start_present, count_present, stride_present, xtype, num_elem));
 
-	    /* Send the data. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast((void *)buf, num_elem * typelen, MPI_BYTE, ios->compmaster,
-				   ios->intercomm);
-	}
+            /* Send the data. */
+            if (!mpierr)
+                mpierr = MPI_Bcast((void *)buf, num_elem * typelen, MPI_BYTE, ios->compmaster,
+                                   ios->intercomm);
+        }
 
-	/* Handle MPI errors. */
-	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    return check_mpi(file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    check_mpi(file, mpierr, __FILE__, __LINE__);
-	LOG((2, "PIOc_put_vars_tc checked mpierr = %d", mpierr));
+        /* Handle MPI errors. */
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(file, mpierr2, __FILE__, __LINE__);
+        if (mpierr)
+            check_mpi(file, mpierr, __FILE__, __LINE__);
+        LOG((2, "PIOc_put_vars_tc checked mpierr = %d", mpierr));
 
-	/* Broadcast values currently only known on computation tasks to IO tasks. */
-	LOG((2, "PIOc_put_vars_tc bcast from comproot"));
-	if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    return check_mpi(file, mpierr, __FILE__, __LINE__);
-	LOG((2, "PIOc_put_vars_tc complete bcast from comproot ndims = %d", ndims));
+        /* Broadcast values currently only known on computation tasks to IO tasks. */
+        LOG((2, "PIOc_put_vars_tc bcast from comproot"));
+        if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
+        LOG((2, "PIOc_put_vars_tc complete bcast from comproot ndims = %d", ndims));
     }
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
 #ifdef _PNETCDF
-	if (file->iotype == PIO_IOTYPE_PNETCDF)
-	{
-	    PIO_Offset *fake_stride;
-		
-	    if (!stride_present)
-	    {
-		LOG((2, "stride not present"));
-		if (!(fake_stride = malloc(ndims * sizeof(PIO_Offset))))
-		    return PIO_ENOMEM;
-		for (int d = 0; d < ndims; d++)
-		    fake_stride[d] = 1;
-	    }
-	    else
-		fake_stride = (PIO_Offset *)stride;
-	    
-	    LOG((2, "PIOc_put_vars_tc calling pnetcdf function"));
-	    vdesc = file->varlist + varid;
-	    if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
-		vdesc->request = realloc(vdesc->request,
-					 sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK));
-	    request = vdesc->request + vdesc->nreqs;
-	    LOG((2, "PIOc_put_vars_tc request = %d", vdesc->request));	    
+        if (file->iotype == PIO_IOTYPE_PNETCDF)
+        {
+            PIO_Offset *fake_stride;
 
-	    /* Only the IO master actually does the call. */
-	    if (ios->iomaster)
-	    {
-/*		LOG((2, "PIOc_put_vars_tc ncid = %d varid = %d start[0] = %d count[0] = %d fake_stride[0] = %d",
-		ncid, varid, start[0], count[0], fake_stride[0]));*/
-		/* for (int d = 0; d < ndims; d++) */
-		/*     LOG((2, "start[%d] = %d count[%d] = %d stride[%d] = %d", d, start[d], d, count[d], d, stride[d])); */
-		switch(xtype)
-		{
-		case NC_BYTE:
-		    ierr = ncmpi_bput_vars_schar(file->fh, varid, start, count, fake_stride, buf, request);
-		    break;
-		case NC_CHAR:
-		    ierr = ncmpi_bput_vars_text(file->fh, varid, start, count, fake_stride, buf, request);
-		    break;
-		case NC_SHORT:
-		    ierr = ncmpi_bput_vars_short(file->fh, varid, start, count, fake_stride, buf, request);
-		    break;
-		case NC_INT:
-		    LOG((2, "PIOc_put_vars_tc io_rank 0 doing pnetcdf for int"));
-		    ierr = ncmpi_bput_vars_int(file->fh, varid, start, count, fake_stride, buf, request);
-		    LOG((2, "PIOc_put_vars_tc io_rank 0 done with pnetcdf call for int ierr = %d", ierr));	    		    
-		    break;
-		case NC_FLOAT:
-		    ierr = ncmpi_bput_vars_float(file->fh, varid, start, count, fake_stride, buf, request);
-		    break;
-		case NC_DOUBLE:
-		    ierr = ncmpi_bput_vars_double(file->fh, varid, start, count, fake_stride, buf, request);
-		    break;
-		case NC_INT64:
-		    ierr = ncmpi_bput_vars_longlong(file->fh, varid, start, count, fake_stride, buf, request);
-		    break;
-		default:
-		    LOG((0, "Unknown type for pnetcdf file! xtype = %d", xtype));
-		}
-		LOG((2, "PIOc_put_vars_tc io_rank 0 done with pnetcdf call"));	    
-	    }
-	    else
-		*request = PIO_REQ_NULL;
+            if (!stride_present)
+            {
+                LOG((2, "stride not present"));
+                if (!(fake_stride = malloc(ndims * sizeof(PIO_Offset))))
+                    return PIO_ENOMEM;
+                for (int d = 0; d < ndims; d++)
+                    fake_stride[d] = 1;
+            }
+            else
+                fake_stride = (PIO_Offset *)stride;
 
-	    vdesc->nreqs++;
-	    LOG((2, "PIOc_put_vars_tc flushing output buffer"));
-	    flush_output_buffer(file, false, 0);
-	    LOG((2, "PIOc_put_vars_tc flushed output buffer"));
+            LOG((2, "PIOc_put_vars_tc calling pnetcdf function"));
+            vdesc = file->varlist + varid;
+            if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK));
+            request = vdesc->request + vdesc->nreqs;
+            LOG((2, "PIOc_put_vars_tc request = %d", vdesc->request));
 
-	    /* Free malloced resources. */
-	    if (!stride_present)
-		free(fake_stride);
-	}
+            /* Only the IO master actually does the call. */
+            if (ios->iomaster)
+            {
+/*              LOG((2, "PIOc_put_vars_tc ncid = %d varid = %d start[0] = %d count[0] = %d fake_stride[0] = %d",
+                ncid, varid, start[0], count[0], fake_stride[0]));*/
+                /* for (int d = 0; d < ndims; d++) */
+                /*     LOG((2, "start[%d] = %d count[%d] = %d stride[%d] = %d", d, start[d], d, count[d], d, stride[d])); */
+                switch(xtype)
+                {
+                case NC_BYTE:
+                    ierr = ncmpi_bput_vars_schar(file->fh, varid, start, count, fake_stride, buf, request);
+                    break;
+                case NC_CHAR:
+                    ierr = ncmpi_bput_vars_text(file->fh, varid, start, count, fake_stride, buf, request);
+                    break;
+                case NC_SHORT:
+                    ierr = ncmpi_bput_vars_short(file->fh, varid, start, count, fake_stride, buf, request);
+                    break;
+                case NC_INT:
+                    LOG((2, "PIOc_put_vars_tc io_rank 0 doing pnetcdf for int"));
+                    ierr = ncmpi_bput_vars_int(file->fh, varid, start, count, fake_stride, buf, request);
+                    LOG((2, "PIOc_put_vars_tc io_rank 0 done with pnetcdf call for int ierr = %d", ierr));
+                    break;
+                case NC_FLOAT:
+                    ierr = ncmpi_bput_vars_float(file->fh, varid, start, count, fake_stride, buf, request);
+                    break;
+                case NC_DOUBLE:
+                    ierr = ncmpi_bput_vars_double(file->fh, varid, start, count, fake_stride, buf, request);
+                    break;
+                case NC_INT64:
+                    ierr = ncmpi_bput_vars_longlong(file->fh, varid, start, count, fake_stride, buf, request);
+                    break;
+                default:
+                    LOG((0, "Unknown type for pnetcdf file! xtype = %d", xtype));
+                }
+                LOG((2, "PIOc_put_vars_tc io_rank 0 done with pnetcdf call"));
+            }
+            else
+                *request = PIO_REQ_NULL;
+
+            vdesc->nreqs++;
+            LOG((2, "PIOc_put_vars_tc flushing output buffer"));
+            flush_output_buffer(file, false, 0);
+            LOG((2, "PIOc_put_vars_tc flushed output buffer"));
+
+            /* Free malloced resources. */
+            if (!stride_present)
+                free(fake_stride);
+        }
 #endif /* _PNETCDF */
 #ifdef _NETCDF
-	if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
-	{
-	    LOG((2, "PIOc_put_vars_tc calling netcdf function file->iotype = %d",
-		 file->iotype));	    
-	    switch(xtype)
-	    {
-	    case NC_BYTE:
-		ierr = nc_put_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_CHAR:
-		ierr = nc_put_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_SHORT:
-		ierr = nc_put_vars_short(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_INT:
-		ierr = nc_put_vars_int(file->fh, varid, (size_t *)start, (size_t *)count,
-				       (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_FLOAT:
-		ierr = nc_put_vars_float(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_DOUBLE:
-		ierr = nc_put_vars_double(file->fh, varid, (size_t *)start, (size_t *)count,
-					  (ptrdiff_t *)stride, buf);
-		break;
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
+        {
+            LOG((2, "PIOc_put_vars_tc calling netcdf function file->iotype = %d",
+                 file->iotype));
+            switch(xtype)
+            {
+            case NC_BYTE:
+                ierr = nc_put_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_CHAR:
+                ierr = nc_put_vars_schar(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_SHORT:
+                ierr = nc_put_vars_short(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_INT:
+                ierr = nc_put_vars_int(file->fh, varid, (size_t *)start, (size_t *)count,
+                                       (ptrdiff_t *)stride, buf);
+                break;
+            case NC_FLOAT:
+                ierr = nc_put_vars_float(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_DOUBLE:
+                ierr = nc_put_vars_double(file->fh, varid, (size_t *)start, (size_t *)count,
+                                          (ptrdiff_t *)stride, buf);
+                break;
 #ifdef _NETCDF4
-	    case NC_UBYTE:
-		ierr = nc_put_vars_uchar(file->fh, varid, (size_t *)start, (size_t *)count,
-					 (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_USHORT:
-		ierr = nc_put_vars_ushort(file->fh, varid, (size_t *)start, (size_t *)count,
-					  (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_UINT:
-		ierr = nc_put_vars_uint(file->fh, varid, (size_t *)start, (size_t *)count,
-					(ptrdiff_t *)stride, buf);
-		break;
-	    case NC_INT64:
-		ierr = nc_put_vars_longlong(file->fh, varid, (size_t *)start, (size_t *)count,
-					    (ptrdiff_t *)stride, buf);
-		break;
-	    case NC_UINT64:
-		ierr = nc_put_vars_ulonglong(file->fh, varid, (size_t *)start, (size_t *)count,
-					     (ptrdiff_t *)stride, buf);
-		break;
-		/* case NC_STRING: */
-		/* 	ierr = nc_put_vars_string(file->fh, varid, (size_t *)start, (size_t *)count, */
-		/* 				  (ptrdiff_t *)stride, (void *)buf); */
-		/* 	break; */
-	    default:
-		ierr = nc_put_vars(file->fh, varid, (size_t *)start, (size_t *)count,
-				   (ptrdiff_t *)stride, buf);
+            case NC_UBYTE:
+                ierr = nc_put_vars_uchar(file->fh, varid, (size_t *)start, (size_t *)count,
+                                         (ptrdiff_t *)stride, buf);
+                break;
+            case NC_USHORT:
+                ierr = nc_put_vars_ushort(file->fh, varid, (size_t *)start, (size_t *)count,
+                                          (ptrdiff_t *)stride, buf);
+                break;
+            case NC_UINT:
+                ierr = nc_put_vars_uint(file->fh, varid, (size_t *)start, (size_t *)count,
+                                        (ptrdiff_t *)stride, buf);
+                break;
+            case NC_INT64:
+                ierr = nc_put_vars_longlong(file->fh, varid, (size_t *)start, (size_t *)count,
+                                            (ptrdiff_t *)stride, buf);
+                break;
+            case NC_UINT64:
+                ierr = nc_put_vars_ulonglong(file->fh, varid, (size_t *)start, (size_t *)count,
+                                             (ptrdiff_t *)stride, buf);
+                break;
+                /* case NC_STRING: */
+                /*      ierr = nc_put_vars_string(file->fh, varid, (size_t *)start, (size_t *)count, */
+                /*                                (ptrdiff_t *)stride, (void *)buf); */
+                /*      break; */
+            default:
+                ierr = nc_put_vars(file->fh, varid, (size_t *)start, (size_t *)count,
+                                   (ptrdiff_t *)stride, buf);
 #endif /* _NETCDF4 */
-	    }
-	}
+            }
+        }
 #endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
     LOG((2, "PIOc_put_vars_tc bcasting netcdf return code %d", ierr));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	return check_mpi(file, mpierr, __FILE__, __LINE__);
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
     LOG((2, "PIOc_put_vars_tc bcast netcdf return code %d complete", ierr));
 
     return ierr;
@@ -358,104 +358,104 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		       const PIO_Offset *stride, const char *op)
+                       const PIO_Offset *stride, const char *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_CHAR, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_uchar(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const PIO_Offset *stride,
-			const unsigned char *op)
+                        const PIO_Offset *count, const PIO_Offset *stride,
+                        const unsigned char *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_UBYTE, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			const PIO_Offset *stride, const signed char *op)
+                        const PIO_Offset *stride, const signed char *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_BYTE, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			 const PIO_Offset *stride, const unsigned short *op)
+                         const PIO_Offset *stride, const unsigned short *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_USHORT, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_short(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const PIO_Offset *stride, const short *op)
+                        const PIO_Offset *count, const PIO_Offset *stride, const short *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_SHORT, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		       const PIO_Offset *stride, const unsigned int *op)
+                       const PIO_Offset *stride, const unsigned int *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_UINT, op);
 }
 
 /** PIO interface to nc_put_vars_int */
 int PIOc_put_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		      const PIO_Offset *stride, const int *op)
+                      const PIO_Offset *stride, const int *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_INT, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		       const PIO_Offset *stride, const long *op)
+                       const PIO_Offset *stride, const long *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_INT, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			const PIO_Offset *stride, const float *op)
+                        const PIO_Offset *stride, const float *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_FLOAT, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   const PIO_Offset *stride, const long long *op)
+                           const PIO_Offset *stride, const long long *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_INT64, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			 const PIO_Offset *stride, const double *op)
+                         const PIO_Offset *stride, const double *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_DOUBLE, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vars_ulonglong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const PIO_Offset *stride, const unsigned long long *op)
+                            const PIO_Offset *stride, const unsigned long long *op)
 {
     return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_UINT64, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_tc(int ncid, int varid, const PIO_Offset *index, nc_type xtype,
-		     const void *op)
+                     const void *op)
 {
     int ndims;
     int ierr;
 
     /* Find the number of dimensions. */
     if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
-	return ierr;
+        return ierr;
 
     /* Set up count array. */
     PIO_Offset count[ndims];
     for (int c = 0; c < ndims; c++)
-	count[c] = 1;
+        count[c] = 1;
 
     return PIOc_put_vars_tc(ncid, varid, index, count, NULL, xtype, op);
 }
@@ -468,35 +468,35 @@ int PIOc_put_var1_text(int ncid, int varid, const PIO_Offset *index, const char 
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_uchar(int ncid, int varid, const PIO_Offset *index,
-			const unsigned char *op)
+                        const unsigned char *op)
 {
     return PIOc_put_var1_tc(ncid, varid, index, NC_UBYTE, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_schar(int ncid, int varid, const PIO_Offset *index,
-			const signed char *op)
+                        const signed char *op)
 {
     return PIOc_put_var1_tc(ncid, varid, index, NC_BYTE, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_ushort(int ncid, int varid, const PIO_Offset *index,
-			 const unsigned short *op)
+                         const unsigned short *op)
 {
     return PIOc_put_var1_tc(ncid, varid, index, NC_USHORT, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_short(int ncid, int varid, const PIO_Offset *index,
-			const short *op)
+                        const short *op)
 {
     return PIOc_put_var1_tc(ncid, varid, index, NC_SHORT, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_uint(int ncid, int varid, const PIO_Offset *index,
-		       const unsigned int *op)
+                       const unsigned int *op)
 {
     return PIOc_put_var1_tc(ncid, varid, index, NC_UINT, op);
 }
@@ -510,7 +510,7 @@ int PIOc_put_var1_int(int ncid, int varid, const PIO_Offset *index, const int *o
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_float(int ncid, int varid, const PIO_Offset *index, const float *op)
 {
-    return PIOc_put_var1_tc(ncid, varid, index, NC_FLOAT, op);    
+    return PIOc_put_var1_tc(ncid, varid, index, NC_FLOAT, op);
 }
 
 /** Interface to netCDF data write function. */
@@ -521,105 +521,105 @@ int PIOc_put_var1_long(int ncid, int varid, const PIO_Offset *index, const long 
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_double(int ncid, int varid, const PIO_Offset *index,
-			 const double *op)
+                         const double *op)
 {
-    return PIOc_put_var1_tc(ncid, varid, index, NC_DOUBLE, op);    
+    return PIOc_put_var1_tc(ncid, varid, index, NC_DOUBLE, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_ulonglong(int ncid, int varid, const PIO_Offset *index,
-			    const unsigned long long *op)
+                            const unsigned long long *op)
 {
     return PIOc_put_var1_tc(ncid, varid, index, NC_UINT64, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1_longlong(int ncid, int varid, const PIO_Offset *index,
-			   const long long *op)
+                           const long long *op)
 {
-    return PIOc_put_var1_tc(ncid, varid, index, NC_INT64, op);    
+    return PIOc_put_var1_tc(ncid, varid, index, NC_INT64, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_text(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const char *op)
+                       const PIO_Offset *count, const char *op)
 {
     return PIOc_put_vars_text(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_uchar(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const unsigned char *op)
+                        const PIO_Offset *count, const unsigned char *op)
 {
     return PIOc_put_vars_uchar(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_schar(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const signed char *op)
+                        const PIO_Offset *count, const signed char *op)
 {
     return PIOc_put_vars_schar(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_ushort(int ncid, int varid, const PIO_Offset *start,
-			 const PIO_Offset *count, const unsigned short *op)
+                         const PIO_Offset *count, const unsigned short *op)
 {
     return PIOc_put_vars_ushort(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_short(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const short *op)
+                        const PIO_Offset *count, const short *op)
 {
     return PIOc_put_vars_short(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_uint(int ncid, int varid, const PIO_Offset *start,
-		       const PIO_Offset *count, const unsigned int *op)
+                       const PIO_Offset *count, const unsigned int *op)
 {
     return PIOc_put_vars_uint(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_int(int ncid, int varid, const PIO_Offset *start,
-		      const PIO_Offset *count, const int *op)
+                      const PIO_Offset *count, const int *op)
 {
     return PIOc_put_vars_int(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_long(int ncid, int varid, const PIO_Offset *start,
-		       const PIO_Offset *count, const long *op)
+                       const PIO_Offset *count, const long *op)
 {
     return PIOc_put_vars_long(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_float(int ncid, int varid, const PIO_Offset *start,
-			const PIO_Offset *count, const float *op)
+                        const PIO_Offset *count, const float *op)
 {
     return PIOc_put_vars_float(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_ulonglong(int ncid, int varid, const PIO_Offset *start,
-			    const PIO_Offset *count, const unsigned long long *op)
+                            const PIO_Offset *count, const unsigned long long *op)
 {
     return PIOc_put_vars_ulonglong(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_longlong(int ncid, int varid, const PIO_Offset *start,
-			   const PIO_Offset *count, const long long *op)
+                           const PIO_Offset *count, const long long *op)
 {
     return PIOc_put_vars_longlong(ncid, varid, start, count, NULL, op);
 }
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara_double(int ncid, int varid, const PIO_Offset *start,
-			 const PIO_Offset *count, const double *op)
+                         const PIO_Offset *count, const double *op)
 {
     return PIOc_put_vars_double(ncid, varid, start, count, NULL, op);
 }
@@ -698,7 +698,7 @@ int PIOc_put_var_double(int ncid, int varid, const double *op)
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
-		 MPI_Datatype buftype)
+                 MPI_Datatype buftype)
 {
     int ierr;
     int msg;
@@ -713,56 +713,56 @@ int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     msg = PIO_MSG_PUT_VAR;
 
     if(ios->async_interface && ! ios->ioproc){
-	if(ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid,1, MPI_INT, ios->compmaster, ios->intercomm);
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid,1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
 
     if(ios->ioproc){
-	switch(file->iotype){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-	    ierr = nc_put_var(file->fh, varid,   buf);;
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_var(file->fh, varid,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    if(ios->io_rank==0){
-		ierr = nc_put_var(file->fh, varid,   buf);;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_var(file->fh, varid,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-	    if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-		vdesc->request = realloc(vdesc->request,
-					 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-	    }
-	    request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-	    if(ios->io_rank==0){
-		ierr = ncmpi_bput_var(file->fh, varid, buf, bufcount, buftype, request);;
-	    }else{
-		*request = PIO_REQ_NULL;
-	    }
-	    vdesc->nreqs++;
-	    flush_output_buffer(file, false, 0);
-	    break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_var(file->fh, varid, buf, bufcount, buftype, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
@@ -780,8 +780,8 @@ int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
  * HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html">
  * netcdf documentation. </A> */
 int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		  const PIO_Offset *stride, const void *buf, PIO_Offset bufcount,
-		  MPI_Datatype buftype)
+                  const PIO_Offset *stride, const void *buf, PIO_Offset bufcount,
+                  MPI_Datatype buftype)
 {
     int ierr;
     int msg;
@@ -796,58 +796,58 @@ int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     msg = PIO_MSG_PUT_VARS;
 
     if(ios->async_interface && ! ios->ioproc){
-	if(ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
 
     if(ios->ioproc){
-	switch(file->iotype){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-	    ierr = nc_put_vars(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride,   buf);;
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_vars(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    if(ios->io_rank==0){
-		ierr = nc_put_vars(file->fh, varid, (size_t *)start, (size_t *)count,
-				   (ptrdiff_t *)stride,   buf);;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_vars(file->fh, varid, (size_t *)start, (size_t *)count,
+                                   (ptrdiff_t *)stride,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-	    if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-		vdesc->request = realloc(vdesc->request,
-					 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-	    }
-	    request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-	    if(ios->io_rank==0){
-		ierr = ncmpi_bput_vars(file->fh, varid, start, count, stride, buf,
-				       bufcount, buftype, request);;
-	    }else{
-		*request = PIO_REQ_NULL;
-	    }
-	    vdesc->nreqs++;
-	    flush_output_buffer(file, false, 0);
-	    break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_vars(file->fh, varid, start, count, stride, buf,
+                                       bufcount, buftype, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
@@ -857,7 +857,7 @@ int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
 /** Interface to netCDF data write function. */
 int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
-		  PIO_Offset bufcount, MPI_Datatype buftype)
+                  PIO_Offset bufcount, MPI_Datatype buftype)
 {
     int ierr;
     int msg;
@@ -872,56 +872,56 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     msg = PIO_MSG_PUT_VAR1;
 
     if(ios->async_interface && ! ios->ioproc){
-	if(ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
 
     if(ios->ioproc){
-	switch(file->iotype){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-	    ierr = nc_put_var1(file->fh, varid, (size_t *) index,   buf);;
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_var1(file->fh, varid, (size_t *) index,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    if(ios->io_rank==0){
-		ierr = nc_put_var1(file->fh, varid, (size_t *) index,   buf);;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_var1(file->fh, varid, (size_t *) index,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-	    if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-		vdesc->request = realloc(vdesc->request,
-					 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-	    }
-	    request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-	    if(ios->io_rank==0){
-		ierr = ncmpi_bput_var1(file->fh, varid, index, buf, bufcount, buftype, request);;
-	    }else{
-		*request = PIO_REQ_NULL;
-	    }
-	    vdesc->nreqs++;
-	    flush_output_buffer(file, false, 0);
-	    break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_var1(file->fh, varid, index, buf, bufcount, buftype, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
@@ -931,7 +931,7 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
 
 /** Interface to netCDF data write function. */
 int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count, const void *buf,
-		  PIO_Offset bufcount, MPI_Datatype buftype)
+                  PIO_Offset bufcount, MPI_Datatype buftype)
 {
     int ierr;
     int msg;
@@ -946,56 +946,56 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
-	return ierr;
+        return ierr;
     ios = file->iosystem;
-    
+
     msg = PIO_MSG_PUT_VARA;
 
     if(ios->async_interface && ! ios->ioproc){
-	if(ios->compmaster)
-	    mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-	mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
 
     if(ios->ioproc){
-	switch(file->iotype){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-	    ierr = nc_put_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    if(ios->io_rank==0){
-		ierr = nc_put_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-	    if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-		vdesc->request = realloc(vdesc->request,
-					 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-	    }
-	    request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-	    if(ios->io_rank==0){
-		ierr = ncmpi_bput_vara(file->fh, varid, start, count, buf, bufcount, buftype, request);;
-	    }else{
-		*request = PIO_REQ_NULL;
-	    }
-	    vdesc->nreqs++;
-	    flush_output_buffer(file, false, 0);
-	    break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_vara(file->fh, varid, start, count, buf, bufcount, buftype, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-	default:
-	    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-	}
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
 
     ierr = check_netcdf(file, ierr, __FILE__,__LINE__);

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -4,35 +4,35 @@
 /// @date 2014
 /// @brief Code to map IO to model decomposition
 ///
-/// 
-/// 
-/// 
+///
+///
+///
 /// @see  http://code.google.com/p/parallelio/
 ////
 #include <pio.h>
 #include <pio_internal.h>
 
 /** internal variable used for debugging */
-int tmpioproc=-1;  
+int tmpioproc=-1;
 
 
 /** @internal
  ** Convert an index into a list of dimensions. E.g., for index 4 into a
  ** array defined as a[3][2], will return 1 1.
  ** @endinternal
-*/
+ */
 void idx_to_dim_list(const int ndims, const int gdims[], const PIO_Offset idx,
                      PIO_Offset dim_list[])
 {
-  int i, curr_idx, next_idx;
-  curr_idx = idx;
-  // Easiest to start from the right and move left.
-  for (i = ndims-1; i >= 0; --i) {
-    // This way of doing div/mod is slightly faster than using "/" and "%".
-    next_idx = curr_idx / gdims[i];
-    dim_list[i] = curr_idx - (next_idx*gdims[i]);
-    curr_idx = next_idx;
-  }
+    int i, curr_idx, next_idx;
+    curr_idx = idx;
+    // Easiest to start from the right and move left.
+    for (i = ndims-1; i >= 0; --i) {
+        // This way of doing div/mod is slightly faster than using "/" and "%".
+        next_idx = curr_idx / gdims[i];
+        dim_list[i] = curr_idx - (next_idx*gdims[i]);
+        curr_idx = next_idx;
+    }
 }
 /**
  ** @internal
@@ -50,40 +50,40 @@ void expand_region(const int dim, const int gdims[], const int maplen,
                    const int region_stride, const int max_size[],
                    PIO_Offset count[])
 {
-  int i, j, test_idx, expansion_done;
-  // Precondition: maplen >= region_size (thus loop runs at least once).
+    int i, j, test_idx, expansion_done;
+    // Precondition: maplen >= region_size (thus loop runs at least once).
 
-  // Flag used to signal that we can no longer expand the region along
-  // dimension dim.
-  expansion_done = 0;
+    // Flag used to signal that we can no longer expand the region along
+    // dimension dim.
+    expansion_done = 0;
 
-  // Expand no greater than max_size along this dimension.
-  for (i = 1; i <= max_size[dim]; ++i) {
-    // Count so far is at least i.
-    count[dim] = i;
+    // Expand no greater than max_size along this dimension.
+    for (i = 1; i <= max_size[dim]; ++i) {
+        // Count so far is at least i.
+        count[dim] = i;
 
-    // Now see if we can expand to i+1 by checking that the next
-    // region_size elements are ahead by exactly region_stride.
-    // Assuming monotonicity in the map, we could skip this for the
-    // innermost dimension, but it's necessary past that because the
-    // region does not necessarily comprise contiguous values.
-    for (j = 0; j < region_size; ++j) {
-      test_idx = j + i*region_size;
-      // If we have exhausted the map, or the map no longer matches,
-      // we are done, break out of both loops.
-      if (test_idx >= maplen || map[test_idx] != map[j] + i*region_stride) {
-        expansion_done = 1;
-        break;
-      }
+        // Now see if we can expand to i+1 by checking that the next
+        // region_size elements are ahead by exactly region_stride.
+        // Assuming monotonicity in the map, we could skip this for the
+        // innermost dimension, but it's necessary past that because the
+        // region does not necessarily comprise contiguous values.
+        for (j = 0; j < region_size; ++j) {
+            test_idx = j + i*region_size;
+            // If we have exhausted the map, or the map no longer matches,
+            // we are done, break out of both loops.
+            if (test_idx >= maplen || map[test_idx] != map[j] + i*region_stride) {
+                expansion_done = 1;
+                break;
+            }
+        }
+        if (expansion_done) break;
     }
-    if (expansion_done) break;
-  }
 
-  // Move on to next outermost dimension if there are more left, else return.
-  if (dim > 0) {
-    expand_region(dim-1, gdims, maplen, map, region_size*count[dim],
-                  region_stride*gdims[dim], max_size, count);
-  }
+    // Move on to next outermost dimension if there are more left, else return.
+    if (dim > 0) {
+        expand_region(dim-1, gdims, maplen, map, region_size*count[dim],
+                      region_stride*gdims[dim], max_size, count);
+    }
 }
 /**
  ** @internal
@@ -94,499 +94,499 @@ PIO_Offset find_region(const int ndims, const int gdims[],
                        const int maplen, const PIO_Offset map[],
                        PIO_Offset start[], PIO_Offset count[])
 {
-  int dim;
-  int max_size[ndims];
-  PIO_Offset regionlen=1;
-  // Preconditions (which might be useful to check/assert):
-  //   ndims is > 0
-  //   maplen is > 0
-  //   all elements of map are inside the bounds specified by gdims
-  // The map array is 1 based, but calculations are 0 based
-  idx_to_dim_list(ndims, gdims, map[0]-1, start);
+    int dim;
+    int max_size[ndims];
+    PIO_Offset regionlen=1;
+    // Preconditions (which might be useful to check/assert):
+    //   ndims is > 0
+    //   maplen is > 0
+    //   all elements of map are inside the bounds specified by gdims
+    // The map array is 1 based, but calculations are 0 based
+    idx_to_dim_list(ndims, gdims, map[0]-1, start);
 
-  for (dim = 0; dim < ndims; ++dim) {
-    // Can't expand beyond the array edge.
-    max_size[dim] = gdims[dim] - start[dim];
-  }
+    for (dim = 0; dim < ndims; ++dim) {
+        // Can't expand beyond the array edge.
+        max_size[dim] = gdims[dim] - start[dim];
+    }
 
-  // For each dimension, figure out how far we can expand in that dimension
-  // while staying contiguous in the input array.
-  //
-  // Start with the innermost dimension (ndims-1), and it will recurse
-  // through to the outermost dimensions.
-  expand_region(ndims-1, gdims, maplen, map, 1, 1, max_size, count);
+    // For each dimension, figure out how far we can expand in that dimension
+    // while staying contiguous in the input array.
+    //
+    // Start with the innermost dimension (ndims-1), and it will recurse
+    // through to the outermost dimensions.
+    expand_region(ndims-1, gdims, maplen, map, 1, 1, max_size, count);
 
-  for(dim=0;dim<ndims;dim++)
-    regionlen*=count[dim];
-  return(regionlen);
+    for(dim=0;dim<ndims;dim++)
+        regionlen*=count[dim];
+    return(regionlen);
 
 }
 
 /**
  ** @internal
-** Convert a global coordinate value into a local array index
-** @endinternal
-*/
+ ** Convert a global coordinate value into a local array index
+ ** @endinternal
+ */
 PIO_Offset coord_to_lindex(const int ndims, const PIO_Offset lcoord[], const PIO_Offset count[])
 {
-  PIO_Offset lindex=0;
-  PIO_Offset stride=1;
+    PIO_Offset lindex=0;
+    PIO_Offset stride=1;
 
-  for(int i=ndims-1; i>=0; i--){
-    lindex += lcoord[i]*stride;
-    stride = stride*count[i];
-  }
-  return lindex;
+    for(int i=ndims-1; i>=0; i--){
+        lindex += lcoord[i]*stride;
+        stride = stride*count[i];
+    }
+    return lindex;
 
 }
 
 /**
  ** @internal
-** Compute the max io buffersize needed for a given variable
-** @endinternal
-*/
+ ** Compute the max io buffersize needed for a given variable
+ ** @endinternal
+ */
 void compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
 {
-  PIO_Offset iosize, totiosize;
-  int i;
-  io_region *region;
+    PIO_Offset iosize, totiosize;
+    int i;
+    io_region *region;
 
-  //  compute the max io buffer size, for conveneance it is the combined size of all regions
-  totiosize=0;
-  region = iodesc->firstregion;
-  while(region != NULL){
-    if(region->count[0]>0){
-      iosize=1;
-      for(i=0;i<iodesc->ndims;i++)
-	iosize*=region->count[i];
-      totiosize+=iosize;
+    //  compute the max io buffer size, for conveneance it is the combined size of all regions
+    totiosize=0;
+    region = iodesc->firstregion;
+    while(region != NULL){
+        if(region->count[0]>0){
+            iosize=1;
+            for(i=0;i<iodesc->ndims;i++)
+                iosize*=region->count[i];
+            totiosize+=iosize;
+        }
+        region = region->next;
     }
-    region = region->next;
-  }
-  // Share the max io buffer size with all io tasks
-  CheckMPIReturn(MPI_Allreduce(MPI_IN_PLACE, &totiosize, 1, MPI_OFFSET, MPI_MAX, io_comm),__FILE__,__LINE__);
-  iodesc->maxiobuflen = totiosize;
-  if(iodesc->maxiobuflen<=0  ){
-    fprintf(stderr,"%s %d %ld %ld %d %d %d\n",__FILE__,__LINE__,iodesc->maxiobuflen,totiosize,MPI_OFFSET,MPI_MAX,io_comm); 
-    piodie("ERROR: maxiobuflen<=0",__FILE__,__LINE__);
-  }
+    // Share the max io buffer size with all io tasks
+    CheckMPIReturn(MPI_Allreduce(MPI_IN_PLACE, &totiosize, 1, MPI_OFFSET, MPI_MAX, io_comm),__FILE__,__LINE__);
+    iodesc->maxiobuflen = totiosize;
+    if(iodesc->maxiobuflen<=0  ){
+        fprintf(stderr,"%s %d %ld %ld %d %d %d\n",__FILE__,__LINE__,iodesc->maxiobuflen,totiosize,MPI_OFFSET,MPI_MAX,io_comm);
+        piodie("ERROR: maxiobuflen<=0",__FILE__,__LINE__);
+    }
 
 }
 /**
  ** @internal
-** Create the derived MPI datatypes used for comp2io and io2comp transfers
-** @param basetype The type of data (int,real,double). 
-** @param msgcnt The number of MPI messages/tasks to use.
-** @param dlen The length of the data array.
-** @param mindex An array of indexes into the data array from the comp map
-** @param mcount The number of indexes to be put on each mpi message/task
-** @param *mfrom A pointer to the previous structure in the read/write list
-** @param mtype The final data structure sent through MPI to the read/write
-** @endinternal
-*/
+ ** Create the derived MPI datatypes used for comp2io and io2comp transfers
+ ** @param basetype The type of data (int,real,double).
+ ** @param msgcnt The number of MPI messages/tasks to use.
+ ** @param dlen The length of the data array.
+ ** @param mindex An array of indexes into the data array from the comp map
+ ** @param mcount The number of indexes to be put on each mpi message/task
+ ** @param *mfrom A pointer to the previous structure in the read/write list
+ ** @param mtype The final data structure sent through MPI to the read/write
+ ** @endinternal
+ */
 int create_mpi_datatypes(const MPI_Datatype basetype,const int msgcnt,const PIO_Offset dlen, const PIO_Offset mindex[],const int mcount[],
-			 int *mfrom, MPI_Datatype mtype[])
+                         int *mfrom, MPI_Datatype mtype[])
 {
-  PIO_Offset bsizeT[msgcnt];
-  int blocksize;
-  int numinds;
-  PIO_Offset *lindex = NULL;
+    PIO_Offset bsizeT[msgcnt];
+    int blocksize;
+    int numinds;
+    PIO_Offset *lindex = NULL;
 
-  numinds=0;
-  for(int j=0;j<msgcnt;j++){
-    numinds+=mcount[j];
-  }
-
-  pioassert(dlen>=0,"dlen < 0",__FILE__,__LINE__);
-  pioassert(numinds>=0, "num inds < 0",__FILE__,__LINE__);
-
-
-  if(mindex != NULL){
-    // memcpy(lindex, mindex, (size_t) (dlen*sizeof(PIO_Offset)));
-    lindex = malloc(numinds*sizeof(PIO_Offset));
-    memcpy(lindex, mindex, (size_t) (numinds*sizeof(PIO_Offset)));
-  }
-
-  bsizeT[0]=0;
-  mtype[0] = MPI_DATATYPE_NULL;
-  int pos = 0;
-  int ii = 0;
-  if(msgcnt>0){
-
-     if(mfrom == NULL){
-      for(int i=0;i<msgcnt;i++){
-	if(mcount[i]>0){
-	  bsizeT[ii] = GCDblocksize(mcount[i], lindex+pos);
-	  ii++;
-	  pos+=mcount[i];
-
-	}
-      }
-      blocksize = (int) lgcd_array(ii ,bsizeT);
-    }else{
-      blocksize=1;
+    numinds=0;
+    for(int j=0;j<msgcnt;j++){
+        numinds+=mcount[j];
     }
 
-    pos = 0;
-    for(int i=0;i< msgcnt; i++){
-      if(mcount[i]>0){
-	int len = mcount[i]/blocksize;
-	int displace[len];
-	if(blocksize==1){
-	  if(mfrom == NULL){
-	    for(int j=0;j<len;j++) {
-		displace[j] = (int) (lindex[pos+j]);
-	    }
-	  }else{
-	    int k=0;
-	    for(int j=0;j<numinds;j++)
-	      if(mfrom[j]==i) {
-		displace[k++] = (int) (lindex[j]);
-	      }
-	  }
-	    
-	}else{
-	  for(int j=0;j<mcount[i];j++)
-	    (lindex+pos)[j]++;
-	  for(int j=0;j<len;j++){
-	    displace[j]= ((lindex+pos)[j*blocksize]-1);
-	  }
-	}
+    pioassert(dlen>=0,"dlen < 0",__FILE__,__LINE__);
+    pioassert(numinds>=0, "num inds < 0",__FILE__,__LINE__);
 
-	CheckMPIReturn(MPI_Type_create_indexed_block(len, blocksize, displace, basetype, mtype+i),__FILE__,__LINE__);
-	if(mtype[i] == MPI_DATATYPE_NULL){
-	  piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
-	}
-	CheckMPIReturn(MPI_Type_commit(mtype+i), __FILE__,__LINE__);
-	pos+=mcount[i];
-      }
+
+    if(mindex != NULL){
+        // memcpy(lindex, mindex, (size_t) (dlen*sizeof(PIO_Offset)));
+        lindex = malloc(numinds*sizeof(PIO_Offset));
+        memcpy(lindex, mindex, (size_t) (numinds*sizeof(PIO_Offset)));
     }
-    if (lindex)
-	free(lindex);
 
-  }
+    bsizeT[0]=0;
+    mtype[0] = MPI_DATATYPE_NULL;
+    int pos = 0;
+    int ii = 0;
+    if(msgcnt>0){
 
-  return PIO_NOERR;
+        if(mfrom == NULL){
+            for(int i=0;i<msgcnt;i++){
+                if(mcount[i]>0){
+                    bsizeT[ii] = GCDblocksize(mcount[i], lindex+pos);
+                    ii++;
+                    pos+=mcount[i];
+
+                }
+            }
+            blocksize = (int) lgcd_array(ii ,bsizeT);
+        }else{
+            blocksize=1;
+        }
+
+        pos = 0;
+        for(int i=0;i< msgcnt; i++){
+            if(mcount[i]>0){
+                int len = mcount[i]/blocksize;
+                int displace[len];
+                if(blocksize==1){
+                    if(mfrom == NULL){
+                        for(int j=0;j<len;j++) {
+                            displace[j] = (int) (lindex[pos+j]);
+                        }
+                    }else{
+                        int k=0;
+                        for(int j=0;j<numinds;j++)
+                            if(mfrom[j]==i) {
+                                displace[k++] = (int) (lindex[j]);
+                            }
+                    }
+
+                }else{
+                    for(int j=0;j<mcount[i];j++)
+                        (lindex+pos)[j]++;
+                    for(int j=0;j<len;j++){
+                        displace[j]= ((lindex+pos)[j*blocksize]-1);
+                    }
+                }
+
+                CheckMPIReturn(MPI_Type_create_indexed_block(len, blocksize, displace, basetype, mtype+i),__FILE__,__LINE__);
+                if(mtype[i] == MPI_DATATYPE_NULL){
+                    piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
+                }
+                CheckMPIReturn(MPI_Type_commit(mtype+i), __FILE__,__LINE__);
+                pos+=mcount[i];
+            }
+        }
+        if (lindex)
+            free(lindex);
+
+    }
+
+    return PIO_NOERR;
 
 }
 
 /**
  ** @internal
-** Create the derived MPI datatypes used for comp2io and io2comp transfers
-** @endinternal
-*/
+ ** Create the derived MPI datatypes used for comp2io and io2comp transfers
+ ** @endinternal
+ */
 int define_iodesc_datatypes(const iosystem_desc_t ios, io_desc_t *iodesc)
 {
-  int i;
-  if(ios.ioproc){
-    if(iodesc->rtype==NULL){
-      if(iodesc->nrecvs>0){
-	iodesc->rtype = (MPI_Datatype *) bget(iodesc->nrecvs * sizeof(MPI_Datatype));
-	if(iodesc->rtype == NULL){
-	  piomemerror(ios,iodesc->nrecvs * sizeof(MPI_Datatype), __FILE__,__LINE__);
-	}
-	for(i=0; i<iodesc->nrecvs; i++){
-	  iodesc->rtype[i] = MPI_DATATYPE_NULL;
-	}
-	if(iodesc->rearranger==PIO_REARR_SUBSET){
-	  create_mpi_datatypes(iodesc->basetype, iodesc->nrecvs, iodesc->llen, iodesc->rindex, iodesc->rcount, iodesc->rfrom, iodesc->rtype);
-	}else{
-	  create_mpi_datatypes(iodesc->basetype, iodesc->nrecvs, iodesc->llen, iodesc->rindex, iodesc->rcount, NULL, iodesc->rtype);
-	}
-      }
-            /*      if(tmpioproc==95)     {
-	MPI_Aint lb;
-	MPI_Aint extent;
-	for(i=0;i<ntypes;i++){
-	  MPI_Type_get_extent(iodesc->rtype[i], &lb, &extent);
-	  printf("%s %d %d %d %d \n",__FILE__,__LINE__,i,lb,extent);
-	  
-	}
-		}
-	      */
-    }
-  }
-
-
-  if(iodesc->stype==NULL){
-    int ntypes;
-    int ncnt;
-    if(iodesc->rearranger==PIO_REARR_SUBSET){
-      ntypes = 1;
-      ncnt = iodesc->scount[0];
-    }else{
-      ntypes = ios.num_iotasks;
-      ncnt = iodesc->ndof;
-    }
-
-    //  printf("COMP: %d\n",ntypes);
-
-
-    iodesc->stype = (MPI_Datatype *) bget(ntypes * sizeof(MPI_Datatype));
-    if(iodesc->stype == NULL){
-      piomemerror(ios,ntypes * sizeof(MPI_Datatype), __FILE__,__LINE__);
-    }
-    for(i=0; i<ntypes; i++){
-      iodesc->stype[i] = MPI_DATATYPE_NULL;
-    }
-    iodesc->num_stypes = ntypes;
-
-    create_mpi_datatypes(iodesc->basetype, ntypes, ncnt, iodesc->sindex, iodesc->scount, NULL, iodesc->stype);
-       /*    if(tmpioproc==95)   {
-      MPI_Aint lb;
-      MPI_Aint extent;
-      for(i=0;i<ntypes;i++){
-	MPI_Type_get_extent(iodesc->stype[i], &lb, &extent);
-	printf("%s %d %d %d %d \n",__FILE__,__LINE__,i,lb,extent);
-      }
+    int i;
+    if(ios.ioproc){
+        if(iodesc->rtype==NULL){
+            if(iodesc->nrecvs>0){
+                iodesc->rtype = (MPI_Datatype *) bget(iodesc->nrecvs * sizeof(MPI_Datatype));
+                if(iodesc->rtype == NULL){
+                    piomemerror(ios,iodesc->nrecvs * sizeof(MPI_Datatype), __FILE__,__LINE__);
+                }
+                for(i=0; i<iodesc->nrecvs; i++){
+                    iodesc->rtype[i] = MPI_DATATYPE_NULL;
+                }
+                if(iodesc->rearranger==PIO_REARR_SUBSET){
+                    create_mpi_datatypes(iodesc->basetype, iodesc->nrecvs, iodesc->llen, iodesc->rindex, iodesc->rcount, iodesc->rfrom, iodesc->rtype);
+                }else{
+                    create_mpi_datatypes(iodesc->basetype, iodesc->nrecvs, iodesc->llen, iodesc->rindex, iodesc->rcount, NULL, iodesc->rtype);
+                }
             }
-      */
-  }
+            /*      if(tmpioproc==95)     {
+                    MPI_Aint lb;
+                    MPI_Aint extent;
+                    for(i=0;i<ntypes;i++){
+                    MPI_Type_get_extent(iodesc->rtype[i], &lb, &extent);
+                    printf("%s %d %d %d %d \n",__FILE__,__LINE__,i,lb,extent);
 
-  return PIO_NOERR;
+                    }
+                    }
+            */
+        }
+    }
+
+
+    if(iodesc->stype==NULL){
+        int ntypes;
+        int ncnt;
+        if(iodesc->rearranger==PIO_REARR_SUBSET){
+            ntypes = 1;
+            ncnt = iodesc->scount[0];
+        }else{
+            ntypes = ios.num_iotasks;
+            ncnt = iodesc->ndof;
+        }
+
+        //  printf("COMP: %d\n",ntypes);
+
+
+        iodesc->stype = (MPI_Datatype *) bget(ntypes * sizeof(MPI_Datatype));
+        if(iodesc->stype == NULL){
+            piomemerror(ios,ntypes * sizeof(MPI_Datatype), __FILE__,__LINE__);
+        }
+        for(i=0; i<ntypes; i++){
+            iodesc->stype[i] = MPI_DATATYPE_NULL;
+        }
+        iodesc->num_stypes = ntypes;
+
+        create_mpi_datatypes(iodesc->basetype, ntypes, ncnt, iodesc->sindex, iodesc->scount, NULL, iodesc->stype);
+        /*    if(tmpioproc==95)   {
+              MPI_Aint lb;
+              MPI_Aint extent;
+              for(i=0;i<ntypes;i++){
+              MPI_Type_get_extent(iodesc->stype[i], &lb, &extent);
+              printf("%s %d %d %d %d \n",__FILE__,__LINE__,i,lb,extent);
+              }
+              }
+        */
+    }
+
+    return PIO_NOERR;
 
 }
 
 
 /**
  ** @internal
-**  Completes the mapping for the box rearranger
-** @endinternal
-*/
+ **  Completes the mapping for the box rearranger
+ ** @endinternal
+ */
 
-int compute_counts(const iosystem_desc_t ios, io_desc_t *iodesc, const int maplen, 
-		   const int dest_ioproc[], const PIO_Offset dest_ioindex[], MPI_Comm mycomm)
+int compute_counts(const iosystem_desc_t ios, io_desc_t *iodesc, const int maplen,
+                   const int dest_ioproc[], const PIO_Offset dest_ioindex[], MPI_Comm mycomm)
 {
 
-  int i;
-  int iorank;
+    int i;
+    int iorank;
 
-  int rank;
-  int ntasks;
+    int rank;
+    int ntasks;
 
-  MPI_Comm_rank(mycomm, &rank);
-  MPI_Comm_size(mycomm, &ntasks);
-
-
-  MPI_Datatype sr_types[ntasks];
-  int send_counts[ntasks];
-  int send_displs[ntasks];
-  int recv_counts[ntasks];
-  int recv_displs[ntasks];
-  int *recv_buf=NULL;
-  int nrecvs;
-  int maxreq = MAX_GATHER_BLOCK_SIZE;
-  int ierr;
-  int io_comprank;
-  int ioindex;
-  int tsize;
-  int numiotasks;
-  PIO_Offset s2rindex[iodesc->ndof];
+    MPI_Comm_rank(mycomm, &rank);
+    MPI_Comm_size(mycomm, &ntasks);
 
 
-  
-  if(iodesc->rearranger==PIO_REARR_BOX)
-    numiotasks = ios.num_iotasks;
-  else
-    numiotasks=1;
-
-  iodesc->scount = (int *) bget(numiotasks*sizeof(int));
-  if(iodesc->scount == NULL){
-    piomemerror(ios,numiotasks * sizeof(int), __FILE__,__LINE__);
-  }
-  for(i=0;i<numiotasks;i++)
-    iodesc->scount[i]=0;
-
-  // iodesc->scount is the amount of data sent to each task from the current task
-  for(i=0;i<maplen; i++){
-    if(dest_ioindex[i] >= 0){
-      (iodesc->scount[dest_ioproc[i]])++;
-    }
-  }
-
-  //  for(i=0;i<ios.num_iotasks;i++)
-  //   printf("iodesc->scount = %d\n",iodesc->scount[i]);
-
-  for(i=0;i<ntasks;i++){
-    send_counts[i] = 0;
-    send_displs[i] = 0;
-    recv_counts[i] = 0;
-    recv_displs[i] = 0;
-    sr_types[i] = MPI_INT;
-  }
-  for(i=0;i<numiotasks;i++){
+    MPI_Datatype sr_types[ntasks];
+    int send_counts[ntasks];
+    int send_displs[ntasks];
+    int recv_counts[ntasks];
+    int recv_displs[ntasks];
+    int *recv_buf=NULL;
+    int nrecvs;
+    int maxreq = MAX_GATHER_BLOCK_SIZE;
+    int ierr;
     int io_comprank;
-    if(iodesc->rearranger==PIO_REARR_SUBSET)
-      io_comprank=0;
+    int ioindex;
+    int tsize;
+    int numiotasks;
+    PIO_Offset s2rindex[iodesc->ndof];
+
+
+
+    if(iodesc->rearranger==PIO_REARR_BOX)
+        numiotasks = ios.num_iotasks;
     else
-      io_comprank = ios.ioranks[i];
-    send_counts[io_comprank] = 1;
-    send_displs[io_comprank] = i*sizeof(int);
-  }
+        numiotasks=1;
 
-  if(ios.ioproc){
-    recv_buf = (int *) bget(ntasks * sizeof(int));
-    if(recv_buf == NULL){
-      piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+    iodesc->scount = (int *) bget(numiotasks*sizeof(int));
+    if(iodesc->scount == NULL){
+        piomemerror(ios,numiotasks * sizeof(int), __FILE__,__LINE__);
     }
+    for(i=0;i<numiotasks;i++)
+        iodesc->scount[i]=0;
+
+    // iodesc->scount is the amount of data sent to each task from the current task
+    for(i=0;i<maplen; i++){
+        if(dest_ioindex[i] >= 0){
+            (iodesc->scount[dest_ioproc[i]])++;
+        }
+    }
+
+    //  for(i=0;i<ios.num_iotasks;i++)
+    //   printf("iodesc->scount = %d\n",iodesc->scount[i]);
+
     for(i=0;i<ntasks;i++){
-      recv_buf[i] = 0;
-      recv_counts[i] = 1;
-      recv_displs[i] = i*sizeof(int);
+        send_counts[i] = 0;
+        send_displs[i] = 0;
+        recv_counts[i] = 0;
+        recv_displs[i] = 0;
+        sr_types[i] = MPI_INT;
     }
-  }
-  //  for(i=0;i<numiotasks;i++)
-  //  printf("%s %d %d\n",__FILE__,__LINE__,iodesc->scount[i]);
+    for(i=0;i<numiotasks;i++){
+        int io_comprank;
+        if(iodesc->rearranger==PIO_REARR_SUBSET)
+            io_comprank=0;
+        else
+            io_comprank = ios.ioranks[i];
+        send_counts[io_comprank] = 1;
+        send_displs[io_comprank] = i*sizeof(int);
+    }
 
-  // Share the iodesc->scount from each compute task to all io tasks
-  ierr = pio_swapm( iodesc->scount, send_counts, send_displs, sr_types, 
-                    recv_buf,  recv_counts, recv_displs, sr_types,
-		    mycomm, false, false, maxreq);
+    if(ios.ioproc){
+        recv_buf = (int *) bget(ntasks * sizeof(int));
+        if(recv_buf == NULL){
+            piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+        }
+        for(i=0;i<ntasks;i++){
+            recv_buf[i] = 0;
+            recv_counts[i] = 1;
+            recv_displs[i] = i*sizeof(int);
+        }
+    }
+    //  for(i=0;i<numiotasks;i++)
+    //  printf("%s %d %d\n",__FILE__,__LINE__,iodesc->scount[i]);
 
-  nrecvs = 0;
-  if(ios.ioproc){
-    //       printf("recv_buf = ");
-    for(i=0;i<ntasks; i++){
-      //     printf(" %d ",recv_buf[i]);
-      if(recv_buf[i] != 0)
-	nrecvs++;
-    }
-    // printf("\n");
-
-    iodesc->rcount = (int *) bget(max(1,nrecvs)*sizeof(int));
-    if(iodesc->rcount == NULL){
-      piomemerror(ios,max(1,nrecvs) * sizeof(int), __FILE__,__LINE__);
-    }
-    iodesc->rfrom = (int *)  bget(max(1,nrecvs)*sizeof(int));
-    if(iodesc->rfrom == NULL){
-      piomemerror(ios,max(1,nrecvs) * sizeof(int), __FILE__,__LINE__);
-    }
-    for(i=0;i<max(1,nrecvs);i++){
-      iodesc->rcount[i]=0;
-      iodesc->rfrom[i]=0;
-    }
+    // Share the iodesc->scount from each compute task to all io tasks
+    ierr = pio_swapm( iodesc->scount, send_counts, send_displs, sr_types,
+                      recv_buf,  recv_counts, recv_displs, sr_types,
+                      mycomm, false, false, maxreq);
 
     nrecvs = 0;
-    for(i=0;i<ntasks; i++){
-      if(recv_buf[i] != 0){
-	iodesc->rcount[nrecvs] = recv_buf[i];
-	iodesc->rfrom[nrecvs] = i;
-	nrecvs++;
-      }
+    if(ios.ioproc){
+        //       printf("recv_buf = ");
+        for(i=0;i<ntasks; i++){
+            //     printf(" %d ",recv_buf[i]);
+            if(recv_buf[i] != 0)
+                nrecvs++;
+        }
+        // printf("\n");
 
+        iodesc->rcount = (int *) bget(max(1,nrecvs)*sizeof(int));
+        if(iodesc->rcount == NULL){
+            piomemerror(ios,max(1,nrecvs) * sizeof(int), __FILE__,__LINE__);
+        }
+        iodesc->rfrom = (int *)  bget(max(1,nrecvs)*sizeof(int));
+        if(iodesc->rfrom == NULL){
+            piomemerror(ios,max(1,nrecvs) * sizeof(int), __FILE__,__LINE__);
+        }
+        for(i=0;i<max(1,nrecvs);i++){
+            iodesc->rcount[i]=0;
+            iodesc->rfrom[i]=0;
+        }
+
+        nrecvs = 0;
+        for(i=0;i<ntasks; i++){
+            if(recv_buf[i] != 0){
+                iodesc->rcount[nrecvs] = recv_buf[i];
+                iodesc->rfrom[nrecvs] = i;
+                nrecvs++;
+            }
+
+        }
+        brel(recv_buf);
     }
-    brel(recv_buf);
-  }
 
-  iodesc->nrecvs = nrecvs;
-  if(iodesc->sindex == NULL && iodesc->ndof>0){
-    iodesc->sindex = (PIO_Offset *) bget(iodesc->ndof * sizeof(PIO_Offset));
-    if(iodesc->sindex == NULL){
-      piomemerror(ios,iodesc->ndof * sizeof(PIO_Offset), __FILE__,__LINE__);
+    iodesc->nrecvs = nrecvs;
+    if(iodesc->sindex == NULL && iodesc->ndof>0){
+        iodesc->sindex = (PIO_Offset *) bget(iodesc->ndof * sizeof(PIO_Offset));
+        if(iodesc->sindex == NULL){
+            piomemerror(ios,iodesc->ndof * sizeof(PIO_Offset), __FILE__,__LINE__);
+        }
+        for(i=0;i<iodesc->ndof;i++)
+            iodesc->sindex[i]=0;
     }
-    for(i=0;i<iodesc->ndof;i++)
-      iodesc->sindex[i]=0;
-  }
-  int tempcount[numiotasks];
-  int spos[numiotasks];
+    int tempcount[numiotasks];
+    int spos[numiotasks];
 
-  spos[0]=0;
-  tempcount[0]=0;
-  for(i=1;i<numiotasks;i++){
-    spos[i] = spos[i-1] + iodesc->scount[i-1];
-    tempcount[i]=0;
-  }
-
-  for(i=0;i<maplen;i++){
-    iorank =dest_ioproc[i]; 
-    ioindex = dest_ioindex[i];
-    if(iorank > -1){
-      // this should be moved to create_box
-      if(iodesc->rearranger==PIO_REARR_BOX)
-	iodesc->sindex[spos[iorank]+tempcount[iorank]] = i;
-
-      s2rindex[spos[iorank]+tempcount[iorank]] = ioindex;
-      (tempcount[iorank])++;
+    spos[0]=0;
+    tempcount[0]=0;
+    for(i=1;i<numiotasks;i++){
+        spos[i] = spos[i-1] + iodesc->scount[i-1];
+        tempcount[i]=0;
     }
-  }
+
+    for(i=0;i<maplen;i++){
+        iorank =dest_ioproc[i];
+        ioindex = dest_ioindex[i];
+        if(iorank > -1){
+            // this should be moved to create_box
+            if(iodesc->rearranger==PIO_REARR_BOX)
+                iodesc->sindex[spos[iorank]+tempcount[iorank]] = i;
+
+            s2rindex[spos[iorank]+tempcount[iorank]] = ioindex;
+            (tempcount[iorank])++;
+        }
+    }
     //    printf("%s %d %d %d %d %d\n",__FILE__,__LINE__,iodesc->llen,iodesc->ndof, maplen,spos[0]+tempcount[0]);
 
-  for(i=0;i<ntasks;i++){
-    send_counts[i] = 0;
-    send_displs[i]  = 0;
-    recv_counts[i] = 0;
-    recv_displs[i]   =0;
-  }
-  MPI_Type_size(MPI_OFFSET, &tsize);
-
-  for(i=0; i<ntasks; i++){
-    sr_types[i] = MPI_OFFSET;
-  }
-
-  for(i=0;i<numiotasks;i++){
-    if(iodesc->rearranger==PIO_REARR_BOX){
-      io_comprank = ios.ioranks[i];
-    }else{
-      io_comprank=0;
+    for(i=0;i<ntasks;i++){
+        send_counts[i] = 0;
+        send_displs[i]  = 0;
+        recv_counts[i] = 0;
+        recv_displs[i]   =0;
     }
-    send_counts[io_comprank] = iodesc->scount[i];
-    if(send_counts[io_comprank]>0)
-      send_displs[io_comprank]  = spos[i]*tsize ;
-  }
+    MPI_Type_size(MPI_OFFSET, &tsize);
 
-  if(ios.ioproc){
-    int totalrecv=0;
-    for(i=0;i<nrecvs;i++){
-      recv_counts[iodesc->rfrom[i]] = iodesc->rcount[i];
-      totalrecv+=iodesc->rcount[i];
+    for(i=0; i<ntasks; i++){
+        sr_types[i] = MPI_OFFSET;
     }
-    recv_displs[0] = 0;
-    for(i=1;i<nrecvs;i++)
-      recv_displs[iodesc->rfrom[i]] = recv_displs[iodesc->rfrom[i-1]]+iodesc->rcount[i-1]*tsize;
 
-
-    if(totalrecv>0){
-      //      printf("%s %d %d %d\n",__FILE__,__LINE__,totalrecv,iodesc->llen);
-      totalrecv = iodesc->llen;  // can reduce memory usage here
-      iodesc->rindex = (PIO_Offset *) bget(totalrecv*sizeof(PIO_Offset));
-      if(iodesc->rindex == NULL){
-	piomemerror(ios,totalrecv * sizeof(PIO_Offset), __FILE__,__LINE__);
-      }
-      for(i=0;i<totalrecv;i++)
-	iodesc->rindex[i]=0;
+    for(i=0;i<numiotasks;i++){
+        if(iodesc->rearranger==PIO_REARR_BOX){
+            io_comprank = ios.ioranks[i];
+        }else{
+            io_comprank=0;
+        }
+        send_counts[io_comprank] = iodesc->scount[i];
+        if(send_counts[io_comprank]>0)
+            send_displs[io_comprank]  = spos[i]*tsize ;
     }
-  }
-  //   printf("%d rbuf_size %d\n",ios.comp_rank,rbuf_size);
+
+    if(ios.ioproc){
+        int totalrecv=0;
+        for(i=0;i<nrecvs;i++){
+            recv_counts[iodesc->rfrom[i]] = iodesc->rcount[i];
+            totalrecv+=iodesc->rcount[i];
+        }
+        recv_displs[0] = 0;
+        for(i=1;i<nrecvs;i++)
+            recv_displs[iodesc->rfrom[i]] = recv_displs[iodesc->rfrom[i-1]]+iodesc->rcount[i-1]*tsize;
 
 
-  // s2rindex is the list of indeces on each compute task
-  /*        
-  printf("%d s2rindex: ", ios.comp_rank);
-  for(i=0;i<iodesc->ndof;i++)
-    printf("%ld ",s2rindex[i]);
-  printf("\n");
-  */
-  //  printf("%s %d %d %d %d %d %d %d\n",__FILE__,__LINE__,send_counts[0],recv_counts[0],send_displs[0],recv_displs[0],sr_types[0],iodesc->llen);
-  ierr = pio_swapm( s2rindex, send_counts, send_displs, sr_types, 
-		    iodesc->rindex, recv_counts, recv_displs, sr_types,
-  		    mycomm, false, false, 0);
-  // printf("%s %d\n",__FILE__,__LINE__);
+        if(totalrecv>0){
+            //      printf("%s %d %d %d\n",__FILE__,__LINE__,totalrecv,iodesc->llen);
+            totalrecv = iodesc->llen;  // can reduce memory usage here
+            iodesc->rindex = (PIO_Offset *) bget(totalrecv*sizeof(PIO_Offset));
+            if(iodesc->rindex == NULL){
+                piomemerror(ios,totalrecv * sizeof(PIO_Offset), __FILE__,__LINE__);
+            }
+            for(i=0;i<totalrecv;i++)
+                iodesc->rindex[i]=0;
+        }
+    }
+    //   printf("%d rbuf_size %d\n",ios.comp_rank,rbuf_size);
 
-  //  rindex is an array of the indices of the data to be sent from
-  //  this io task to each compute task. 
-  /*   
-  if(ios.ioproc){
-    printf("%d rindex: ",ios.io_rank);
-    for(int j=0;j<iodesc->llen;j++)
-      printf(" %ld ",iodesc->rindex[j]);
-    printf("\n");
-  }
-  */
-  return ierr;
+
+    // s2rindex is the list of indeces on each compute task
+    /*
+              printf("%d s2rindex: ", ios.comp_rank);
+              for(i=0;i<iodesc->ndof;i++)
+              printf("%ld ",s2rindex[i]);
+              printf("\n");
+    */
+    //  printf("%s %d %d %d %d %d %d %d\n",__FILE__,__LINE__,send_counts[0],recv_counts[0],send_displs[0],recv_displs[0],sr_types[0],iodesc->llen);
+    ierr = pio_swapm( s2rindex, send_counts, send_displs, sr_types,
+                      iodesc->rindex, recv_counts, recv_displs, sr_types,
+                      mycomm, false, false, 0);
+    // printf("%s %d\n",__FILE__,__LINE__);
+
+    //  rindex is an array of the indices of the data to be sent from
+    //  this io task to each compute task.
+    /*
+         if(ios.ioproc){
+         printf("%d rindex: ",ios.io_rank);
+         for(int j=0;j<iodesc->llen;j++)
+         printf(" %ld ",iodesc->rindex[j]);
+         printf("\n");
+         }
+    */
+    return ierr;
 
 }
 
-/** 
+/**
  ** @internal
  ** Moves data from compute tasks to IO tasks.
  ** @endinternal
@@ -595,164 +595,164 @@ int compute_counts(const iosystem_desc_t ios, io_desc_t *iodesc, const int maple
 
 
 int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
-			  void *rbuf, const int nvars)
+                      void *rbuf, const int nvars)
 {
-  int ntasks;
-  int niotasks;
-  int *scount = iodesc->scount;
-  int ivar;
-  int i, tsize;
-  int *sendcounts;
-  int *recvcounts;
-  int *sdispls;
-  int *rdispls;
-  MPI_Datatype *sendtypes;
-  MPI_Datatype *recvtypes;
-  MPI_Comm mycomm;
+    int ntasks;
+    int niotasks;
+    int *scount = iodesc->scount;
+    int ivar;
+    int i, tsize;
+    int *sendcounts;
+    int *recvcounts;
+    int *sdispls;
+    int *rdispls;
+    MPI_Datatype *sendtypes;
+    MPI_Datatype *recvtypes;
+    MPI_Comm mycomm;
 
-  //  maxreq = 0;
-  //  printf("%s %d %d %d\n",__FILE__,__LINE__,nvars,iodesc->ndof);
+    //  maxreq = 0;
+    //  printf("%s %d %d %d\n",__FILE__,__LINE__,nvars,iodesc->ndof);
 #ifdef TIMING
-  GPTLstart("PIO:rearrange_comp2io");
+    GPTLstart("PIO:rearrange_comp2io");
 #endif
-  
-  if(iodesc->rearranger == PIO_REARR_BOX){
-    mycomm = ios.union_comm;
-    niotasks = ios.num_iotasks;
-  }else{
-    mycomm = iodesc->subset_comm;
-    niotasks = 1;
-  }  
-  MPI_Comm_size(mycomm, &ntasks);
 
-  pioassert(nvars>0,"nvars must be > 0",__FILE__,__LINE__);
-  MPI_Type_size(iodesc->basetype, &tsize);
-
-  define_iodesc_datatypes(ios, iodesc);
-
-  sendcounts = (int *) bget(ntasks*sizeof(int));
-  if(sendcounts == NULL){
-    piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
-  }
-  recvcounts = (int *) bget(ntasks*sizeof(int));
-  if(recvcounts == NULL){
-    piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
-  }
-  sdispls = (int *) bget(ntasks*sizeof(int));
-  if(sdispls == NULL){
-    piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
-  }
-  rdispls = (int *) bget(ntasks*sizeof(int));
-  if(rdispls == NULL){
-    piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
-  }
-  sendtypes = (MPI_Datatype *) bget(ntasks*sizeof(MPI_Datatype));
-  if(sendtypes == NULL){
-    piomemerror(ios,ntasks * sizeof(MPI_Datatype), __FILE__,__LINE__);
-  }
-  recvtypes = (MPI_Datatype *) bget(ntasks*sizeof(MPI_Datatype));
-  if(recvtypes == NULL){
-    piomemerror(ios,ntasks * sizeof(MPI_Datatype), __FILE__,__LINE__);
-  }
-  //printf("%s %d %ld %ld\n",__FILE__,__LINE__,sendtypes,recvtypes);
-  for(i=0;i<ntasks;i++){
-    sendcounts[i] = 0;
-    recvcounts[i] = 0; 
-    sdispls[i] = 0; 
-    rdispls[i] = 0;
-    recvtypes[ i ] = MPI_DATATYPE_NULL;
-    sendtypes[ i ] =  MPI_DATATYPE_NULL;
-  }
-
-
-  if(ios.ioproc && iodesc->nrecvs>0){
-    //    printf("%d: rindex[%d] %d\n",ios.comp_rank,0,iodesc->rindex[0]);
-    for( i=0;i<iodesc->nrecvs;i++){
-      if(iodesc->rtype[i] != MPI_DATATYPE_NULL){
-	if(iodesc->rearranger==PIO_REARR_SUBSET){
-	  recvcounts[ i ] = 1;
-	  // The stride here is the length of the collected array (llen)
-          MPI_Type_hvector(nvars, 1, (MPI_Aint) iodesc->llen*tsize, iodesc->rtype[i], recvtypes+i);
-	  if(recvtypes[i] == MPI_DATATYPE_NULL){
-	    piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
-	  }
-          MPI_Type_commit(recvtypes+i);
-	  //recvtypes[ i ] = iodesc->rtype[i];
-	}else{
-	  recvcounts[ iodesc->rfrom[i] ] = 1;
-          MPI_Type_hvector(nvars, 1,(MPI_Aint) iodesc->llen*tsize,iodesc->rtype[i], recvtypes+iodesc->rfrom[i]);
-	  if(recvtypes[iodesc->rfrom[i]] == MPI_DATATYPE_NULL){
-	    piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
-	  }
-          MPI_Type_commit(recvtypes+iodesc->rfrom[i]);
-	  // recvtypes[ iodesc->rfrom[i] ] = iodesc->rtype[i];
-	  rdispls[ iodesc->rfrom[i] ] = 0;
-	  //    printf("%d: rindex[%d] %d\n",ios.comp_rank,0,iodesc->rindex[0]);
-	}
-      }
-      //   printf("%d: rindex[%d] %d\n",ios.comp_rank,i,iodesc->rindex[i]);
-      
-    }
-  }
-
-  for( i=0;i<niotasks; i++){
-    int io_comprank = ios.ioranks[i];
-    if(iodesc->rearranger==PIO_REARR_SUBSET)
-      io_comprank=0;
-    
-    //    printf("scount[%d]=%d\n",i,scount[i]);
-    if(scount[i] > 0 && sbuf != NULL) {
-      sendcounts[io_comprank]=1;
-      MPI_Type_hvector(nvars, 1, (MPI_Aint) iodesc->ndof*tsize, iodesc->stype[i], sendtypes+io_comprank);
-      if(sendtypes[io_comprank] == MPI_DATATYPE_NULL){
-	piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
-      }
-      MPI_Type_commit(sendtypes+io_comprank);
+    if(iodesc->rearranger == PIO_REARR_BOX){
+        mycomm = ios.union_comm;
+        niotasks = ios.num_iotasks;
     }else{
-      sendcounts[io_comprank]=0;
+        mycomm = iodesc->subset_comm;
+        niotasks = 1;
     }
-  }      
-  //  printf("%s %d %d\n",__FILE__,__LINE__,((int *)sbuf)[5]);
+    MPI_Comm_size(mycomm, &ntasks);
+
+    pioassert(nvars>0,"nvars must be > 0",__FILE__,__LINE__);
+    MPI_Type_size(iodesc->basetype, &tsize);
+
+    define_iodesc_datatypes(ios, iodesc);
+
+    sendcounts = (int *) bget(ntasks*sizeof(int));
+    if(sendcounts == NULL){
+        piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+    }
+    recvcounts = (int *) bget(ntasks*sizeof(int));
+    if(recvcounts == NULL){
+        piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+    }
+    sdispls = (int *) bget(ntasks*sizeof(int));
+    if(sdispls == NULL){
+        piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+    }
+    rdispls = (int *) bget(ntasks*sizeof(int));
+    if(rdispls == NULL){
+        piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+    }
+    sendtypes = (MPI_Datatype *) bget(ntasks*sizeof(MPI_Datatype));
+    if(sendtypes == NULL){
+        piomemerror(ios,ntasks * sizeof(MPI_Datatype), __FILE__,__LINE__);
+    }
+    recvtypes = (MPI_Datatype *) bget(ntasks*sizeof(MPI_Datatype));
+    if(recvtypes == NULL){
+        piomemerror(ios,ntasks * sizeof(MPI_Datatype), __FILE__,__LINE__);
+    }
+    //printf("%s %d %ld %ld\n",__FILE__,__LINE__,sendtypes,recvtypes);
+    for(i=0;i<ntasks;i++){
+        sendcounts[i] = 0;
+        recvcounts[i] = 0;
+        sdispls[i] = 0;
+        rdispls[i] = 0;
+        recvtypes[ i ] = MPI_DATATYPE_NULL;
+        sendtypes[ i ] =  MPI_DATATYPE_NULL;
+    }
+
+
+    if(ios.ioproc && iodesc->nrecvs>0){
+        //    printf("%d: rindex[%d] %d\n",ios.comp_rank,0,iodesc->rindex[0]);
+        for( i=0;i<iodesc->nrecvs;i++){
+            if(iodesc->rtype[i] != MPI_DATATYPE_NULL){
+                if(iodesc->rearranger==PIO_REARR_SUBSET){
+                    recvcounts[ i ] = 1;
+                    // The stride here is the length of the collected array (llen)
+                    MPI_Type_hvector(nvars, 1, (MPI_Aint) iodesc->llen*tsize, iodesc->rtype[i], recvtypes+i);
+                    if(recvtypes[i] == MPI_DATATYPE_NULL){
+                        piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
+                    }
+                    MPI_Type_commit(recvtypes+i);
+                    //recvtypes[ i ] = iodesc->rtype[i];
+                }else{
+                    recvcounts[ iodesc->rfrom[i] ] = 1;
+                    MPI_Type_hvector(nvars, 1,(MPI_Aint) iodesc->llen*tsize,iodesc->rtype[i], recvtypes+iodesc->rfrom[i]);
+                    if(recvtypes[iodesc->rfrom[i]] == MPI_DATATYPE_NULL){
+                        piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
+                    }
+                    MPI_Type_commit(recvtypes+iodesc->rfrom[i]);
+                    // recvtypes[ iodesc->rfrom[i] ] = iodesc->rtype[i];
+                    rdispls[ iodesc->rfrom[i] ] = 0;
+                    //    printf("%d: rindex[%d] %d\n",ios.comp_rank,0,iodesc->rindex[0]);
+                }
+            }
+            //   printf("%d: rindex[%d] %d\n",ios.comp_rank,i,iodesc->rindex[i]);
+
+        }
+    }
+
+    for( i=0;i<niotasks; i++){
+        int io_comprank = ios.ioranks[i];
+        if(iodesc->rearranger==PIO_REARR_SUBSET)
+            io_comprank=0;
+
+        //    printf("scount[%d]=%d\n",i,scount[i]);
+        if(scount[i] > 0 && sbuf != NULL) {
+            sendcounts[io_comprank]=1;
+            MPI_Type_hvector(nvars, 1, (MPI_Aint) iodesc->ndof*tsize, iodesc->stype[i], sendtypes+io_comprank);
+            if(sendtypes[io_comprank] == MPI_DATATYPE_NULL){
+                piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
+            }
+            MPI_Type_commit(sendtypes+io_comprank);
+        }else{
+            sendcounts[io_comprank]=0;
+        }
+    }
+    //  printf("%s %d %d\n",__FILE__,__LINE__,((int *)sbuf)[5]);
 //printf("%s %d %ld %ld %ld %ld\n",__FILE__,__LINE__,sendtypes[0],recvtypes,sbuf,rbuf);
-  // Data in sbuf on the compute nodes is sent to rbuf on the ionodes
+    // Data in sbuf on the compute nodes is sent to rbuf on the ionodes
 
-  //  for(i=0;i<nvars*iodesc->ndof;i++)
-  //   printf("%s %d %d %d \n",__FILE__,__LINE__,i,((int *)sbuf)[i]);
+    //  for(i=0;i<nvars*iodesc->ndof;i++)
+    //   printf("%s %d %d %d \n",__FILE__,__LINE__,i,((int *)sbuf)[i]);
 
-  pio_swapm( sbuf,  sendcounts, sdispls, sendtypes,
-	     rbuf, recvcounts, rdispls, recvtypes, 
-	     mycomm, iodesc->handshake, iodesc->isend, iodesc->max_requests);
-  //    if(ios.ioproc)
-  //     for(i=0;i<nvars*iodesc->llen;i++)
-  //	printf("%s %d %d %d\n",__FILE__,__LINE__,i,((int *)rbuf)[i]);
-  //printf("%s %d %ld %ld\n",__FILE__,__LINE__,sendtypes[0],recvtypes);  
+    pio_swapm( sbuf,  sendcounts, sdispls, sendtypes,
+               rbuf, recvcounts, rdispls, recvtypes,
+               mycomm, iodesc->handshake, iodesc->isend, iodesc->max_requests);
+    //    if(ios.ioproc)
+    //     for(i=0;i<nvars*iodesc->llen;i++)
+    //  printf("%s %d %d %d\n",__FILE__,__LINE__,i,((int *)rbuf)[i]);
+    //printf("%s %d %ld %ld\n",__FILE__,__LINE__,sendtypes[0],recvtypes);
 
-  brel(sendcounts);
-  brel(recvcounts); 
-  brel(sdispls);
-  brel(rdispls);
+    brel(sendcounts);
+    brel(recvcounts);
+    brel(sdispls);
+    brel(rdispls);
 //printf("%s %d %ld %ld\n",__FILE__,__LINE__,sendtypes[0],recvtypes);
-  for( i=0;i<ntasks; i++){
-    if(sendtypes[i] != MPI_DATATYPE_NULL){
-      //printf("%s %d %d %ld\n",__FILE__,__LINE__,i,sendtypes[i]);
-      MPI_Type_free(sendtypes+i);
+    for( i=0;i<ntasks; i++){
+        if(sendtypes[i] != MPI_DATATYPE_NULL){
+            //printf("%s %d %d %ld\n",__FILE__,__LINE__,i,sendtypes[i]);
+            MPI_Type_free(sendtypes+i);
+        }
+        if(recvtypes[i] != MPI_DATATYPE_NULL){
+            //printf("%s %d %d\n",__FILE__,__LINE__,i);
+            MPI_Type_free(recvtypes+i);
+        }
     }
-    if(recvtypes[i] != MPI_DATATYPE_NULL){     
-      //printf("%s %d %d\n",__FILE__,__LINE__,i);    
-      MPI_Type_free(recvtypes+i);
-    }
-  }
-  
-  brel(sendtypes);
-  brel(recvtypes);
+
+    brel(sendtypes);
+    brel(recvtypes);
 
 #ifdef TIMING
-  GPTLstop("PIO:rearrange_comp2io");
+    GPTLstop("PIO:rearrange_comp2io");
 #endif
 
-  return PIO_NOERR;
+    return PIO_NOERR;
 }
-/** 
+/**
  ** @internal
  ** Moves data from compute tasks to IO tasks.
  ** @endinternal
@@ -761,164 +761,164 @@ int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
 
 int rearrange_io2comp(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf, void *rbuf)
 {
-  
 
-  //  int maxreq = 0;
-  MPI_Comm mycomm;
 
-  int ntasks ;
-  int niotasks;
-  int *scount = iodesc->scount;
+    //  int maxreq = 0;
+    MPI_Comm mycomm;
 
-  int *sendcounts;
-  int *recvcounts;
-  int *sdispls;
-  int *rdispls;
-  MPI_Datatype *sendtypes;
-  MPI_Datatype *recvtypes;
+    int ntasks ;
+    int niotasks;
+    int *scount = iodesc->scount;
 
-  int i, tsize;
+    int *sendcounts;
+    int *recvcounts;
+    int *sdispls;
+    int *rdispls;
+    MPI_Datatype *sendtypes;
+    MPI_Datatype *recvtypes;
+
+    int i, tsize;
 #ifdef TIMING
-  GPTLstart("PIO:rearrange_io2comp");
+    GPTLstart("PIO:rearrange_io2comp");
 #endif
-  if(iodesc->rearranger==PIO_REARR_BOX){
-    mycomm = ios.union_comm;
-    niotasks = ios.num_iotasks;
-  }else{
-    mycomm = iodesc->subset_comm;
-    niotasks=1;
-  }
-  MPI_Comm_size(mycomm, &ntasks);
-
-  define_iodesc_datatypes(ios, iodesc);
-
-  sendcounts = (int *) bget(ntasks*sizeof(int));
-  if(sendcounts == NULL){
-    piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
-  }
-  recvcounts = (int *) bget(ntasks*sizeof(int));
-  if(recvcounts == NULL){
-    piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
-  }
-  sdispls = (int *) bget(ntasks*sizeof(int));
-  if(sdispls == NULL){
-    piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
-  }
-  rdispls = (int *) bget(ntasks*sizeof(int));
-  if(rdispls == NULL){
-    piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
-  }
-  sendtypes = (MPI_Datatype *) bget(ntasks*sizeof(MPI_Datatype));
-  if(sendtypes == NULL){
-    piomemerror(ios,ntasks * sizeof(MPI_Datatype), __FILE__,__LINE__);
-  }
-  recvtypes = (MPI_Datatype *) bget(ntasks*sizeof(MPI_Datatype));
-  if(recvtypes == NULL){
-    piomemerror(ios,ntasks * sizeof(MPI_Datatype), __FILE__,__LINE__);
-  }
-
-  for( i=0;i< ntasks;i++){
-    sendcounts[i] = 0;
-    recvcounts[i] = 0;
-    sdispls[i] = 0;
-    rdispls[i] = 0;
-    sendtypes[ i ] = MPI_DATATYPE_NULL;
-    recvtypes[ i ] = MPI_DATATYPE_NULL;
-  }
-  if(ios.ioproc){
-    for( i=0;i< iodesc->nrecvs;i++){
-      if(iodesc->rtype[i] != MPI_DATATYPE_NULL){
-	if(iodesc->rearranger==PIO_REARR_SUBSET){
-	  if(sbuf != NULL){
-	    sendcounts[ i ] = 1;
-	    sendtypes[ i ] = iodesc->rtype[i];
-	  }
-	}else{
-	  sendcounts[ iodesc->rfrom[i] ] = 1;
-	  sendtypes[ iodesc->rfrom[i] ] = iodesc->rtype[i];
-	}
-      }
+    if(iodesc->rearranger==PIO_REARR_BOX){
+        mycomm = ios.union_comm;
+        niotasks = ios.num_iotasks;
+    }else{
+        mycomm = iodesc->subset_comm;
+        niotasks=1;
     }
-  }
+    MPI_Comm_size(mycomm, &ntasks);
 
-  for( i=0;i<niotasks; i++){
-    int io_comprank = ios.ioranks[i];
-    if(iodesc->rearranger==PIO_REARR_SUBSET)
-      io_comprank=0;
-    if(scount[i] > 0 && iodesc->stype[i] != MPI_DATATYPE_NULL) {
-      recvcounts[io_comprank]=1;
-      recvtypes[io_comprank]=iodesc->stype[i];
+    define_iodesc_datatypes(ios, iodesc);
+
+    sendcounts = (int *) bget(ntasks*sizeof(int));
+    if(sendcounts == NULL){
+        piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
     }
-  } 
-  
-  //
-  // Data in sbuf on the ionodes is sent to rbuf on the compute nodes
-  //
-  #if DEBUG
-  printf("%s %d \n",__FILE__,__LINE__);
-  #endif
-  pio_swapm( sbuf,  sendcounts, sdispls, sendtypes,
-	     rbuf, recvcounts, rdispls, recvtypes, 
-	     mycomm, iodesc->handshake, iodesc->isend, iodesc->max_requests);
-  #if DEBUG
-  printf("%s %d \n",__FILE__,__LINE__);
-  #endif
-  brel(sendcounts);
-  brel(recvcounts); 
-  brel(sdispls);
-  brel(rdispls);
-  brel(sendtypes);
-  brel(recvtypes);
+    recvcounts = (int *) bget(ntasks*sizeof(int));
+    if(recvcounts == NULL){
+        piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+    }
+    sdispls = (int *) bget(ntasks*sizeof(int));
+    if(sdispls == NULL){
+        piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+    }
+    rdispls = (int *) bget(ntasks*sizeof(int));
+    if(rdispls == NULL){
+        piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+    }
+    sendtypes = (MPI_Datatype *) bget(ntasks*sizeof(MPI_Datatype));
+    if(sendtypes == NULL){
+        piomemerror(ios,ntasks * sizeof(MPI_Datatype), __FILE__,__LINE__);
+    }
+    recvtypes = (MPI_Datatype *) bget(ntasks*sizeof(MPI_Datatype));
+    if(recvtypes == NULL){
+        piomemerror(ios,ntasks * sizeof(MPI_Datatype), __FILE__,__LINE__);
+    }
+
+    for( i=0;i< ntasks;i++){
+        sendcounts[i] = 0;
+        recvcounts[i] = 0;
+        sdispls[i] = 0;
+        rdispls[i] = 0;
+        sendtypes[ i ] = MPI_DATATYPE_NULL;
+        recvtypes[ i ] = MPI_DATATYPE_NULL;
+    }
+    if(ios.ioproc){
+        for( i=0;i< iodesc->nrecvs;i++){
+            if(iodesc->rtype[i] != MPI_DATATYPE_NULL){
+                if(iodesc->rearranger==PIO_REARR_SUBSET){
+                    if(sbuf != NULL){
+                        sendcounts[ i ] = 1;
+                        sendtypes[ i ] = iodesc->rtype[i];
+                    }
+                }else{
+                    sendcounts[ iodesc->rfrom[i] ] = 1;
+                    sendtypes[ iodesc->rfrom[i] ] = iodesc->rtype[i];
+                }
+            }
+        }
+    }
+
+    for( i=0;i<niotasks; i++){
+        int io_comprank = ios.ioranks[i];
+        if(iodesc->rearranger==PIO_REARR_SUBSET)
+            io_comprank=0;
+        if(scount[i] > 0 && iodesc->stype[i] != MPI_DATATYPE_NULL) {
+            recvcounts[io_comprank]=1;
+            recvtypes[io_comprank]=iodesc->stype[i];
+        }
+    }
+
+    //
+    // Data in sbuf on the ionodes is sent to rbuf on the compute nodes
+    //
+#if DEBUG
+    printf("%s %d \n",__FILE__,__LINE__);
+#endif
+    pio_swapm( sbuf,  sendcounts, sdispls, sendtypes,
+               rbuf, recvcounts, rdispls, recvtypes,
+               mycomm, iodesc->handshake, iodesc->isend, iodesc->max_requests);
+#if DEBUG
+    printf("%s %d \n",__FILE__,__LINE__);
+#endif
+    brel(sendcounts);
+    brel(recvcounts);
+    brel(sdispls);
+    brel(rdispls);
+    brel(sendtypes);
+    brel(recvtypes);
 
 #ifdef TIMING
-  GPTLstop("PIO:rearrange_io2comp");
+    GPTLstop("PIO:rearrange_io2comp");
 #endif
- 
-  return PIO_NOERR;
+
+    return PIO_NOERR;
 
 }
 
 void determine_fill(iosystem_desc_t ios, io_desc_t *iodesc, const int gsize[], const PIO_Offset compmap[])
 {
-  PIO_Offset totalllen=0;
-  PIO_Offset totalgridsize=1;
-  int i;
-  for( i=0;i<iodesc->ndims;i++){
-    totalgridsize *= gsize[i];
-  }
-  if(iodesc->rearranger==PIO_REARR_SUBSET){
-    totalllen=iodesc->llen;
-  }else{
-    for(i=0;i<iodesc->ndof;i++){
-      if(compmap[i]>0){
-	totalllen++;
-      }
+    PIO_Offset totalllen=0;
+    PIO_Offset totalgridsize=1;
+    int i;
+    for( i=0;i<iodesc->ndims;i++){
+        totalgridsize *= gsize[i];
     }
-  }
-  //  printf("%s %d %ld %ld\n",__FILE__,__LINE__,totalllen,totalgridsize);
-
-  MPI_Allreduce(MPI_IN_PLACE, &totalllen, 1, PIO_OFFSET, MPI_SUM, ios.union_comm);
-
-  
-  if(totalllen < totalgridsize){
-    //if(ios.iomaster) printf("%s %d %ld %ld\n",__FILE__,__LINE__,totalllen,totalgridsize);
-    iodesc->needsfill = true;
-  }else{
-    iodesc->needsfill = false;
-    iodesc->gsize = NULL;
-  }
-  //  TURN OFF FILL for timing test
-  //  iodesc->needsfill=false;
-
-  if(iodesc->needsfill){
-    iodesc->gsize = (PIO_Offset *) bget(iodesc->ndims * sizeof(PIO_Offset));
-    if(iodesc->gsize==NULL){
-      piomemerror(ios,iodesc->ndims * sizeof(MPI_Datatype), __FILE__,__LINE__);
+    if(iodesc->rearranger==PIO_REARR_SUBSET){
+        totalllen=iodesc->llen;
+    }else{
+        for(i=0;i<iodesc->ndof;i++){
+            if(compmap[i]>0){
+                totalllen++;
+            }
+        }
     }
-    for (i=0;i<iodesc->ndims;i++){
-      iodesc->gsize[i] = gsize[i];
+    //  printf("%s %d %ld %ld\n",__FILE__,__LINE__,totalllen,totalgridsize);
+
+    MPI_Allreduce(MPI_IN_PLACE, &totalllen, 1, PIO_OFFSET, MPI_SUM, ios.union_comm);
+
+
+    if(totalllen < totalgridsize){
+        //if(ios.iomaster) printf("%s %d %ld %ld\n",__FILE__,__LINE__,totalllen,totalgridsize);
+        iodesc->needsfill = true;
+    }else{
+        iodesc->needsfill = false;
+        iodesc->gsize = NULL;
     }
-  }
+    //  TURN OFF FILL for timing test
+    //  iodesc->needsfill=false;
+
+    if(iodesc->needsfill){
+        iodesc->gsize = (PIO_Offset *) bget(iodesc->ndims * sizeof(PIO_Offset));
+        if(iodesc->gsize==NULL){
+            piomemerror(ios,iodesc->ndims * sizeof(MPI_Datatype), __FILE__,__LINE__);
+        }
+        for (i=0;i<iodesc->ndims;i++){
+            iodesc->gsize[i] = gsize[i];
+        }
+    }
 
 
 }
@@ -926,265 +926,265 @@ void determine_fill(iosystem_desc_t ios, io_desc_t *iodesc, const int gsize[], c
 
 void iodesc_dump(io_desc_t *iodesc)
 {
-  printf("ioid= %d\n",iodesc->ioid);
-  printf("async_id= %d\n",iodesc->async_id);
-  printf("nrecvs= %d\n",iodesc->nrecvs);
-  printf("ndof= %d\n",iodesc->ndof);
-  printf("ndims= %d\n",iodesc->ndims);
-  printf("num_aiotasks= %d\n",iodesc->num_aiotasks);
-  printf("rearranger= %d\n",iodesc->rearranger);
-  printf("maxregions= %d\n",iodesc->maxregions);
-  printf("needsfill= %d\n",(int) iodesc->needsfill);
+    printf("ioid= %d\n",iodesc->ioid);
+    printf("async_id= %d\n",iodesc->async_id);
+    printf("nrecvs= %d\n",iodesc->nrecvs);
+    printf("ndof= %d\n",iodesc->ndof);
+    printf("ndims= %d\n",iodesc->ndims);
+    printf("num_aiotasks= %d\n",iodesc->num_aiotasks);
+    printf("rearranger= %d\n",iodesc->rearranger);
+    printf("maxregions= %d\n",iodesc->maxregions);
+    printf("needsfill= %d\n",(int) iodesc->needsfill);
 
-  printf("llen= %ld\n",iodesc->llen);
-  printf("maxiobuflen= %d\n",iodesc->maxiobuflen);
-  printf("gsize=");
-  for(int i=0; i< iodesc->ndims; i++){
-      printf(" %d",iodesc->ioid);
-  }
-  printf("\n");
+    printf("llen= %ld\n",iodesc->llen);
+    printf("maxiobuflen= %d\n",iodesc->maxiobuflen);
+    printf("gsize=");
+    for(int i=0; i< iodesc->ndims; i++){
+        printf(" %d",iodesc->ioid);
+    }
+    printf("\n");
 
-  printf("rindex= ");
-  for(int j=0;j<iodesc->llen;j++)
-    printf(" %ld ",iodesc->rindex[j]);
-  printf("\n");
-  
+    printf("rindex= ");
+    for(int j=0;j<iodesc->llen;j++)
+        printf(" %ld ",iodesc->rindex[j]);
+    printf("\n");
+
 
 
 }
 
-/** 
+/**
  ** @internal
  ** The box rearranger computes a mapping between IO tasks and compute tasks such that the data
- ** on io tasks can be written with a single call to the underlying netcdf library.   This 
- ** may involve an all to all rearrangement in the mapping, but should minimize data movement in 
+ ** on io tasks can be written with a single call to the underlying netcdf library.   This
+ ** may involve an all to all rearrangement in the mapping, but should minimize data movement in
  ** lower level libraries
  ** @endinternal
  **
  */
 
 int box_rearrange_create(const iosystem_desc_t ios,const int maplen, const PIO_Offset compmap[], const int gsize[],
-			 const int ndims, io_desc_t *iodesc)
+                         const int ndims, io_desc_t *iodesc)
 {
-  int ierr=PIO_NOERR;
-  int nprocs = ios.num_comptasks;
-  int nioprocs = ios.num_iotasks;
-  PIO_Offset gstride[ndims];
-  PIO_Offset iomap;
-  PIO_Offset start[ndims], count[ndims];
-  int  tsize, i, j, k, llen;
-  MPI_Datatype dtype;
-  int dest_ioproc[maplen];
-  PIO_Offset dest_ioindex[maplen];
-  int sndlths[nprocs]; 
-  int sdispls[nprocs];
-  int recvlths[nprocs];
-  int rdispls[nprocs];
-  MPI_Datatype dtypes[nprocs];
-  PIO_Offset iomaplen[nioprocs];
-  int maxreq = MAX_GATHER_BLOCK_SIZE;
+    int ierr=PIO_NOERR;
+    int nprocs = ios.num_comptasks;
+    int nioprocs = ios.num_iotasks;
+    PIO_Offset gstride[ndims];
+    PIO_Offset iomap;
+    PIO_Offset start[ndims], count[ndims];
+    int  tsize, i, j, k, llen;
+    MPI_Datatype dtype;
+    int dest_ioproc[maplen];
+    PIO_Offset dest_ioindex[maplen];
+    int sndlths[nprocs];
+    int sdispls[nprocs];
+    int recvlths[nprocs];
+    int rdispls[nprocs];
+    MPI_Datatype dtypes[nprocs];
+    PIO_Offset iomaplen[nioprocs];
+    int maxreq = MAX_GATHER_BLOCK_SIZE;
 
-  iodesc->rearranger = PIO_REARR_BOX;
+    iodesc->rearranger = PIO_REARR_BOX;
 
-  iodesc->ndof = maplen;
-  gstride[ndims-1]=1;
-  for(int i=ndims-2;i>=0; i--)
-    gstride[i]=gstride[i+1]*gsize[i+1];
+    iodesc->ndof = maplen;
+    gstride[ndims-1]=1;
+    for(int i=ndims-2;i>=0; i--)
+        gstride[i]=gstride[i+1]*gsize[i+1];
 
-  MPI_Type_size(MPI_OFFSET, &tsize);
+    MPI_Type_size(MPI_OFFSET, &tsize);
 
-  for(i=0; i< maplen; i++){
-    dest_ioproc[i] = -1;
-    dest_ioindex[i] = -1;
-  }
-  for(i=0;i<nprocs;i++){
-    sndlths[i] = 0;
-    sdispls[i] = 0;
-    recvlths[i] = 0;
-    rdispls[i] = 0;
-    dtypes[i] = MPI_OFFSET;
-  }
-  iodesc->llen=0;
-  if(ios.ioproc){
-    for( i=0;i<nprocs;i++){
-      sndlths[ i ] = 1;
+    for(i=0; i< maplen; i++){
+        dest_ioproc[i] = -1;
+        dest_ioindex[i] = -1;
     }
-    // llen here is the number that will be read on each io task
-    iodesc->llen=1;
-    for(i=0;i<ndims;i++)
-      iodesc->llen *= iodesc->firstregion->count[i];
-  }
-  determine_fill(ios, iodesc, gsize, compmap);
-
-  /* 
-  if(ios.ioproc){
-    for(i=0; i<ndims; i++){
-      printf("%d %d %d ",i,iodesc->firstregion->start[i],iodesc->firstregion->count[i]);
+    for(i=0;i<nprocs;i++){
+        sndlths[i] = 0;
+        sdispls[i] = 0;
+        recvlths[i] = 0;
+        rdispls[i] = 0;
+        dtypes[i] = MPI_OFFSET;
     }
-    printf("\n%s %d\n",__FILE__,__LINE__);
-  }
-  */
+    iodesc->llen=0;
+    if(ios.ioproc){
+        for( i=0;i<nprocs;i++){
+            sndlths[ i ] = 1;
+        }
+        // llen here is the number that will be read on each io task
+        iodesc->llen=1;
+        for(i=0;i<ndims;i++)
+            iodesc->llen *= iodesc->firstregion->count[i];
+    }
+    determine_fill(ios, iodesc, gsize, compmap);
 
-  for( i=0;i<nioprocs; i++){
-    int io_comprank = ios.ioranks[i];
-    recvlths[ io_comprank ] = 1;
-    rdispls[ io_comprank ] = i*tsize;
-  }      
+    /*
+       if(ios.ioproc){
+       for(i=0; i<ndims; i++){
+       printf("%d %d %d ",i,iodesc->firstregion->start[i],iodesc->firstregion->count[i]);
+       }
+       printf("\n%s %d\n",__FILE__,__LINE__);
+       }
+    */
 
-  //  The length of each iomap
-  //  iomaplen = calloc(nioprocs, sizeof(PIO_Offset));
-  pio_swapm(&(iodesc->llen), sndlths, sdispls, dtypes,
-	    iomaplen, recvlths, rdispls, dtypes, 	
-	    ios.union_comm, false, false, maxreq);
+    for( i=0;i<nioprocs; i++){
+        int io_comprank = ios.ioranks[i];
+        recvlths[ io_comprank ] = 1;
+        rdispls[ io_comprank ] = i*tsize;
+    }
+
+    //  The length of each iomap
+    //  iomaplen = calloc(nioprocs, sizeof(PIO_Offset));
+    pio_swapm(&(iodesc->llen), sndlths, sdispls, dtypes,
+              iomaplen, recvlths, rdispls, dtypes,
+              ios.union_comm, false, false, maxreq);
 
 
 
 
-  /*
-  printf("%s %d %d\n",__FILE__,__LINE__,nioprocs);
-  for(i=0; i<nioprocs; i++){
-    printf("%ld ",iomaplen[i]);
-  }
-  printf("\n");
-  */
-  for(i=0; i<nioprocs; i++){
-
-    if(iomaplen[i]>0){
-      int io_comprank = ios.ioranks[i];
-      for( j=0; j<nprocs ; j++){
-	sndlths[ j ] = 0;
-	sdispls[ j ] = 0;
-	rdispls[ j ] = 0;
-	recvlths[ j ] = 0;
-	if(ios.union_rank == io_comprank)
-	  sndlths[ j ] = ndims;
+    /*
+      printf("%s %d %d\n",__FILE__,__LINE__,nioprocs);
+      for(i=0; i<nioprocs; i++){
+      printf("%ld ",iomaplen[i]);
       }
-      recvlths[ io_comprank ] = ndims;
-      
-      // The count from iotask i is sent to all compute tasks
-      
-      pio_swapm(iodesc->firstregion->count,  sndlths, sdispls, dtypes,
-		count, recvlths, rdispls, dtypes, 
-		ios.union_comm, false, false, maxreq);
-      
-      // The start from iotask i is sent to all compute tasks
-      pio_swapm(iodesc->firstregion->start,  sndlths, sdispls, dtypes,
-		start, recvlths, rdispls, dtypes, 
-		ios.union_comm, false, false, maxreq);
+      printf("\n");
+    */
+    for(i=0; i<nioprocs; i++){
 
-      for(k=0;k<maplen;k++){
-	PIO_Offset gcoord[ndims], lcoord[ndims];
-	bool found=true;
-	// The compmap array is 1 based but calculations are 0 based
-	idx_to_dim_list(ndims, gsize, compmap[k]-1, gcoord);
+        if(iomaplen[i]>0){
+            int io_comprank = ios.ioranks[i];
+            for( j=0; j<nprocs ; j++){
+                sndlths[ j ] = 0;
+                sdispls[ j ] = 0;
+                rdispls[ j ] = 0;
+                recvlths[ j ] = 0;
+                if(ios.union_rank == io_comprank)
+                    sndlths[ j ] = ndims;
+            }
+            recvlths[ io_comprank ] = ndims;
+
+            // The count from iotask i is sent to all compute tasks
+
+            pio_swapm(iodesc->firstregion->count,  sndlths, sdispls, dtypes,
+                      count, recvlths, rdispls, dtypes,
+                      ios.union_comm, false, false, maxreq);
+
+            // The start from iotask i is sent to all compute tasks
+            pio_swapm(iodesc->firstregion->start,  sndlths, sdispls, dtypes,
+                      start, recvlths, rdispls, dtypes,
+                      ios.union_comm, false, false, maxreq);
+
+            for(k=0;k<maplen;k++){
+                PIO_Offset gcoord[ndims], lcoord[ndims];
+                bool found=true;
+                // The compmap array is 1 based but calculations are 0 based
+                idx_to_dim_list(ndims, gsize, compmap[k]-1, gcoord);
 
 
-	for(j=0;j<ndims;j++){
-	  if(gcoord[j] >= start[j] && gcoord[j] < start[j]+count[j]){
-	    lcoord[j] = gcoord[j] - start[j];
-	  }else{
-	    found = false;
-	    break;
-	  }
-	}
-	if(found){
-	  dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
-	  dest_ioproc[k] = i;
-	}
-      }
+                for(j=0;j<ndims;j++){
+                    if(gcoord[j] >= start[j] && gcoord[j] < start[j]+count[j]){
+                        lcoord[j] = gcoord[j] - start[j];
+                    }else{
+                        found = false;
+                        break;
+                    }
+                }
+                if(found){
+                    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
+                    dest_ioproc[k] = i;
+                }
+            }
+        }
     }
-  }
 
-  for(k=0; k<maplen; k++){
-    //       printf("%s %d %d %d\n",__FILE__,__LINE__,dest_ioproc[k],dest_ioindex[k]);
+    for(k=0; k<maplen; k++){
+        //       printf("%s %d %d %d\n",__FILE__,__LINE__,dest_ioproc[k],dest_ioindex[k]);
 
-    if(dest_ioproc[k] < 0 && compmap[k]>0){
-      fprintf(stderr,"No destination found for compmap[%d] = %ld\n",k,compmap[k]);
-      piodie(" ",__FILE__,__LINE__);
+        if(dest_ioproc[k] < 0 && compmap[k]>0){
+            fprintf(stderr,"No destination found for compmap[%d] = %ld\n",k,compmap[k]);
+            piodie(" ",__FILE__,__LINE__);
+        }
     }
-  }
 
-  compute_counts(ios, iodesc, maplen, dest_ioproc, dest_ioindex, ios.union_comm);
+    compute_counts(ios, iodesc, maplen, dest_ioproc, dest_ioindex, ios.union_comm);
 
-  if(ios.ioproc){
-    compute_maxIObuffersize(ios.io_comm, iodesc);
-  }
-  compute_maxaggregate_bytes(ios, iodesc);
+    if(ios.ioproc){
+        compute_maxIObuffersize(ios.io_comm, iodesc);
+    }
+    compute_maxaggregate_bytes(ios, iodesc);
 
 
-#ifdef DEBUG  
-  iodesc_dump(iodesc);
+#ifdef DEBUG
+    iodesc_dump(iodesc);
 #endif
-  return PIO_NOERR;
+    return PIO_NOERR;
 }
-/** 
+/**
  ** @internal
  ** compare offsets is used by the sort in the subset rearrange
  ** @endinternal
  */
-int compare_offsets(const void *a,const void *b) 
+int compare_offsets(const void *a,const void *b)
 {
-  mapsort *x = (mapsort *) a;
-  mapsort *y = (mapsort *) b;
-  return (int) (x->iomap - y->iomap);
-}    
+    mapsort *x = (mapsort *) a;
+    mapsort *y = (mapsort *) b;
+    return (int) (x->iomap - y->iomap);
+}
 
 /**
  ** @internal
- ** Each region is a block of output which can be represented in a single call to the underlying 
- ** netcdf library.  This can be as small as a single data point, but we hope we've aggragated better than that. 
+ ** Each region is a block of output which can be represented in a single call to the underlying
+ ** netcdf library.  This can be as small as a single data point, but we hope we've aggragated better than that.
  ** @endinternal
  */
-void get_start_and_count_regions(const int ndims, const int gdims[],const int maplen, 
-				 const PIO_Offset map[], int *maxregions, io_region *firstregion)
+void get_start_and_count_regions(const int ndims, const int gdims[],const int maplen,
+                                 const PIO_Offset map[], int *maxregions, io_region *firstregion)
 {
-  int i;
-  int nmaplen;
-  int regionlen;
-  io_region *region, *prevregion;
+    int i;
+    int nmaplen;
+    int regionlen;
+    io_region *region, *prevregion;
 
-  nmaplen = 0;
-  region = firstregion;
-  if(map != NULL){
-    while(map[nmaplen++]<=0);
-    nmaplen--;
-  }
-  region->loffset=nmaplen;
-
-  *maxregions = 1;
-  prevregion=NULL;
-
-  while(nmaplen < maplen){
-    // Here we find the largest region from the current offset into the iomap
-    // regionlen is the size of that region and we step to that point in the map array
-    // until we reach the end 
-    for(i=0;i<ndims;i++){
-      region->count[i]=1;
+    nmaplen = 0;
+    region = firstregion;
+    if(map != NULL){
+        while(map[nmaplen++]<=0);
+        nmaplen--;
     }
+    region->loffset=nmaplen;
 
-    regionlen = find_region(ndims, gdims, maplen-nmaplen, 
-				  map+nmaplen, region->start, region->count);
-    //    printf("%s %d %d %d\n",__FILE__,__LINE__,region->start[0],region->count[0]);
-    pioassert(region->start[0]>=0,"failed to find region",__FILE__,__LINE__);
-    
-    nmaplen = nmaplen+regionlen;
-    if(region->next==NULL && nmaplen< maplen){
-      region->next = alloc_region(ndims);
-      // The offset into the local array buffer is the sum of the sizes of all of the previous regions (loffset) 
-      region=region->next;
-      region->loffset = nmaplen;
-      // The calls to the io library are collective and so we must have the same number of regions on each
-      // io task maxregions will be the total number of regions on this task 
-      (*maxregions)++;
+    *maxregions = 1;
+    prevregion=NULL;
+
+    while(nmaplen < maplen){
+        // Here we find the largest region from the current offset into the iomap
+        // regionlen is the size of that region and we step to that point in the map array
+        // until we reach the end
+        for(i=0;i<ndims;i++){
+            region->count[i]=1;
+        }
+
+        regionlen = find_region(ndims, gdims, maplen-nmaplen,
+                                map+nmaplen, region->start, region->count);
+        //    printf("%s %d %d %d\n",__FILE__,__LINE__,region->start[0],region->count[0]);
+        pioassert(region->start[0]>=0,"failed to find region",__FILE__,__LINE__);
+
+        nmaplen = nmaplen+regionlen;
+        if(region->next==NULL && nmaplen< maplen){
+            region->next = alloc_region(ndims);
+            // The offset into the local array buffer is the sum of the sizes of all of the previous regions (loffset)
+            region=region->next;
+            region->loffset = nmaplen;
+            // The calls to the io library are collective and so we must have the same number of regions on each
+            // io task maxregions will be the total number of regions on this task
+            (*maxregions)++;
+        }
     }
-  }
 
 
 }
 
-/** 
+/**
  ** @internal
- ** The subset rearranger needs a mapping from compute tasks to IO task, the only requirement is 
+ ** The subset rearranger needs a mapping from compute tasks to IO task, the only requirement is
  ** that each compute task map to one and only one IO task.   This mapping groups by mpi task id
  ** others are possible and may be better for certain decompositions
  ** @endinternal
@@ -1192,501 +1192,501 @@ void get_start_and_count_regions(const int ndims, const int gdims[],const int ma
  */
 void default_subset_partition(const iosystem_desc_t ios, io_desc_t *iodesc)
 {
-  int taskratio = ios.num_comptasks/ios.num_iotasks;
-  int color;
-  int key;
+    int taskratio = ios.num_comptasks/ios.num_iotasks;
+    int color;
+    int key;
 
-  /* Create a new comm for each subset group with the io task in rank 0 and
-     only 1 io task per group */
+    /* Create a new comm for each subset group with the io task in rank 0 and
+       only 1 io task per group */
 
-  if(ios.ioproc){
-    key = 0;
-    color= ios.io_rank;
-  }else{
-    key=max(1,ios.comp_rank%taskratio+1);
-    color = min(ios.num_iotasks-1,ios.comp_rank/taskratio);
-  }
+    if(ios.ioproc){
+        key = 0;
+        color= ios.io_rank;
+    }else{
+        key=max(1,ios.comp_rank%taskratio+1);
+        color = min(ios.num_iotasks-1,ios.comp_rank/taskratio);
+    }
 
-  MPI_Comm_split(ios.comp_comm, color, key, &(iodesc->subset_comm));
+    MPI_Comm_split(ios.comp_comm, color, key, &(iodesc->subset_comm));
 
 }
 
-/** 
+/**
  ** @internal
  ** The subset rearranger computes a mapping between IO tasks and compute tasks such that each compute
- ** task communicates with one and only one IO task.  
+ ** task communicates with one and only one IO task.
  ** @endinternal
  **
  */
 
-int subset_rearrange_create(const iosystem_desc_t ios,const int maplen, PIO_Offset compmap[], 
-			    const int gsize[], const int ndims, io_desc_t *iodesc)
+int subset_rearrange_create(const iosystem_desc_t ios,const int maplen, PIO_Offset compmap[],
+                            const int gsize[], const int ndims, io_desc_t *iodesc)
 {
 
-  int taskratio;
+    int taskratio;
 
-  int i, j, jlast;
-  bool hs=false;
-  bool isend=false;
-  PIO_Offset *iomap=NULL;
-  int ierr = PIO_NOERR;
-  mapsort *map=NULL;
-  PIO_Offset totalgridsize;
-  PIO_Offset *srcindex=NULL;
-  PIO_Offset *myfillgrid = NULL;
-  int maxregions;  
-  int maxreq = MAX_GATHER_BLOCK_SIZE;
-  int rank, ntasks, rcnt;
-  size_t pio_offset_size=sizeof(PIO_Offset);
-  
-  
-  tmpioproc = ios.io_rank;
+    int i, j, jlast;
+    bool hs=false;
+    bool isend=false;
+    PIO_Offset *iomap=NULL;
+    int ierr = PIO_NOERR;
+    mapsort *map=NULL;
+    PIO_Offset totalgridsize;
+    PIO_Offset *srcindex=NULL;
+    PIO_Offset *myfillgrid = NULL;
+    int maxregions;
+    int maxreq = MAX_GATHER_BLOCK_SIZE;
+    int rank, ntasks, rcnt;
+    size_t pio_offset_size=sizeof(PIO_Offset);
 
 
-  /* subset partitions each have exactly 1 io task which is task 0 of that subset_comm */ 
-  /* TODO: introduce a mechanism for users to define partitions */
-  default_subset_partition(ios, iodesc);
-  iodesc->rearranger = PIO_REARR_SUBSET;
-  
-  MPI_Comm_rank(iodesc->subset_comm, &rank);
-  MPI_Comm_size(iodesc->subset_comm, &ntasks);
+    tmpioproc = ios.io_rank;
 
-  if(ios.ioproc){
-    pioassert(rank==0,"Bad io rank in subset create",__FILE__,__LINE__);
-  }else{
-    pioassert(rank>0 && rank<ntasks,"Bad comp rank in subset create",__FILE__,__LINE__);
-  }
-  rcnt = 0;
-  iodesc->ndof = maplen;
-  if(ios.ioproc){
-    iodesc->rcount = (int *) bget(ntasks *sizeof(int));
-    if(iodesc->rcount == NULL){
-      piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+
+    /* subset partitions each have exactly 1 io task which is task 0 of that subset_comm */
+    /* TODO: introduce a mechanism for users to define partitions */
+    default_subset_partition(ios, iodesc);
+    iodesc->rearranger = PIO_REARR_SUBSET;
+
+    MPI_Comm_rank(iodesc->subset_comm, &rank);
+    MPI_Comm_size(iodesc->subset_comm, &ntasks);
+
+    if(ios.ioproc){
+        pioassert(rank==0,"Bad io rank in subset create",__FILE__,__LINE__);
+    }else{
+        pioassert(rank>0 && rank<ntasks,"Bad comp rank in subset create",__FILE__,__LINE__);
     }
-    rcnt = 1;
-  } 
-  iodesc->scount = (int *) bget(sizeof(int));
-  if(iodesc->scount == NULL){
-    piomemerror(ios,sizeof(int), __FILE__,__LINE__);
-  }
-  iodesc->scount[0]=0;
-  totalgridsize=1;
-  for( i=0;i<ndims;i++){
-    totalgridsize *= gsize[i];
-  }
-
-  for(i=0;i<maplen;i++){
-    //  turns out this can be allowed in some cases 
-    //    pioassert(compmap[i]>=0 && compmap[i]<=totalgridsize, "Compmap value out of bounds",__FILE__,__LINE__);
-    if(compmap[i]>0){
-      (iodesc->scount[0])++;
+    rcnt = 0;
+    iodesc->ndof = maplen;
+    if(ios.ioproc){
+        iodesc->rcount = (int *) bget(ntasks *sizeof(int));
+        if(iodesc->rcount == NULL){
+            piomemerror(ios,ntasks * sizeof(int), __FILE__,__LINE__);
+        }
+        rcnt = 1;
     }
-  }
-  if(iodesc->scount[0]>0){
-    iodesc->sindex = (PIO_Offset *) bget(iodesc->scount[0]*pio_offset_size); 
-    if(iodesc->sindex == NULL){
-      piomemerror(ios,iodesc->scount[0]*pio_offset_size, __FILE__,__LINE__);
+    iodesc->scount = (int *) bget(sizeof(int));
+    if(iodesc->scount == NULL){
+        piomemerror(ios,sizeof(int), __FILE__,__LINE__);
     }
-    for(i=0;i<iodesc->scount[0];i++)
-      iodesc->sindex[i]=0;
-  }
-
-  j=0;
-  for(i=0;i<maplen;i++){
-    if(compmap[i]>0){
-      iodesc->sindex[j++]=i;
-
+    iodesc->scount[0]=0;
+    totalgridsize=1;
+    for( i=0;i<ndims;i++){
+        totalgridsize *= gsize[i];
     }
-  }
 
-  // Pass the reduced maplen (without holes) from each compute task to its associated IO task
-  //  printf("%s %d %ld\n",__FILE__,__LINE__,iodesc->scount);
-  
-  pio_fc_gather( (void *) iodesc->scount, 1, MPI_INT,
-		 (void *) iodesc->rcount, rcnt, MPI_INT, 
-		 0, iodesc->subset_comm, maxreq);
-
-  iodesc->llen = 0;
-
-  int rdispls[ntasks];
-  int recvlths[ntasks];
-
-  if(ios.ioproc){
-    for(i=0;i<ntasks;i++){
-      iodesc->llen+=iodesc->rcount[i];
-      rdispls[i]=0;
-      recvlths[i]= iodesc->rcount[ i ];
-      if(i>0)
-	rdispls[i] = rdispls[i-1]+ iodesc->rcount[ i-1 ];
+    for(i=0;i<maplen;i++){
+        //  turns out this can be allowed in some cases
+        //    pioassert(compmap[i]>=0 && compmap[i]<=totalgridsize, "Compmap value out of bounds",__FILE__,__LINE__);
+        if(compmap[i]>0){
+            (iodesc->scount[0])++;
+        }
     }
-    //    printf("%s %d %ld %d %d\n",__FILE__,__LINE__,iodesc,iodesc->llen,maplen);
-      
-    if(iodesc->llen>0){
-      srcindex = (PIO_Offset *) bget(iodesc->llen*pio_offset_size);
-      if(srcindex == NULL){
-	piomemerror(ios,iodesc->llen * pio_offset_size, __FILE__,__LINE__);
-      }
-      for(i=0;i < iodesc->llen; i++)
-	srcindex[i]=0;
+    if(iodesc->scount[0]>0){
+        iodesc->sindex = (PIO_Offset *) bget(iodesc->scount[0]*pio_offset_size);
+        if(iodesc->sindex == NULL){
+            piomemerror(ios,iodesc->scount[0]*pio_offset_size, __FILE__,__LINE__);
+        }
+        for(i=0;i<iodesc->scount[0];i++)
+            iodesc->sindex[i]=0;
     }
-  }else{
-    for(i=0;i<ntasks;i++){
-      recvlths[i]=0;
-      rdispls[i]=0;
-    }
-  }
-  determine_fill(ios, iodesc, gsize, compmap);
-
-  // Pass the sindex from each compute task to its associated IO task
-
-  pio_fc_gatherv((void *) iodesc->sindex, iodesc->scount[0], PIO_OFFSET,
-		 (void *) srcindex, recvlths, rdispls, PIO_OFFSET,  
-		 0, iodesc->subset_comm, maxreq);
-
-  if(ios.ioproc && iodesc->llen>0){
-    map = (mapsort *) bget(iodesc->llen * sizeof(mapsort));    
-    if(map == NULL){
-      piomemerror(ios,iodesc->llen * sizeof(mapsort), __FILE__,__LINE__);
-    }
-    iomap = (PIO_Offset *) bget(iodesc->llen*pio_offset_size);
-    if(iomap == NULL){
-      piomemerror(ios,iodesc->llen * pio_offset_size, __FILE__,__LINE__);
-    }
-    for(i=0;i<iodesc->llen;i++)
-      iomap[i]=0;
-  }
-
-  // Now pass the compmap, skipping the holes
-
-  PIO_Offset *shrtmap;
-  if(maplen>iodesc->scount[0] && iodesc->scount[0]>0){
-    shrtmap = (PIO_Offset *) bget(iodesc->scount[0]*pio_offset_size);
-    if(shrtmap == NULL){
-      piomemerror(ios,iodesc->scount[0] * pio_offset_size, __FILE__,__LINE__);
-    }
-    for(i=0;i<iodesc->scount[0];i++)
-      shrtmap[i]=0;
 
     j=0;
-    for(i=0;i<maplen;i++)
-      if(compmap[i]>0)
-	shrtmap[j++]=compmap[i];
-  }else{
-    shrtmap = compmap;
-  }
+    for(i=0;i<maplen;i++){
+        if(compmap[i]>0){
+            iodesc->sindex[j++]=i;
 
-  pio_fc_gatherv((void *) shrtmap, iodesc->scount[0], PIO_OFFSET,
-		 (void *) iomap, recvlths, rdispls, PIO_OFFSET,  
-		 0, iodesc->subset_comm, maxreq);
+        }
+    }
+
+    // Pass the reduced maplen (without holes) from each compute task to its associated IO task
+    //  printf("%s %d %ld\n",__FILE__,__LINE__,iodesc->scount);
+
+    pio_fc_gather( (void *) iodesc->scount, 1, MPI_INT,
+                   (void *) iodesc->rcount, rcnt, MPI_INT,
+                   0, iodesc->subset_comm, maxreq);
+
+    iodesc->llen = 0;
+
+    int rdispls[ntasks];
+    int recvlths[ntasks];
+
+    if(ios.ioproc){
+        for(i=0;i<ntasks;i++){
+            iodesc->llen+=iodesc->rcount[i];
+            rdispls[i]=0;
+            recvlths[i]= iodesc->rcount[ i ];
+            if(i>0)
+                rdispls[i] = rdispls[i-1]+ iodesc->rcount[ i-1 ];
+        }
+        //    printf("%s %d %ld %d %d\n",__FILE__,__LINE__,iodesc,iodesc->llen,maplen);
+
+        if(iodesc->llen>0){
+            srcindex = (PIO_Offset *) bget(iodesc->llen*pio_offset_size);
+            if(srcindex == NULL){
+                piomemerror(ios,iodesc->llen * pio_offset_size, __FILE__,__LINE__);
+            }
+            for(i=0;i < iodesc->llen; i++)
+                srcindex[i]=0;
+        }
+    }else{
+        for(i=0;i<ntasks;i++){
+            recvlths[i]=0;
+            rdispls[i]=0;
+        }
+    }
+    determine_fill(ios, iodesc, gsize, compmap);
+
+    // Pass the sindex from each compute task to its associated IO task
+
+    pio_fc_gatherv((void *) iodesc->sindex, iodesc->scount[0], PIO_OFFSET,
+                   (void *) srcindex, recvlths, rdispls, PIO_OFFSET,
+                   0, iodesc->subset_comm, maxreq);
+
+    if(ios.ioproc && iodesc->llen>0){
+        map = (mapsort *) bget(iodesc->llen * sizeof(mapsort));
+        if(map == NULL){
+            piomemerror(ios,iodesc->llen * sizeof(mapsort), __FILE__,__LINE__);
+        }
+        iomap = (PIO_Offset *) bget(iodesc->llen*pio_offset_size);
+        if(iomap == NULL){
+            piomemerror(ios,iodesc->llen * pio_offset_size, __FILE__,__LINE__);
+        }
+        for(i=0;i<iodesc->llen;i++)
+            iomap[i]=0;
+    }
+
+    // Now pass the compmap, skipping the holes
+
+    PIO_Offset *shrtmap;
+    if(maplen>iodesc->scount[0] && iodesc->scount[0]>0){
+        shrtmap = (PIO_Offset *) bget(iodesc->scount[0]*pio_offset_size);
+        if(shrtmap == NULL){
+            piomemerror(ios,iodesc->scount[0] * pio_offset_size, __FILE__,__LINE__);
+        }
+        for(i=0;i<iodesc->scount[0];i++)
+            shrtmap[i]=0;
+
+        j=0;
+        for(i=0;i<maplen;i++)
+            if(compmap[i]>0)
+                shrtmap[j++]=compmap[i];
+    }else{
+        shrtmap = compmap;
+    }
+
+    pio_fc_gatherv((void *) shrtmap, iodesc->scount[0], PIO_OFFSET,
+                   (void *) iomap, recvlths, rdispls, PIO_OFFSET,
+                   0, iodesc->subset_comm, maxreq);
 
 
-  if(shrtmap != compmap)
-    brel(shrtmap);
+    if(shrtmap != compmap)
+        brel(shrtmap);
 
-  if(ios.ioproc && iodesc->llen>0){
-    int pos=0;
-    int k=0;
+    if(ios.ioproc && iodesc->llen>0){
+        int pos=0;
+        int k=0;
+        mapsort *mptr;
+        for(i=0;i<ntasks;i++){
+            for(j=0;j<iodesc->rcount[i];j++){
+                mptr = map+k;
+                mptr->rfrom = i;
+                mptr->soffset = srcindex[pos+j];
+                mptr->iomap = iomap[pos+j];
+                k++;
+            }
+            pos += iodesc->rcount[i];
+        }
+        // sort the mapping, this will transpose the data into IO order
+        qsort(map, iodesc->llen, sizeof(mapsort), compare_offsets);
+
+        iodesc->rindex = (PIO_Offset *) bget(iodesc->llen*pio_offset_size);
+        if(iodesc->rindex == NULL){
+            piomemerror(ios,iodesc->llen * pio_offset_size, __FILE__,__LINE__);
+        }
+        iodesc->rfrom = (int *) bget(iodesc->llen*sizeof(int));
+        if(iodesc->rfrom == NULL){
+            piomemerror(ios,iodesc->llen * sizeof(int), __FILE__,__LINE__);
+        }
+        for(i=0;i<iodesc->llen;i++){
+            iodesc->rindex[i]=0;
+            iodesc->rfrom[i]=0;
+        }
+    }
+    int cnt[ntasks];
+    int sndlths[ntasks];
+    int sdispls[ntasks];
+    MPI_Datatype dtypes[ntasks];
+    for(i=0;i<ntasks;i++){
+        cnt[i]=rdispls[i];
+
+        /* offsets to swapm are in bytes */
+        //    rdispls[i]*=pio_offset_size;
+        sdispls[i]=0;
+        sndlths[i]=0;
+        dtypes[i]=PIO_OFFSET;
+    }
+    sndlths[0]=iodesc->scount[0];
     mapsort *mptr;
-    for(i=0;i<ntasks;i++){
-      for(j=0;j<iodesc->rcount[i];j++){
-	mptr = map+k;
-	mptr->rfrom = i;
-	mptr->soffset = srcindex[pos+j];
-	mptr->iomap = iomap[pos+j];
-	k++;
-      }
-      pos += iodesc->rcount[i];
-    }
-    // sort the mapping, this will transpose the data into IO order        
-    qsort(map, iodesc->llen, sizeof(mapsort), compare_offsets); 
-
-    iodesc->rindex = (PIO_Offset *) bget(iodesc->llen*pio_offset_size);
-    if(iodesc->rindex == NULL){
-      piomemerror(ios,iodesc->llen * pio_offset_size, __FILE__,__LINE__);
-    }
-    iodesc->rfrom = (int *) bget(iodesc->llen*sizeof(int));
-    if(iodesc->rfrom == NULL){
-      piomemerror(ios,iodesc->llen * sizeof(int), __FILE__,__LINE__);
-    }
     for(i=0;i<iodesc->llen;i++){
-      iodesc->rindex[i]=0;
-      iodesc->rfrom[i]=0;
+        mptr = map+i;
+        iodesc->rfrom[i] = mptr->rfrom;
+        iodesc->rindex[i]=i;
+        iomap[i] = mptr->iomap;
+        srcindex[ (cnt[iodesc->rfrom[i]])++   ]=mptr->soffset;
     }
-  }
-  int cnt[ntasks];
-  int sndlths[ntasks];
-  int sdispls[ntasks];
-  MPI_Datatype dtypes[ntasks];
-  for(i=0;i<ntasks;i++){
-    cnt[i]=rdispls[i];
 
-    /* offsets to swapm are in bytes */
-    //    rdispls[i]*=pio_offset_size;
-    sdispls[i]=0;
-    sndlths[i]=0;
-    dtypes[i]=PIO_OFFSET;
-  }
-  sndlths[0]=iodesc->scount[0];
-  mapsort *mptr;
-  for(i=0;i<iodesc->llen;i++){
-    mptr = map+i;
-    iodesc->rfrom[i] = mptr->rfrom;
-    iodesc->rindex[i]=i;
-    iomap[i] = mptr->iomap;
-    srcindex[ (cnt[iodesc->rfrom[i]])++   ]=mptr->soffset;
-  }
+    if(ios.ioproc && iodesc->needsfill){
+        /* we need the list of offsets which are not in the union of iomap */
+        PIO_Offset thisgridsize[ios.num_iotasks];
+        PIO_Offset thisgridmin[ios.num_iotasks], thisgridmax[ios.num_iotasks];
+        int nio;
+        PIO_Offset *myusegrid = NULL;
+        int gcnt[ios.num_iotasks];
+        int displs[ios.num_iotasks];
 
-  if(ios.ioproc && iodesc->needsfill){
-    /* we need the list of offsets which are not in the union of iomap */
-    PIO_Offset thisgridsize[ios.num_iotasks];
-    PIO_Offset thisgridmin[ios.num_iotasks], thisgridmax[ios.num_iotasks];
-    int nio;
-    PIO_Offset *myusegrid = NULL;
-    int gcnt[ios.num_iotasks];
-    int displs[ios.num_iotasks];
+        thisgridmin[0] = 1;
+        thisgridsize[0] =  totalgridsize/ios.num_iotasks;
+        thisgridmax[0] = thisgridsize[0];
+        int xtra = totalgridsize - thisgridsize[0]*ios.num_iotasks;
 
-    thisgridmin[0] = 1;
-    thisgridsize[0] =  totalgridsize/ios.num_iotasks;
-    thisgridmax[0] = thisgridsize[0];
-    int xtra = totalgridsize - thisgridsize[0]*ios.num_iotasks;
-  
-    for(nio=0;nio<ios.num_iotasks;nio++){
-      int cnt=0;
-      int imin=0;
-      if(nio>0){
-	thisgridsize[nio] =  totalgridsize/ios.num_iotasks;
-	if(nio>=ios.num_iotasks-xtra) thisgridsize[nio]++;
-	thisgridmin[nio]=thisgridmax[nio-1]+1;
-	thisgridmax[nio]= thisgridmin[nio] + thisgridsize[nio]-1;
-      }
-      for(int i=0;i<iodesc->llen;i++){
-	//	printf("%s %d %d %d %ld %d %d\n",__FILE__,__LINE__,i,nio,iomap[i],thisgridmin[nio],thisgridmax[nio]);
-	if(iomap[i]>=thisgridmin[nio] && iomap[i]<=thisgridmax[nio]){
-	  cnt++;
-	  if(cnt==1) imin=i;
-	}
-      }
-      //      printf("%s %d %d %d %d\n",__FILE__,__LINE__,nio,cnt,imin);
-      MPI_Gather(&cnt, 1, MPI_INT, gcnt, 1, MPI_INT, nio, ios.io_comm);
-      if(nio==ios.io_rank){
-	displs[0]=0;
-	//	printf("%s %d %d %d %d %d\n",__FILE__,__LINE__,nio,0,gcnt[0],displs[0]);
-	for(i=1;i<ios.num_iotasks;i++){
-	  displs[i] = displs[i-1]+gcnt[i-1];
-	  //	  printf("%s %d %d %d %d %d\n",__FILE__,__LINE__,nio,i,gcnt[i],displs[i]);
-	} 
-	myusegrid = (PIO_Offset *) bget(thisgridsize[nio]*sizeof(PIO_Offset));
-	for(i=0;i<thisgridsize[nio];i++){
-	  myusegrid[i]=-1;
-	}
-      }
-      pio_fc_gatherv((void *) (iomap+imin), cnt, PIO_OFFSET,
-		 (void *) myusegrid, gcnt, displs, PIO_OFFSET,  
-		 nio, ios.io_comm, maxreq);
+        for(nio=0;nio<ios.num_iotasks;nio++){
+            int cnt=0;
+            int imin=0;
+            if(nio>0){
+                thisgridsize[nio] =  totalgridsize/ios.num_iotasks;
+                if(nio>=ios.num_iotasks-xtra) thisgridsize[nio]++;
+                thisgridmin[nio]=thisgridmax[nio-1]+1;
+                thisgridmax[nio]= thisgridmin[nio] + thisgridsize[nio]-1;
+            }
+            for(int i=0;i<iodesc->llen;i++){
+                //      printf("%s %d %d %d %ld %d %d\n",__FILE__,__LINE__,i,nio,iomap[i],thisgridmin[nio],thisgridmax[nio]);
+                if(iomap[i]>=thisgridmin[nio] && iomap[i]<=thisgridmax[nio]){
+                    cnt++;
+                    if(cnt==1) imin=i;
+                }
+            }
+            //      printf("%s %d %d %d %d\n",__FILE__,__LINE__,nio,cnt,imin);
+            MPI_Gather(&cnt, 1, MPI_INT, gcnt, 1, MPI_INT, nio, ios.io_comm);
+            if(nio==ios.io_rank){
+                displs[0]=0;
+                //      printf("%s %d %d %d %d %d\n",__FILE__,__LINE__,nio,0,gcnt[0],displs[0]);
+                for(i=1;i<ios.num_iotasks;i++){
+                    displs[i] = displs[i-1]+gcnt[i-1];
+                    //    printf("%s %d %d %d %d %d\n",__FILE__,__LINE__,nio,i,gcnt[i],displs[i]);
+                }
+                myusegrid = (PIO_Offset *) bget(thisgridsize[nio]*sizeof(PIO_Offset));
+                for(i=0;i<thisgridsize[nio];i++){
+                    myusegrid[i]=-1;
+                }
+            }
+            pio_fc_gatherv((void *) (iomap+imin), cnt, PIO_OFFSET,
+                           (void *) myusegrid, gcnt, displs, PIO_OFFSET,
+                           nio, ios.io_comm, maxreq);
+        }
+        PIO_Offset grid[thisgridsize[ios.io_rank]];
+        for(i=0;i<thisgridsize[ios.io_rank];i++){
+            grid[i]=0;
+        }
+        int cnt=0;
+        for(i=0;i<thisgridsize[ios.io_rank];i++){
+            int j = myusegrid[i] - thisgridmin[ios.io_rank];
+            //      printf("%s %d %d %d %d %d\n",__FILE__,__LINE__,i,j,thisgridmin[ios.io_rank],myusegrid[i]);
+
+            pioassert(j<thisgridsize[ios.io_rank] ,"out of bounds array index",__FILE__,__LINE__);
+            if(j>=0){
+                grid[j]=1;
+                cnt++;
+            }
+        }
+        if(myusegrid!=NULL){
+            brel(myusegrid);
+        }
+        iodesc->holegridsize=thisgridsize[ios.io_rank]-cnt;
+        if(iodesc->holegridsize>0){
+            myfillgrid = (PIO_Offset *) bget(iodesc->holegridsize * sizeof(PIO_Offset));
+        }
+        for(i=0;i<iodesc->holegridsize;i++){
+            myfillgrid[i]=-1;
+        }
+
+        j=0;
+        for(i=0;i<thisgridsize[ios.io_rank];i++){
+            if(grid[i]==0 ){
+                if(myfillgrid[j] == -1){
+                    myfillgrid[j++]=thisgridmin[ios.io_rank]+i;
+                }else{
+                    piodie("something wrong",__FILE__,__LINE__);
+                    // printf("%s %d %d %d %d\n",__FILE__,__LINE__,i,j,myfillgrid[j]);
+                }
+            }
+        }
+        maxregions = 0;
+        iodesc->maxfillregions=0;
+        if(myfillgrid!=NULL){
+            iodesc->fillregion = alloc_region(iodesc->ndims);
+            get_start_and_count_regions(iodesc->ndims,gsize,iodesc->holegridsize, myfillgrid,&(iodesc->maxfillregions),
+                                        iodesc->fillregion);
+            brel(myfillgrid);
+            maxregions = iodesc->maxfillregions;
+        }
+        MPI_Allreduce(MPI_IN_PLACE,&maxregions,1, MPI_INT, MPI_MAX, ios.io_comm);
+        iodesc->maxfillregions = maxregions;
     }
-    PIO_Offset grid[thisgridsize[ios.io_rank]];
-    for(i=0;i<thisgridsize[ios.io_rank];i++){
-      grid[i]=0;
-    }
-    int cnt=0;
-    for(i=0;i<thisgridsize[ios.io_rank];i++){
-      int j = myusegrid[i] - thisgridmin[ios.io_rank];
-      //      printf("%s %d %d %d %d %d\n",__FILE__,__LINE__,i,j,thisgridmin[ios.io_rank],myusegrid[i]);
 
-      pioassert(j<thisgridsize[ios.io_rank] ,"out of bounds array index",__FILE__,__LINE__);
-      if(j>=0){
-	grid[j]=1;
-	cnt++;
-      }
-    }
-    if(myusegrid!=NULL){
-      brel(myusegrid);
-    }
-    iodesc->holegridsize=thisgridsize[ios.io_rank]-cnt;
-    if(iodesc->holegridsize>0){
-      myfillgrid = (PIO_Offset *) bget(iodesc->holegridsize * sizeof(PIO_Offset));
-    }
-    for(i=0;i<iodesc->holegridsize;i++){
-      myfillgrid[i]=-1;
-    }
-	
-    j=0;
-    for(i=0;i<thisgridsize[ios.io_rank];i++){
-      if(grid[i]==0 ){
-	if(myfillgrid[j] == -1){
-	  myfillgrid[j++]=thisgridmin[ios.io_rank]+i;
-	}else{
-	  piodie("something wrong",__FILE__,__LINE__);
-	  // printf("%s %d %d %d %d\n",__FILE__,__LINE__,i,j,myfillgrid[j]);
-	}
-      }
-    } 
-    maxregions = 0;	
-    iodesc->maxfillregions=0;
-    if(myfillgrid!=NULL){
-      iodesc->fillregion = alloc_region(iodesc->ndims);
-      get_start_and_count_regions(iodesc->ndims,gsize,iodesc->holegridsize, myfillgrid,&(iodesc->maxfillregions),
-				  iodesc->fillregion);
-      brel(myfillgrid);
-      maxregions = iodesc->maxfillregions;
-    }
-    MPI_Allreduce(MPI_IN_PLACE,&maxregions,1, MPI_INT, MPI_MAX, ios.io_comm);
-    iodesc->maxfillregions = maxregions;
-  }
-
-  CheckMPIReturn(MPI_Scatterv((void *) srcindex, recvlths, rdispls, PIO_OFFSET, 
-			      (void *) iodesc->sindex, iodesc->scount[0],  PIO_OFFSET,
-			      0, iodesc->subset_comm),__FILE__,__LINE__);
+    CheckMPIReturn(MPI_Scatterv((void *) srcindex, recvlths, rdispls, PIO_OFFSET,
+                                (void *) iodesc->sindex, iodesc->scount[0],  PIO_OFFSET,
+                                0, iodesc->subset_comm),__FILE__,__LINE__);
 
 
 
-  if(ios.ioproc){
+    if(ios.ioproc){
 
-    /*
-    printf("%s %d %d\n",__FILE__,__LINE__,ios.io_rank);
-    for(i=0;i<iodesc->llen;i++)
-      printf("%d ",iomap[i]);
-    printf("\n");
-    */
-    iodesc->maxregions = 0;
-    get_start_and_count_regions(iodesc->ndims,gsize,iodesc->llen, iomap,&(iodesc->maxregions),
-				iodesc->firstregion);
-    maxregions = iodesc->maxregions;
-    MPI_Allreduce(MPI_IN_PLACE,&maxregions,1, MPI_INT, MPI_MAX, ios.io_comm);
-    iodesc->maxregions = maxregions; 
-    if(iomap != NULL)
-      brel(iomap);
-    
-    
-    if(map != NULL)
-      brel(map);
+        /*
+          printf("%s %d %d\n",__FILE__,__LINE__,ios.io_rank);
+          for(i=0;i<iodesc->llen;i++)
+          printf("%d ",iomap[i]);
+          printf("\n");
+        */
+        iodesc->maxregions = 0;
+        get_start_and_count_regions(iodesc->ndims,gsize,iodesc->llen, iomap,&(iodesc->maxregions),
+                                    iodesc->firstregion);
+        maxregions = iodesc->maxregions;
+        MPI_Allreduce(MPI_IN_PLACE,&maxregions,1, MPI_INT, MPI_MAX, ios.io_comm);
+        iodesc->maxregions = maxregions;
+        if(iomap != NULL)
+            brel(iomap);
 
-    if(srcindex != NULL)
-      brel(srcindex);
-    
-    compute_maxIObuffersize(ios.io_comm, iodesc);
-    
-    iodesc->nrecvs=ntasks;
+
+        if(map != NULL)
+            brel(map);
+
+        if(srcindex != NULL)
+            brel(srcindex);
+
+        compute_maxIObuffersize(ios.io_comm, iodesc);
+
+        iodesc->nrecvs=ntasks;
 #ifdef DEBUG
-    iodesc_dump(iodesc);
-#endif  
+        iodesc_dump(iodesc);
+#endif
 
-  }
-  /* using maxiobuflen compute the maximum number of vars of this type that the io
-     task buffer can handle */
+    }
+    /* using maxiobuflen compute the maximum number of vars of this type that the io
+       task buffer can handle */
 
-  compute_maxaggregate_bytes(ios, iodesc);
+    compute_maxaggregate_bytes(ios, iodesc);
 
 
-  return ierr;
+    return ierr;
 
 
 }
-  
-    
+
+
 
 void performance_tune_rearranger(iosystem_desc_t ios, io_desc_t *iodesc)
 {
-  bool handshake;
-  bool isend;
-  int nreqs;
-  int maxreqs;
-  int nprocs;
-  MPI_Comm mycomm;
+    bool handshake;
+    bool isend;
+    int nreqs;
+    int maxreqs;
+    int nprocs;
+    MPI_Comm mycomm;
 #ifdef TIMING
-#ifdef PERFTUNE  
-  double *wall, usr[2], sys[2];
-  void *cbuf, *ibuf;
-  int tsize;
-  int myrank;
+#ifdef PERFTUNE
+    double *wall, usr[2], sys[2];
+    void *cbuf, *ibuf;
+    int tsize;
+    int myrank;
 
-  MPI_Type_size(iodesc->basetype, &tsize);
-  cbuf = NULL;
-  ibuf = NULL;
-  if(iodesc->ndof>0){
-    cbuf = bget( iodesc->ndof * tsize );
-  }
-  if(iodesc->llen>0){
-    ibuf = bget( iodesc->llen * tsize );
-  }
+    MPI_Type_size(iodesc->basetype, &tsize);
+    cbuf = NULL;
+    ibuf = NULL;
+    if(iodesc->ndof>0){
+        cbuf = bget( iodesc->ndof * tsize );
+    }
+    if(iodesc->llen>0){
+        ibuf = bget( iodesc->llen * tsize );
+    }
 
-  if(iodesc->rearranger == PIO_REARR_BOX){
-    mycomm = ios.union_comm;
-  }else{
-    mycomm = iodesc->subset_comm;
-  }  
-
-  MPI_Comm_size(mycomm, &nprocs);
-  MPI_Comm_rank(mycomm, &myrank);
-
-  int log2 = log(nprocs) / log(2) + 1;
-  wall = bget(2*4*log2*sizeof(double));
-  double mintime;
-  int k=0;
-
-  MPI_Barrier(mycomm);
-  GPTLstamp( &wall[0], &usr[0], &sys[0]);
-  rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
-  rearrange_io2comp(ios, iodesc, ibuf, cbuf);
-  GPTLstamp( &wall[1], &usr[1], &sys[1]);
-  mintime = wall[1]-wall[0];
-  MPI_Allreduce(MPI_IN_PLACE, &mintime, 1, MPI_DOUBLE, MPI_MAX, mycomm);
-
-  handshake = iodesc->handshake;
-  isend = iodesc->isend;
-  maxreqs = iodesc->max_requests;
-
-  for(int i=0; i<2; i++){
-    if(i==0){
-      iodesc->handshake = false;
+    if(iodesc->rearranger == PIO_REARR_BOX){
+        mycomm = ios.union_comm;
     }else{
-      iodesc->handshake = true;
+        mycomm = iodesc->subset_comm;
     }
-    for(int j=0; j<2; j++){
-      if(j==0){
-	iodesc->isend = false;
-      }else{
-	iodesc->isend = true;
-      }
-      iodesc->max_requests = 0;
 
-      for(nreqs=nprocs;nreqs>=2;nreqs/=2){
-	iodesc->max_requests = nreqs;
+    MPI_Comm_size(mycomm, &nprocs);
+    MPI_Comm_rank(mycomm, &myrank);
 
-	//	if(myrank==0){
-	//	  printf("%s %d %d %d %d %f\n",__FILE__,__LINE__,nreqs,handshake,isend,mintime);
-	//	}
-	MPI_Barrier(mycomm);
-	GPTLstamp( wall, usr, sys);
-	rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
-	rearrange_io2comp(ios, iodesc, ibuf, cbuf);
-	GPTLstamp( wall+1, usr, sys);
-	wall[1]-=wall[0];
-	MPI_Allreduce(MPI_IN_PLACE, wall+1,1,MPI_DOUBLE, MPI_MAX, mycomm);
+    int log2 = log(nprocs) / log(2) + 1;
+    wall = bget(2*4*log2*sizeof(double));
+    double mintime;
+    int k=0;
 
-	if(wall[1] < mintime*0.95){
-	  handshake = iodesc->handshake;
-	  isend = iodesc->isend;
-	  maxreqs = nreqs;
-	  mintime = wall[1];
-	}else if(wall[1]> (mintime*1.05)){
-	  exit;
-	}
-      }
+    MPI_Barrier(mycomm);
+    GPTLstamp( &wall[0], &usr[0], &sys[0]);
+    rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
+    rearrange_io2comp(ios, iodesc, ibuf, cbuf);
+    GPTLstamp( &wall[1], &usr[1], &sys[1]);
+    mintime = wall[1]-wall[0];
+    MPI_Allreduce(MPI_IN_PLACE, &mintime, 1, MPI_DOUBLE, MPI_MAX, mycomm);
+
+    handshake = iodesc->handshake;
+    isend = iodesc->isend;
+    maxreqs = iodesc->max_requests;
+
+    for(int i=0; i<2; i++){
+        if(i==0){
+            iodesc->handshake = false;
+        }else{
+            iodesc->handshake = true;
+        }
+        for(int j=0; j<2; j++){
+            if(j==0){
+                iodesc->isend = false;
+            }else{
+                iodesc->isend = true;
+            }
+            iodesc->max_requests = 0;
+
+            for(nreqs=nprocs;nreqs>=2;nreqs/=2){
+                iodesc->max_requests = nreqs;
+
+                //      if(myrank==0){
+                //        printf("%s %d %d %d %d %f\n",__FILE__,__LINE__,nreqs,handshake,isend,mintime);
+                //      }
+                MPI_Barrier(mycomm);
+                GPTLstamp( wall, usr, sys);
+                rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
+                rearrange_io2comp(ios, iodesc, ibuf, cbuf);
+                GPTLstamp( wall+1, usr, sys);
+                wall[1]-=wall[0];
+                MPI_Allreduce(MPI_IN_PLACE, wall+1,1,MPI_DOUBLE, MPI_MAX, mycomm);
+
+                if(wall[1] < mintime*0.95){
+                    handshake = iodesc->handshake;
+                    isend = iodesc->isend;
+                    maxreqs = nreqs;
+                    mintime = wall[1];
+                }else if(wall[1]> (mintime*1.05)){
+                    exit;
+                }
+            }
+        }
     }
-  }
-  
 
-  iodesc->handshake = handshake;
-  iodesc->isend = isend;
-  iodesc->max_requests = maxreqs;
-  if(myrank==0){
-    printf("spmd optimization: maxreqs: %d handshake:%d isend:%d mintime=%f\n",maxreqs,handshake,isend,mintime);
-  }
-  brel(wall);
-  brel(cbuf);
-  brel(ibuf);
+
+    iodesc->handshake = handshake;
+    iodesc->isend = isend;
+    iodesc->max_requests = maxreqs;
+    if(myrank==0){
+        printf("spmd optimization: maxreqs: %d handshake:%d isend:%d mintime=%f\n",maxreqs,handshake,isend,mintime);
+    }
+    brel(wall);
+    brel(cbuf);
+    brel(ibuf);
 #endif
 #endif
 
-}  
+}

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -4,7 +4,7 @@
  * @date 2014
  * @brief MPI_Gather, MPI_Gatherv, and MPI_Alltoallw with flow control options
  */
- 
+
 #ifdef TESTSWAPM
 #include <mpi.h>
 #include <stdlib.h>
@@ -12,10 +12,10 @@
 #include <stdbool.h>
 #include <string.h>
 #define PIO_NOERR 0
-#define min(a,b) \
-   ({ __typeof__ (a) _a = (a); \
-       __typeof__ (b) _b = (b); \
-     _a < _b ? _a : _b; })
+#define min(a,b)                                \
+    ({ __typeof__ (a) _a = (a);                 \
+        __typeof__ (b) _b = (b);                \
+        _a < _b ? _a : _b; })
 #define MAX_GATHER_BLOCK_SIZE 32
 #else
 #include <pio.h>
@@ -24,22 +24,22 @@
 
 #if PIO_ENABLE_LOGGING
 extern FILE *LOG_FILE;
-#endif /* PIO_ENABLE_LOGGING */    
+#endif /* PIO_ENABLE_LOGGING */
 
-/** 
+/**
  ** @brief Wrapper for MPI calls to print the Error string on error
  */
 void CheckMPIReturn(const int ierr,const char file[],const int line)
 {
-  
-  if(ierr != MPI_SUCCESS){
-    char errstring[MPI_MAX_ERROR_STRING];
-    int errstrlen;
-    int mpierr = MPI_Error_string( ierr, errstring, &errstrlen);
 
-    fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n",errstring, file, line);
-    
-  }
+    if(ierr != MPI_SUCCESS){
+        char errstring[MPI_MAX_ERROR_STRING];
+        int errstrlen;
+        int mpierr = MPI_Error_string( ierr, errstring, &errstrlen);
+
+        fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n",errstring, file, line);
+
+    }
 }
 
 
@@ -48,86 +48,86 @@ void CheckMPIReturn(const int ierr,const char file[],const int line)
  */
 
 int pio_fc_gather( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype,
-		   void *recvbuf, const int recvcnt, const MPI_Datatype recvtype, const int root, 
-		   const MPI_Comm comm, const int flow_cntl)
+                   void *recvbuf, const int recvcnt, const MPI_Datatype recvtype, const int root,
+                   const MPI_Comm comm, const int flow_cntl)
 {
-  bool fc_gather;
-  int gather_block_size;
-  int mytask, nprocs;
-  int mtag;
-  MPI_Status status;
-  int ierr;
-  int hs;
-  int displs;
-  int dsize;
-  
+    bool fc_gather;
+    int gather_block_size;
+    int mytask, nprocs;
+    int mtag;
+    MPI_Status status;
+    int ierr;
+    int hs;
+    int displs;
+    int dsize;
 
 
-  if(flow_cntl > 0){
-    fc_gather = true;
-    gather_block_size = min(flow_cntl,MAX_GATHER_BLOCK_SIZE);
-  }else{
-    fc_gather = false;
-  }
 
-  if(fc_gather){
-    CheckMPIReturn(MPI_Comm_rank (comm, &mytask), __FILE__,__LINE__);
-    CheckMPIReturn(MPI_Comm_size (comm, &nprocs), __FILE__,__LINE__);
-
-    mtag = 2*nprocs;
-    hs = 1;
-
-    if(mytask == root){
-      int preposts = min(nprocs-1, gather_block_size);
-      int head=0;
-      int count=0;
-      int tail = 0;
-      MPI_Request rcvid[gather_block_size];
-
-      CheckMPIReturn(MPI_Type_size(recvtype, &dsize), __FILE__,__LINE__);
-
-      for(int p=0;p<nprocs;p++){
-	if(p != root){
-	  if(recvcnt > 0){
-	    count++;
-	    if(count > preposts){
-	      CheckMPIReturn(MPI_Wait(rcvid+tail, &status), __FILE__,__LINE__);
-	      tail = (tail+1) % preposts;
-	    }
-	    displs = p*recvcnt*dsize;
-
-	    char *ptr = (char *) recvbuf + displs;
-
-	    CheckMPIReturn(MPI_Irecv(  ptr, recvcnt, recvtype, p, mtag, comm, rcvid+head), __FILE__,__LINE__);
-	    head= (head+1) % preposts;
-	    CheckMPIReturn(MPI_Send( &hs, 1, MPI_INT, p, mtag, comm), __FILE__,__LINE__);
-	  }
-	}
-      }
-
-      // copy local data
-      CheckMPIReturn(MPI_Type_size(sendtype, &dsize), __FILE__,__LINE__);      
-      memcpy(recvbuf, sendbuf, sendcnt*dsize );
-
-      count = min(count, preposts);
-
-      if(count>0){
-	CheckMPIReturn(MPI_Waitall( count, rcvid, MPI_STATUSES_IGNORE),__FILE__,__LINE__);
-      }
+    if(flow_cntl > 0){
+        fc_gather = true;
+        gather_block_size = min(flow_cntl,MAX_GATHER_BLOCK_SIZE);
     }else{
-      if(sendcnt > 0){
-	CheckMPIReturn(MPI_Recv( &hs, 1, MPI_INT, root, mtag, comm, &status), __FILE__,__LINE__);
-	CheckMPIReturn(MPI_Send( sendbuf, sendcnt, sendtype, root, mtag, comm), __FILE__,__LINE__);
-      }
+        fc_gather = false;
     }
-  }else{
-    //    printf("%s %d %ld %d %ld %d %d\n",__FILE__,__LINE__,sendbuf,sendcnt,recvbuf,recvcnt,root);
-    CheckMPIReturn(MPI_Gather ( sendbuf, sendcnt, sendtype, recvbuf, recvcnt, recvtype, root, comm), __FILE__,__LINE__);
-  }
 
-  return PIO_NOERR;
+    if(fc_gather){
+        CheckMPIReturn(MPI_Comm_rank (comm, &mytask), __FILE__,__LINE__);
+        CheckMPIReturn(MPI_Comm_size (comm, &nprocs), __FILE__,__LINE__);
+
+        mtag = 2*nprocs;
+        hs = 1;
+
+        if(mytask == root){
+            int preposts = min(nprocs-1, gather_block_size);
+            int head=0;
+            int count=0;
+            int tail = 0;
+            MPI_Request rcvid[gather_block_size];
+
+            CheckMPIReturn(MPI_Type_size(recvtype, &dsize), __FILE__,__LINE__);
+
+            for(int p=0;p<nprocs;p++){
+                if(p != root){
+                    if(recvcnt > 0){
+                        count++;
+                        if(count > preposts){
+                            CheckMPIReturn(MPI_Wait(rcvid+tail, &status), __FILE__,__LINE__);
+                            tail = (tail+1) % preposts;
+                        }
+                        displs = p*recvcnt*dsize;
+
+                        char *ptr = (char *) recvbuf + displs;
+
+                        CheckMPIReturn(MPI_Irecv(  ptr, recvcnt, recvtype, p, mtag, comm, rcvid+head), __FILE__,__LINE__);
+                        head= (head+1) % preposts;
+                        CheckMPIReturn(MPI_Send( &hs, 1, MPI_INT, p, mtag, comm), __FILE__,__LINE__);
+                    }
+                }
+            }
+
+            // copy local data
+            CheckMPIReturn(MPI_Type_size(sendtype, &dsize), __FILE__,__LINE__);
+            memcpy(recvbuf, sendbuf, sendcnt*dsize );
+
+            count = min(count, preposts);
+
+            if(count>0){
+                CheckMPIReturn(MPI_Waitall( count, rcvid, MPI_STATUSES_IGNORE),__FILE__,__LINE__);
+            }
+        }else{
+            if(sendcnt > 0){
+                CheckMPIReturn(MPI_Recv( &hs, 1, MPI_INT, root, mtag, comm, &status), __FILE__,__LINE__);
+                CheckMPIReturn(MPI_Send( sendbuf, sendcnt, sendtype, root, mtag, comm), __FILE__,__LINE__);
+            }
+        }
+    }else{
+        //    printf("%s %d %ld %d %ld %d %d\n",__FILE__,__LINE__,sendbuf,sendcnt,recvbuf,recvcnt,root);
+        CheckMPIReturn(MPI_Gather ( sendbuf, sendcnt, sendtype, recvbuf, recvcnt, recvtype, root, comm), __FILE__,__LINE__);
+    }
+
+    return PIO_NOERR;
 }
-  
+
 
 
 /**
@@ -135,337 +135,337 @@ int pio_fc_gather( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype
  */
 
 int pio_fc_gatherv( void *sendbuf, const int sendcnt, const MPI_Datatype sendtype,
-		    void *recvbuf, const int recvcnts[], const int displs[],
-		    const MPI_Datatype recvtype, const int root, 
-		    const MPI_Comm comm, const int flow_cntl)
+                    void *recvbuf, const int recvcnts[], const int displs[],
+                    const MPI_Datatype recvtype, const int root,
+                    const MPI_Comm comm, const int flow_cntl)
 {
-  bool fc_gather;
-  int gather_block_size;
-  int mytask, nprocs;
-  int mtag;
-  MPI_Status status;
-  int ierr;
-  int hs;
-  int dsize;
-  
+    bool fc_gather;
+    int gather_block_size;
+    int mytask, nprocs;
+    int mtag;
+    MPI_Status status;
+    int ierr;
+    int hs;
+    int dsize;
 
-  if(flow_cntl > 0){
-    fc_gather = true;
-    gather_block_size = min(flow_cntl,MAX_GATHER_BLOCK_SIZE);
-  }else{
-    fc_gather = false;
-  }
 
-  if(fc_gather){
-    CheckMPIReturn(MPI_Comm_rank (comm, &mytask), __FILE__,__LINE__);
-    CheckMPIReturn(MPI_Comm_size (comm, &nprocs), __FILE__,__LINE__);
-
-    mtag = 2*nprocs;
-    hs = 1;
-
-    if(mytask == root){
-      int preposts = min(nprocs-1, gather_block_size);
-      int head=0;
-      int count=0;
-      int tail = 0;
-      MPI_Request rcvid[gather_block_size];
-      // printf("%s %d %d\n",__FILE__,__LINE__,(int) recvtype);
-      CheckMPIReturn(MPI_Type_size(recvtype, &dsize), __FILE__,__LINE__);
-
-      for(int p=0;p<nprocs;p++){
-	if(p != root){
-	  if(recvcnts[p] > 0){
-	    count++;
-	    if(count > preposts){
-	      CheckMPIReturn(MPI_Wait(rcvid+tail, &status), __FILE__,__LINE__);
-	      tail = (tail+1) % preposts;
-	    }
-
-	    void *ptr = (void *)((char *) recvbuf + dsize*displs[p]);
-
-	    //	  printf("%s %d %d %d\n",__FILE__,__LINE__,p,(int) recvtype);
-	    CheckMPIReturn(MPI_Irecv(  ptr, recvcnts[p], recvtype, p, mtag, comm, rcvid+head), __FILE__,__LINE__);
-	    head= (head+1) % preposts;
-	    CheckMPIReturn(MPI_Send( &hs, 1, MPI_INT, p, mtag, comm), __FILE__,__LINE__);
-	  }
-	}
-      }
-
-      // copy local data
-      CheckMPIReturn(MPI_Type_size(sendtype, &dsize), __FILE__,__LINE__);      
-      CheckMPIReturn(MPI_Sendrecv(sendbuf, sendcnt, sendtype,
-				  mytask, 102, recvbuf, recvcnts[mytask], recvtype,
-				  mytask, 102, comm, &status),__FILE__,__LINE__);
-
-      count = min(count, preposts);
-      if(count>0)
-	CheckMPIReturn(MPI_Waitall( count, rcvid, MPI_STATUSES_IGNORE),__FILE__,__LINE__);
+    if(flow_cntl > 0){
+        fc_gather = true;
+        gather_block_size = min(flow_cntl,MAX_GATHER_BLOCK_SIZE);
     }else{
-      if(sendcnt > 0){
-	CheckMPIReturn(MPI_Recv( &hs, 1, MPI_INT, root, mtag, comm, &status), __FILE__,__LINE__);
-	CheckMPIReturn(MPI_Send( sendbuf, sendcnt, sendtype, root, mtag, comm), __FILE__,__LINE__);
-      }
+        fc_gather = false;
     }
-  }else{
-    CheckMPIReturn(MPI_Gatherv ( sendbuf, sendcnt, sendtype, recvbuf, recvcnts, displs, recvtype, root, comm), __FILE__,__LINE__);
-  }
 
-  return PIO_NOERR;
+    if(fc_gather){
+        CheckMPIReturn(MPI_Comm_rank (comm, &mytask), __FILE__,__LINE__);
+        CheckMPIReturn(MPI_Comm_size (comm, &nprocs), __FILE__,__LINE__);
+
+        mtag = 2*nprocs;
+        hs = 1;
+
+        if(mytask == root){
+            int preposts = min(nprocs-1, gather_block_size);
+            int head=0;
+            int count=0;
+            int tail = 0;
+            MPI_Request rcvid[gather_block_size];
+            // printf("%s %d %d\n",__FILE__,__LINE__,(int) recvtype);
+            CheckMPIReturn(MPI_Type_size(recvtype, &dsize), __FILE__,__LINE__);
+
+            for(int p=0;p<nprocs;p++){
+                if(p != root){
+                    if(recvcnts[p] > 0){
+                        count++;
+                        if(count > preposts){
+                            CheckMPIReturn(MPI_Wait(rcvid+tail, &status), __FILE__,__LINE__);
+                            tail = (tail+1) % preposts;
+                        }
+
+                        void *ptr = (void *)((char *) recvbuf + dsize*displs[p]);
+
+                        //        printf("%s %d %d %d\n",__FILE__,__LINE__,p,(int) recvtype);
+                        CheckMPIReturn(MPI_Irecv(  ptr, recvcnts[p], recvtype, p, mtag, comm, rcvid+head), __FILE__,__LINE__);
+                        head= (head+1) % preposts;
+                        CheckMPIReturn(MPI_Send( &hs, 1, MPI_INT, p, mtag, comm), __FILE__,__LINE__);
+                    }
+                }
+            }
+
+            // copy local data
+            CheckMPIReturn(MPI_Type_size(sendtype, &dsize), __FILE__,__LINE__);
+            CheckMPIReturn(MPI_Sendrecv(sendbuf, sendcnt, sendtype,
+                                        mytask, 102, recvbuf, recvcnts[mytask], recvtype,
+                                        mytask, 102, comm, &status),__FILE__,__LINE__);
+
+            count = min(count, preposts);
+            if(count>0)
+                CheckMPIReturn(MPI_Waitall( count, rcvid, MPI_STATUSES_IGNORE),__FILE__,__LINE__);
+        }else{
+            if(sendcnt > 0){
+                CheckMPIReturn(MPI_Recv( &hs, 1, MPI_INT, root, mtag, comm, &status), __FILE__,__LINE__);
+                CheckMPIReturn(MPI_Send( sendbuf, sendcnt, sendtype, root, mtag, comm), __FILE__,__LINE__);
+            }
+        }
+    }else{
+        CheckMPIReturn(MPI_Gatherv ( sendbuf, sendcnt, sendtype, recvbuf, recvcnts, displs, recvtype, root, comm), __FILE__,__LINE__);
+    }
+
+    return PIO_NOERR;
 }
 
 ///
 ///  @brief Returns the smallest power of 2 greater than i
-///  
+///
 int ceil2(const int i)
 {
-  int p=1;
-  while(p<i){
-    p*=2;
-  }
-  return(p);
+    int p=1;
+    while(p<i){
+        p*=2;
+    }
+    return(p);
 }
 
 ///
-///  @brief Given integers p and k between 0 and np-1,  
+///  @brief Given integers p and k between 0 and np-1,
 ///  if (p+1)^k <= np-1 then return (p+1)^k else -1
 int pair(const int np, const int p, const int k)
 {
-  int q = (p+1) ^ k ;
-  int pair = (q > np-1)? -1: q;
-  return pair;
+    int q = (p+1) ^ k ;
+    int pair = (q > np-1)? -1: q;
+    return pair;
 }
 
 /**
  **  @brief Provides the functionality of MPI_Alltoallw with flow control options
  */
-int pio_swapm(void *sndbuf,   int sndlths[], int sdispls[],  MPI_Datatype stypes[], 
-	      void *rcvbuf,  int rcvlths[],  int rdispls[],  MPI_Datatype rtypes[], 
-	       MPI_Comm comm,const  bool handshake, bool isend,const  int max_requests)
+int pio_swapm(void *sndbuf,   int sndlths[], int sdispls[],  MPI_Datatype stypes[],
+              void *rcvbuf,  int rcvlths[],  int rdispls[],  MPI_Datatype rtypes[],
+              MPI_Comm comm,const  bool handshake, bool isend,const  int max_requests)
 {
 
-  int nprocs;
-  int mytask;
+    int nprocs;
+    int mytask;
 
-  int maxsend=0;
-  int maxrecv=0;
+    int maxsend=0;
+    int maxrecv=0;
 
-  CheckMPIReturn(MPI_Comm_size(comm, &nprocs),__FILE__,__LINE__);
-  CheckMPIReturn(MPI_Comm_rank(comm, &mytask),__FILE__,__LINE__);
+    CheckMPIReturn(MPI_Comm_size(comm, &nprocs),__FILE__,__LINE__);
+    CheckMPIReturn(MPI_Comm_rank(comm, &mytask),__FILE__,__LINE__);
 
 
-  if(max_requests == 0) {
+    if(max_requests == 0) {
 #ifdef DEBUG
-    int totalrecv=0;
-    int totalsend=0;
-    for(int i=0;i<nprocs;i++){
-      //      printf("%d sndlths %d %d %d %d\n",i,sndlths[i],sdispls[i],rcvlths[i],rdispls[i]);
-      totalsend+=sndlths[i];
-      totalrecv+=rcvlths[i];
-    }
-    printf("%s %d totalsend %d totalrecv %d \n",__FILE__,__LINE__,totalsend,totalrecv);
+        int totalrecv=0;
+        int totalsend=0;
+        for(int i=0;i<nprocs;i++){
+            //      printf("%d sndlths %d %d %d %d\n",i,sndlths[i],sdispls[i],rcvlths[i],rdispls[i]);
+            totalsend+=sndlths[i];
+            totalrecv+=rcvlths[i];
+        }
+        printf("%s %d totalsend %d totalrecv %d \n",__FILE__,__LINE__,totalsend,totalrecv);
 
 #endif
 #ifdef OPEN_MPI
-    for(int i=0;i<nprocs;i++){
-      if(stypes[i]==MPI_DATATYPE_NULL){
-	stypes[i]=MPI_CHAR;
-      }
-      if(rtypes[i]==MPI_DATATYPE_NULL){
-	rtypes[i]=MPI_CHAR;
-      }
-    }
+        for(int i=0;i<nprocs;i++){
+            if(stypes[i]==MPI_DATATYPE_NULL){
+                stypes[i]=MPI_CHAR;
+            }
+            if(rtypes[i]==MPI_DATATYPE_NULL){
+                rtypes[i]=MPI_CHAR;
+            }
+        }
 #endif
-    CheckMPIReturn(MPI_Alltoallw( sndbuf, sndlths, sdispls, stypes, rcvbuf, rcvlths, rdispls, rtypes, comm),__FILE__,__LINE__);
-    
+        CheckMPIReturn(MPI_Alltoallw( sndbuf, sndlths, sdispls, stypes, rcvbuf, rcvlths, rdispls, rtypes, comm),__FILE__,__LINE__);
+
 #ifdef OPEN_MPI
-    for(int i=0;i<nprocs;i++){
-      if(stypes[i]==MPI_CHAR){
-        stypes[i]=MPI_DATATYPE_NULL;
-      }
-      if(rtypes[i]==MPI_CHAR){
-	rtypes[i]=MPI_DATATYPE_NULL;
-      }
-    }
+        for(int i=0;i<nprocs;i++){
+            if(stypes[i]==MPI_CHAR){
+                stypes[i]=MPI_DATATYPE_NULL;
+            }
+            if(rtypes[i]==MPI_CHAR){
+                rtypes[i]=MPI_DATATYPE_NULL;
+            }
+        }
 #endif
-    return PIO_NOERR;
-  }
+        return PIO_NOERR;
+    }
 
 
-  int tag;
-  int offset_t;
-  int ierr;
-  MPI_Status status;
-  int steps;
-  int istep;
-  int rstep;
-  int p;
-  int maxreq;
-  int maxreqh;
-  int hs;
-  int cnt;
-  void *ptr;
-  MPI_Request rcvids[nprocs];
+    int tag;
+    int offset_t;
+    int ierr;
+    MPI_Status status;
+    int steps;
+    int istep;
+    int rstep;
+    int p;
+    int maxreq;
+    int maxreqh;
+    int hs;
+    int cnt;
+    void *ptr;
+    MPI_Request rcvids[nprocs];
 
 
 
-  offset_t = nprocs;
-  // send to self
-  if(sndlths[mytask] > 0){
-    void *sptr, *rptr;
-    int extent, lb;
-    tag = mytask + offset_t;
-    sptr = (void *)((char *) sndbuf + sdispls[mytask]);
-    rptr = (void *)((char *) rcvbuf  + rdispls[mytask]);
+    offset_t = nprocs;
+    // send to self
+    if(sndlths[mytask] > 0){
+        void *sptr, *rptr;
+        int extent, lb;
+        tag = mytask + offset_t;
+        sptr = (void *)((char *) sndbuf + sdispls[mytask]);
+        rptr = (void *)((char *) rcvbuf  + rdispls[mytask]);
 
-    /*
-      MPI_Type_get_extent(stypes[mytask], &lb, &extent);
-      printf("%s %d %d %d\n",__FILE__,__LINE__,extent, lb);
-      MPI_Type_get_extent(rtypes[mytask], &lb, &extent);
-      printf("%s %d %d %d\n",__FILE__,__LINE__,extent, lb);
-    */
+        /*
+          MPI_Type_get_extent(stypes[mytask], &lb, &extent);
+          printf("%s %d %d %d\n",__FILE__,__LINE__,extent, lb);
+          MPI_Type_get_extent(rtypes[mytask], &lb, &extent);
+          printf("%s %d %d %d\n",__FILE__,__LINE__,extent, lb);
+        */
 #ifdef ONEWAY
-    CheckMPIReturn(MPI_Sendrecv(sptr, sndlths[mytask],stypes[mytask],
-				mytask, tag, rptr, rcvlths[mytask], rtypes[mytask],
-				mytask, tag, comm, &status),__FILE__,__LINE__);
+        CheckMPIReturn(MPI_Sendrecv(sptr, sndlths[mytask],stypes[mytask],
+                                    mytask, tag, rptr, rcvlths[mytask], rtypes[mytask],
+                                    mytask, tag, comm, &status),__FILE__,__LINE__);
 #else
-    //   printf("%s %d \n",__FILE__,__LINE__);
-    CheckMPIReturn(MPI_Irecv(rptr, rcvlths[mytask], rtypes[mytask],
-			     mytask, tag, comm, rcvids),__FILE__,__LINE__);
-    //printf("%s %d \n",__FILE__,__LINE__);
-    CheckMPIReturn(MPI_Send(sptr, sndlths[mytask], stypes[mytask],
-			     mytask, tag, comm),__FILE__,__LINE__);
+        //   printf("%s %d \n",__FILE__,__LINE__);
+        CheckMPIReturn(MPI_Irecv(rptr, rcvlths[mytask], rtypes[mytask],
+                                 mytask, tag, comm, rcvids),__FILE__,__LINE__);
+        //printf("%s %d \n",__FILE__,__LINE__);
+        CheckMPIReturn(MPI_Send(sptr, sndlths[mytask], stypes[mytask],
+                                mytask, tag, comm),__FILE__,__LINE__);
 
-    //printf("%s %d %d\n",__FILE__,__LINE__,rcvids[0]);
-    CheckMPIReturn(MPI_Wait(rcvids, &status),__FILE__,__LINE__);
+        //printf("%s %d %d\n",__FILE__,__LINE__,rcvids[0]);
+        CheckMPIReturn(MPI_Wait(rcvids, &status),__FILE__,__LINE__);
 
 #endif
 
 
-  }
-  if(nprocs==1)
-    return PIO_NOERR;
-
-  int swapids[nprocs];
-  MPI_Request sndids[nprocs];
-  MPI_Request hs_rcvids[nprocs];
-
-  for(int i=0;i<nprocs;i++){
-    rcvids[i] = MPI_REQUEST_NULL;
-    swapids[i]=0;
-  }
-  if(isend)
-    for(int i=0;i<nprocs;i++)
-      sndids[i]=MPI_REQUEST_NULL;
-  if(handshake)
-    for(int i=0;i<nprocs;i++)
-      hs_rcvids[i]=MPI_REQUEST_NULL;
-  
-  steps = 0;
-  for(istep=0;istep<ceil2(nprocs)-1;istep++){
-    p = pair(nprocs, istep, mytask) ;
-    if( p >= 0 && (sndlths[p] > 0 || rcvlths[p] > 0)){
-      swapids[steps++] = p;
     }
-  }
+    if(nprocs==1)
+        return PIO_NOERR;
 
-  if(steps == 1){
-    maxreq = 1;
-    maxreqh = 1;
-  }else{
-    if(max_requests > 1 && max_requests<steps){
-      maxreq = max_requests;
-      maxreqh = maxreq/2;
-    }else if(max_requests>=steps){
-      maxreq = steps;
-      maxreqh = steps;
-    }else{
-      maxreq = 2;
-      maxreqh = 1;
+    int swapids[nprocs];
+    MPI_Request sndids[nprocs];
+    MPI_Request hs_rcvids[nprocs];
+
+    for(int i=0;i<nprocs;i++){
+        rcvids[i] = MPI_REQUEST_NULL;
+        swapids[i]=0;
     }
-  } 
-  if(handshake){
-    hs = 1;
-    for(istep=0; istep<maxreq; istep++){
-      p = swapids[istep];
-      if( sndlths[p] > 0){
-	tag = mytask+offset_t;
-	CheckMPIReturn(MPI_Irecv( &hs, 1, MPI_INT, p, tag, comm, hs_rcvids+istep), __FILE__,__LINE__);
-      }
-    }
-  }
-  for(istep=0;istep < maxreq; istep++){
-    p = swapids[istep];
-    if(rcvlths[p] > 0){
-      tag = p + offset_t;
-      ptr = (void *)((char *) rcvbuf + rdispls[p]);
-
-      //	  printf("%s %d %d %d\n",__FILE__,__LINE__,p,(int) rtypes[p]);
-      CheckMPIReturn(MPI_Irecv( ptr, rcvlths[p], rtypes[p], p, tag, comm, rcvids+istep), __FILE__,__LINE__);
-
-      if(handshake)
-	CheckMPIReturn(MPI_Send( &hs, 1, MPI_INT, p, tag, comm), __FILE__,__LINE__);
-    }
-  }
-
-  rstep = maxreq;
-  for(istep = 0; istep < steps; istep++){
-    p = swapids[istep];
-    if(sndlths[p] > 0){
-      tag = mytask + offset_t;
-      if(handshake){
-	CheckMPIReturn(MPI_Wait ( hs_rcvids+istep, &status), __FILE__,__LINE__);
-	hs_rcvids[istep] = MPI_REQUEST_NULL;
-      }
-      ptr = (void *)((char *) sndbuf + sdispls[p]);
-
-      if(isend){
-	CheckMPIReturn(MPI_Irsend(ptr, sndlths[p], stypes[p], p, tag, comm,sndids+istep), __FILE__,__LINE__);
-      }else{
-	CheckMPIReturn(MPI_Send(ptr, sndlths[p], stypes[p], p, tag, comm), __FILE__,__LINE__);
-      }
-
-    }
-    if(istep > maxreqh){
-      p = istep - maxreqh;
-      if(rcvids[p] != MPI_REQUEST_NULL){
-	CheckMPIReturn(MPI_Wait(rcvids+p, &status), __FILE__,__LINE__);
-	rcvids[p] = MPI_REQUEST_NULL;
-      }
-      if(rstep < steps){
-	p = swapids[rstep];
-	if(handshake && sndlths[p] > 0){
-	  tag = mytask + offset_t;
-	  CheckMPIReturn(MPI_Irecv( &hs, 1, MPI_INT, p, tag, comm, hs_rcvids+rstep), __FILE__,__LINE__);
-	}
-	if(rcvlths[p] > 0){
-	  tag = p + offset_t;
-	  
-	  ptr = (void *)((char *) rcvbuf + rdispls[p]);
-	  CheckMPIReturn(MPI_Irecv( ptr, rcvlths[p], rtypes[p], p, tag, comm, rcvids+rstep), __FILE__,__LINE__);
-	  if(handshake)
-	    CheckMPIReturn(MPI_Send( &hs, 1, MPI_INT, p, tag, comm), __FILE__,__LINE__);
-	}
-	rstep++;
-      }
-    }
-  }
-  //     printf("%s %d %d \n",__FILE__,__LINE__,nprocs);
-  if(steps>0){
-    CheckMPIReturn(MPI_Waitall(steps, rcvids, MPI_STATUSES_IGNORE), __FILE__,__LINE__);
     if(isend)
-      CheckMPIReturn(MPI_Waitall(steps, sndids, MPI_STATUSES_IGNORE), __FILE__,__LINE__);
-  }
-  //      printf("%s %d %d \n",__FILE__,__LINE__,nprocs);
-  
-  return PIO_NOERR;
+        for(int i=0;i<nprocs;i++)
+            sndids[i]=MPI_REQUEST_NULL;
+    if(handshake)
+        for(int i=0;i<nprocs;i++)
+            hs_rcvids[i]=MPI_REQUEST_NULL;
+
+    steps = 0;
+    for(istep=0;istep<ceil2(nprocs)-1;istep++){
+        p = pair(nprocs, istep, mytask) ;
+        if( p >= 0 && (sndlths[p] > 0 || rcvlths[p] > 0)){
+            swapids[steps++] = p;
+        }
+    }
+
+    if(steps == 1){
+        maxreq = 1;
+        maxreqh = 1;
+    }else{
+        if(max_requests > 1 && max_requests<steps){
+            maxreq = max_requests;
+            maxreqh = maxreq/2;
+        }else if(max_requests>=steps){
+            maxreq = steps;
+            maxreqh = steps;
+        }else{
+            maxreq = 2;
+            maxreqh = 1;
+        }
+    }
+    if(handshake){
+        hs = 1;
+        for(istep=0; istep<maxreq; istep++){
+            p = swapids[istep];
+            if( sndlths[p] > 0){
+                tag = mytask+offset_t;
+                CheckMPIReturn(MPI_Irecv( &hs, 1, MPI_INT, p, tag, comm, hs_rcvids+istep), __FILE__,__LINE__);
+            }
+        }
+    }
+    for(istep=0;istep < maxreq; istep++){
+        p = swapids[istep];
+        if(rcvlths[p] > 0){
+            tag = p + offset_t;
+            ptr = (void *)((char *) rcvbuf + rdispls[p]);
+
+            //    printf("%s %d %d %d\n",__FILE__,__LINE__,p,(int) rtypes[p]);
+            CheckMPIReturn(MPI_Irecv( ptr, rcvlths[p], rtypes[p], p, tag, comm, rcvids+istep), __FILE__,__LINE__);
+
+            if(handshake)
+                CheckMPIReturn(MPI_Send( &hs, 1, MPI_INT, p, tag, comm), __FILE__,__LINE__);
+        }
+    }
+
+    rstep = maxreq;
+    for(istep = 0; istep < steps; istep++){
+        p = swapids[istep];
+        if(sndlths[p] > 0){
+            tag = mytask + offset_t;
+            if(handshake){
+                CheckMPIReturn(MPI_Wait ( hs_rcvids+istep, &status), __FILE__,__LINE__);
+                hs_rcvids[istep] = MPI_REQUEST_NULL;
+            }
+            ptr = (void *)((char *) sndbuf + sdispls[p]);
+
+            if(isend){
+                CheckMPIReturn(MPI_Irsend(ptr, sndlths[p], stypes[p], p, tag, comm,sndids+istep), __FILE__,__LINE__);
+            }else{
+                CheckMPIReturn(MPI_Send(ptr, sndlths[p], stypes[p], p, tag, comm), __FILE__,__LINE__);
+            }
+
+        }
+        if(istep > maxreqh){
+            p = istep - maxreqh;
+            if(rcvids[p] != MPI_REQUEST_NULL){
+                CheckMPIReturn(MPI_Wait(rcvids+p, &status), __FILE__,__LINE__);
+                rcvids[p] = MPI_REQUEST_NULL;
+            }
+            if(rstep < steps){
+                p = swapids[rstep];
+                if(handshake && sndlths[p] > 0){
+                    tag = mytask + offset_t;
+                    CheckMPIReturn(MPI_Irecv( &hs, 1, MPI_INT, p, tag, comm, hs_rcvids+rstep), __FILE__,__LINE__);
+                }
+                if(rcvlths[p] > 0){
+                    tag = p + offset_t;
+
+                    ptr = (void *)((char *) rcvbuf + rdispls[p]);
+                    CheckMPIReturn(MPI_Irecv( ptr, rcvlths[p], rtypes[p], p, tag, comm, rcvids+rstep), __FILE__,__LINE__);
+                    if(handshake)
+                        CheckMPIReturn(MPI_Send( &hs, 1, MPI_INT, p, tag, comm), __FILE__,__LINE__);
+                }
+                rstep++;
+            }
+        }
+    }
+    //     printf("%s %d %d \n",__FILE__,__LINE__,nprocs);
+    if(steps>0){
+        CheckMPIReturn(MPI_Waitall(steps, rcvids, MPI_STATUSES_IGNORE), __FILE__,__LINE__);
+        if(isend)
+            CheckMPIReturn(MPI_Waitall(steps, sndids, MPI_STATUSES_IGNORE), __FILE__,__LINE__);
+    }
+    //      printf("%s %d %d \n",__FILE__,__LINE__,nprocs);
+
+    return PIO_NOERR;
 }
 
 #ifdef TESTSWAPM_OLD
 #include <sys/time.h>
 /*
-This program tests MPI_Alltoallw by having processor i send different
-amounts of data to each processor.
-The first test sends i items to processor i from all processors.
+  This program tests MPI_Alltoallw by having processor i send different
+  amounts of data to each processor.
+  The first test sends i items to processor i from all processors.
 */
 int main( int argc, char **argv )
 {
@@ -492,50 +492,50 @@ int main( int argc, char **argv )
         MPI_Abort( comm, 1 );
     }
     /* Test pio_fc_gather */
-    
+
     msg_cnt=0;
     while(msg_cnt<= MAX_GATHER_BLOCK_SIZE){
-      /* Load up the buffers */
-      for (i=0; i<size*size; i++) {
-        sbuf[i] = i + 100*rank;
-        rbuf[i] = -i;
-      }
+        /* Load up the buffers */
+        for (i=0; i<size*size; i++) {
+            sbuf[i] = i + 100*rank;
+            rbuf[i] = -i;
+        }
 
-      MPI_Barrier(comm);
-      if(rank==0) printf("Start gather test %d\n",msg_cnt);
-      if(rank == 0) gettimeofday(&t1, NULL);
-      
-      err = pio_fc_gather( sbuf, size, MPI_INT, rbuf, size, MPI_INT, 0, comm, msg_cnt);
+        MPI_Barrier(comm);
+        if(rank==0) printf("Start gather test %d\n",msg_cnt);
+        if(rank == 0) gettimeofday(&t1, NULL);
 
-
-      if(rank == 0){
-	gettimeofday(&t2, NULL);
-	printf("time = %f\n",t2.tv_sec - t1.tv_sec + 1.e-6*( t2.tv_usec - t1.tv_usec));
-      }
-      if(rank==0){
-	for(j=0;j<size;j++){
-	  for(i=0;i<size;i++){
-	    if(rbuf[i + j*size] != i + 100*j){ 
-	      printf("got %d expected %d\n",rbuf[i+j*size] , i+100*j);
-	    }
-	  }
-	}
-      }
-
-      MPI_Barrier(comm);
+        err = pio_fc_gather( sbuf, size, MPI_INT, rbuf, size, MPI_INT, 0, comm, msg_cnt);
 
 
-      if(msg_cnt==0)
-	msg_cnt=1;
-      else
-	msg_cnt*=2;
+        if(rank == 0){
+            gettimeofday(&t2, NULL);
+            printf("time = %f\n",t2.tv_sec - t1.tv_sec + 1.e-6*( t2.tv_usec - t1.tv_usec));
+        }
+        if(rank==0){
+            for(j=0;j<size;j++){
+                for(i=0;i<size;i++){
+                    if(rbuf[i + j*size] != i + 100*j){
+                        printf("got %d expected %d\n",rbuf[i+j*size] , i+100*j);
+                    }
+                }
+            }
+        }
+
+        MPI_Barrier(comm);
+
+
+        if(msg_cnt==0)
+            msg_cnt=1;
+        else
+            msg_cnt*=2;
 
 
 
 
     }
 
-    
+
 
     /* Test pio_swapm Create and load the arguments to alltoallv */
     sendcounts = (int *)malloc( size * sizeof(int) );
@@ -557,83 +557,83 @@ int main( int argc, char **argv )
         sdispls[i] = (((i+1) * (i))/2) * sizeof(int) ;
         sendtypes[i] = recvtypes[i] = MPI_INT;
     }
-    
+
     //    for(int msg_cnt=4; msg_cnt<size; msg_cnt*=2){
     //   if(rank==0) printf("message count %d\n",msg_cnt);
     msg_cnt = 0;
     for(int itest=0;itest<5; itest++){
-      bool hs=false; 
-      bool isend=false;
-      /* Load up the buffers */
-      for (i=0; i<size*size; i++) {
-        sbuf[i] = i + 100*rank;
-        rbuf[i] = -i;
-      }
-      MPI_Barrier(comm);
+        bool hs=false;
+        bool isend=false;
+        /* Load up the buffers */
+        for (i=0; i<size*size; i++) {
+            sbuf[i] = i + 100*rank;
+            rbuf[i] = -i;
+        }
+        MPI_Barrier(comm);
 
-      if(rank==0) printf("Start itest %d\n",itest);
-      if(rank == 0) gettimeofday(&t1, NULL);
+        if(rank==0) printf("Start itest %d\n",itest);
+        if(rank == 0) gettimeofday(&t1, NULL);
 
-      if(itest==0){
-	err = pio_swapm( size, rank, sbuf,  sendcounts, sdispls, sendtypes, 
-			 rbuf,  recvcounts, rdispls, recvtypes, comm, hs, isend, 0);
-      }else if(itest==1){
-	hs = true;
-	isend = true;
-	err = pio_swapm( size, rank, sbuf,  sendcounts, sdispls, sendtypes, 
-			 rbuf,  recvcounts, rdispls, recvtypes, comm, hs, isend, msg_cnt);
-      }else if(itest==2){
-	hs = false;
-	isend = true;
-	err = pio_swapm( size, rank, sbuf, sendcounts, sdispls, sendtypes, 
-			 rbuf, recvcounts, rdispls, recvtypes, comm, hs, isend, msg_cnt);
+        if(itest==0){
+            err = pio_swapm( size, rank, sbuf,  sendcounts, sdispls, sendtypes,
+                             rbuf,  recvcounts, rdispls, recvtypes, comm, hs, isend, 0);
+        }else if(itest==1){
+            hs = true;
+            isend = true;
+            err = pio_swapm( size, rank, sbuf,  sendcounts, sdispls, sendtypes,
+                             rbuf,  recvcounts, rdispls, recvtypes, comm, hs, isend, msg_cnt);
+        }else if(itest==2){
+            hs = false;
+            isend = true;
+            err = pio_swapm( size, rank, sbuf, sendcounts, sdispls, sendtypes,
+                             rbuf, recvcounts, rdispls, recvtypes, comm, hs, isend, msg_cnt);
 
-      }else if(itest==3){
-	hs = false;
-	isend = false;
-	err = pio_swapm( size, rank, sbuf, sendcounts, sdispls, sendtypes, 
-			 rbuf, recvcounts, rdispls, recvtypes, comm, hs, isend, msg_cnt);
+        }else if(itest==3){
+            hs = false;
+            isend = false;
+            err = pio_swapm( size, rank, sbuf, sendcounts, sdispls, sendtypes,
+                             rbuf, recvcounts, rdispls, recvtypes, comm, hs, isend, msg_cnt);
 
-      }else if(itest==4){
-	hs = true;
-	isend = false;
-	err = pio_swapm( size, rank, sbuf,  sendcounts, sdispls, sendtypes, 
-			 rbuf,  recvcounts, rdispls, recvtypes, comm, hs, isend, msg_cnt);
+        }else if(itest==4){
+            hs = true;
+            isend = false;
+            err = pio_swapm( size, rank, sbuf,  sendcounts, sdispls, sendtypes,
+                             rbuf,  recvcounts, rdispls, recvtypes, comm, hs, isend, msg_cnt);
 
-      }
+        }
 
-      if(rank == 0){
-	gettimeofday(&t2, NULL);
-	printf("itest = %d time = %f\n",itest,t2.tv_sec - t1.tv_sec + 1.e-6*( t2.tv_usec - t1.tv_usec));
-      }
-      /*
-      printf("scnt: %d %d %d %d\n",sendcounts[0],sendcounts[1],sendcounts[2],sendcounts[3]);
-      printf("sdispls: %d %d %d %d\n",sdispls[0],sdispls[1],sdispls[2],sdispls[3]);
-      printf("rcnt: %d %d %d %d\n",recvcounts[0],recvcounts[1],recvcounts[2],recvcounts[3]);
-      printf("rdispls: %d %d %d %d\n",rdispls[0],rdispls[1],rdispls[2],rdispls[3]);
+        if(rank == 0){
+            gettimeofday(&t2, NULL);
+            printf("itest = %d time = %f\n",itest,t2.tv_sec - t1.tv_sec + 1.e-6*( t2.tv_usec - t1.tv_usec));
+        }
+        /*
+          printf("scnt: %d %d %d %d\n",sendcounts[0],sendcounts[1],sendcounts[2],sendcounts[3]);
+          printf("sdispls: %d %d %d %d\n",sdispls[0],sdispls[1],sdispls[2],sdispls[3]);
+          printf("rcnt: %d %d %d %d\n",recvcounts[0],recvcounts[1],recvcounts[2],recvcounts[3]);
+          printf("rdispls: %d %d %d %d\n",rdispls[0],rdispls[1],rdispls[2],rdispls[3]);
 
-      printf("send: ");
-      for(i=0;i<size*size;i++)
-	printf("%d ",sbuf[i]);
-      printf("\n");
-      printf("recv: ");
-      for(i=0;i<size*size;i++)
-	printf("%d ",rbuf[i]);
-      printf("\n");
-      */
-      MPI_Barrier(comm);
-      /* Check rbuf */
-      for (i=0; i<size; i++) {
-	p = rbuf + rdispls[i]/sizeof(int);
-	for (j=0; j<rank+1; j++) {
-	  if (p[j] != i * 100 + (rank*(rank+1))/2 + j) {
-	    fprintf( stderr, "[%d] got %d expected %d for %d %dth in itest=%d\n",
-		     rank, p[j],(i*100 + (rank*(rank+1))/2+j), i, j, itest);
-	    fflush(stderr);
-	    err++;
-	  }
-	}
-      }
+          printf("send: ");
+          for(i=0;i<size*size;i++)
+          printf("%d ",sbuf[i]);
+          printf("\n");
+          printf("recv: ");
+          for(i=0;i<size*size;i++)
+          printf("%d ",rbuf[i]);
+          printf("\n");
+        */
+        MPI_Barrier(comm);
+        /* Check rbuf */
+        for (i=0; i<size; i++) {
+            p = rbuf + rdispls[i]/sizeof(int);
+            for (j=0; j<rank+1; j++) {
+                if (p[j] != i * 100 + (rank*(rank+1))/2 + j) {
+                    fprintf( stderr, "[%d] got %d expected %d for %d %dth in itest=%d\n",
+                             rank, p[j],(i*100 + (rank*(rank+1))/2+j), i, j, itest);
+                    fflush(stderr);
+                    err++;
+                }
+            }
+        }
     }
 
     //    }
@@ -650,7 +650,7 @@ int main( int argc, char **argv )
 
 #if PIO_ENABLE_LOGGING
     fclose(LOG_FILE);
-#endif /* PIO_ENABLE_LOGGING */    
+#endif /* PIO_ENABLE_LOGGING */
     return 0;
 }
 

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -5,1990 +5,1989 @@
 ///
 /// PIO interface to nc_put_varm
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype) 
+int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm(file->fh, varid, start, count, stride, imap, buf, bufcount, buftype, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm(file->fh, varid, start, count, stride, imap, buf, bufcount, buftype, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
 ///
 /// PIO interface to nc_put_varm_uchar
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned char *op) 
+int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned char *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_UCHAR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_UCHAR;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_uchar(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_uchar(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
 ///
 /// PIO interface to nc_put_varm_short
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const short *op) 
+int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const short *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_SHORT;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_SHORT;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_short(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_short(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 ///
 /// PIO interface to nc_put_varm_text
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const char *op) 
+int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const char *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_TEXT;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_TEXT;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_text(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_text(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
 ///
 /// PIO interface to nc_put_varm_ushort
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned short *op) 
+int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned short *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_USHORT;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_USHORT;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_ushort(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_ushort(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
 ///
 /// PIO interface to nc_put_varm_ulonglong
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned long long *op) 
+int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned long long *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_ULONGLONG;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_ULONGLONG;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_ulonglong(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_ulonglong(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 ///
 /// PIO interface to nc_put_varm_int
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const int *op) 
+int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const int *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_INT;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_INT;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_int(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_int(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
 ///
 /// PIO interface to nc_put_varm_float
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const float *op) 
+int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const float *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_FLOAT;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_FLOAT;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_float(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_float(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 ///
 /// PIO interface to nc_put_varm_long
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long *op) 
+int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_LONG;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_LONG;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_long(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_long(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
 ///
 /// PIO interface to nc_put_varm_uint
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned int *op) 
+int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const unsigned int *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_UINT;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_UINT;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_uint(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_uint(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
 ///
 /// PIO interface to nc_put_varm_double
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const double *op) 
+int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const double *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_DOUBLE;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_DOUBLE;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_double(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_double(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 ///
 /// PIO interface to nc_put_varm_schar
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const signed char *op) 
+int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const signed char *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_SCHAR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_SCHAR;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_schar(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_schar(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
 ///
 /// PIO interface to nc_put_varm_longlong
 ///
-/// This routine is called collectively by all tasks in the communicator ios.union_comm.  
-/// 
+/// This routine is called collectively by all tasks in the communicator ios.union_comm.
+///
 /// Refer to the <A HREF="http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_documentation.html"> netcdf documentation. </A>
 ///
-int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long long *op) 
+int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], const long long *op)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  var_desc_t *vdesc;
-  PIO_Offset usage;
-  int *request;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    var_desc_t *vdesc;
+    PIO_Offset usage;
+    int *request;
 
-  ierr = PIO_NOERR;
+    ierr = PIO_NOERR;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_PUT_VARM_LONGLONG;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_PUT_VARM_LONGLONG;
 
-  /* Sorry, but varm functions are not supported by the async interface. */
-  if(ios->async_interface)
-      return PIO_EINVAL;
+    /* Sorry, but varm functions are not supported by the async interface. */
+    if(ios->async_interface)
+        return PIO_EINVAL;
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-      ierr = nc_put_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
+            ierr = nc_put_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      if(ios->io_rank==0){
-	ierr = nc_put_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            if(ios->io_rank==0){
+                ierr = nc_put_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
-      vdesc = file->varlist + varid;
+        case PIO_IOTYPE_PNETCDF:
+            vdesc = file->varlist + varid;
 
-      if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
-	vdesc->request = realloc(vdesc->request, 
-				 sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
-      }
-      request = vdesc->request+vdesc->nreqs;
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+                vdesc->request = realloc(vdesc->request,
+                                         sizeof(int)*(vdesc->nreqs+PIO_REQUEST_ALLOC_CHUNK));
+            }
+            request = vdesc->request+vdesc->nreqs;
 
-      if(ios->io_rank==0){
-	ierr = ncmpi_bput_varm_longlong(file->fh, varid, start, count, stride, imap, op, request);;
-      }else{
-	*request = PIO_REQ_NULL;
-      }
-      vdesc->nreqs++;
-      flush_output_buffer(file, false, 0);
-      break;
+            if(ios->io_rank==0){
+                ierr = ncmpi_bput_varm_longlong(file->fh, varid, start, count, stride, imap, op, request);;
+            }else{
+                *request = PIO_REQ_NULL;
+            }
+            vdesc->nreqs++;
+            flush_output_buffer(file, false, 0);
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned char *buf) 
+int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned char *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_UCHAR;
-  ibuftype = MPI_UNSIGNED_CHAR;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_UCHAR;
+    ibuftype = MPI_UNSIGNED_CHAR;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_uchar(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_uchar(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_uchar_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_uchar_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], signed char *buf) 
+int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], signed char *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_SCHAR;
-  ibuftype = MPI_CHAR;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_SCHAR;
+    ibuftype = MPI_CHAR;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_schar(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_schar(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_schar_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_schar_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], double *buf) 
+int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], double *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_DOUBLE;
-  ibuftype = MPI_DOUBLE;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_DOUBLE;
+    ibuftype = MPI_DOUBLE;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_double(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_double(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_double_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_double_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], char *buf) 
+int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], char *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_TEXT;
-  ibuftype = MPI_CHAR;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_TEXT;
+    ibuftype = MPI_CHAR;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_text(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_text(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_text_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_text_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], int *buf) 
+int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], int *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_INT;
-  ibuftype = MPI_INT;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_INT;
+    ibuftype = MPI_INT;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_int(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_int(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_int_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_int_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned int *buf) 
+int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned int *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_UINT;
-  ibuftype = MPI_UNSIGNED;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_UINT;
+    ibuftype = MPI_UNSIGNED;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_uint(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_uint(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_uint_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_uint_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype) 
+int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM;
-  ibufcnt = bufcount;
-  ibuftype = buftype;
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM;
+    ibufcnt = bufcount;
+    ibuftype = buftype;
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm(file->fh, varid, start, count, stride, imap, buf, bufcount, buftype);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm(file->fh, varid, start, count, stride, imap, buf, bufcount, buftype);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_all(file->fh, varid, start, count, stride, imap, buf, bufcount, buftype);;
+            ierr = ncmpi_get_varm_all(file->fh, varid, start, count, stride, imap, buf, bufcount, buftype);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], float *buf) 
+int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], float *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_FLOAT;
-  ibuftype = MPI_FLOAT;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_FLOAT;
+    ibuftype = MPI_FLOAT;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_float(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_float(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_float_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_float_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long *buf) 
+int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_LONG;
-  ibuftype = MPI_LONG;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_LONG;
+    ibuftype = MPI_LONG;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_long(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_long(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_long_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_long_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned short *buf) 
+int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned short *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_USHORT;
-  ibuftype = MPI_UNSIGNED_SHORT;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_USHORT;
+    ibuftype = MPI_UNSIGNED_SHORT;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_ushort(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_ushort(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_ushort_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_ushort_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long long *buf) 
+int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], long long *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_LONGLONG;
-  ibuftype = MPI_LONG_LONG;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_LONGLONG;
+    ibuftype = MPI_LONG_LONG;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_longlong(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_longlong(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_longlong_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_longlong_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], short *buf) 
+int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], short *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_SHORT;
-  ibuftype = MPI_SHORT;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_SHORT;
+    ibuftype = MPI_SHORT;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_short(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_short(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_short_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_short_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
 
-int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned long long *buf) 
+int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], const PIO_Offset stride[], const PIO_Offset imap[], unsigned long long *buf)
 {
-  int ierr;
-  int msg;
-  int mpierr;
-  iosystem_desc_t *ios;
-  file_desc_t *file;
-  MPI_Datatype ibuftype;
-  int ndims;
-  int ibufcnt;
-  bool bcast = false;
+    int ierr;
+    int msg;
+    int mpierr;
+    iosystem_desc_t *ios;
+    file_desc_t *file;
+    MPI_Datatype ibuftype;
+    int ndims;
+    int ibufcnt;
+    bool bcast = false;
 
-  /* Get file info. */
-  if ((ierr = pio_get_file(ncid, &file)))
-      return ierr;
-  ios = file->iosystem;
-  msg = PIO_MSG_GET_VARM_ULONGLONG;
-  ibuftype = MPI_UNSIGNED_LONG_LONG;
-  ierr = PIOc_inq_varndims(ncid, varid, &ndims);
-  ibufcnt = 1;
-  for(int i=0;i<ndims;i++){
-    ibufcnt *= count[i]/stride[i];
-  }
-  ierr = PIO_NOERR;
+    /* Get file info. */
+    if ((ierr = pio_get_file(ncid, &file)))
+        return ierr;
+    ios = file->iosystem;
+    msg = PIO_MSG_GET_VARM_ULONGLONG;
+    ibuftype = MPI_UNSIGNED_LONG_LONG;
+    ierr = PIOc_inq_varndims(ncid, varid, &ndims);
+    ibufcnt = 1;
+    for(int i=0;i<ndims;i++){
+        ibufcnt *= count[i]/stride[i];
+    }
+    ierr = PIO_NOERR;
 
-  if(ios->async_interface && ! ios->ioproc){
-    if(ios->compmaster) 
-      mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
-    mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-  }
+    if(ios->async_interface && ! ios->ioproc){
+        if(ios->compmaster)
+            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+    }
 
 
-  if(ios->ioproc){
-    switch(file->iotype){
+    if(ios->ioproc){
+        switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-    case PIO_IOTYPE_NETCDF4P:
-      ierr = nc_get_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      break;
-    case PIO_IOTYPE_NETCDF4C:
+        case PIO_IOTYPE_NETCDF4P:
+            ierr = nc_get_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            break;
+        case PIO_IOTYPE_NETCDF4C:
 #endif
-    case PIO_IOTYPE_NETCDF:
-      bcast = true;
-      if(ios->iomaster){
-	ierr = nc_get_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
-      }
-      break;
+        case PIO_IOTYPE_NETCDF:
+            bcast = true;
+            if(ios->iomaster){
+                ierr = nc_get_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
+            }
+            break;
 #endif
 #ifdef _PNETCDF
-    case PIO_IOTYPE_PNETCDF:
+        case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
-        ncmpi_begin_indep_data(file->fh);
-        if(ios->iomaster){
-      ierr = ncmpi_get_varm_ulonglong(file->fh, varid, start, count, stride, imap,  buf);;
-        };
-         ncmpi_end_indep_data(file->fh);
-        bcast=true;
+            ncmpi_begin_indep_data(file->fh);
+            if(ios->iomaster){
+                ierr = ncmpi_get_varm_ulonglong(file->fh, varid, start, count, stride, imap,  buf);;
+            };
+            ncmpi_end_indep_data(file->fh);
+            bcast=true;
 #else
-      ierr = ncmpi_get_varm_ulonglong_all(file->fh, varid, start, count, stride, imap,  buf);;
+            ierr = ncmpi_get_varm_ulonglong_all(file->fh, varid, start, count, stride, imap,  buf);;
 #endif
-      break;
+            break;
 #endif
-    default:
-      ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        default:
+            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        }
     }
-  }
 
-  ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
 
-  if(ios->async_interface || bcast ||  
-     (ios->num_iotasks < ios->num_comptasks)){
-    MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
-  }
+    if(ios->async_interface || bcast ||
+       (ios->num_iotasks < ios->num_comptasks)){
+        MPI_Bcast(buf, ibufcnt, ibuftype, ios->ioroot, ios->my_comm);
+    }
 
-  return ierr;
+    return ierr;
 }
-

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -18,17 +18,17 @@ static int counter=0;
  */
 int PIOc_iosystem_is_active(const int iosysid, bool *active)
 {
-  iosystem_desc_t *ios;
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
+    iosystem_desc_t *ios;
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
 
-  if(ios->comp_comm == MPI_COMM_NULL && ios->io_comm == MPI_COMM_NULL){
-    *active = false;
-  }else{
-    *active = true;
-  }
-  return PIO_NOERR;
+    if(ios->comp_comm == MPI_COMM_NULL && ios->io_comm == MPI_COMM_NULL){
+        *active = false;
+    }else{
+        *active = true;
+    }
+    return PIO_NOERR;
 }
 /**
  ** @brief Check to see if PIO file is open.
@@ -40,9 +40,9 @@ int PIOc_File_is_Open(int ncid)
 
     /* If get file returns non-zero, then this file is not open. */
     if (pio_get_file(ncid, &file))
-	return 0;
+        return 0;
     else
-	return 1;
+        return 1;
 }
 
 /**
@@ -51,17 +51,17 @@ int PIOc_File_is_Open(int ncid)
  */
 int PIOc_Set_File_Error_Handling(int ncid, int method)
 {
-  file_desc_t *file;
-  int oldmethod;
-  int ret;
+    file_desc_t *file;
+    int oldmethod;
+    int ret;
 
-  /* Find info for this file. */
-  if ((ret = pio_get_file(ncid, &file)))
-      return ret;
-  
-  oldmethod = file->iosystem->error_handler;
-  file->iosystem->error_handler = method;
-  return oldmethod;
+    /* Find info for this file. */
+    if ((ret = pio_get_file(ncid, &file)))
+        return ret;
+
+    oldmethod = file->iosystem->error_handler;
+    file->iosystem->error_handler = method;
+    return oldmethod;
 }
 
 /**
@@ -69,16 +69,16 @@ int PIOc_Set_File_Error_Handling(int ncid, int method)
  */
 int PIOc_advanceframe(int ncid, int varid)
 {
-  file_desc_t *file;
-  int ret;
+    file_desc_t *file;
+    int ret;
 
-  /* Get the file info. */
-  if ((ret = pio_get_file(ncid, &file)))
-      return ret;
-      
-  file->varlist[varid].record++;
+    /* Get the file info. */
+    if ((ret = pio_get_file(ncid, &file)))
+        return ret;
 
-  return(PIO_NOERR);
+    file->varlist[varid].record++;
+
+    return(PIO_NOERR);
 }
 
 /**
@@ -94,20 +94,20 @@ int PIOc_advanceframe(int ncid, int varid)
  */
 int PIOc_setframe(const int ncid, const int varid, const int frame)
 {
-  file_desc_t *file;
-  int ret;
+    file_desc_t *file;
+    int ret;
 
-  /* Check inputs. */
-  if (varid < 0 || varid >= PIO_MAX_VARS)
-    return PIO_EINVAL;
-  
-  /* Get file info. */
-  if ((ret = pio_get_file(ncid, &file)))
-      return ret;
+    /* Check inputs. */
+    if (varid < 0 || varid >= PIO_MAX_VARS)
+        return PIO_EINVAL;
 
-  file->varlist[varid].record = frame;
+    /* Get file info. */
+    if ((ret = pio_get_file(ncid, &file)))
+        return ret;
 
-  return PIO_NOERR;
+    file->varlist[varid].record = frame;
+
+    return PIO_NOERR;
 }
 
 /**
@@ -115,14 +115,14 @@ int PIOc_setframe(const int ncid, const int varid, const int frame)
  */
 int PIOc_get_numiotasks(int iosysid, int *numiotasks)
 {
-  iosystem_desc_t *ios;
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
+    iosystem_desc_t *ios;
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
 
-  *numiotasks = ios->num_iotasks;
+    *numiotasks = ios->num_iotasks;
 
-  return PIO_NOERR;
+    return PIO_NOERR;
 
 }
 
@@ -132,14 +132,14 @@ int PIOc_get_numiotasks(int iosysid, int *numiotasks)
  */
 int PIOc_get_iorank(int iosysid, int *iorank)
 {
-  iosystem_desc_t *ios;
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
+    iosystem_desc_t *ios;
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
 
-  *iorank = ios->io_rank;
+    *iorank = ios->io_rank;
 
-  return PIO_NOERR;
+    return PIO_NOERR;
 
 }
 
@@ -149,9 +149,9 @@ int PIOc_get_iorank(int iosysid, int *iorank)
 
 int PIOc_get_local_array_size(int ioid)
 {
-  io_desc_t *iodesc;
-  iodesc = pio_get_iodesc_from_id(ioid);
-  return(iodesc->ndof);
+    io_desc_t *iodesc;
+    iodesc = pio_get_iodesc_from_id(ioid);
+    return(iodesc->ndof);
 }
 
 /**
@@ -160,24 +160,24 @@ int PIOc_get_local_array_size(int ioid)
  */
 int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
 {
-  iosystem_desc_t *ios;
-  int oldmethod;
+    iosystem_desc_t *ios;
+    int oldmethod;
 
-  /* Find info about this iosystem. */
-  if (!(ios = pio_get_iosystem_from_id(iosysid)))
-  {
-      fprintf(stderr,"%s %d Error setting eh method\n",__FILE__,__LINE__);
-      print_trace(stderr);
-      return PIO_EBADID;
-  }
+    /* Find info about this iosystem. */
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
+    {
+        fprintf(stderr,"%s %d Error setting eh method\n",__FILE__,__LINE__);
+        print_trace(stderr);
+        return PIO_EBADID;
+    }
 
-  /* Remember old method setting. */
-  oldmethod = ios->error_handler;
+    /* Remember old method setting. */
+    oldmethod = ios->error_handler;
 
-  /* Set new error handler. */
-  ios->error_handler = method;
-  
-  return oldmethod;
+    /* Set new error handler. */
+    ios->error_handler = method;
+
+    return oldmethod;
 }
 
 /**
@@ -195,98 +195,98 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
  ** @param iocount An optional array of count values for block cyclic decompositions  (optional input)
  */
 int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const int dims[],
-		    const int maplen, const PIO_Offset *compmap, int *ioidp,const int *rearranger,
-		    const PIO_Offset *iostart,const PIO_Offset *iocount)
+                    const int maplen, const PIO_Offset *compmap, int *ioidp,const int *rearranger,
+                    const PIO_Offset *iostart,const PIO_Offset *iocount)
 {
-  iosystem_desc_t *ios;
-  io_desc_t *iodesc;
-  int mpierr;
-  int ierr;
-  int iosize;
-  int ndisp;
+    iosystem_desc_t *ios;
+    io_desc_t *iodesc;
+    int mpierr;
+    int ierr;
+    int iosize;
+    int ndisp;
 
-  for(int i=0;i<ndims;i++){
-    if(dims[i]<=0){
-      piodie("Invalid dims argument",__FILE__,__LINE__);
+    for(int i=0;i<ndims;i++){
+        if(dims[i]<=0){
+            piodie("Invalid dims argument",__FILE__,__LINE__);
+        }
     }
-  }
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
 
 
-  if(PIO_Save_Decomps){
-    char filename[30];
-    if(ios->num_comptasks < 100) {
-      sprintf(filename, "piodecomp%2.2dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
-    }else if(ios->num_comptasks < 10000) {
-      sprintf(filename, "piodecomp%4.4dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
+    if(PIO_Save_Decomps){
+        char filename[30];
+        if(ios->num_comptasks < 100) {
+            sprintf(filename, "piodecomp%2.2dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
+        }else if(ios->num_comptasks < 10000) {
+            sprintf(filename, "piodecomp%4.4dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
+        }else{
+            sprintf(filename, "piodecomp%6.6dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
+        }
+        PIOc_writemap(filename,ndims,dims,maplen, (PIO_Offset *)compmap,ios->comp_comm);
+        counter++;
+    }
+
+
+    iodesc = malloc_iodesc(basetype, ndims);
+    if(rearranger == NULL)
+        iodesc->rearranger = ios->default_rearranger;
+    else
+        iodesc->rearranger = *rearranger;
+
+    if(iodesc->rearranger==PIO_REARR_SUBSET){
+        if((iostart != NULL) && (iocount != NULL)){
+            fprintf(stderr,"%s %s\n","Iostart and iocount arguments to PIOc_InitDecomp",
+                    "are incompatable with subset rearrange method and will be ignored");
+        }
+        iodesc->num_aiotasks = ios->num_iotasks;
+        ierr = subset_rearrange_create( *ios, maplen, compmap, dims, ndims, iodesc);
     }else{
-      sprintf(filename, "piodecomp%6.6dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
+        if(ios->ioproc){
+            //  Unless the user specifies the start and count for each IO task compute it.
+            if((iostart != NULL) && (iocount != NULL)){
+                //        printf("iocount[0] = %ld %ld\n",iocount[0], iocount);
+                iodesc->maxiobuflen=1;
+                for(int i=0;i<ndims;i++){
+                    iodesc->firstregion->start[i] = iostart[i];
+                    iodesc->firstregion->count[i] = iocount[i];
+                    compute_maxIObuffersize(ios->io_comm, iodesc);
+
+                }
+                iodesc->num_aiotasks = ios->num_iotasks;
+            }else{
+                iodesc->num_aiotasks = CalcStartandCount(basetype, ndims, dims,
+                                                         ios->num_iotasks, ios->io_rank,
+                                                         iodesc->firstregion->start, iodesc->firstregion->count);
+            }
+            compute_maxIObuffersize(ios->io_comm, iodesc);
+
+        }
+        // Depending on array size and io-blocksize the actual number of io tasks used may vary
+        CheckMPIReturn(MPI_Bcast(&(iodesc->num_aiotasks), 1, MPI_INT, ios->ioroot,
+                                 ios->my_comm),__FILE__,__LINE__);
+        // Compute the communications pattern for this decomposition
+        if(iodesc->rearranger==PIO_REARR_BOX){
+            ierr = box_rearrange_create( *ios, maplen, compmap, dims, ndims, iodesc);
+        }
+        /*
+          if(ios->ioproc){
+          io_region *ioregion = iodesc->firstregion;
+          while(ioregion != NULL){
+          for(int i=0;i<ndims;i++)
+          printf("%s %d i %d dim %d start %ld count %ld\n",__FILE__,__LINE__,i,dims[i],ioregion->start[i],ioregion->count[i]);
+          ioregion = ioregion->next;
+          }
+          }
+        */
     }
-    PIOc_writemap(filename,ndims,dims,maplen, (PIO_Offset *)compmap,ios->comp_comm);
-    counter++;
-  }
 
+    *ioidp = pio_add_to_iodesc_list(iodesc);
 
-  iodesc = malloc_iodesc(basetype, ndims);
-  if(rearranger == NULL)
-    iodesc->rearranger = ios->default_rearranger;
-  else
-    iodesc->rearranger = *rearranger;
+    performance_tune_rearranger(*ios, iodesc);
 
-  if(iodesc->rearranger==PIO_REARR_SUBSET){
-    if((iostart != NULL) && (iocount != NULL)){
-      fprintf(stderr,"%s %s\n","Iostart and iocount arguments to PIOc_InitDecomp",
-	      "are incompatable with subset rearrange method and will be ignored");
-    }
-    iodesc->num_aiotasks = ios->num_iotasks;
-    ierr = subset_rearrange_create( *ios, maplen, compmap, dims, ndims, iodesc);
-  }else{
-      if(ios->ioproc){
-      //  Unless the user specifies the start and count for each IO task compute it.
-	if((iostart != NULL) && (iocount != NULL)){
-	  //	  printf("iocount[0] = %ld %ld\n",iocount[0], iocount);
-	  iodesc->maxiobuflen=1;
-	  for(int i=0;i<ndims;i++){
-	    iodesc->firstregion->start[i] = iostart[i];
-	    iodesc->firstregion->count[i] = iocount[i];
-	    compute_maxIObuffersize(ios->io_comm, iodesc);
-
-	  }
-	  iodesc->num_aiotasks = ios->num_iotasks;
-	}else{
-	  iodesc->num_aiotasks = CalcStartandCount(basetype, ndims, dims,
-						   ios->num_iotasks, ios->io_rank,
-						   iodesc->firstregion->start, iodesc->firstregion->count);
-      }
-      compute_maxIObuffersize(ios->io_comm, iodesc);
-
-    }
-    // Depending on array size and io-blocksize the actual number of io tasks used may vary
-    CheckMPIReturn(MPI_Bcast(&(iodesc->num_aiotasks), 1, MPI_INT, ios->ioroot,
-			     ios->my_comm),__FILE__,__LINE__);
-    // Compute the communications pattern for this decomposition
-    if(iodesc->rearranger==PIO_REARR_BOX){
-      ierr = box_rearrange_create( *ios, maplen, compmap, dims, ndims, iodesc);
-    }
-    /*
-    if(ios->ioproc){
-      io_region *ioregion = iodesc->firstregion;
-      while(ioregion != NULL){
-	for(int i=0;i<ndims;i++)
-	  printf("%s %d i %d dim %d start %ld count %ld\n",__FILE__,__LINE__,i,dims[i],ioregion->start[i],ioregion->count[i]);
-	ioregion = ioregion->next;
-      }
-    }
-    */
-  }
-
-  *ioidp = pio_add_to_iodesc_list(iodesc);
-
-  performance_tune_rearranger(*ios, iodesc);
-
-  return PIO_NOERR;
+    return PIO_NOERR;
 }
 
 /**
@@ -296,60 +296,60 @@ int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const
  ** in this case we compute the compdof and use the subset rearranger
  */
 int PIOc_InitDecomp_bc(const int iosysid, const int basetype,const int ndims, const int dims[],
-		       const long int start[], const long int count[], int *ioidp)
+                       const long int start[], const long int count[], int *ioidp)
 
 {
-  iosystem_desc_t *ios;
-  io_desc_t *iodesc;
-  int mpierr;
-  int ierr;
-  int iosize;
-  int ndisp;
+    iosystem_desc_t *ios;
+    io_desc_t *iodesc;
+    int mpierr;
+    int ierr;
+    int iosize;
+    int ndisp;
 
 
-  for(int i=0;i<ndims;i++){
-    if(dims[i]<=0){
-      piodie("Invalid dims argument",__FILE__,__LINE__);
+    for(int i=0;i<ndims;i++){
+        if(dims[i]<=0){
+            piodie("Invalid dims argument",__FILE__,__LINE__);
+        }
+        if(start[i]<0 || count[i]< 0 || (start[i]+count[i])>dims[i]){
+            piodie("Invalid start or count argument ",__FILE__,__LINE__);
+        }
     }
-    if(start[i]<0 || count[i]< 0 || (start[i]+count[i])>dims[i]){
-      piodie("Invalid start or count argument ",__FILE__,__LINE__);
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
+
+    int n, i, maplen=1;
+
+    for( i=0;i<ndims;i++){
+        maplen*=count[i];
     }
-  }
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
+    PIO_Offset compmap[maplen], prod[ndims], loc[ndims];
 
-  int n, i, maplen=1;
-
-  for( i=0;i<ndims;i++){
-    maplen*=count[i];
-  }
-  PIO_Offset compmap[maplen], prod[ndims], loc[ndims];
-
-  prod[ndims-1]=1;
-  loc[ndims-1]=0;
-  for(n=ndims-2;n>=0;n--){
-    prod[n]=prod[n+1]*dims[n+1];
-    loc[n]=0;
-  }
-  for(i=0;i<maplen;i++){
-    compmap[i]=0;
-    for(n=ndims-1;n>=0;n--){
-      compmap[i]+=(start[n]+loc[n])*prod[n];
+    prod[ndims-1]=1;
+    loc[ndims-1]=0;
+    for(n=ndims-2;n>=0;n--){
+        prod[n]=prod[n+1]*dims[n+1];
+        loc[n]=0;
     }
-    n=ndims-1;
-    loc[n]=(loc[n]+1)%count[n];
-    while(loc[n]==0 && n>0){
-      n--;
-      loc[n]=(loc[n]+1)%count[n];
+    for(i=0;i<maplen;i++){
+        compmap[i]=0;
+        for(n=ndims-1;n>=0;n--){
+            compmap[i]+=(start[n]+loc[n])*prod[n];
+        }
+        n=ndims-1;
+        loc[n]=(loc[n]+1)%count[n];
+        while(loc[n]==0 && n>0){
+            n--;
+            loc[n]=(loc[n]+1)%count[n];
+        }
     }
-  }
-  int rearr = PIO_REARR_SUBSET;
-  PIOc_InitDecomp( iosysid, basetype,ndims, dims,
-		   maplen,  compmap, ioidp, &rearr, NULL, NULL);
+    int rearr = PIO_REARR_SUBSET;
+    PIOc_InitDecomp( iosysid, basetype,ndims, dims,
+                     maplen,  compmap, ioidp, &rearr, NULL, NULL);
 
 
-  return PIO_NOERR;
+    return PIO_NOERR;
 }
 
 /* @ingroup PIO_init
@@ -379,124 +379,124 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype,const int ndims, co
  * @return 0 on success, otherwise a PIO error code.
  */
 int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
-			const int stride, const int base, const int rearr,
-			int *iosysidp)
+                        const int stride, const int base, const int rearr,
+                        int *iosysidp)
 {
-  iosystem_desc_t *iosys;
-  int ierr = PIO_NOERR;
-  int ustride;
-  int lbase;
-  int mpierr;
+    iosystem_desc_t *iosys;
+    int ierr = PIO_NOERR;
+    int ustride;
+    int lbase;
+    int mpierr;
 
-  LOG((1, "PIOc_Init_Intracomm comp_comm = %d num_iotasks = %d stride = %d base = %d "
-       "rearr = %d", comp_comm, num_iotasks, stride, base, rearr));
-  
-  iosys = (iosystem_desc_t *) malloc(sizeof(iosystem_desc_t));
+    LOG((1, "PIOc_Init_Intracomm comp_comm = %d num_iotasks = %d stride = %d base = %d "
+         "rearr = %d", comp_comm, num_iotasks, stride, base, rearr));
 
-  /* Copy the computation communicator into union_comm. */
-  mpierr = MPI_Comm_dup(comp_comm, &iosys->union_comm);
-  CheckMPIReturn(mpierr, __FILE__, __LINE__);
-  if (mpierr)
-      ierr = PIO_EIO;
+    iosys = (iosystem_desc_t *) malloc(sizeof(iosystem_desc_t));
 
-  /* Copy the computation communicator into comp_comm. */
-  if (!ierr)
-  {
-      mpierr = MPI_Comm_dup(comp_comm, &iosys->comp_comm);
-      CheckMPIReturn(mpierr, __FILE__, __LINE__);
-      if (mpierr)
-	  ierr = PIO_EIO;
-  }
-  LOG((2, "union_comm = %d comp_comm = %d", iosys->union_comm, iosys->comp_comm));
+    /* Copy the computation communicator into union_comm. */
+    mpierr = MPI_Comm_dup(comp_comm, &iosys->union_comm);
+    CheckMPIReturn(mpierr, __FILE__, __LINE__);
+    if (mpierr)
+        ierr = PIO_EIO;
 
-  if (!ierr)
-  {
-      iosys->my_comm = iosys->comp_comm;
-      iosys->io_comm = MPI_COMM_NULL;
-      iosys->intercomm = MPI_COMM_NULL;
-      iosys->error_handler = PIO_INTERNAL_ERROR;
-      iosys->async_interface= false;
-      iosys->compmaster = 0;
-      iosys->iomaster = 0;
-      iosys->ioproc = false;
-      iosys->default_rearranger = rearr;
-      iosys->num_iotasks = num_iotasks;
+    /* Copy the computation communicator into comp_comm. */
+    if (!ierr)
+    {
+        mpierr = MPI_Comm_dup(comp_comm, &iosys->comp_comm);
+        CheckMPIReturn(mpierr, __FILE__, __LINE__);
+        if (mpierr)
+            ierr = PIO_EIO;
+    }
+    LOG((2, "union_comm = %d comp_comm = %d", iosys->union_comm, iosys->comp_comm));
 
-      ustride = stride;
+    if (!ierr)
+    {
+        iosys->my_comm = iosys->comp_comm;
+        iosys->io_comm = MPI_COMM_NULL;
+        iosys->intercomm = MPI_COMM_NULL;
+        iosys->error_handler = PIO_INTERNAL_ERROR;
+        iosys->async_interface= false;
+        iosys->compmaster = 0;
+        iosys->iomaster = 0;
+        iosys->ioproc = false;
+        iosys->default_rearranger = rearr;
+        iosys->num_iotasks = num_iotasks;
 
-      /* Find MPI rank and number of tasks in comp_comm communicator. */
-      CheckMPIReturn(MPI_Comm_rank(iosys->comp_comm, &(iosys->comp_rank)),__FILE__,__LINE__);
-      CheckMPIReturn(MPI_Comm_size(iosys->comp_comm, &(iosys->num_comptasks)),__FILE__,__LINE__);
-      if(iosys->comp_rank==0)
-	  iosys->compmaster = MPI_ROOT;
-      LOG((2, "comp_rank = %d num_comptasks = %d", iosys->comp_rank, iosys->num_comptasks));
+        ustride = stride;
 
-      /* Ensure that settings for number of computation tasks, number
-       * of IO tasks, and the stride are reasonable. */
-      if((iosys->num_comptasks == 1) && (num_iotasks*ustride > 1)) {
-	  // This is a serial run with a bad configuration. Set up a single task.
-	  fprintf(stderr, "PIO_TP PIOc_Init_Intracomm reset stride and tasks.\n");
-	  iosys->num_iotasks = 1;
-	  ustride = 1;
-      }
-      if((iosys->num_iotasks < 1) || ((iosys->num_iotasks*ustride) > iosys->num_comptasks)){
-	  fprintf(stderr, "PIO_TP PIOc_Init_Intracomm error\n");
-	  fprintf(stderr, "num_iotasks=%d, ustride=%d, num_comptasks=%d\n", num_iotasks, ustride, iosys->num_comptasks);
-	  return PIO_EBADID;
-      }
+        /* Find MPI rank and number of tasks in comp_comm communicator. */
+        CheckMPIReturn(MPI_Comm_rank(iosys->comp_comm, &(iosys->comp_rank)),__FILE__,__LINE__);
+        CheckMPIReturn(MPI_Comm_size(iosys->comp_comm, &(iosys->num_comptasks)),__FILE__,__LINE__);
+        if(iosys->comp_rank==0)
+            iosys->compmaster = MPI_ROOT;
+        LOG((2, "comp_rank = %d num_comptasks = %d", iosys->comp_rank, iosys->num_comptasks));
 
-      /* Create an array that holds the ranks of the tasks to be used for IO. */
-      iosys->ioranks = (int *) calloc(sizeof(int), iosys->num_iotasks);
-      for(int i=0;i< iosys->num_iotasks; i++){
-	  iosys->ioranks[i] = (base + i*ustride) % iosys->num_comptasks;
-	  if(iosys->ioranks[i] == iosys->comp_rank)
-	      iosys->ioproc = true;
-      }
-      iosys->ioroot = iosys->ioranks[0];
+        /* Ensure that settings for number of computation tasks, number
+         * of IO tasks, and the stride are reasonable. */
+        if((iosys->num_comptasks == 1) && (num_iotasks*ustride > 1)) {
+            // This is a serial run with a bad configuration. Set up a single task.
+            fprintf(stderr, "PIO_TP PIOc_Init_Intracomm reset stride and tasks.\n");
+            iosys->num_iotasks = 1;
+            ustride = 1;
+        }
+        if((iosys->num_iotasks < 1) || ((iosys->num_iotasks*ustride) > iosys->num_comptasks)){
+            fprintf(stderr, "PIO_TP PIOc_Init_Intracomm error\n");
+            fprintf(stderr, "num_iotasks=%d, ustride=%d, num_comptasks=%d\n", num_iotasks, ustride, iosys->num_comptasks);
+            return PIO_EBADID;
+        }
 
-      for(int i = 0; i < iosys->num_iotasks; i++)
-	  LOG((3, "iosys->ioranks[%d] = %d", i, iosys->ioranks[i]));
+        /* Create an array that holds the ranks of the tasks to be used for IO. */
+        iosys->ioranks = (int *) calloc(sizeof(int), iosys->num_iotasks);
+        for(int i=0;i< iosys->num_iotasks; i++){
+            iosys->ioranks[i] = (base + i*ustride) % iosys->num_comptasks;
+            if(iosys->ioranks[i] == iosys->comp_rank)
+                iosys->ioproc = true;
+        }
+        iosys->ioroot = iosys->ioranks[0];
 
-      /* Create an MPI info object. */
-      CheckMPIReturn(MPI_Info_create(&(iosys->info)),__FILE__,__LINE__);
-      iosys->info = MPI_INFO_NULL;
+        for(int i = 0; i < iosys->num_iotasks; i++)
+            LOG((3, "iosys->ioranks[%d] = %d", i, iosys->ioranks[i]));
 
-      if(iosys->comp_rank == iosys->ioranks[0])
-	  iosys->iomaster = MPI_ROOT;
+        /* Create an MPI info object. */
+        CheckMPIReturn(MPI_Info_create(&(iosys->info)),__FILE__,__LINE__);
+        iosys->info = MPI_INFO_NULL;
 
-      /* Create a group for the computation tasks. */
-      CheckMPIReturn(MPI_Comm_group(iosys->comp_comm, &(iosys->compgroup)),__FILE__,__LINE__);
+        if(iosys->comp_rank == iosys->ioranks[0])
+            iosys->iomaster = MPI_ROOT;
 
-      /* Create a group for the IO tasks. */
-      CheckMPIReturn(MPI_Group_incl(iosys->compgroup, iosys->num_iotasks, iosys->ioranks,
-				    &(iosys->iogroup)),__FILE__,__LINE__);
+        /* Create a group for the computation tasks. */
+        CheckMPIReturn(MPI_Comm_group(iosys->comp_comm, &(iosys->compgroup)),__FILE__,__LINE__);
 
-      /* Create an MPI communicator for the IO tasks. */
-      CheckMPIReturn(MPI_Comm_create(iosys->comp_comm, iosys->iogroup, &(iosys->io_comm))
-		     ,__FILE__,__LINE__);
+        /* Create a group for the IO tasks. */
+        CheckMPIReturn(MPI_Group_incl(iosys->compgroup, iosys->num_iotasks, iosys->ioranks,
+                                      &(iosys->iogroup)),__FILE__,__LINE__);
 
-      /* For the tasks that are doing IO, get their rank. */
-      if (iosys->ioproc)
-	  CheckMPIReturn(MPI_Comm_rank(iosys->io_comm, &(iosys->io_rank)),__FILE__,__LINE__);
-      else
-	  iosys->io_rank = -1;
-      LOG((3, "iosys->io_comm = %d iosys->io_rank = %d", iosys->io_comm, iosys->io_rank));
+        /* Create an MPI communicator for the IO tasks. */
+        CheckMPIReturn(MPI_Comm_create(iosys->comp_comm, iosys->iogroup, &(iosys->io_comm))
+                       ,__FILE__,__LINE__);
 
-      iosys->union_rank = iosys->comp_rank;
+        /* For the tasks that are doing IO, get their rank. */
+        if (iosys->ioproc)
+            CheckMPIReturn(MPI_Comm_rank(iosys->io_comm, &(iosys->io_rank)),__FILE__,__LINE__);
+        else
+            iosys->io_rank = -1;
+        LOG((3, "iosys->io_comm = %d iosys->io_rank = %d", iosys->io_comm, iosys->io_rank));
 
-      /* Add this iosys struct to the list in the PIO library. */
-      *iosysidp = pio_add_to_iosystem_list(iosys);
+        iosys->union_rank = iosys->comp_rank;
 
-      /* Get some info from the environment. */
-      pio_get_env();
+        /* Add this iosys struct to the list in the PIO library. */
+        *iosysidp = pio_add_to_iosystem_list(iosys);
 
-      /* Allocate buffer space for compute nodes. */
-      compute_buffer_init(*iosys);
-      
-      LOG((2, "Init_Intracomm complete iosysid = %d", *iosysidp));
-  }
+        /* Get some info from the environment. */
+        pio_get_env();
 
-  return ierr;
+        /* Allocate buffer space for compute nodes. */
+        compute_buffer_init(*iosys);
+
+        LOG((2, "Init_Intracomm complete iosysid = %d", *iosysidp));
+    }
+
+    return ierr;
 }
 
 /**
@@ -505,9 +505,9 @@ int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
  ** @endinternal
  */
 int PIOc_Init_Intracomm_from_F90(int f90_comp_comm,
-			const int num_iotasks, const int stride,
-				 const int base, const int rearr, int *iosysidp){
-  return PIOc_Init_Intracomm(MPI_Comm_f2c(f90_comp_comm), num_iotasks, stride,base,rearr, iosysidp);
+                                 const int num_iotasks, const int stride,
+                                 const int base, const int rearr, int *iosysidp){
+    return PIOc_Init_Intracomm(MPI_Comm_f2c(f90_comp_comm), num_iotasks, stride,base,rearr, iosysidp);
 }
 
 /**
@@ -516,15 +516,15 @@ int PIOc_Init_Intracomm_from_F90(int f90_comp_comm,
  */
 int PIOc_set_hint(const int iosysid, char hint[], const char hintval[])
 {
-  iosystem_desc_t *ios;
+    iosystem_desc_t *ios;
 
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
-  if(ios->ioproc)
-    CheckMPIReturn( MPI_Info_set(ios->info, hint, hintval), __FILE__,__LINE__);
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
+    if(ios->ioproc)
+        CheckMPIReturn( MPI_Info_set(ios->info, hint, hintval), __FILE__,__LINE__);
 
-  return PIO_NOERR;
+    return PIO_NOERR;
 
 }
 
@@ -543,13 +543,13 @@ int PIOc_finalize(const int iosysid)
     int ierr = PIO_NOERR;
 
     LOG((1, "PIOc_finalize iosysid = %d MPI_COMM_NULL = %d", iosysid,
-	 MPI_COMM_NULL));
+         MPI_COMM_NULL));
 
     /* Find the IO system information. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return PIO_EBADID;
+        return PIO_EBADID;
     LOG((3, "found iosystem info comproot = %d union_comm = %d comp_idx = %d",
-	 ios->comproot, ios->union_comm, ios->comp_idx));
+         ios->comproot, ios->union_comm, ios->comp_idx));
 
     /* If asynch IO is in use, send the PIO_MSG_EXIT message from the
      * comp master to the IO processes. This may be called by
@@ -557,60 +557,60 @@ int PIOc_finalize(const int iosysid)
      * there is a valid union_comm. */
     if (ios->async_interface && ios->union_comm != MPI_COMM_NULL)
     {
-	int msg = PIO_MSG_EXIT;
-	LOG((3, "async"));
-	
-	if (!ios->ioproc)
-	{
-	    LOG((2, "sending msg = %d ioroot = %d union_comm = %d", msg,
-		 ios->ioroot, ios->union_comm));
-	    
-	    /* Send the message to the message handler. */
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-	    
-	    LOG((2, "sending iosysid = %d", iosysid));
-	    
-	    /* Send the parameters of the function call. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast((int *)&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
-	    
-	/* Handle MPI errors. */
-	LOG((3, "handling async errors mpierr = %d my_comm = %d", mpierr, ios->my_comm));
-	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    return check_mpi(NULL, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(NULL, mpierr, __FILE__, __LINE__);
-	LOG((3, "async errors bcast"));
+        int msg = PIO_MSG_EXIT;
+        LOG((3, "async"));
+
+        if (!ios->ioproc)
+        {
+            LOG((2, "sending msg = %d ioroot = %d union_comm = %d", msg,
+                 ios->ioroot, ios->union_comm));
+
+            /* Send the message to the message handler. */
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+
+            LOG((2, "sending iosysid = %d", iosysid));
+
+            /* Send the parameters of the function call. */
+            if (!mpierr)
+                mpierr = MPI_Bcast((int *)&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        }
+
+        /* Handle MPI errors. */
+        LOG((3, "handling async errors mpierr = %d my_comm = %d", mpierr, ios->my_comm));
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(NULL, mpierr2, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+        LOG((3, "async errors bcast"));
     }
 
     /* Free this memory that was allocated in init_intracomm. */
     if (ios->ioranks)
-    	free(ios->ioranks);
+        free(ios->ioranks);
     LOG((3, "Freed ioranks."));
 
     /* Free the buffer pool. */
     int niosysid;
     if ((ierr = pio_num_iosystem(&niosysid)))
-	return ierr;
+        return ierr;
     LOG((2, "%d iosystems are still open.", niosysid));
 
     /* Only free the buffer pool if this is the last open iosysid. */
     if (niosysid == 1)
     {
-	free_cn_buffer_pool(*ios);
-	LOG((2, "Freed buffer pool."));
+        free_cn_buffer_pool(*ios);
+        LOG((2, "Freed buffer pool."));
     }
 
     /* Free the MPI groups. */
     if (ios->compgroup != MPI_GROUP_NULL)
-    	MPI_Group_free(&ios->compgroup);
+        MPI_Group_free(&ios->compgroup);
 
     if (ios->iogroup != MPI_GROUP_NULL)
     {
-    	MPI_Group_free(&(ios->iogroup));
-    	LOG((2, "Freed MPI groups."));
+        MPI_Group_free(&(ios->iogroup));
+        LOG((2, "Freed MPI groups."));
     }
 
     /* Free the MPI communicators. my_comm is just a copy (but not an
@@ -619,26 +619,26 @@ int PIOc_finalize(const int iosysid)
      * handed into init_intercomm. So they need to be freed by MPI. */
     if (ios->intercomm != MPI_COMM_NULL)
     {
-    	LOG((3, "freeing intercomm %d", ios->intercomm));
-    	MPI_Comm_free(&ios->intercomm);
+        LOG((3, "freeing intercomm %d", ios->intercomm));
+        MPI_Comm_free(&ios->intercomm);
     }
     if (ios->union_comm != MPI_COMM_NULL)
     {
-    	LOG((3, "freeing union_comm %d", ios->union_comm));
-    	MPI_Comm_free(&ios->union_comm);
+        LOG((3, "freeing union_comm %d", ios->union_comm));
+        MPI_Comm_free(&ios->union_comm);
     }
     if (ios->io_comm != MPI_COMM_NULL)
     {
-    	LOG((3, "freeing io_comm %d", ios->io_comm));
-    	MPI_Comm_free(&ios->io_comm);
+        LOG((3, "freeing io_comm %d", ios->io_comm));
+        MPI_Comm_free(&ios->io_comm);
     }
     if (ios->comp_comm != MPI_COMM_NULL)
     {
-    	LOG((3, "freeing comp_comm %d", ios->comp_comm));
-    	MPI_Comm_free(&ios->comp_comm);
+        LOG((3, "freeing comp_comm %d", ios->comp_comm));
+        MPI_Comm_free(&ios->comp_comm);
     }
     if (ios->my_comm != MPI_COMM_NULL)
-    	ios->my_comm = MPI_COMM_NULL;
+        ios->my_comm = MPI_COMM_NULL;
 
     /* Delete the iosystem_desc_t data associated with this id. */
     LOG((2, "About to delete iosysid %d.", iosysid));
@@ -654,13 +654,13 @@ int PIOc_finalize(const int iosysid)
  */
 int PIOc_iam_iotask(const int iosysid, bool *ioproc)
 {
-  iosystem_desc_t *ios;
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
+    iosystem_desc_t *ios;
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
 
-  *ioproc = ios->ioproc;
-  return PIO_NOERR;
+    *ioproc = ios->ioproc;
+    return PIO_NOERR;
 }
 
 /**
@@ -669,14 +669,14 @@ int PIOc_iam_iotask(const int iosysid, bool *ioproc)
  */
 int PIOc_iotask_rank(const int iosysid, int *iorank)
 {
-  iosystem_desc_t *ios;
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
+    iosystem_desc_t *ios;
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
 
-  *iorank = ios->io_rank;
+    *iorank = ios->io_rank;
 
-  return PIO_NOERR;
+    return PIO_NOERR;
 
 }
 
@@ -687,23 +687,23 @@ int PIOc_iotask_rank(const int iosysid, int *iorank)
 int PIOc_iotype_available(const int iotype)
 {
 
-  switch(iotype){
+    switch(iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
     case PIO_IOTYPE_NETCDF4C:
-      return(1);
+        return(1);
 #endif
     case PIO_IOTYPE_NETCDF:
-      return(1);
+        return(1);
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-      return(1);
-      break;
+        return(1);
+        break;
 #endif
     default:
-      return(0);
+        return(0);
     }
 
 }

--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -4,28 +4,28 @@
  * @date  2014
  * @brief Compute start and count arrays for the box rearranger
  *
- * 
- * 
- * 
+ *
+ *
+ *
  * @see http://code.google.com/p/parallelio/
  */
 #ifdef TESTCALCDECOMP
 enum PIO_DATATYPE{
-  PIO_REAL,
-  PIO_INT,
-  PIO_DOUBLE
+    PIO_REAL,
+    PIO_INT,
+    PIO_DOUBLE
 };
 #define PIO_NOERR 0
 typedef long long PIO_Offset;
-#define max(a,b) \
-   ({ __typeof__ (a) _a = (a); \
-       __typeof__ (b) _b = (b); \
-     _a > _b ? _a : _b; })
+#define max(a,b)                                \
+    ({ __typeof__ (a) _a = (a);                 \
+        __typeof__ (b) _b = (b);                \
+        _a > _b ? _a : _b; })
 
-#define min(a,b) \
-   ({ __typeof__ (a) _a = (a); \
-       __typeof__ (b) _b = (b); \
-     _a < _b ? _a : _b; })
+#define min(a,b)                                \
+    ({ __typeof__ (a) _a = (a);                 \
+        __typeof__ (b) _b = (b);                \
+        _a < _b ? _a : _b; })
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -52,9 +52,9 @@ int blocksize = default_blocksize;
  */
 int PIOc_set_blocksize(const int newblocksize)
 {
-  if(newblocksize > 0)
-    blocksize = newblocksize;
-  return PIO_NOERR;
+    if(newblocksize > 0)
+        blocksize = newblocksize;
+    return PIO_NOERR;
 }
 
 
@@ -63,177 +63,177 @@ int PIOc_set_blocksize(const int newblocksize)
 
 int gcd (int a,int b )
 {
-  if ( a==0 ) return b;
-  return gcd ( b%a, a );
+    if ( a==0 ) return b;
+    return gcd ( b%a, a );
 }
 
 long long lgcd (long long a,long long b )
 {
-  if ( a==0 ) return b;
-  return lgcd ( b%a, a );
+    if ( a==0 ) return b;
+    return lgcd ( b%a, a );
 }
 
 
 int gcd_array(int nain, int *ain){
-  int i;
-  int bsize=1;
+    int i;
+    int bsize=1;
 
-  for(i=0;i<nain;i++){
-    if(ain[i]<=1) return bsize;
-  }
-
-  bsize= ain[0];
-  i=1;
-  while(i<nain && bsize > 1){
-      bsize = gcd(bsize,ain[i]);
-      i++;
+    for(i=0;i<nain;i++){
+        if(ain[i]<=1) return bsize;
     }
 
-  return bsize;
+    bsize= ain[0];
+    i=1;
+    while(i<nain && bsize > 1){
+        bsize = gcd(bsize,ain[i]);
+        i++;
+    }
+
+    return bsize;
 }
 
 long long lgcd_array(int nain, long long*ain){
-  int i;
-  long long bsize=1;
+    int i;
+    long long bsize=1;
 
-  for(i=0;i<nain;i++){
-    if(ain[i]<=1) return bsize;
-  }
-
-  bsize= ain[0];
-  i=1;
-  while(i<nain && bsize > 1){
-      bsize = gcd(bsize,ain[i]);
-      i++;
+    for(i=0;i<nain;i++){
+        if(ain[i]<=1) return bsize;
     }
 
-  return bsize;
+    bsize= ain[0];
+    i=1;
+    while(i<nain && bsize > 1){
+        bsize = gcd(bsize,ain[i]);
+        i++;
+    }
+
+    return bsize;
 }
 
 
 int calcdisplace(const int bsize, const int numblocks,const PIO_Offset map[], int displace[])
 {
-  for(int i=0;i<numblocks;i++){
-    displace[i] = (map[i*bsize]-1)/bsize;
-  }
-  return PIO_NOERR;
+    for(int i=0;i<numblocks;i++){
+        displace[i] = (map[i*bsize]-1)/bsize;
+    }
+    return PIO_NOERR;
 }
 
 
-void computestartandcount(const int gdim, const int ioprocs, const int rank, 
-			 PIO_Offset *start, PIO_Offset *kount)
+void computestartandcount(const int gdim, const int ioprocs, const int rank,
+                          PIO_Offset *start, PIO_Offset *kount)
 {
-  int irank;
-  int remainder;
-  int adds;
-  PIO_Offset lstart, lkount;
+    int irank;
+    int remainder;
+    int adds;
+    PIO_Offset lstart, lkount;
 
-  irank = rank % ioprocs;
-  lkount =(long int) (gdim/ioprocs);
-  lstart = (long int) (lkount*irank);
-  remainder = gdim - lkount*ioprocs;
+    irank = rank % ioprocs;
+    lkount =(long int) (gdim/ioprocs);
+    lstart = (long int) (lkount*irank);
+    remainder = gdim - lkount*ioprocs;
 
-  if(remainder>= ioprocs-irank){
-    lkount++;
-    if((adds = irank+remainder-ioprocs)>0)
-      lstart+= adds;
-  }
-  *start = lstart;
-  *kount = lkount;
-  
+    if(remainder>= ioprocs-irank){
+        lkount++;
+        if((adds = irank+remainder-ioprocs)>0)
+            lstart+= adds;
+    }
+    *start = lstart;
+    *kount = lkount;
+
 }
 
 PIO_Offset GCDblocksize(const int arrlen, const PIO_Offset arr_in[]){
-  //  PIO_Offset del_arr[arrlen-1];
-  // PIO_Offset loc_arr[arrlen-1]; 
-  PIO_Offset *gaps=NULL;
-  PIO_Offset *blk_len=NULL;
-  int i, j, k, n, numblks, numtimes, ii, numgaps;
-  PIO_Offset bsize, bsizeg, blklensum;
-  //  PIO_Offset *del_arr = (PIO_Offset *) calloc((arrlen-1),sizeof(PIO_Offset));
-  // PIO_Offset *loc_arr = (PIO_Offset *) calloc((arrlen-1),sizeof(PIO_Offset));  
-  PIO_Offset del_arr[arrlen-1];
-  PIO_Offset loc_arr[arrlen-1];
+    //  PIO_Offset del_arr[arrlen-1];
+    // PIO_Offset loc_arr[arrlen-1];
+    PIO_Offset *gaps=NULL;
+    PIO_Offset *blk_len=NULL;
+    int i, j, k, n, numblks, numtimes, ii, numgaps;
+    PIO_Offset bsize, bsizeg, blklensum;
+    //  PIO_Offset *del_arr = (PIO_Offset *) calloc((arrlen-1),sizeof(PIO_Offset));
+    // PIO_Offset *loc_arr = (PIO_Offset *) calloc((arrlen-1),sizeof(PIO_Offset));
+    PIO_Offset del_arr[arrlen-1];
+    PIO_Offset loc_arr[arrlen-1];
 
-  // printf("%s %d\n",__FILE__,__LINE__);
-
-  numblks=0;
-  numgaps=0;
-  numtimes=0;
-
-  for(i=0;i<arrlen-1;i++){
-    del_arr[i] = arr_in[i+1] - arr_in[i];
-    if(del_arr[i] != 1){
-      numtimes++;
-      if(i>0 && del_arr[i-1]>1){
-	return(1);
-      }
-      //      printf("%s %d %d %d %d\n",__FILE__,__LINE__,i,del_arr[i],arr_in[i]);
-      
-    }
-  }
-
-  
-
-  numblks = numtimes+1;
-  if(numtimes==0)
-    n = numblks;
-  else
-    n = numtimes;
-
-  //    printf("%s %d %d %d\n",__FILE__,__LINE__,numblks,numtimes);
-  bsize = (PIO_Offset) arrlen;
-  if(numblks>1){
-    PIO_Offset blk_len[numblks];
-    PIO_Offset gaps[numtimes];
-    //    blk_len =  (PIO_Offset*) calloc(numblks,sizeof(PIO_Offset));
-    //  loc_arr = (PIO_Offset*) malloc((arrlen-1)*sizeof(PIO_Offset));
-    //printf("%s %d %d\n",__FILE__,__LINE__,numtimes);
-    if(numtimes>0){
-      //      gaps = (PIO_Offset *) calloc(numtimes,sizeof(PIO_Offset));
-      ii=0;
-      // printf("%s %d %d\n",__FILE__,__LINE__,arrlen);
-      for(i=0;i<arrlen-1;i++){
-	if(del_arr[i]>1)
-	  gaps[ii++] = del_arr[i] - 1;
-      }
-      numgaps=ii;
-    }
     // printf("%s %d\n",__FILE__,__LINE__);
-    
-    j=0;
-    for(i=0;i<n;i++)
-      loc_arr[i]=1;
+
+    numblks=0;
+    numgaps=0;
+    numtimes=0;
+
     for(i=0;i<arrlen-1;i++){
-      if(del_arr[i] != 1)
-	loc_arr[ j++ ]  = i;
-    }
-    // printf("%s %d\n",__FILE__,__LINE__);
+        del_arr[i] = arr_in[i+1] - arr_in[i];
+        if(del_arr[i] != 1){
+            numtimes++;
+            if(i>0 && del_arr[i-1]>1){
+                return(1);
+            }
+            //      printf("%s %d %d %d %d\n",__FILE__,__LINE__,i,del_arr[i],arr_in[i]);
 
-    blk_len[0] = loc_arr[0];
-    blklensum=blk_len[0];
-    for(i=1;i<numblks-1;i++){
-      blk_len[i] = loc_arr[i] - loc_arr[i-1];
-      blklensum+= blk_len[i];
+        }
     }
-    blk_len[numblks-1] = arrlen - blklensum;
-    
-    bsize = lgcd_array(numblks, blk_len);
-    if(numgaps > 0) {
-      bsizeg = lgcd_array(numgaps, gaps);
-      bsize = lgcd(bsize,bsizeg);
-      //   free(gaps);
-    }
-    if(arr_in[0]>0) 
-      bsize = lgcd(bsize,arr_in[0]);
-    //   printf("%s %d\n",__FILE__,__LINE__);
 
-    //  free(loc_arr);
-    // free(del_arr);
-    // free(blk_len);
-  }
-  //  printf("%s %d\n",__FILE__,__LINE__);
-  return bsize;
+
+
+    numblks = numtimes+1;
+    if(numtimes==0)
+        n = numblks;
+    else
+        n = numtimes;
+
+    //    printf("%s %d %d %d\n",__FILE__,__LINE__,numblks,numtimes);
+    bsize = (PIO_Offset) arrlen;
+    if(numblks>1){
+        PIO_Offset blk_len[numblks];
+        PIO_Offset gaps[numtimes];
+        //    blk_len =  (PIO_Offset*) calloc(numblks,sizeof(PIO_Offset));
+        //  loc_arr = (PIO_Offset*) malloc((arrlen-1)*sizeof(PIO_Offset));
+        //printf("%s %d %d\n",__FILE__,__LINE__,numtimes);
+        if(numtimes>0){
+            //      gaps = (PIO_Offset *) calloc(numtimes,sizeof(PIO_Offset));
+            ii=0;
+            // printf("%s %d %d\n",__FILE__,__LINE__,arrlen);
+            for(i=0;i<arrlen-1;i++){
+                if(del_arr[i]>1)
+                    gaps[ii++] = del_arr[i] - 1;
+            }
+            numgaps=ii;
+        }
+        // printf("%s %d\n",__FILE__,__LINE__);
+
+        j=0;
+        for(i=0;i<n;i++)
+            loc_arr[i]=1;
+        for(i=0;i<arrlen-1;i++){
+            if(del_arr[i] != 1)
+                loc_arr[ j++ ]  = i;
+        }
+        // printf("%s %d\n",__FILE__,__LINE__);
+
+        blk_len[0] = loc_arr[0];
+        blklensum=blk_len[0];
+        for(i=1;i<numblks-1;i++){
+            blk_len[i] = loc_arr[i] - loc_arr[i-1];
+            blklensum+= blk_len[i];
+        }
+        blk_len[numblks-1] = arrlen - blklensum;
+
+        bsize = lgcd_array(numblks, blk_len);
+        if(numgaps > 0) {
+            bsizeg = lgcd_array(numgaps, gaps);
+            bsize = lgcd(bsize,bsizeg);
+            //   free(gaps);
+        }
+        if(arr_in[0]>0)
+            bsize = lgcd(bsize,arr_in[0]);
+        //   printf("%s %d\n",__FILE__,__LINE__);
+
+        //  free(loc_arr);
+        // free(del_arr);
+        // free(blk_len);
+    }
+    //  printf("%s %d\n",__FILE__,__LINE__);
+    return bsize;
 }
 
 
@@ -241,204 +241,203 @@ PIO_Offset GCDblocksize(const int arrlen, const PIO_Offset arr_in[]){
 
 
 int CalcStartandCount(const int basetype, const int ndims,const int *gdims, const int num_io_procs,
-		       const int myiorank, PIO_Offset *start, PIO_Offset *kount)
+                      const int myiorank, PIO_Offset *start, PIO_Offset *kount)
 {
-  int minbytes;
-  int maxbytes;
-  int minblocksize;
-  int basesize;
-  int use_io_procs;
-  int i;
-  long int p;
-  long int pgdims;
-  bool converged;
-  int iorank;
-  int ldims;
-  int tiorank;
-  int ioprocs;
-  int tioprocs;
-  int mystart[ndims], mykount[ndims];
-  long int pknt;
-  long int tpsize=0;
+    int minbytes;
+    int maxbytes;
+    int minblocksize;
+    int basesize;
+    int use_io_procs;
+    int i;
+    long int p;
+    long int pgdims;
+    bool converged;
+    int iorank;
+    int ldims;
+    int tiorank;
+    int ioprocs;
+    int tioprocs;
+    int mystart[ndims], mykount[ndims];
+    long int pknt;
+    long int tpsize=0;
 
-  minbytes = blocksize-256;
-  maxbytes  = blocksize+256;
+    minbytes = blocksize-256;
+    maxbytes  = blocksize+256;
 
-  switch (basetype){
-  case PIO_INT:
-    basesize = sizeof(int);
-    break;
-  case PIO_REAL:
-    basesize = sizeof(float);
-    break;
-  case PIO_DOUBLE:
-    basesize = sizeof(double);
-    break;
-  default:
+    switch (basetype){
+    case PIO_INT:
+        basesize = sizeof(int);
+        break;
+    case PIO_REAL:
+        basesize = sizeof(float);
+        break;
+    case PIO_DOUBLE:
+        basesize = sizeof(double);
+        break;
+    default:
 #ifndef TESTCALCDECOMP
-    piodie("Invalid basetype ",__FILE__,__LINE__);
+        piodie("Invalid basetype ",__FILE__,__LINE__);
 #endif
-    break;
-  }
-  minblocksize = minbytes/basesize;
+        break;
+    }
+    minblocksize = minbytes/basesize;
 
-  pgdims = 1;
-  for( i=0;i<ndims;i++)
-    pgdims *= (long int) gdims[i];
-  p = pgdims;
-  use_io_procs = max(1, min((int) ((float) p/ (float) minblocksize + 0.5),num_io_procs));
-  converged = 0;
-  for( i=0;i<ndims;i++){
-    mystart[i]=0;
-    mykount[i]=0;
-  }
+    pgdims = 1;
+    for( i=0;i<ndims;i++)
+        pgdims *= (long int) gdims[i];
+    p = pgdims;
+    use_io_procs = max(1, min((int) ((float) p/ (float) minblocksize + 0.5),num_io_procs));
+    converged = 0;
+    for( i=0;i<ndims;i++){
+        mystart[i]=0;
+        mykount[i]=0;
+    }
 
 
-  while(! converged){
-    for(iorank=0;iorank<use_io_procs;iorank++){
-      for( i=0;i<ndims;i++){
-	start[i]=0;
-	kount[i]=gdims[i];
-      }
-      ldims = ndims-1;
-      p=basesize;
-      for(i=ndims-1;i>=0;i--){
-	p=p*gdims[i];
-	if(p/use_io_procs > maxbytes){
-	  ldims = i;
-	  break;
-	}
-      }
+    while(! converged){
+        for(iorank=0;iorank<use_io_procs;iorank++){
+            for( i=0;i<ndims;i++){
+                start[i]=0;
+                kount[i]=gdims[i];
+            }
+            ldims = ndims-1;
+            p=basesize;
+            for(i=ndims-1;i>=0;i--){
+                p=p*gdims[i];
+                if(p/use_io_procs > maxbytes){
+                    ldims = i;
+                    break;
+                }
+            }
 
-      if(gdims[ldims]< use_io_procs){
-	if(ldims>0 && gdims[ldims-1] > use_io_procs)
-	  ldims--;
-	else
-	  use_io_procs -= (use_io_procs % gdims[ldims]);
-      }
+            if(gdims[ldims]< use_io_procs){
+                if(ldims>0 && gdims[ldims-1] > use_io_procs)
+                    ldims--;
+                else
+                    use_io_procs -= (use_io_procs % gdims[ldims]);
+            }
 
-      ioprocs = use_io_procs;
-      tiorank = iorank;
+            ioprocs = use_io_procs;
+            tiorank = iorank;
 #ifdef TESTCALCDECOMP
-      if(myiorank==0)      printf("%d use_io_procs %d ldims %d\n",__LINE__,use_io_procs,ldims);
+            if(myiorank==0)      printf("%d use_io_procs %d ldims %d\n",__LINE__,use_io_procs,ldims);
 #endif
-      for(i=0;i<=ldims;i++){
-	if(gdims[i]>= ioprocs){
-	  computestartandcount(gdims[i],ioprocs,tiorank,start+i,kount+i);      
+            for(i=0;i<=ldims;i++){
+                if(gdims[i]>= ioprocs){
+                    computestartandcount(gdims[i],ioprocs,tiorank,start+i,kount+i);
 #ifdef TESTCALCDECOMP
-	  if(myiorank==0)      printf("%d tiorank %d i %d start %d count %d\n",__LINE__,tiorank,i,start[i],kount[i]);
+                    if(myiorank==0)      printf("%d tiorank %d i %d start %d count %d\n",__LINE__,tiorank,i,start[i],kount[i]);
 #endif
-	  if(start[i]+kount[i]>gdims[i]+1){
+                    if(start[i]+kount[i]>gdims[i]+1){
 #ifndef TESTCALCDECOMP
-	    piodie("Start plus count exceeds dimension bound",__FILE__,__LINE__);
+                        piodie("Start plus count exceeds dimension bound",__FILE__,__LINE__);
 #endif
-	  }
-	}else if(gdims[i]>1){
-	  tioprocs=gdims[i];
-	  tiorank = (iorank*tioprocs)/ioprocs;
-	  computestartandcount(gdims[i],tioprocs,tiorank,start+i,kount+i);
-	  ioprocs = ioprocs/tioprocs;
-	  tiorank  = iorank % ioprocs;
-	}
+                    }
+                }else if(gdims[i]>1){
+                    tioprocs=gdims[i];
+                    tiorank = (iorank*tioprocs)/ioprocs;
+                    computestartandcount(gdims[i],tioprocs,tiorank,start+i,kount+i);
+                    ioprocs = ioprocs/tioprocs;
+                    tiorank  = iorank % ioprocs;
+                }
 
-      }
-      if(myiorank==iorank){
-	for(i=0;i<ndims;i++){
-	  mystart[i]=start[i];
-	  mykount[i]=kount[i];
-	}
-      }
-      pknt = 1;
-      
-      for(i=0;i<ndims;i++)
-	pknt*=kount[i];
-	
-      tpsize+=pknt;
+            }
+            if(myiorank==iorank){
+                for(i=0;i<ndims;i++){
+                    mystart[i]=start[i];
+                    mykount[i]=kount[i];
+                }
+            }
+            pknt = 1;
 
-      //      printf("%d myiorank %d tpsize %ld pknt %ld kount %ld %ld\n",__LINE__,myiorank,tpsize,pknt, kount[0],kount[1]);
+            for(i=0;i<ndims;i++)
+                pknt*=kount[i];
 
-      if(tpsize==pgdims && use_io_procs==iorank+1){
-	converged = true;
-	break;
-      }else if(tpsize>=pgdims) {
-	break;
-      }
-    }
-    if(! converged) {
+            tpsize+=pknt;
+
+            //      printf("%d myiorank %d tpsize %ld pknt %ld kount %ld %ld\n",__LINE__,myiorank,tpsize,pknt, kount[0],kount[1]);
+
+            if(tpsize==pgdims && use_io_procs==iorank+1){
+                converged = true;
+                break;
+            }else if(tpsize>=pgdims) {
+                break;
+            }
+        }
+        if(! converged) {
 #ifdef TESTCALCDECOMP
-      printf("%d start %d %d count %d %d tpsize %ld\n",__LINE__,mystart[0],mystart[1],mykount[0],mykount[1],tpsize);
-#endif      
-      tpsize = 0;
-      use_io_procs--;
+            printf("%d start %d %d count %d %d tpsize %ld\n",__LINE__,mystart[0],mystart[1],mykount[0],mykount[1],tpsize);
+#endif
+            tpsize = 0;
+            use_io_procs--;
+        }
+
     }
 
-  }
+    if(myiorank<use_io_procs){
+        for(i=0;i<ndims;i++){
+            start[i]=mystart[i];
+            kount[i]=mykount[i];
+            //      printf("%s %d %ld %ld\n",__FILE__,__LINE__,start[i],kount[i]);
+        }
+    }else{
+        for(i=0;i<ndims;i++){
+            start[i]=0;
+            kount[i]=0;
+        }
+    }
 
-  if(myiorank<use_io_procs){
-    for(i=0;i<ndims;i++){
-      start[i]=mystart[i];
-      kount[i]=mykount[i];
-      //      printf("%s %d %ld %ld\n",__FILE__,__LINE__,start[i],kount[i]);
-    }
-  }else{
-    for(i=0;i<ndims;i++){
-      start[i]=0;
-      kount[i]=0;
-    }
-  }
-      
-  return use_io_procs;
+    return use_io_procs;
 }
 
 #ifdef TESTCALCDECOMP
 int main()
 {
-  int ndims=2;
-  int gdims[2]={31,777602};
-  int num_io_procs=24;
-  bool converged=false;
-  long int start[ndims], kount[ndims];
-  int iorank, numaiotasks;
-  long int tpsize;
-  long int psize;
-  long int pgdims;
-  int scnt;
+    int ndims=2;
+    int gdims[2]={31,777602};
+    int num_io_procs=24;
+    bool converged=false;
+    long int start[ndims], kount[ndims];
+    int iorank, numaiotasks;
+    long int tpsize;
+    long int psize;
+    long int pgdims;
+    int scnt;
 
-  pgdims=1;
-  for(int i=0;i<ndims;i++)
-    pgdims*=gdims[i];
+    pgdims=1;
+    for(int i=0;i<ndims;i++)
+        pgdims*=gdims[i];
 
-  tpsize = 0;
-  numaiotasks = 0;
-  while (! converged){
-    for(iorank=0;iorank<num_io_procs;iorank++){
-      numaiotasks = CalcStartandCount(PIO_DOUBLE,ndims,gdims,num_io_procs, iorank, start,kount);
-      if(iorank<numaiotasks)
-	printf("iorank %d start %ld %ld count %ld %ld\n",iorank,start[0],start[1],kount[0],kount[1]);
+    tpsize = 0;
+    numaiotasks = 0;
+    while (! converged){
+        for(iorank=0;iorank<num_io_procs;iorank++){
+            numaiotasks = CalcStartandCount(PIO_DOUBLE,ndims,gdims,num_io_procs, iorank, start,kount);
+            if(iorank<numaiotasks)
+                printf("iorank %d start %ld %ld count %ld %ld\n",iorank,start[0],start[1],kount[0],kount[1]);
 
-      if(numaiotasks<0) return numaiotasks;
+            if(numaiotasks<0) return numaiotasks;
 
-      psize=1;
-      scnt=0;
-      for(int i=0;i<ndims;i++){
-	psize*=kount[i];
-	scnt+=kount[i];
-      }
-      tpsize+=psize;
+            psize=1;
+            scnt=0;
+            for(int i=0;i<ndims;i++){
+                psize*=kount[i];
+                scnt+=kount[i];
+            }
+            tpsize+=psize;
 
+        }
+        if(tpsize==pgdims)
+            converged = true;
+        else{
+            printf("Failed to converge %ld %ld %d\n",tpsize,pgdims,num_io_procs);
+            tpsize=0;
+            num_io_procs--;
+        }
     }
-    if(tpsize==pgdims)
-      converged = true;
-    else{
-      printf("Failed to converge %ld %ld %d\n",tpsize,pgdims,num_io_procs);
-      tpsize=0;
-      num_io_procs--;
-    }
-  }
 
-  
+
 
 
 }
-#endif      
-
+#endif

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1,4 +1,4 @@
-/** @file 
+/** @file
  * Support functions.
  */
 #include <config.h>
@@ -15,7 +15,7 @@
 #if PIO_ENABLE_LOGGING
 #define MAX_LOG_MSG 1024
 #define MAX_RANK_STR 12
-#define ERROR_PREFIX "ERROR: " 
+#define ERROR_PREFIX "ERROR: "
 int pio_log_level = 0;
 int my_rank;
 FILE *LOG_FILE;
@@ -24,47 +24,46 @@ FILE *LOG_FILE;
 /** Return a string description of an error code. If zero is passed, a
  * null is returned.
  *
- * @param pioerr the error code returned by a PIO function call. 
+ * @param pioerr the error code returned by a PIO function call.
  * @param errmsg Pointer that will get the error message. It will be
  * PIO_MAX_NAME chars or less.
  *
  * @return 0 on success
  */
-int
-PIOc_strerror(int pioerr, char *errmsg)
+int PIOc_strerror(int pioerr, char *errmsg)
 {
 
     /* System error? */
     if(pioerr > 0)
     {
-	const char *cp = (const char *)strerror(pioerr);
-	if (cp)
-	    strncpy(errmsg, cp, PIO_MAX_NAME);
-	else
-	    strcpy(errmsg, "Unknown Error");
+        const char *cp = (const char *)strerror(pioerr);
+        if (cp)
+            strncpy(errmsg, cp, PIO_MAX_NAME);
+        else
+            strcpy(errmsg, "Unknown Error");
     }
     else if (pioerr == PIO_NOERR)
     {
-	strcpy(errmsg, "No error");
+        strcpy(errmsg, "No error");
     }
     else if (pioerr <= NC2_ERR && pioerr >= NC4_LAST_ERROR)     /* NetCDF error? */
     {
 #if defined( _PNETCDF) || defined(_NETCDF)
-	strncpy(errmsg, nc_strerror(pioerr), NC_MAX_NAME);
+        strncpy(errmsg, nc_strerror(pioerr), NC_MAX_NAME);
 #else /* defined( _PNETCDF) || defined(_NETCDF) */
-	strcpy(errmsg, "NetCDF error code, PIO not built with netCDF.");
+        strcpy(errmsg, "NetCDF error code, PIO not built with netCDF.");
 #endif /* defined( _PNETCDF) || defined(_NETCDF) */
     }
     else
     {
-	/* Handle PIO errors. */
-	switch(pioerr) {
-	case PIO_EBADIOTYPE:
-	    strcpy(errmsg, "Bad IO type");
-	    break;
-	default:
-	    strcpy(errmsg, "unknown PIO error");
-	}
+        /* Handle PIO errors. */
+        switch(pioerr) {
+        case PIO_EBADIOTYPE:
+            strcpy(errmsg, "Bad IO type");
+            break;
+        default:
+            strcpy(errmsg, "unknown PIO error");
+        }
     }
 
     return PIO_NOERR;
@@ -78,7 +77,7 @@ int PIOc_set_log_level(int level)
 {
 #if PIO_ENABLE_LOGGING
     char log_filename[NC_MAX_NAME];
-    
+
     printf("setting log level to %d\n", level);
     pio_log_level = level;
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
@@ -90,67 +89,66 @@ int PIOc_set_log_level(int level)
 
 #if PIO_ENABLE_LOGGING
 /** This function prints out a message, if the severity of the message
-   is lower than the global pio_log_level. To use it, do something
-   like this:
-   
-   pio_log(0, "this computer will explode in %d seconds", i);
+    is lower than the global pio_log_level. To use it, do something
+    like this:
 
-   After the first arg (the severity), use the rest like a normal
-   printf statement. Output will appear on stdout.
-   This function is heavily based on the function in section 15.5 of
-   the C FAQ. 
+    pio_log(0, "this computer will explode in %d seconds", i);
+
+    After the first arg (the severity), use the rest like a normal
+    printf statement. Output will appear on stdout.
+    This function is heavily based on the function in section 15.5 of
+    the C FAQ.
 */
-void 
-pio_log(int severity, const char *fmt, ...)
+void pio_log(int severity, const char *fmt, ...)
 {
-   va_list argp;
-   int t;
-   char msg[MAX_LOG_MSG];
-   char *ptr = msg;
-   char rank_str[MAX_RANK_STR];
+    va_list argp;
+    int t;
+    char msg[MAX_LOG_MSG];
+    char *ptr = msg;
+    char rank_str[MAX_RANK_STR];
 
-   /* If the severity is greater than the log level, we don't print
-      this message. */
-   if (severity > pio_log_level)
-      return;
+    /* If the severity is greater than the log level, we don't print
+       this message. */
+    if (severity > pio_log_level)
+        return;
 
-   /* If the severity is 0, only print on rank 0. */
-   if (severity < 1 && my_rank != 0)
-       return;
+    /* If the severity is 0, only print on rank 0. */
+    if (severity < 1 && my_rank != 0)
+        return;
 
-   /* If the severity is zero, this is an error. Otherwise insert that
-      many tabs before the message. */
-   if (!severity)
-   {
-       strcpy(ptr, ERROR_PREFIX);
-       ptr += strlen(ERROR_PREFIX);
-   }
-   for (t = 0; t < severity; t++)
-       strcpy(ptr++, "\t");
+    /* If the severity is zero, this is an error. Otherwise insert that
+       many tabs before the message. */
+    if (!severity)
+    {
+        strcpy(ptr, ERROR_PREFIX);
+        ptr += strlen(ERROR_PREFIX);
+    }
+    for (t = 0; t < severity; t++)
+        strcpy(ptr++, "\t");
 
-   /* Show the rank. */
-   sprintf(rank_str, "%d ", my_rank);
-   strcpy(ptr, rank_str);
-   ptr += strlen(rank_str);
-   
-   /* Print out the variable list of args with vprintf. */
-   va_start(argp, fmt);
-   vsprintf(ptr, fmt, argp);
-   va_end(argp);
-   
-   /* Put on a final linefeed. */
-   ptr = msg + strlen(msg);
-   strcpy(ptr, "\n\0");
+    /* Show the rank. */
+    sprintf(rank_str, "%d ", my_rank);
+    strcpy(ptr, rank_str);
+    ptr += strlen(rank_str);
 
-   /* Send message to stdout. */
-   fprintf(stdout, "%s", msg);
+    /* Print out the variable list of args with vprintf. */
+    va_start(argp, fmt);
+    vsprintf(ptr, fmt, argp);
+    va_end(argp);
 
-   /* Send message to log file. */
-   fprintf(LOG_FILE, "%s", msg);
+    /* Put on a final linefeed. */
+    ptr = msg + strlen(msg);
+    strcpy(ptr, "\n\0");
 
-   /* Ensure an immediate flush of stdout. */
-   fflush(stdout);
-   fflush(LOG_FILE);
+    /* Send message to stdout. */
+    fprintf(stdout, "%s", msg);
+
+    /* Send message to log file. */
+    fprintf(LOG_FILE, "%s", msg);
+
+    /* Ensure an immediate flush of stdout. */
+    fflush(stdout);
+    fflush(LOG_FILE);
 }
 #endif /* PIO_ENABLE_LOGGING */
 
@@ -162,91 +160,91 @@ bool PIO_Save_Decomps=false;
  **/
 void pio_get_env(void)
 {
-  char *envptr;
-  extern bufsize PIO_CNBUFFER_LIMIT;
-  envptr = getenv("PIO_Save_Decomps");
-  
-  if(envptr != NULL && (strcmp(envptr,"true")==0)){
-    PIO_Save_Decomps=true;
-  }
-  swapm_defaults.nreqs = 0;
-  swapm_defaults.handshake=false;
-  swapm_defaults.isend=false;
+    char *envptr;
+    extern bufsize PIO_CNBUFFER_LIMIT;
+    envptr = getenv("PIO_Save_Decomps");
 
-  envptr = getenv("PIO_SWAPM");
-  if(envptr != NULL){
-    char *token = strtok(envptr, ":");
-    
-    swapm_defaults.nreqs = atoi(token);
-
-    token = strtok(NULL, ":");
-
-    if((token!=NULL) && strcmp(token,"t")==0){
-      swapm_defaults.handshake = true;
+    if(envptr != NULL && (strcmp(envptr,"true")==0)){
+        PIO_Save_Decomps=true;
     }
-    token = strtok(NULL, ":");
-    
-    if((token!=NULL) && strcmp(token,"t")==0){
-      swapm_defaults.isend = true;
-    }
-    //printf("nreqs %d handshake %d isend %d\n",swapm_defaults.nreqs, swapm_defaults.handshake, swapm_defaults.isend);
-  }
-  envptr = getenv("PIO_CNBUFFER_LIMIT");
-  if(envptr != NULL){
-    int mult=1;
-    if(strchr(envptr,"M") != NULL){
-      mult = 1000000;
-    }else if(strchr(envptr,"K") != NULL){
-      mult = 1000;
-    }
-    PIO_CNBUFFER_LIMIT=(bufsize) atoll(envptr)*mult;
-    
-  }
+    swapm_defaults.nreqs = 0;
+    swapm_defaults.handshake=false;
+    swapm_defaults.isend=false;
 
- 
+    envptr = getenv("PIO_SWAPM");
+    if(envptr != NULL){
+        char *token = strtok(envptr, ":");
+
+        swapm_defaults.nreqs = atoi(token);
+
+        token = strtok(NULL, ":");
+
+        if((token!=NULL) && strcmp(token,"t")==0){
+            swapm_defaults.handshake = true;
+        }
+        token = strtok(NULL, ":");
+
+        if((token!=NULL) && strcmp(token,"t")==0){
+            swapm_defaults.isend = true;
+        }
+        //printf("nreqs %d handshake %d isend %d\n",swapm_defaults.nreqs, swapm_defaults.handshake, swapm_defaults.isend);
+    }
+    envptr = getenv("PIO_CNBUFFER_LIMIT");
+    if(envptr != NULL){
+        int mult=1;
+        if(strchr(envptr,"M") != NULL){
+            mult = 1000000;
+        }else if(strchr(envptr,"K") != NULL){
+            mult = 1000;
+        }
+        PIO_CNBUFFER_LIMIT=(bufsize) atoll(envptr)*mult;
+
+    }
+
+
 
 }
 
 
-     
+
 /* Obtain a backtrace and print it to stderr. */
 void print_trace (FILE *fp)
 {
-  void *array[10];
-  size_t size;
-  char **strings;
-  size_t i;
-  
-  if(fp==NULL)
-    fp = stderr;
+    void *array[10];
+    size_t size;
+    char **strings;
+    size_t i;
 
-  size = backtrace (array, 10);
-  strings = backtrace_symbols (array, size);
-  
-  fprintf (fp,"Obtained %zd stack frames.\n", size);
-     
-  for (i = 0; i < size; i++)
-    fprintf (fp,"%s\n", strings[i]);
-     
-  free (strings);
+    if(fp==NULL)
+        fp = stderr;
+
+    size = backtrace (array, 10);
+    strings = backtrace_symbols (array, size);
+
+    fprintf (fp,"Obtained %zd stack frames.\n", size);
+
+    for (i = 0; i < size; i++)
+        fprintf (fp,"%s\n", strings[i]);
+
+    free (strings);
 }
 
 void piomemerror(iosystem_desc_t ios, size_t req, char *fname, const int line){
-  char msg[80];
-  sprintf(msg,"out of memory requesting: %ld",req);
-  cn_buffer_report(ios,false);
-  piodie(msg,fname,line);
+    char msg[80];
+    sprintf(msg,"out of memory requesting: %ld",req);
+    cn_buffer_report(ios,false);
+    piodie(msg,fname,line);
 }
 
 
 void piodie(const char *msg,const char *fname, const int line){
-  fprintf(stderr,"Abort with message %s in file %s at line %d\n",msg,fname,line);
-  
-  print_trace(stderr);
+    fprintf(stderr,"Abort with message %s in file %s at line %d\n",msg,fname,line);
+
+    print_trace(stderr);
 #ifdef MPI_SERIAL
-  abort();
+    abort();
 #else
-  MPI_Abort(MPI_COMM_WORLD, -1);
+    MPI_Abort(MPI_COMM_WORLD, -1);
 #endif
 }
 
@@ -254,96 +252,96 @@ void piodie(const char *msg,const char *fname, const int line){
 void pioassert(_Bool expression, const char *msg, const char *fname, const int line)
 {
 #ifndef NDEBUG
-  if(! expression){
-    piodie(msg,fname,line);
-  }
-#endif  
+    if(! expression){
+        piodie(msg,fname,line);
+    }
+#endif
 
 }
 
 /** Handle MPI errors. An error message is sent to stderr, then the
-  check_netcdf() function is called with PIO_EIO.
+    check_netcdf() function is called with PIO_EIO.
 
-  @param file pointer to the file_desc_t info. May be NULL, in which
-  case check_netcdf() is not called.
-  @param mpierr the MPI return code to handle
-  @param filename the name of the code file where error occured.
-  @param line the line of code where error occured.
-  @return PIO_NOERR for no error, otherwise PIO_EIO.
- */
+    @param file pointer to the file_desc_t info. May be NULL, in which
+    case check_netcdf() is not called.
+    @param mpierr the MPI return code to handle
+    @param filename the name of the code file where error occured.
+    @param line the line of code where error occured.
+    @return PIO_NOERR for no error, otherwise PIO_EIO.
+*/
 int check_mpi(file_desc_t *file, const int mpierr, const char *filename,
-	       const int line)
+              const int line)
 {
     if (mpierr)
     {
-	char errstring[MPI_MAX_ERROR_STRING];
-	int errstrlen;
+        char errstring[MPI_MAX_ERROR_STRING];
+        int errstrlen;
 
-	/* If we can get an error string from MPI, print it to stderr. */
-	if (!MPI_Error_string(mpierr, errstring, &errstrlen))
-	    fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n",
-		    errstring, filename, line);
+        /* If we can get an error string from MPI, print it to stderr. */
+        if (!MPI_Error_string(mpierr, errstring, &errstrlen))
+            fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n",
+                    errstring, filename, line);
 
-	/* Handle all MPI errors as PIO_EIO. */
-	if (file)
-	    check_netcdf(file, PIO_EIO, filename, line);
-	return PIO_EIO;
+        /* Handle all MPI errors as PIO_EIO. */
+        if (file)
+            check_netcdf(file, PIO_EIO, filename, line);
+        return PIO_EIO;
     }
     return PIO_NOERR;
 }
 
-/** Check the result of a netCDF API call. 
- * 
+/** Check the result of a netCDF API call.
+ *
  * @param file pointer to the PIO structure describing this file.
  * @param status the return value from the netCDF call.
- * @param fname the name of the code file. 
- * @param line the line number of the netCDF call in the code. 
- * 
+ * @param fname the name of the code file.
+ * @param line the line number of the netCDF call in the code.
+ *
  * @return the error code
-*/
+ */
 int check_netcdf(file_desc_t *file, int status, const char *fname, const int line){
-  iosystem_desc_t *ios;
-  int ierr;
-  char errstr[160];
-  ios = file->iosystem;
-  ierr = PIO_NOERR;
+    iosystem_desc_t *ios;
+    int ierr;
+    char errstr[160];
+    ios = file->iosystem;
+    ierr = PIO_NOERR;
 
-  switch(file->iotype){
+    switch(file->iotype){
 #ifdef _NETCDF
 #ifdef _NETCDF4
-  case PIO_IOTYPE_NETCDF4P:
-  case PIO_IOTYPE_NETCDF4C:
+    case PIO_IOTYPE_NETCDF4P:
+    case PIO_IOTYPE_NETCDF4C:
 #endif
-  case PIO_IOTYPE_NETCDF:
-    if(ios->iomaster){
-      if(status != NC_NOERR && (ios->error_handler == PIO_INTERNAL_ERROR))
-         piodie(nc_strerror(status),fname,line);	
-//	fprintf(stderr,"NETCDF ERROR: %s %s %d\n",nc_strerror(status),fname,line);
-    }
-    if(ios->error_handler == PIO_INTERNAL_ERROR){
-      if(status != NC_NOERR)	
-	MPI_Abort(MPI_COMM_WORLD,status);
-      // abort
-    }else if(ios->error_handler==PIO_BCAST_ERROR){
-      ierr =MPI_Bcast(&status, 1, MPI_INTEGER, ios->ioroot, ios->my_comm);
-    }
-    break;
+    case PIO_IOTYPE_NETCDF:
+        if(ios->iomaster){
+            if(status != NC_NOERR && (ios->error_handler == PIO_INTERNAL_ERROR))
+                piodie(nc_strerror(status),fname,line);
+//      fprintf(stderr,"NETCDF ERROR: %s %s %d\n",nc_strerror(status),fname,line);
+        }
+        if(ios->error_handler == PIO_INTERNAL_ERROR){
+            if(status != NC_NOERR)
+                MPI_Abort(MPI_COMM_WORLD,status);
+            // abort
+        }else if(ios->error_handler==PIO_BCAST_ERROR){
+            ierr =MPI_Bcast(&status, 1, MPI_INTEGER, ios->ioroot, ios->my_comm);
+        }
+        break;
 #endif
 #ifdef _PNETCDF
-  case PIO_IOTYPE_PNETCDF:
-    if(status != NC_NOERR && (ios->error_handler == PIO_INTERNAL_ERROR)) {
-      //	  fprintf(stderr,"PNETCDF ERROR: %s %s %d\n",ncmpi_strerror(status),fname,line);
-      piodie(ncmpi_strerror(status),fname,line);
-    }
-    if(ios->error_handler==PIO_BCAST_ERROR){
-      ierr = MPI_Bcast(&status, 1, MPI_INTEGER, ios->ioroot, ios->my_comm);
-    }
-    break;
+    case PIO_IOTYPE_PNETCDF:
+        if(status != NC_NOERR && (ios->error_handler == PIO_INTERNAL_ERROR)) {
+            //    fprintf(stderr,"PNETCDF ERROR: %s %s %d\n",ncmpi_strerror(status),fname,line);
+            piodie(ncmpi_strerror(status),fname,line);
+        }
+        if(ios->error_handler==PIO_BCAST_ERROR){
+            ierr = MPI_Bcast(&status, 1, MPI_INTEGER, ios->ioroot, ios->my_comm);
+        }
+        break;
 #endif
-  default:
-    ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-  } 
-  return status;
+    default:
+        ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+    }
+    return status;
 }
 
 int iotype_error(const int iotype, const char *fname, const int line)
@@ -354,302 +352,301 @@ int iotype_error(const int iotype, const char *fname, const int line)
 
 io_region *alloc_region(const int ndims)
 {
-  io_region *region;
+    io_region *region;
 
-  region = (io_region *) bget(sizeof(io_region));
-  region->start = (PIO_Offset *) bget(ndims* sizeof(PIO_Offset));
-  region->count = (PIO_Offset *) bget(ndims* sizeof(PIO_Offset));
-  region->loffset = 0;
-  region->next=NULL;
-  for(int i=0;i< ndims; i++){
-    region->start[i] = 0;
-    region->count[i] = 0;
-  }
-  return region;
+    region = (io_region *) bget(sizeof(io_region));
+    region->start = (PIO_Offset *) bget(ndims* sizeof(PIO_Offset));
+    region->count = (PIO_Offset *) bget(ndims* sizeof(PIO_Offset));
+    region->loffset = 0;
+    region->next=NULL;
+    for(int i=0;i< ndims; i++){
+        region->start[i] = 0;
+        region->count[i] = 0;
+    }
+    return region;
 }
 
 io_desc_t *malloc_iodesc(const int piotype, const int ndims)
 {
-  io_desc_t *iodesc;
-  iodesc = (io_desc_t *) bget(sizeof(io_desc_t));
+    io_desc_t *iodesc;
+    iodesc = (io_desc_t *) bget(sizeof(io_desc_t));
 
-  if(iodesc == NULL)
-    fprintf(stderr,"ERROR: allocation error \n");
+    if(iodesc == NULL)
+        fprintf(stderr,"ERROR: allocation error \n");
 
-  switch(piotype){
-  case PIO_REAL:			
-    iodesc->basetype=MPI_FLOAT;
-    break;
-  case PIO_DOUBLE:
-    iodesc->basetype=MPI_DOUBLE;
-    break;
-  case PIO_CHAR:
-    iodesc->basetype=MPI_CHAR;
-    break;
-  case PIO_INT:   
-  default:
-    iodesc->basetype = MPI_INTEGER;
-    break;
-  }    
-  iodesc->rearranger = 0;
-  iodesc->maxregions=1;
-  iodesc->rfrom = NULL;
-  iodesc->scount = NULL;
-  iodesc->rtype = NULL;
-  iodesc->stype = NULL;
-  iodesc->num_stypes = 0;
-  iodesc->sindex = NULL;
-  iodesc->rindex = NULL;
-  iodesc->rcount = NULL;
-  iodesc->ioid=-1;
-  iodesc->llen=0;
-  iodesc->maxiobuflen=0;
-  iodesc->holegridsize=0;
-  iodesc->maxbytes=0;
-  iodesc->ndims = ndims;
-  iodesc->firstregion = alloc_region(ndims);
-  iodesc->fillregion = NULL;
+    switch(piotype){
+    case PIO_REAL:
+        iodesc->basetype=MPI_FLOAT;
+        break;
+    case PIO_DOUBLE:
+        iodesc->basetype=MPI_DOUBLE;
+        break;
+    case PIO_CHAR:
+        iodesc->basetype=MPI_CHAR;
+        break;
+    case PIO_INT:
+    default:
+        iodesc->basetype = MPI_INTEGER;
+        break;
+    }
+    iodesc->rearranger = 0;
+    iodesc->maxregions=1;
+    iodesc->rfrom = NULL;
+    iodesc->scount = NULL;
+    iodesc->rtype = NULL;
+    iodesc->stype = NULL;
+    iodesc->num_stypes = 0;
+    iodesc->sindex = NULL;
+    iodesc->rindex = NULL;
+    iodesc->rcount = NULL;
+    iodesc->ioid=-1;
+    iodesc->llen=0;
+    iodesc->maxiobuflen=0;
+    iodesc->holegridsize=0;
+    iodesc->maxbytes=0;
+    iodesc->ndims = ndims;
+    iodesc->firstregion = alloc_region(ndims);
+    iodesc->fillregion = NULL;
 
-  iodesc->handshake=swapm_defaults.handshake;
-  iodesc->isend=swapm_defaults.isend;
-  iodesc->max_requests=swapm_defaults.nreqs;
+    iodesc->handshake=swapm_defaults.handshake;
+    iodesc->isend=swapm_defaults.isend;
+    iodesc->max_requests=swapm_defaults.nreqs;
 
-  return iodesc;
+    return iodesc;
 }
 
 void free_region_list(io_region *top)
 {
-  io_region *ptr, *tptr;
+    io_region *ptr, *tptr;
 
-  ptr = top;
-  while(ptr != NULL) {
-    if(ptr->start != NULL)
-      brel(ptr->start);
-    if(ptr->count != NULL)
-      brel(ptr->count);
-    tptr=ptr;
-    ptr=ptr->next;
-    brel(tptr);      
-  }
+    ptr = top;
+    while(ptr != NULL) {
+        if(ptr->start != NULL)
+            brel(ptr->start);
+        if(ptr->count != NULL)
+            brel(ptr->count);
+        tptr=ptr;
+        ptr=ptr->next;
+        brel(tptr);
+    }
 
 }
 
-
 int PIOc_freedecomp(int iosysid, int ioid)
 {
-  iosystem_desc_t *ios;
-  io_desc_t *iodesc;
-  int i;
+    iosystem_desc_t *ios;
+    io_desc_t *iodesc;
+    int i;
 
-  ios = pio_get_iosystem_from_id(iosysid);
-  if(ios == NULL)
-    return PIO_EBADID;
+    ios = pio_get_iosystem_from_id(iosysid);
+    if(ios == NULL)
+        return PIO_EBADID;
 
-  iodesc = pio_get_iodesc_from_id(ioid);
-  if(iodesc == NULL)
-    return PIO_EBADID;
+    iodesc = pio_get_iodesc_from_id(ioid);
+    if(iodesc == NULL)
+        return PIO_EBADID;
 
-  if(iodesc->rfrom != NULL)
-    brel(iodesc->rfrom);
-  if(iodesc->rtype != NULL){
-    for(i=0; i<iodesc->nrecvs; i++){
-      if(iodesc->rtype[i] != MPI_DATATYPE_NULL){
-        MPI_Type_free(iodesc->rtype+i);
-      }
+    if(iodesc->rfrom != NULL)
+        brel(iodesc->rfrom);
+    if(iodesc->rtype != NULL){
+        for(i=0; i<iodesc->nrecvs; i++){
+            if(iodesc->rtype[i] != MPI_DATATYPE_NULL){
+                MPI_Type_free(iodesc->rtype+i);
+            }
+        }
+        brel(iodesc->rtype);
     }
-    brel(iodesc->rtype);
-  }
-  if(iodesc->stype != NULL){
-    for(i=0; i<iodesc->num_stypes; i++){
-      if(iodesc->stype[i] != MPI_DATATYPE_NULL){
-        MPI_Type_free(iodesc->stype+i);
-      }
+    if(iodesc->stype != NULL){
+        for(i=0; i<iodesc->num_stypes; i++){
+            if(iodesc->stype[i] != MPI_DATATYPE_NULL){
+                MPI_Type_free(iodesc->stype+i);
+            }
+        }
+        iodesc->num_stypes = 0;
+        brel(iodesc->stype);
     }
-    iodesc->num_stypes = 0;
-    brel(iodesc->stype);
-  }
-  if(iodesc->scount != NULL)
-    brel(iodesc->scount);
-  if(iodesc->rcount != NULL)
-    brel(iodesc->rcount);
-  if(iodesc->sindex != NULL)
-    brel(iodesc->sindex);
-  if(iodesc->rindex != NULL)
-    brel(iodesc->rindex);
+    if(iodesc->scount != NULL)
+        brel(iodesc->scount);
+    if(iodesc->rcount != NULL)
+        brel(iodesc->rcount);
+    if(iodesc->sindex != NULL)
+        brel(iodesc->sindex);
+    if(iodesc->rindex != NULL)
+        brel(iodesc->rindex);
 
 
-  if(iodesc->firstregion != NULL)
-    free_region_list(iodesc->firstregion);
+    if(iodesc->firstregion != NULL)
+        free_region_list(iodesc->firstregion);
 
-  if(iodesc->rearranger == PIO_REARR_SUBSET){
-    MPI_Comm_free(&(iodesc->subset_comm));
-  }
+    if(iodesc->rearranger == PIO_REARR_SUBSET){
+        MPI_Comm_free(&(iodesc->subset_comm));
+    }
 
-  return pio_delete_iodesc_from_list(ioid);
+    return pio_delete_iodesc_from_list(ioid);
 
 
 }
 
 int PIOc_readmap(const char file[], int *ndims, int *gdims[], PIO_Offset *fmaplen, PIO_Offset *map[], const MPI_Comm comm)
 {
-  int npes, myrank;  
-  int rnpes, rversno;
-  int j;
-  int *tdims;
-  PIO_Offset *tmap;
-  MPI_Status status;
-  PIO_Offset maplen;
+    int npes, myrank;
+    int rnpes, rversno;
+    int j;
+    int *tdims;
+    PIO_Offset *tmap;
+    MPI_Status status;
+    PIO_Offset maplen;
 
-  MPI_Comm_size(comm, &npes);
-  MPI_Comm_rank(comm, &myrank);
-  
-  if(myrank == 0) {
-    FILE *fp = fopen(file, "r");
-    if(fp==NULL)
-      piodie("Failed to open dof file",__FILE__,__LINE__);
-    
-    fscanf(fp,"version %d npes %d ndims %d\n",&rversno, &rnpes,ndims);
+    MPI_Comm_size(comm, &npes);
+    MPI_Comm_rank(comm, &myrank);
 
-    if(rversno != versno)
-      piodie("Attempt to read incompatable map file version",__FILE__,__LINE__);
+    if(myrank == 0) {
+        FILE *fp = fopen(file, "r");
+        if(fp==NULL)
+            piodie("Failed to open dof file",__FILE__,__LINE__);
 
-    if(rnpes < 1 || rnpes > npes)
-      piodie("Incompatable pe count in map file ",__FILE__,__LINE__);
+        fscanf(fp,"version %d npes %d ndims %d\n",&rversno, &rnpes,ndims);
 
-    MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm);
-    MPI_Bcast(ndims, 1, MPI_INT, 0, comm);
-    tdims = (int *) calloc((*ndims), sizeof(int));
-    for(int i=0;i<(*ndims);i++)
-      fscanf(fp,"%d ",tdims+i);
+        if(rversno != versno)
+            piodie("Attempt to read incompatable map file version",__FILE__,__LINE__);
 
-    MPI_Bcast(tdims, (*ndims), MPI_INT, 0, comm);
+        if(rnpes < 1 || rnpes > npes)
+            piodie("Incompatable pe count in map file ",__FILE__,__LINE__);
 
-    for(int i=0; i< rnpes; i++){
-      fscanf(fp,"%d %ld",&j,&maplen);
-      if( j != i)  // Not sure how this could be possible
-	piodie("Incomprehensable error reading map file ",__FILE__,__LINE__);
+        MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm);
+        MPI_Bcast(ndims, 1, MPI_INT, 0, comm);
+        tdims = (int *) calloc((*ndims), sizeof(int));
+        for(int i=0;i<(*ndims);i++)
+            fscanf(fp,"%d ",tdims+i);
 
-      tmap = (PIO_Offset *) malloc(maplen*sizeof(PIO_Offset));
-      for(j=0;j<maplen;j++)
-	fscanf(fp,"%ld ",tmap+j);
-      
-      if(i>0){
-	MPI_Send(&maplen, 1, PIO_OFFSET, i, i+npes, comm);
-	MPI_Send(tmap, maplen, PIO_OFFSET, i, i, comm);
-	free(tmap);
-      }else{
-	*map = tmap;
-	*fmaplen = maplen;
-      }
-    }
-    fclose(fp);
-  }else{
-    MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm);
-    MPI_Bcast(ndims, 1, MPI_INT, 0, comm);
-    tdims = (int *) calloc((*ndims), sizeof(int));
-    MPI_Bcast(tdims, (*ndims), MPI_INT, 0, comm);
+        MPI_Bcast(tdims, (*ndims), MPI_INT, 0, comm);
 
-    if(myrank<rnpes){
-      MPI_Recv(&maplen, 1, PIO_OFFSET, 0, myrank+npes, comm, &status);
-      tmap = (PIO_Offset *) malloc(maplen*sizeof(PIO_Offset));
-      MPI_Recv(tmap, maplen, PIO_OFFSET, 0, myrank, comm, &status);
-      *map = tmap;
+        for(int i=0; i< rnpes; i++){
+            fscanf(fp,"%d %ld",&j,&maplen);
+            if( j != i)  // Not sure how this could be possible
+                piodie("Incomprehensable error reading map file ",__FILE__,__LINE__);
+
+            tmap = (PIO_Offset *) malloc(maplen*sizeof(PIO_Offset));
+            for(j=0;j<maplen;j++)
+                fscanf(fp,"%ld ",tmap+j);
+
+            if(i>0){
+                MPI_Send(&maplen, 1, PIO_OFFSET, i, i+npes, comm);
+                MPI_Send(tmap, maplen, PIO_OFFSET, i, i, comm);
+                free(tmap);
+            }else{
+                *map = tmap;
+                *fmaplen = maplen;
+            }
+        }
+        fclose(fp);
     }else{
-      tmap=NULL;
-      maplen=0;
+        MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm);
+        MPI_Bcast(ndims, 1, MPI_INT, 0, comm);
+        tdims = (int *) calloc((*ndims), sizeof(int));
+        MPI_Bcast(tdims, (*ndims), MPI_INT, 0, comm);
+
+        if(myrank<rnpes){
+            MPI_Recv(&maplen, 1, PIO_OFFSET, 0, myrank+npes, comm, &status);
+            tmap = (PIO_Offset *) malloc(maplen*sizeof(PIO_Offset));
+            MPI_Recv(tmap, maplen, PIO_OFFSET, 0, myrank, comm, &status);
+            *map = tmap;
+        }else{
+            tmap=NULL;
+            maplen=0;
+        }
+        *fmaplen = maplen;
     }
-    *fmaplen = maplen;
-  }      
-  *gdims = tdims;
-  return PIO_NOERR;
+    *gdims = tdims;
+    return PIO_NOERR;
 }
 
 int PIOc_readmap_from_f90(const char file[],int *ndims, int *gdims[], PIO_Offset *maplen, PIO_Offset *map[], const int f90_comm)
 {
-  int ierr;
+    int ierr;
 
-  ierr = PIOc_readmap(file, ndims, gdims, maplen, map, MPI_Comm_f2c(f90_comm));
+    ierr = PIOc_readmap(file, ndims, gdims, maplen, map, MPI_Comm_f2c(f90_comm));
 
-  return(ierr);
+    return(ierr);
 }
 
 
 int PIOc_writemap(const char file[], const int ndims, const int gdims[], PIO_Offset maplen, PIO_Offset map[], const MPI_Comm comm)
 {
-  int npes, myrank;
-  PIO_Offset *nmaplen;
-  MPI_Status status;
-  int i;
-  PIO_Offset *nmap;
+    int npes, myrank;
+    PIO_Offset *nmaplen;
+    MPI_Status status;
+    int i;
+    PIO_Offset *nmap;
 
-  MPI_Comm_size(comm, &npes);
-  MPI_Comm_rank(comm, &myrank);
-  if(myrank==0)
-    nmaplen = (PIO_Offset *) malloc(npes*sizeof(PIO_Offset));
-  else
-    nmaplen = NULL;
+    MPI_Comm_size(comm, &npes);
+    MPI_Comm_rank(comm, &myrank);
+    if(myrank==0)
+        nmaplen = (PIO_Offset *) malloc(npes*sizeof(PIO_Offset));
+    else
+        nmaplen = NULL;
 
-  //  printf("maplen[%d] = %ld\n",myrank,maplen);
-
-
-  MPI_Gather(&maplen, 1, PIO_OFFSET, nmaplen, 1, PIO_OFFSET, 0, comm);
-
-  if(myrank==0){
-    FILE *fp;
+    //  printf("maplen[%d] = %ld\n",myrank,maplen);
 
 
-    fp = fopen( file, "w");
-    if(fp==NULL){
-      fprintf(stderr,"Failed to open file %s to write\n",file);
-      return PIO_EIO;
+    MPI_Gather(&maplen, 1, PIO_OFFSET, nmaplen, 1, PIO_OFFSET, 0, comm);
+
+    if(myrank==0){
+        FILE *fp;
+
+
+        fp = fopen( file, "w");
+        if(fp==NULL){
+            fprintf(stderr,"Failed to open file %s to write\n",file);
+            return PIO_EIO;
+        }
+        fprintf(fp,"version %d npes %d ndims %d \n",versno, npes,ndims);
+        for(i=0;i<ndims;i++){
+            fprintf(fp,"%d ",gdims[i]);
+        }
+        fprintf(fp,"\n");
+        fprintf(fp,"0 %ld\n",nmaplen[0]);
+        for( i=0;i<nmaplen[0];i++)
+            fprintf(fp,"%ld ",map[i]);
+        fprintf(fp,"\n");
+        for( i=1; i<npes;i++){
+            nmap = (PIO_Offset *) malloc(nmaplen[i] * sizeof(PIO_Offset));
+
+            MPI_Send(&i, 1, MPI_INT, i, npes+i, comm);
+            MPI_Recv(nmap, nmaplen[i], PIO_OFFSET, i, i, comm, &status);
+
+            fprintf(fp,"%d %ld\n",i,nmaplen[i]);
+            for(int j=0;j<nmaplen[i];j++)
+                fprintf(fp,"%ld ",nmap[j]);
+            fprintf(fp,"\n");
+
+            free(nmap);
+
+        }
+
+        fprintf(fp,"\n");
+        print_trace(fp);
+
+        fclose(fp);
+    }else{
+        MPI_Recv(&i, 1, MPI_INT, 0, npes+myrank, comm, &status);
+        MPI_Send(map, maplen, PIO_OFFSET, 0, myrank, comm);
     }
-    fprintf(fp,"version %d npes %d ndims %d \n",versno, npes,ndims);
-    for(i=0;i<ndims;i++){
-      fprintf(fp,"%d ",gdims[i]);
-    }
-    fprintf(fp,"\n");    
-    fprintf(fp,"0 %ld\n",nmaplen[0]);
-    for( i=0;i<nmaplen[0];i++)
-      fprintf(fp,"%ld ",map[i]);
-    fprintf(fp,"\n");    
-    for( i=1; i<npes;i++){
-      nmap = (PIO_Offset *) malloc(nmaplen[i] * sizeof(PIO_Offset));
-
-      MPI_Send(&i, 1, MPI_INT, i, npes+i, comm);
-      MPI_Recv(nmap, nmaplen[i], PIO_OFFSET, i, i, comm, &status);
-
-      fprintf(fp,"%d %ld\n",i,nmaplen[i]);
-      for(int j=0;j<nmaplen[i];j++)
-	fprintf(fp,"%ld ",nmap[j]);
-      fprintf(fp,"\n");
-
-      free(nmap);
-      
-    }
-
-    fprintf(fp,"\n");
-    print_trace(fp);
-
-    fclose(fp);
-  }else{
-    MPI_Recv(&i, 1, MPI_INT, 0, npes+myrank, comm, &status);
-    MPI_Send(map, maplen, PIO_OFFSET, 0, myrank, comm);
-  }
-  return PIO_NOERR;
+    return PIO_NOERR;
 }
 
-int PIOc_writemap_from_f90(const char file[], const int ndims, const int gdims[], 
-			   const PIO_Offset maplen, const PIO_Offset map[], const int f90_comm)
+int PIOc_writemap_from_f90(const char file[], const int ndims, const int gdims[],
+                           const PIO_Offset maplen, const PIO_Offset map[], const int f90_comm)
 {
-  // printf("%s %d %s %ld\n",__FILE__,__LINE__,file,maplen);
-  return(PIOc_writemap(file, ndims, gdims, maplen, map, MPI_Comm_f2c(f90_comm)));
+    // printf("%s %d %s %ld\n",__FILE__,__LINE__,file,maplen);
+    return(PIOc_writemap(file, ndims, gdims, maplen, map, MPI_Comm_f2c(f90_comm)));
 }
 /*
-#ifdef BGQ
-#include <stdio.h>
-#include <spi/include/kernel/memory.h>
-void print_memusage()
-{
+  #ifdef BGQ
+  #include <stdio.h>
+  #include <spi/include/kernel/memory.h>
+  void print_memusage()
+  {
   uint64_t shared, persist, heapavail, stackavail, stack, heap, guard, mmap;
 
   Kernel_GetMemorySize(KERNEL_MEMSIZE_SHARED, &shared);
@@ -665,7 +662,7 @@ void print_memusage()
   printf("Allocated stack: %.2f MB, avail. stack: %.2f MB\n", (double)stack/(1024*1024), (double)stackavail/(1024*1024));
   printf("Memory: shared: %.2f MB, persist: %.2f MB, guard: %.2f MB, mmap: %.2f MB\n", (double)shared/(1024*1024), (double)persist/(1024*1024), (double)guard/(1024*1024), (double)mmap/(1024*1024));
 
-  return; 
-}
-#endif
+  return;
+  }
+  #endif
 */

--- a/src/clib/topology.c
+++ b/src/clib/topology.c
@@ -19,260 +19,260 @@ char my_name[255];
 
 void identity(const MPI_Comm comm, int *iotask)
 {
-  MPIX_Hardware_t hw;
-  char message[100];
-   /* Number of MPI tasks per Pset */
-   int coreId;
-   int *TasksPerPset;
-   int *tmp;
-   int i,ierr;
-   Personality_t pers;
+    MPIX_Hardware_t hw;
+    char message[100];
+    /* Number of MPI tasks per Pset */
+    int coreId;
+    int *TasksPerPset;
+    int *tmp;
+    int i,ierr;
+    Personality_t pers;
 
-   MPI_Comm_rank(comm,&rank);
-   MPI_Comm_size(comm,&np);
-   MPI_Get_processor_name(my_name, &my_name_len);
-
-
-   MPIX_Hardware(&hw);
-   
-   Kernel_GetPersonality(&pers, sizeof(pers));
-   
-   int numIONodes,numPsets,numNodesInPset,rankInPset;
-   int numpsets, psetID, psetsize, psetrank;
-
-   bgq_pset_info (comm, &numpsets, &psetID, &psetsize, &psetrank);
- 
-   numIONodes = numpsets; 
-   numNodesInPset = psetsize; 
-   rankInPset = rank; 
-   numPsets = numpsets; 
-   
-   if(rank == 0) { printf("number of IO nodes in block: %i \n",numIONodes);}
-   if(rank == 0) { printf("number of Psets in block : %i \n",numPsets);}
-   if(rank == 0) { printf("number of compute nodes in Pset: %i \n",numNodesInPset);}
-   
-   int psetNum;
-   psetNum = psetID;
-
-#ifdef DEBUG
-   if((*iotask)>0) {
-      printf( "%04i (%-50s %s) %i yes\n", rank, my_name, message, psetNum );
-   } else {
-      printf( "%04i (%-50s %s) %i --\n", rank, my_name, message, psetNum);
-   }
-   printf("MPI task %6i is rank %3i in Pset: %3i \n",rank, rankInPset,psetNum);
-#endif
-  /* Determine which core on node....  I don't want to put more than one io-task per node */
-   coreId = Kernel_PhysicalProcessorID ();
-
-   TasksPerPset = malloc(numPsets*sizeof(int));
-   tmp = malloc(numPsets*sizeof(int));
-   for(i=0;i<numPsets;i++) tmp[i]=0;
-   if(coreId == 0) {tmp[psetNum]=1;}
-   ierr = MPI_Allreduce(tmp,TasksPerPset,numPsets,MPI_INT,MPI_SUM,comm);
-   if(rank == 0) {
-     for(i=0;i<numPsets;i++) {printf("Pset: %3i has %3i nodes \n",i,TasksPerPset[i]);}
-   }
-   free(tmp);
-   free(TasksPerPset);
-}
-
-void determineiotasks(const MPI_Comm comm, int *numiotasks,int *base, int *stride, int *rearr, 
-		      bool *iamIOtask)
-{
-
-/*  
-
-     Returns the correct numiotasks and the flag iamIOtask
-
-     Some concepts:
-
-     processor set:     A group of processors on the Blue Gene system which have 
-                        one or more IO processor (Pset)
-
-     IO-node:           A special Blue Gene node dedicated to performing IO.  There 
-                        are one or more per processor set
-
-     IO-client:         This is software concept.  This refers to the MPI task 
-                        which performs IO for the PIO library 
-*/
-   int psetNum;                                 
-   int coreId;
-   int iam;
-   int task_count;
-
-   MPIX_Hardware_t hw;
-   /*  Get the personality  */
-   Personality_t pers;
-
-   MPIX_Hardware(&hw);
-
-   MPI_Comm_rank(comm, &rank);
-
-   MPI_Comm_size(comm, &np);
-
-   MPI_Get_processor_name(my_name, &my_name_len);
+    MPI_Comm_rank(comm,&rank);
+    MPI_Comm_size(comm,&np);
+    MPI_Get_processor_name(my_name, &my_name_len);
 
 
-
-   /* printf("Determine io tasks: proc %i: tasks= %i numiotasks=%i stride= %i \n", rank, np, (*numiotasks), (*stride)); */
-
-   if((*rearr) > 0) {
-
+    MPIX_Hardware(&hw);
 
     Kernel_GetPersonality(&pers, sizeof(pers));
-     
-     int numIONodes,numPsets,numNodesInPset,rankInPset;
-     int numiotasks_per_node,remainder,numIONodes_per_pset;
-     int lstride;
-     
-     /* Number of computational nodes in processor set */
 
-     int numpsets, psetID, psetsize, psetrank;
-    bgq_pset_info (comm,&numpsets, &psetID, &psetsize, &psetrank);
-     numIONodes = numpsets; 
-     numNodesInPset = psetsize;
+    int numIONodes,numPsets,numNodesInPset,rankInPset;
+    int numpsets, psetID, psetsize, psetrank;
 
-     /*     printf("Determine io tasks: me %i : nodes in pset= %i ionodes = %i\n", rank, numNodesInPset, numIONodes); */
-     
-     if((*numiotasks) < 0 ) { 
-       /* negative numiotasks value indicates that this is the number per IO-node */
-       (*numiotasks) = - (*numiotasks);
-       if((*numiotasks) > numNodesInPset) {
-	 numiotasks_per_node = numNodesInPset;
-       } else  {
-	 numiotasks_per_node = (*numiotasks);
-       }
-       remainder = 0;
-     } else if ((*numiotasks) > 0 ) {
-       /* balance the number of iotasks to number of IO nodes */
-       numiotasks_per_node = floor((float)(*numiotasks)/ (float) numIONodes);
-       /* put a minumum here so that we have a chance  - though this may be too low */
-       if (numiotasks_per_node < 1) {
-          numiotasks_per_node = 1;
-       	   *numiotasks = numIONodes;
-       }
-       remainder = (*numiotasks) - numiotasks_per_node * numIONodes;
-     } else if ((*numiotasks) == 0 ) {
-       if((*stride) > 0) {
-	 numiotasks_per_node = numNodesInPset/(*stride);
-	 if (numiotasks_per_node < 1) {
-	     numiotasks_per_node = 1;
-	     *numiotasks = numIONodes;
-	 }
-       } else {
-	 numiotasks_per_node = 8;  /* default number of IO-client per IO-node is not otherwise specificied */
-       }
-       remainder = 0;
-     } 
+    bgq_pset_info (comm, &numpsets, &psetID, &psetsize, &psetrank);
 
-     /* number of IO nodes with a larger number of io-client per io-node */
-     if(remainder > 0) {
-       if(rank ==0) {printf("Unbalanced IO-configuration: %i IO-nodes have %i IO-clients : %i IO-nodes have %i IO-clients \n",
-			    remainder, numiotasks_per_node+1, numIONodes-remainder,numiotasks_per_node);}
-      lstride = min(np,floor((float)numNodesInPset/(float)(numiotasks_per_node+1)));
-     } else {
-       if(rank == 0) {
-	 printf("Balanced IO-configuration: %i IO-nodes have %i IO-clients\n",numIONodes-remainder, numiotasks_per_node);
-       }
-       lstride = min(np,floor((float)numNodesInPset/(float)numiotasks_per_node));
-     }
-     
-     /* Number of processor sets */
-     numPsets = numpsets; 
-     
-     /* number of IO nodes in processor set (I need to add
-	code to deal with the case where numIONodes_per_pset != 1 works 
-	correctly) */
-     numIONodes_per_pset = numIONodes/numPsets;
-     
-     /* Determine which core on node....  I don't want to put more than one io-task per node */
-     coreId = Kernel_PhysicalProcessorID ();
-     
-     /* What is the rank of this node in the processor set */
+    numIONodes = numpsets;
+    numNodesInPset = psetsize;
+    rankInPset = rank;
+    numPsets = numpsets;
 
-     psetNum = psetID;
-     rankInPset = psetrank;
-     
-     /* printf("Pset #: %i has %i nodes in Pset; base = %i\n",psetNum,numNodesInPset, *base); */
-     
-     (*iamIOtask) = false;   /* initialize to zero */
-     
-     if (numiotasks_per_node == numNodesInPset)(*base) = 0;  /* Reset the base to 0 if we are using all tasks */
+    if(rank == 0) { printf("number of IO nodes in block: %i \n",numIONodes);}
+    if(rank == 0) { printf("number of Psets in block : %i \n",numPsets);}
+    if(rank == 0) { printf("number of compute nodes in Pset: %i \n",numNodesInPset);}
+
+    int psetNum;
+    psetNum = psetID;
+
+#ifdef DEBUG
+    if((*iotask)>0) {
+        printf( "%04i (%-50s %s) %i yes\n", rank, my_name, message, psetNum );
+    } else {
+        printf( "%04i (%-50s %s) %i --\n", rank, my_name, message, psetNum);
+    }
+    printf("MPI task %6i is rank %3i in Pset: %3i \n",rank, rankInPset,psetNum);
+#endif
+    /* Determine which core on node....  I don't want to put more than one io-task per node */
+    coreId = Kernel_PhysicalProcessorID ();
+
+    TasksPerPset = malloc(numPsets*sizeof(int));
+    tmp = malloc(numPsets*sizeof(int));
+    for(i=0;i<numPsets;i++) tmp[i]=0;
+    if(coreId == 0) {tmp[psetNum]=1;}
+    ierr = MPI_Allreduce(tmp,TasksPerPset,numPsets,MPI_INT,MPI_SUM,comm);
+    if(rank == 0) {
+        for(i=0;i<numPsets;i++) {printf("Pset: %3i has %3i nodes \n",i,TasksPerPset[i]);}
+    }
+    free(tmp);
+    free(TasksPerPset);
+}
+
+void determineiotasks(const MPI_Comm comm, int *numiotasks,int *base, int *stride, int *rearr,
+                      bool *iamIOtask)
+{
+
+/*
+
+    Returns the correct numiotasks and the flag iamIOtask
+
+    Some concepts:
+
+    processor set:     A group of processors on the Blue Gene system which have
+    one or more IO processor (Pset)
+
+    IO-node:           A special Blue Gene node dedicated to performing IO.  There
+    are one or more per processor set
+
+    IO-client:         This is software concept.  This refers to the MPI task
+    which performs IO for the PIO library
+*/
+    int psetNum;
+    int coreId;
+    int iam;
+    int task_count;
+
+    MPIX_Hardware_t hw;
+    /*  Get the personality  */
+    Personality_t pers;
+
+    MPIX_Hardware(&hw);
+
+    MPI_Comm_rank(comm, &rank);
+
+    MPI_Comm_size(comm, &np);
+
+    MPI_Get_processor_name(my_name, &my_name_len);
 
 
-     /* start stridding MPI tasks from base task */ 
-     iam = max(0,rankInPset-(*base));
-     if (iam >= 0)  {
-       /* mark tasks that will be IO-tasks  or IO-clients */
-       /*    printf("iam = %d lstride = %d coreID = %d\n",iam,lstride,coreId); */
-       if((iam % lstride == 0) && (coreId == 0) ) {  /* only io tasks indicated by stride and coreId = 0 */
-	 if((iam/lstride) < numiotasks_per_node) { 
-	   /* only set the first (numiotasks_per_node - 1) tasks */
-	   (*iamIOtask) = true;
-	 } else if ((iam/lstride) == numiotasks_per_node) {
-	   /*  If there is an uneven number of io-clients to io-nodes 
-	       allocate the first remainder - 1 processor sets to 
-	       have a total of numiotasks_per_node */
-	   if(psetNum < remainder) {(*iamIOtask) = true;
-	   };   
-	 }
-       }
-       /*       printf("comm = %d iam = %d lstride = %d coreID = %d iamIOtask = %i \n",comm, iam,lstride,coreId,(*iamIOtask)); */
-     }
-   }else{ 
-       /* We are not doing rearrangement.... so all tasks are io-tasks */
-       (*iamIOtask) = true;
-     }
-   
-   /*printf("comm = %d myrank = %i iotask = %i \n", comm, rank, (*iamIOtask));*/ 
-   
-   /* now we need to correctly determine the numiotasks */
-   MPI_Allreduce(iamIOtask, &task_count, 1, MPI_INT, MPI_SUM, comm);
 
-   (*numiotasks) = task_count;
- 
-  
+    /* printf("Determine io tasks: proc %i: tasks= %i numiotasks=%i stride= %i \n", rank, np, (*numiotasks), (*stride)); */
+
+    if((*rearr) > 0) {
+
+
+        Kernel_GetPersonality(&pers, sizeof(pers));
+
+        int numIONodes,numPsets,numNodesInPset,rankInPset;
+        int numiotasks_per_node,remainder,numIONodes_per_pset;
+        int lstride;
+
+        /* Number of computational nodes in processor set */
+
+        int numpsets, psetID, psetsize, psetrank;
+        bgq_pset_info (comm,&numpsets, &psetID, &psetsize, &psetrank);
+        numIONodes = numpsets;
+        numNodesInPset = psetsize;
+
+        /*     printf("Determine io tasks: me %i : nodes in pset= %i ionodes = %i\n", rank, numNodesInPset, numIONodes); */
+
+        if((*numiotasks) < 0 ) {
+            /* negative numiotasks value indicates that this is the number per IO-node */
+            (*numiotasks) = - (*numiotasks);
+            if((*numiotasks) > numNodesInPset) {
+                numiotasks_per_node = numNodesInPset;
+            } else  {
+                numiotasks_per_node = (*numiotasks);
+            }
+            remainder = 0;
+        } else if ((*numiotasks) > 0 ) {
+            /* balance the number of iotasks to number of IO nodes */
+            numiotasks_per_node = floor((float)(*numiotasks)/ (float) numIONodes);
+            /* put a minumum here so that we have a chance  - though this may be too low */
+            if (numiotasks_per_node < 1) {
+                numiotasks_per_node = 1;
+                *numiotasks = numIONodes;
+            }
+            remainder = (*numiotasks) - numiotasks_per_node * numIONodes;
+        } else if ((*numiotasks) == 0 ) {
+            if((*stride) > 0) {
+                numiotasks_per_node = numNodesInPset/(*stride);
+                if (numiotasks_per_node < 1) {
+                    numiotasks_per_node = 1;
+                    *numiotasks = numIONodes;
+                }
+            } else {
+                numiotasks_per_node = 8;  /* default number of IO-client per IO-node is not otherwise specificied */
+            }
+            remainder = 0;
+        }
+
+        /* number of IO nodes with a larger number of io-client per io-node */
+        if(remainder > 0) {
+            if(rank ==0) {printf("Unbalanced IO-configuration: %i IO-nodes have %i IO-clients : %i IO-nodes have %i IO-clients \n",
+                                 remainder, numiotasks_per_node+1, numIONodes-remainder,numiotasks_per_node);}
+            lstride = min(np,floor((float)numNodesInPset/(float)(numiotasks_per_node+1)));
+        } else {
+            if(rank == 0) {
+                printf("Balanced IO-configuration: %i IO-nodes have %i IO-clients\n",numIONodes-remainder, numiotasks_per_node);
+            }
+            lstride = min(np,floor((float)numNodesInPset/(float)numiotasks_per_node));
+        }
+
+        /* Number of processor sets */
+        numPsets = numpsets;
+
+        /* number of IO nodes in processor set (I need to add
+           code to deal with the case where numIONodes_per_pset != 1 works
+           correctly) */
+        numIONodes_per_pset = numIONodes/numPsets;
+
+        /* Determine which core on node....  I don't want to put more than one io-task per node */
+        coreId = Kernel_PhysicalProcessorID ();
+
+        /* What is the rank of this node in the processor set */
+
+        psetNum = psetID;
+        rankInPset = psetrank;
+
+        /* printf("Pset #: %i has %i nodes in Pset; base = %i\n",psetNum,numNodesInPset, *base); */
+
+        (*iamIOtask) = false;   /* initialize to zero */
+
+        if (numiotasks_per_node == numNodesInPset)(*base) = 0;  /* Reset the base to 0 if we are using all tasks */
+
+
+        /* start stridding MPI tasks from base task */
+        iam = max(0,rankInPset-(*base));
+        if (iam >= 0)  {
+            /* mark tasks that will be IO-tasks  or IO-clients */
+            /*    printf("iam = %d lstride = %d coreID = %d\n",iam,lstride,coreId); */
+            if((iam % lstride == 0) && (coreId == 0) ) {  /* only io tasks indicated by stride and coreId = 0 */
+                if((iam/lstride) < numiotasks_per_node) {
+                    /* only set the first (numiotasks_per_node - 1) tasks */
+                    (*iamIOtask) = true;
+                } else if ((iam/lstride) == numiotasks_per_node) {
+                    /*  If there is an uneven number of io-clients to io-nodes
+                        allocate the first remainder - 1 processor sets to
+                        have a total of numiotasks_per_node */
+                    if(psetNum < remainder) {(*iamIOtask) = true;
+                    };
+                }
+            }
+            /*       printf("comm = %d iam = %d lstride = %d coreID = %d iamIOtask = %i \n",comm, iam,lstride,coreId,(*iamIOtask)); */
+        }
+    }else{
+        /* We are not doing rearrangement.... so all tasks are io-tasks */
+        (*iamIOtask) = true;
+    }
+
+    /*printf("comm = %d myrank = %i iotask = %i \n", comm, rank, (*iamIOtask));*/
+
+    /* now we need to correctly determine the numiotasks */
+    MPI_Allreduce(iamIOtask, &task_count, 1, MPI_INT, MPI_SUM, comm);
+
+    (*numiotasks) = task_count;
+
+
 }
 
 int bgq_ion_id (void)
 {
-  int iA,  iB,  iC,  iD,  iE;                /* The local node's coordinates  */
-  int nA,  nB,  nC,  nD,  nE;                /* Size of each torus dimension  */
-  int brA, brB, brC, brD, brE;               /* The bridge node's coordinates */
-  int io_node_route_id;
+    int iA,  iB,  iC,  iD,  iE;                /* The local node's coordinates  */
+    int nA,  nB,  nC,  nD,  nE;                /* Size of each torus dimension  */
+    int brA, brB, brC, brD, brE;               /* The bridge node's coordinates */
+    int io_node_route_id;
 
-  Personality_t personality;
+    Personality_t personality;
 
-  Kernel_GetPersonality(&personality, sizeof(personality));
+    Kernel_GetPersonality(&personality, sizeof(personality));
 
-  iA  = personality.Network_Config.Acoord;
-  iB  = personality.Network_Config.Bcoord;
-  iC  = personality.Network_Config.Ccoord;
-  iD  = personality.Network_Config.Dcoord;
-  iE  = personality.Network_Config.Ecoord;
+    iA  = personality.Network_Config.Acoord;
+    iB  = personality.Network_Config.Bcoord;
+    iC  = personality.Network_Config.Ccoord;
+    iD  = personality.Network_Config.Dcoord;
+    iE  = personality.Network_Config.Ecoord;
 
-  nA  = personality.Network_Config.Anodes;
-  nB  = personality.Network_Config.Bnodes;
-  nC  = personality.Network_Config.Cnodes;
-  nD  = personality.Network_Config.Dnodes;
-  nE  = personality.Network_Config.Enodes;
+    nA  = personality.Network_Config.Anodes;
+    nB  = personality.Network_Config.Bnodes;
+    nC  = personality.Network_Config.Cnodes;
+    nD  = personality.Network_Config.Dnodes;
+    nE  = personality.Network_Config.Enodes;
 
-  brA = personality.Network_Config.cnBridge_A;
-  brB = personality.Network_Config.cnBridge_B;
-  brC = personality.Network_Config.cnBridge_C;
-  brD = personality.Network_Config.cnBridge_D;
-  brE = personality.Network_Config.cnBridge_E;
+    brA = personality.Network_Config.cnBridge_A;
+    brB = personality.Network_Config.cnBridge_B;
+    brC = personality.Network_Config.cnBridge_C;
+    brD = personality.Network_Config.cnBridge_D;
+    brE = personality.Network_Config.cnBridge_E;
 
 /*
-* This is the bridge node, numbered in ABCDE order, E increments first.
-* It is considered the unique "io node route identifer" because each
-* bridge node only has one torus link to one io node.
-*/
+ * This is the bridge node, numbered in ABCDE order, E increments first.
+ * It is considered the unique "io node route identifer" because each
+ * bridge node only has one torus link to one io node.
+ */
 
-  io_node_route_id = brE + brD*nE + brC*nD*nE + brB*nC*nD*nE + brA*nB*nC*nD*nE;
+    io_node_route_id = brE + brD*nE + brC*nD*nE + brB*nC*nD*nE + brA*nB*nC*nD*nE;
 
-  return io_node_route_id;
+    return io_node_route_id;
 
 }
 
@@ -280,84 +280,84 @@ int bgq_ion_id (void)
 
 int bgq_pset_info (MPI_Comm comm, int* tot_pset, int* psetID, int* pset_size, int* rank_in_pset)
 {
-  MPI_Comm comp_comm, pset_comm, bridge_comm;
-  int comp_rank, status, key, bridge_root, tot_bridges, cur_pset, itr, t_buf;
-  int temp_id, rem_psets;
-  MPI_Status mpi_status;
+    MPI_Comm comp_comm, pset_comm, bridge_comm;
+    int comp_rank, status, key, bridge_root, tot_bridges, cur_pset, itr, t_buf;
+    int temp_id, rem_psets;
+    MPI_Status mpi_status;
 
-  MPI_Comm_rank (comm, &comp_rank);
+    MPI_Comm_rank (comm, &comp_rank);
 
-  status = MPI_Comm_dup ( comm, &comp_comm);
-  if ( MPI_SUCCESS != status)
+    status = MPI_Comm_dup ( comm, &comp_comm);
+    if ( MPI_SUCCESS != status)
     {
-      printf(" Error duplicating communicator \n");
-      MPI_Abort(comm, status);
+        printf(" Error duplicating communicator \n");
+        MPI_Abort(comm, status);
     }
 
-  // Compute the ION BridgeNode ID
-  key = bgq_ion_id ();
-  
-  // Create the pset_comm per bridge node
-  status = MPI_Comm_split ( comp_comm, key, comp_rank, &pset_comm);
-  if ( MPI_SUCCESS != status)
+    // Compute the ION BridgeNode ID
+    key = bgq_ion_id ();
+
+    // Create the pset_comm per bridge node
+    status = MPI_Comm_split ( comp_comm, key, comp_rank, &pset_comm);
+    if ( MPI_SUCCESS != status)
     {
-      printf(" Error splitting communicator \n");
-      MPI_Abort(comm, status);
+        printf(" Error splitting communicator \n");
+        MPI_Abort(comm, status);
     }
 
-  // Calculate the rank in pset and pset size
-  MPI_Comm_rank (pset_comm, rank_in_pset);
-  MPI_Comm_size (pset_comm, pset_size);
-  
-  // Create the Bridge root nodes communicator
-  bridge_root = 0;
-  if (0 == *rank_in_pset)
-    bridge_root = 1;
+    // Calculate the rank in pset and pset size
+    MPI_Comm_rank (pset_comm, rank_in_pset);
+    MPI_Comm_size (pset_comm, pset_size);
 
-  // Calculate the total number of bridge nodes / psets
-  tot_bridges = 0;
-  MPI_Allreduce (&bridge_root, &tot_bridges, 1, MPI_INT, MPI_SUM, comm);
-  
-  *tot_pset = tot_bridges;
+    // Create the Bridge root nodes communicator
+    bridge_root = 0;
+    if (0 == *rank_in_pset)
+        bridge_root = 1;
 
-  // Calculate the Pset ID
-  cur_pset = 0;
-  rem_psets = tot_bridges;
-  if ((0 == comp_rank) && (bridge_root ==1))
+    // Calculate the total number of bridge nodes / psets
+    tot_bridges = 0;
+    MPI_Allreduce (&bridge_root, &tot_bridges, 1, MPI_INT, MPI_SUM, comm);
+
+    *tot_pset = tot_bridges;
+
+    // Calculate the Pset ID
+    cur_pset = 0;
+    rem_psets = tot_bridges;
+    if ((0 == comp_rank) && (bridge_root ==1))
     {
-      *psetID = 0;
-      rem_psets = tot_bridges-1;
-      cur_pset++;
-    }
-  
-  t_buf = 0; // Dummy value
-  if (0 == comp_rank)
-    {
-      for (itr = 0; itr < rem_psets; itr++)
-	{
-	  MPI_Recv (&t_buf,1, MPI_INT,  MPI_ANY_SOURCE, MPI_ANY_TAG,comm, &mpi_status);
-	  MPI_Send (&cur_pset, 1, MPI_INT, mpi_status.MPI_SOURCE, 0, comm);
-	  cur_pset++;
-	}
+        *psetID = 0;
+        rem_psets = tot_bridges-1;
+        cur_pset++;
     }
 
-  if ((1 == bridge_root) && ( 0 != comp_rank))
+    t_buf = 0; // Dummy value
+    if (0 == comp_rank)
     {
-      MPI_Send (&t_buf, 1, MPI_INT, 0, 0, comm);
-      MPI_Recv (&temp_id,1, MPI_INT, 0, 0, comm, &mpi_status);
-      
-      *psetID = temp_id;
-      /*printf (" Pset ID is %d \n", *psetID);*/
+        for (itr = 0; itr < rem_psets; itr++)
+        {
+            MPI_Recv (&t_buf,1, MPI_INT,  MPI_ANY_SOURCE, MPI_ANY_TAG,comm, &mpi_status);
+            MPI_Send (&cur_pset, 1, MPI_INT, mpi_status.MPI_SOURCE, 0, comm);
+            cur_pset++;
+        }
     }
-  // Broadcast the PSET ID to all ranks in the psetcomm
-  MPI_Bcast ( psetID, 1, MPI_INT, 0, pset_comm);
-  
-  // Free the split comm
-  MPI_Comm_free (&pset_comm);
-  
-  MPI_Barrier (comm);
-  
-  return 0;
+
+    if ((1 == bridge_root) && ( 0 != comp_rank))
+    {
+        MPI_Send (&t_buf, 1, MPI_INT, 0, 0, comm);
+        MPI_Recv (&temp_id,1, MPI_INT, 0, 0, comm, &mpi_status);
+
+        *psetID = temp_id;
+        /*printf (" Pset ID is %d \n", *psetID);*/
+    }
+    // Broadcast the PSET ID to all ranks in the psetcomm
+    MPI_Bcast ( psetID, 1, MPI_INT, 0, pset_comm);
+
+    // Free the split comm
+    MPI_Comm_free (&pset_comm);
+
+    MPI_Barrier (comm);
+
+    return 0;
 }
 
 #endif


### PR DESCRIPTION
A good suggestion from the meeting is that reformatting be applied to the entire codebase, without any other changes, as its own pull request.

That is what this is. In emacs I opened each file and ran the following commands:
M-x indent-region (for the whole file)
M-x untabify
M-x delete-trailing-whitespace

So there are no actual code changes. Just a lot of whitespace changes.

