### PR TITLE
documentation fixes for pioc.c

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1,5 +1,5 @@
-/** 
- * @file 
+/**
+ * @file
  * Some initialization and support functions.
  * @author Jim Edwards
  * @date  2014
@@ -13,7 +13,7 @@
 
 static int counter = 0;
 
-/** 
+/**
  * Check to see if PIO has been initialized.
  *
  * @param iosysid the IO system ID
@@ -24,7 +24,7 @@ static int counter = 0;
 int PIOc_iosystem_is_active(const int iosysid, bool *active)
 {
     iosystem_desc_t *ios;
-    
+
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
 
@@ -37,7 +37,7 @@ int PIOc_iosystem_is_active(const int iosysid, bool *active)
     return PIO_NOERR;
 }
 
-/** 
+/**
  * Check to see if PIO file is open.
  *
  * @param ncid the ncid of an open file
@@ -54,7 +54,7 @@ int PIOc_File_is_Open(int ncid)
         return 1;
 }
 
-/** 
+/**
  * Set the error handling method to be used for subsequent pio
  * library calls, returns the previous method setting.
  *
@@ -77,7 +77,7 @@ int PIOc_Set_File_Error_Handling(int ncid, int method)
     return oldmethod;
 }
 
-/** 
+/**
  * Increment the unlimited dimension of the given variable.
  *
  * @param ncid the ncid of the open file
@@ -98,7 +98,7 @@ int PIOc_advanceframe(int ncid, int varid)
     return(PIO_NOERR);
 }
 
-/** 
+/**
  * @ingroup PIO_setframe
  * Set the unlimited dimension of the given variable
  *
@@ -127,7 +127,7 @@ int PIOc_setframe(const int ncid, const int varid, const int frame)
     return PIO_NOERR;
 }
 
-/** 
+/**
  * Get the number of IO tasks set.
  *
  * @param iosysid the IO system ID
@@ -148,7 +148,7 @@ int PIOc_get_numiotasks(int iosysid, int *numiotasks)
     return PIO_NOERR;
 }
 
-/** 
+/**
  * Get the IO rank on the current task.
  *
  * @param iosysid the IO system ID
@@ -169,7 +169,7 @@ int PIOc_get_iorank(int iosysid, int *iorank)
     return PIO_NOERR;
 }
 
-/** 
+/**
  * Get the local size of the variable.
  *
  * @param ioid
@@ -178,16 +178,16 @@ int PIOc_get_iorank(int iosysid, int *iorank)
 int PIOc_get_local_array_size(int ioid)
 {
     io_desc_t *iodesc;
-    
+
     iodesc = pio_get_iodesc_from_id(ioid);
-	    
+
     return iodesc->ndof;
 }
 
-/** 
+/**
  * @ingroup PIO_error_method
  * Set the error handling method used for subsequent calls.
- * 
+ *
  * @param iosysid the IO system ID
  * @param method the error handling method
  * @returns 0 on success, error code otherwise
@@ -210,7 +210,7 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
     return oldmethod;
 }
 
-/** 
+/**
  * @ingroup PIO_initdecomp
  * C interface to the initdecomp.
  *
@@ -326,7 +326,7 @@ int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const
     return PIO_NOERR;
 }
 
-/** 
+/**
  * @ingroup PIO_initdecomp
  * This is a simplified initdecomp which can be used if the memory
  * order of the data can be expressed in terms of start and count on
@@ -398,7 +398,7 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
     return PIO_NOERR;
 }
 
-/** 
+/**
  * @ingroup PIO_init
  * Library initialization used when IO tasks are a subset of compute
  * tasks.
@@ -559,13 +559,13 @@ int PIOc_Init_Intracomm_from_F90(int f90_comp_comm,
 			       iosysidp);
 }
 
-/** 
+/**
  * Send a hint to the MPI-IO library.
  *
  * @param iosysid the IO system ID
  * @param hint the hint for MPI
  * @param hintval the value of the hint
- * @returns 0 for success, or PIO_BADID if iosysid can't be found. 
+ * @returns 0 for success, or PIO_BADID if iosysid can't be found.
  */
 int PIOc_set_hint(const int iosysid, char hint[], const char hintval[])
 {
@@ -582,7 +582,7 @@ int PIOc_set_hint(const int iosysid, char hint[], const char hintval[])
 
 }
 
-/** 
+/**
  * @ingroup PIO_finalize
  * Clean up internal data structures, free MPI resources, and exit the
  * pio library.
@@ -684,28 +684,28 @@ int PIOc_finalize(const int iosysid)
     return ierr;
 }
 
-/** 
+/**
  * Return a logical indicating whether this task is an IO task.
  *
  * @param iosysid the io system ID
  * @param ioproc a pointer that gets 1 if task is an IO task, 0
  * otherwise. Ignored if NULL.
- * @returns 0 for success, or PIO_BADID if iosysid can't be found. 
+ * @returns 0 for success, or PIO_BADID if iosysid can't be found.
  */
 int PIOc_iam_iotask(const int iosysid, bool *ioproc)
 {
     iosystem_desc_t *ios;
-    
+
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
 
     if (ioproc)
 	*ioproc = ios->ioproc;
-    
+
     return PIO_NOERR;
 }
 
-/** 
+/**
  * Return the rank of this task in the IO communicator or -1 if this
  * task is not in the communicator.
  *
@@ -717,7 +717,7 @@ int PIOc_iam_iotask(const int iosysid, bool *ioproc)
 int PIOc_iotask_rank(const int iosysid, int *iorank)
 {
     iosystem_desc_t *ios;
-    
+
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
 
@@ -727,7 +727,7 @@ int PIOc_iotask_rank(const int iosysid, int *iorank)
     return PIO_NOERR;
 }
 
-/** 
+/**
  * Return true if this iotype is supported in the build, 0 otherwise.
  *
  * @param iotype the io type to check

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1,8 +1,8 @@
-/**
- * @file
+/** 
+ * @file 
+ * Some initialization and support functions.
  * @author Jim Edwards
  * @date  2014
- * PIO C interface
  *
  * @see http://code.google.com/p/parallelio/
  */
@@ -13,7 +13,8 @@
 
 static int counter = 0;
 
-/** Check to see if PIO has been initialized.
+/** 
+ * Check to see if PIO has been initialized.
  *
  * @param iosysid the IO system ID
  * @param active pointer that gets true if IO system is active, false
@@ -36,7 +37,8 @@ int PIOc_iosystem_is_active(const int iosysid, bool *active)
     return PIO_NOERR;
 }
 
-/** Check to see if PIO file is open.
+/** 
+ * Check to see if PIO file is open.
  *
  * @param ncid the ncid of an open file
  * @returns 1 if file is open, 0 otherwise.
@@ -52,7 +54,8 @@ int PIOc_File_is_Open(int ncid)
         return 1;
 }
 
-/** Set the error handling method to be used for subsequent pio
+/** 
+ * Set the error handling method to be used for subsequent pio
  * library calls, returns the previous method setting.
  *
  * @param ncid the ncid of an open file
@@ -74,7 +77,8 @@ int PIOc_Set_File_Error_Handling(int ncid, int method)
     return oldmethod;
 }
 
-/** Increment the unlimited dimension of the given variable.
+/** 
+ * Increment the unlimited dimension of the given variable.
  *
  * @param ncid the ncid of the open file
  * @param varid the variable ID
@@ -94,7 +98,8 @@ int PIOc_advanceframe(int ncid, int varid)
     return(PIO_NOERR);
 }
 
-/** @ingroup PIO_setframe
+/** 
+ * @ingroup PIO_setframe
  * Set the unlimited dimension of the given variable
  *
  * @param ncid the ncid of the file.
@@ -122,7 +127,8 @@ int PIOc_setframe(const int ncid, const int varid, const int frame)
     return PIO_NOERR;
 }
 
-/** Get the number of IO tasks set.
+/** 
+ * Get the number of IO tasks set.
  *
  * @param iosysid the IO system ID
  * @param numiotasks a pointer taht gets the number of IO
@@ -132,8 +138,8 @@ int PIOc_setframe(const int ncid, const int varid, const int frame)
 int PIOc_get_numiotasks(int iosysid, int *numiotasks)
 {
     iosystem_desc_t *ios;
-    ios = pio_get_iosystem_from_id(iosysid);
-    if(ios == NULL)
+
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
 
     if (numiotasks)
@@ -142,7 +148,8 @@ int PIOc_get_numiotasks(int iosysid, int *numiotasks)
     return PIO_NOERR;
 }
 
-/** Get the IO rank on the current task.
+/** 
+ * Get the IO rank on the current task.
  *
  * @param iosysid the IO system ID
  * @param iorank a pointer that gets the IO rank of the current task,
@@ -152,8 +159,8 @@ int PIOc_get_numiotasks(int iosysid, int *numiotasks)
 int PIOc_get_iorank(int iosysid, int *iorank)
 {
     iosystem_desc_t *ios;
-    ios = pio_get_iosystem_from_id(iosysid);
-    if(ios == NULL)
+
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
 
     if (iorank)
@@ -162,7 +169,8 @@ int PIOc_get_iorank(int iosysid, int *iorank)
     return PIO_NOERR;
 }
 
-/** Get the local size of the variable.
+/** 
+ * Get the local size of the variable.
  *
  * @param ioid
  * @returns 0 on success, error code otherwise
@@ -170,11 +178,14 @@ int PIOc_get_iorank(int iosysid, int *iorank)
 int PIOc_get_local_array_size(int ioid)
 {
     io_desc_t *iodesc;
+    
     iodesc = pio_get_iodesc_from_id(ioid);
-    return(iodesc->ndof);
+	    
+    return iodesc->ndof;
 }
 
-/** @ingroup PIO_error_method
+/** 
+ * @ingroup PIO_error_method
  * Set the error handling method used for subsequent calls.
  * 
  * @param iosysid the IO system ID
@@ -199,7 +210,8 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
     return oldmethod;
 }
 
-/** @ingroup PIO_initdecomp
+/** 
+ * @ingroup PIO_initdecomp
  * C interface to the initdecomp.
  *
  * @param  iosysid @copydoc iosystem_desc_t (input)
@@ -230,21 +242,21 @@ int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const
     int iosize;
     int ndisp;
 
-    for(int i=0;i<ndims;i++){
-        if(dims[i]<=0){
+    for (int i=0;i<ndims;i++){
+        if (dims[i]<=0){
             piodie("Invalid dims argument",__FILE__,__LINE__);
         }
     }
     ios = pio_get_iosystem_from_id(iosysid);
-    if(ios == NULL)
+    if (ios == NULL)
         return PIO_EBADID;
 
 
-    if(PIO_Save_Decomps){
+    if (PIO_Save_Decomps){
         char filename[30];
-        if(ios->num_comptasks < 100) {
+        if (ios->num_comptasks < 100) {
             sprintf(filename, "piodecomp%2.2dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
-        }else if(ios->num_comptasks < 10000) {
+        }else if (ios->num_comptasks < 10000) {
             sprintf(filename, "piodecomp%4.4dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
         }else{
             sprintf(filename, "piodecomp%6.6dtasks%2.2ddims%2.2d.dat",ios->num_comptasks,ndims,counter);
@@ -255,25 +267,25 @@ int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const
 
 
     iodesc = malloc_iodesc(basetype, ndims);
-    if(rearranger == NULL)
+    if (rearranger == NULL)
         iodesc->rearranger = ios->default_rearranger;
     else
         iodesc->rearranger = *rearranger;
 
-    if(iodesc->rearranger==PIO_REARR_SUBSET){
-        if((iostart != NULL) && (iocount != NULL)){
+    if (iodesc->rearranger==PIO_REARR_SUBSET){
+        if ((iostart != NULL) && (iocount != NULL)){
             fprintf(stderr,"%s %s\n","Iostart and iocount arguments to PIOc_InitDecomp",
                     "are incompatable with subset rearrange method and will be ignored");
         }
         iodesc->num_aiotasks = ios->num_iotasks;
         ierr = subset_rearrange_create( *ios, maplen, compmap, dims, ndims, iodesc);
     }else{
-        if(ios->ioproc){
+        if (ios->ioproc){
             //  Unless the user specifies the start and count for each IO task compute it.
-            if((iostart != NULL) && (iocount != NULL)){
+            if ((iostart != NULL) && (iocount != NULL)){
                 //        printf("iocount[0] = %ld %ld\n",iocount[0], iocount);
                 iodesc->maxiobuflen=1;
-                for(int i=0;i<ndims;i++){
+                for (int i=0;i<ndims;i++){
                     iodesc->firstregion->start[i] = iostart[i];
                     iodesc->firstregion->count[i] = iocount[i];
                     compute_maxIObuffersize(ios->io_comm, iodesc);
@@ -292,14 +304,14 @@ int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const
         CheckMPIReturn(MPI_Bcast(&(iodesc->num_aiotasks), 1, MPI_INT, ios->ioroot,
                                  ios->my_comm),__FILE__,__LINE__);
         // Compute the communications pattern for this decomposition
-        if(iodesc->rearranger==PIO_REARR_BOX){
+        if (iodesc->rearranger==PIO_REARR_BOX){
             ierr = box_rearrange_create( *ios, maplen, compmap, dims, ndims, iodesc);
         }
         /*
-          if(ios->ioproc){
+          if (ios->ioproc){
           io_region *ioregion = iodesc->firstregion;
           while(ioregion != NULL){
-          for(int i=0;i<ndims;i++)
+          for (int i=0;i<ndims;i++)
           printf("%s %d i %d dim %d start %ld count %ld\n",__FILE__,__LINE__,i,dims[i],ioregion->start[i],ioregion->count[i]);
           ioregion = ioregion->next;
           }
@@ -314,7 +326,8 @@ int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const
     return PIO_NOERR;
 }
 
-/** @ingroup PIO_initdecomp
+/** 
+ * @ingroup PIO_initdecomp
  * This is a simplified initdecomp which can be used if the memory
  * order of the data can be expressed in terms of start and count on
  * the file.  In this case we compute the compdof and use the subset
@@ -340,35 +353,34 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
     int iosize;
     int ndisp;
 
-
-    for(int i=0;i<ndims;i++){
-        if(dims[i]<=0){
+    for (int i=0;i<ndims;i++){
+        if (dims[i]<=0){
             piodie("Invalid dims argument",__FILE__,__LINE__);
         }
-        if(start[i]<0 || count[i]< 0 || (start[i]+count[i])>dims[i]){
+        if (start[i]<0 || count[i]< 0 || (start[i]+count[i])>dims[i]){
             piodie("Invalid start or count argument ",__FILE__,__LINE__);
         }
     }
     ios = pio_get_iosystem_from_id(iosysid);
-    if(ios == NULL)
+    if (ios == NULL)
         return PIO_EBADID;
 
     int n, i, maplen=1;
 
-    for( i=0;i<ndims;i++){
+    for ( i=0;i<ndims;i++){
         maplen*=count[i];
     }
     PIO_Offset compmap[maplen], prod[ndims], loc[ndims];
 
     prod[ndims-1]=1;
     loc[ndims-1]=0;
-    for(n=ndims-2;n>=0;n--){
+    for (n=ndims-2;n>=0;n--){
         prod[n]=prod[n+1]*dims[n+1];
         loc[n]=0;
     }
-    for(i=0;i<maplen;i++){
+    for (i=0;i<maplen;i++){
         compmap[i]=0;
-        for(n=ndims-1;n>=0;n--){
+        for (n=ndims-1;n>=0;n--){
             compmap[i]+=(start[n]+loc[n])*prod[n];
         }
         n=ndims-1;
@@ -386,8 +398,8 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
     return PIO_NOERR;
 }
 
-/* @ingroup PIO_init
- *
+/** 
+ * @ingroup PIO_init
  * Library initialization used when IO tasks are a subset of compute
  * tasks.
  *
@@ -398,18 +410,12 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
  * communicators before calling this function.
  *
  * @param comp_comm the MPI_Comm of the compute tasks
- *
  * @param num_iotasks the number of io tasks to use
- *
  * @param stride the offset between io tasks in the comp_comm
- *
  * @param base the comp_comm index of the first io task
- *
  * @param rearr the rearranger to use by default, this may be
  * overriden in the @ref PIO_initdecomp
- *
  * @param iosysidp index of the defined system descriptor
- *
  * @return 0 on success, otherwise a PIO error code.
  */
 int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
@@ -425,7 +431,8 @@ int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
     LOG((1, "PIOc_Init_Intracomm comp_comm = %d num_iotasks = %d stride = %d base = %d "
          "rearr = %d", comp_comm, num_iotasks, stride, base, rearr));
 
-    iosys = (iosystem_desc_t *) malloc(sizeof(iosystem_desc_t));
+    if (!(iosys = malloc(sizeof(iosystem_desc_t))))
+	return PIO_ENOMEM;
 
     /* Copy the computation communicator into union_comm. */
     mpierr = MPI_Comm_dup(comp_comm, &iosys->union_comm);
@@ -461,19 +468,19 @@ int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
         /* Find MPI rank and number of tasks in comp_comm communicator. */
         CheckMPIReturn(MPI_Comm_rank(iosys->comp_comm, &(iosys->comp_rank)),__FILE__,__LINE__);
         CheckMPIReturn(MPI_Comm_size(iosys->comp_comm, &(iosys->num_comptasks)),__FILE__,__LINE__);
-        if(iosys->comp_rank==0)
+        if (iosys->comp_rank==0)
             iosys->compmaster = MPI_ROOT;
         LOG((2, "comp_rank = %d num_comptasks = %d", iosys->comp_rank, iosys->num_comptasks));
 
         /* Ensure that settings for number of computation tasks, number
          * of IO tasks, and the stride are reasonable. */
-        if((iosys->num_comptasks == 1) && (num_iotasks*ustride > 1)) {
+        if ((iosys->num_comptasks == 1) && (num_iotasks*ustride > 1)) {
             // This is a serial run with a bad configuration. Set up a single task.
             fprintf(stderr, "PIO_TP PIOc_Init_Intracomm reset stride and tasks.\n");
             iosys->num_iotasks = 1;
             ustride = 1;
         }
-        if((iosys->num_iotasks < 1) || ((iosys->num_iotasks*ustride) > iosys->num_comptasks)){
+        if ((iosys->num_iotasks < 1) || ((iosys->num_iotasks*ustride) > iosys->num_comptasks)){
             fprintf(stderr, "PIO_TP PIOc_Init_Intracomm error\n");
             fprintf(stderr, "num_iotasks=%d, ustride=%d, num_comptasks=%d\n", num_iotasks, ustride, iosys->num_comptasks);
             return PIO_EBADID;
@@ -481,21 +488,21 @@ int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
 
         /* Create an array that holds the ranks of the tasks to be used for IO. */
         iosys->ioranks = (int *) calloc(sizeof(int), iosys->num_iotasks);
-        for(int i=0;i< iosys->num_iotasks; i++){
+        for (int i=0;i< iosys->num_iotasks; i++){
             iosys->ioranks[i] = (base + i*ustride) % iosys->num_comptasks;
-            if(iosys->ioranks[i] == iosys->comp_rank)
+            if (iosys->ioranks[i] == iosys->comp_rank)
                 iosys->ioproc = true;
         }
         iosys->ioroot = iosys->ioranks[0];
 
-        for(int i = 0; i < iosys->num_iotasks; i++)
+        for (int i = 0; i < iosys->num_iotasks; i++)
             LOG((3, "iosys->ioranks[%d] = %d", i, iosys->ioranks[i]));
 
         /* Create an MPI info object. */
         CheckMPIReturn(MPI_Info_create(&(iosys->info)),__FILE__,__LINE__);
         iosys->info = MPI_INFO_NULL;
 
-        if(iosys->comp_rank == iosys->ioranks[0])
+        if (iosys->comp_rank == iosys->ioranks[0])
             iosys->iomaster = MPI_ROOT;
 
         /* Create a group for the computation tasks. */
@@ -534,7 +541,6 @@ int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
 }
 
 /**
- * @internal
  * Interface to call from pio_init from fortran.
  *
  * @param f90_comp_comm
@@ -544,15 +550,17 @@ int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
  * @param rearr the rearranger
  * @param iosysidp a pointer that gets the IO system ID
  * @returns 0 for success, error code otherwise
- * @endinternal
  */
 int PIOc_Init_Intracomm_from_F90(int f90_comp_comm,
                                  const int num_iotasks, const int stride,
-                                 const int base, const int rearr, int *iosysidp){
-    return PIOc_Init_Intracomm(MPI_Comm_f2c(f90_comp_comm), num_iotasks, stride,base,rearr, iosysidp);
+                                 const int base, const int rearr, int *iosysidp)
+{
+    return PIOc_Init_Intracomm(MPI_Comm_f2c(f90_comp_comm), num_iotasks, stride, base, rearr,
+			       iosysidp);
 }
 
-/** Send a hint to the MPI-IO library.
+/** 
+ * Send a hint to the MPI-IO library.
  *
  * @param iosysid the IO system ID
  * @param hint the hint for MPI
@@ -563,17 +571,19 @@ int PIOc_set_hint(const int iosysid, char hint[], const char hintval[])
 {
     iosystem_desc_t *ios;
 
-    ios = pio_get_iosystem_from_id(iosysid);
-    if(ios == NULL)
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
-    if(ios->ioproc)
-        CheckMPIReturn( MPI_Info_set(ios->info, hint, hintval), __FILE__,__LINE__);
+
+    /* Set the MPI hint. */
+    if (ios->ioproc)
+        CheckMPIReturn(MPI_Info_set(ios->info, hint, hintval), __FILE__,__LINE__);
 
     return PIO_NOERR;
 
 }
 
-/** @ingroup PIO_finalize
+/** 
+ * @ingroup PIO_finalize
  * Clean up internal data structures, free MPI resources, and exit the
  * pio library.
  *
@@ -674,7 +684,8 @@ int PIOc_finalize(const int iosysid)
     return ierr;
 }
 
-/** Return a logical indicating whether this task is an IO task.
+/** 
+ * Return a logical indicating whether this task is an IO task.
  *
  * @param iosysid the io system ID
  * @param ioproc a pointer that gets 1 if task is an IO task, 0
@@ -694,7 +705,8 @@ int PIOc_iam_iotask(const int iosysid, bool *ioproc)
     return PIO_NOERR;
 }
 
-/** Return the rank of this task in the IO communicator or -1 if this
+/** 
+ * Return the rank of this task in the IO communicator or -1 if this
  * task is not in the communicator.
  *
  * @param iosysid the io system ID
@@ -715,15 +727,14 @@ int PIOc_iotask_rank(const int iosysid, int *iorank)
     return PIO_NOERR;
 }
 
-/** Return true if this iotype is supported in the build, 0 otherwise.
+/** 
+ * Return true if this iotype is supported in the build, 0 otherwise.
  *
  * @param iotype the io type to check
  * @returns 1 if iotype is in build, 0 if not.
  */
-
 int PIOc_iotype_available(const int iotype)
 {
-
     switch(iotype)
     {
 #ifdef _NETCDF

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -2,7 +2,7 @@
  * @file
  * @author Jim Edwards
  * @date  2014
- * @brief PIO C interface
+ * PIO C interface
  *
  * @see http://code.google.com/p/parallelio/
  */
@@ -11,29 +11,36 @@
 #include <pio.h>
 #include <pio_internal.h>
 
-static int counter=0;
+static int counter = 0;
 
-/**
- ** @brief Check to see if PIO has been initialized.
+/** Check to see if PIO has been initialized.
+ *
+ * @param iosysid the IO system ID
+ * @param active pointer that gets true if IO system is active, false
+ * otherwise.
+ * @returns 0 on success, error code otherwise
  */
 int PIOc_iosystem_is_active(const int iosysid, bool *active)
 {
     iosystem_desc_t *ios;
-    ios = pio_get_iosystem_from_id(iosysid);
-    if(ios == NULL)
+    
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
 
-    if(ios->comp_comm == MPI_COMM_NULL && ios->io_comm == MPI_COMM_NULL){
-        *active = false;
-    }else{
-        *active = true;
-    }
+    if (active)
+	if (ios->comp_comm == MPI_COMM_NULL && ios->io_comm == MPI_COMM_NULL)
+	    *active = false;
+	else
+	    *active = true;
+
     return PIO_NOERR;
 }
-/**
- ** @brief Check to see if PIO file is open.
- */
 
+/** Check to see if PIO file is open.
+ *
+ * @param ncid the ncid of an open file
+ * @returns 1 if file is open, 0 otherwise.
+ */
 int PIOc_File_is_Open(int ncid)
 {
     file_desc_t *file;
@@ -45,9 +52,12 @@ int PIOc_File_is_Open(int ncid)
         return 1;
 }
 
-/**
- ** Set the error handling method to be used for subsequent
- ** pio library calls, returns the previous method setting
+/** Set the error handling method to be used for subsequent pio
+ * library calls, returns the previous method setting.
+ *
+ * @param ncid the ncid of an open file
+ * @param method the error handling method
+ * @returns 0 on success, error code otherwise
  */
 int PIOc_Set_File_Error_Handling(int ncid, int method)
 {
@@ -64,8 +74,11 @@ int PIOc_Set_File_Error_Handling(int ncid, int method)
     return oldmethod;
 }
 
-/**
- ** @brief Increment the unlimited dimension of the given variable
+/** Increment the unlimited dimension of the given variable.
+ *
+ * @param ncid the ncid of the open file
+ * @param varid the variable ID
+ * @returns 0 on success, error code otherwise
  */
 int PIOc_advanceframe(int ncid, int varid)
 {
@@ -81,9 +94,8 @@ int PIOc_advanceframe(int ncid, int varid)
     return(PIO_NOERR);
 }
 
-/**
- * @ingroup PIO_setframe
- * @brief Set the unlimited dimension of the given variable
+/** @ingroup PIO_setframe
+ * Set the unlimited dimension of the given variable
  *
  * @param ncid the ncid of the file.
  * @param varid the varid of the variable
@@ -110,8 +122,12 @@ int PIOc_setframe(const int ncid, const int varid, const int frame)
     return PIO_NOERR;
 }
 
-/**
- ** @brief Get the number of IO tasks set.
+/** Get the number of IO tasks set.
+ *
+ * @param iosysid the IO system ID
+ * @param numiotasks a pointer taht gets the number of IO
+ * tasks. Ignored if NULL.
+ * @returns 0 on success, error code otherwise
  */
 int PIOc_get_numiotasks(int iosysid, int *numiotasks)
 {
@@ -120,15 +136,18 @@ int PIOc_get_numiotasks(int iosysid, int *numiotasks)
     if(ios == NULL)
         return PIO_EBADID;
 
-    *numiotasks = ios->num_iotasks;
+    if (numiotasks)
+	*numiotasks = ios->num_iotasks;
 
     return PIO_NOERR;
-
 }
 
-
-/**
- ** @brief Get the IO rank on the current task
+/** Get the IO rank on the current task.
+ *
+ * @param iosysid the IO system ID
+ * @param iorank a pointer that gets the IO rank of the current task,
+ * or -1 if it is not an IO task. Ignored if NULL.
+ * @returns 0 on success, error code otherwise
  */
 int PIOc_get_iorank(int iosysid, int *iorank)
 {
@@ -137,16 +156,17 @@ int PIOc_get_iorank(int iosysid, int *iorank)
     if(ios == NULL)
         return PIO_EBADID;
 
-    *iorank = ios->io_rank;
+    if (iorank)
+	*iorank = ios->io_rank;
 
     return PIO_NOERR;
-
 }
 
-/**
- ** @brief Get the local size of the variable
+/** Get the local size of the variable.
+ *
+ * @param ioid
+ * @returns 0 on success, error code otherwise
  */
-
 int PIOc_get_local_array_size(int ioid)
 {
     io_desc_t *iodesc;
@@ -154,9 +174,12 @@ int PIOc_get_local_array_size(int ioid)
     return(iodesc->ndof);
 }
 
-/**
- * @ingroup PIO_error_method
+/** @ingroup PIO_error_method
  * Set the error handling method used for subsequent calls.
+ * 
+ * @param iosysid the IO system ID
+ * @param method the error handling method
+ * @returns 0 on success, error code otherwise
  */
 int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
 {
@@ -165,11 +188,7 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
 
     /* Find info about this iosystem. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-    {
-        fprintf(stderr,"%s %d Error setting eh method\n",__FILE__,__LINE__);
-        print_trace(stderr);
         return PIO_EBADID;
-    }
 
     /* Remember old method setting. */
     oldmethod = ios->error_handler;
@@ -180,19 +199,25 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
     return oldmethod;
 }
 
-/**
- ** @ingroup PIO_initdecomp
- ** @brief C interface to the initdecomp
- ** @param  iosysid @copydoc iosystem_desc_t (input)
- ** @param  basetype the basic PIO data type used (input)
- ** @param  ndims the number of dimensions in the variable (input)
- ** @param  dims[] the global size of each dimension (input)
- ** @param  maplen the local length of the compmap array (input)
- ** @param  compmap[] a 1 based array of offsets into the array record on file.  A 0 in this array indicates a value which should not be transfered. (input)
- ** @param ioidp  the io description pointer (output)
- ** @param rearranger the rearranger to be used for this decomp or NULL to use the default (optional input)
- ** @param iostart An optional array of start values for block cyclic decompositions  (optional input)
- ** @param iocount An optional array of count values for block cyclic decompositions  (optional input)
+/** @ingroup PIO_initdecomp
+ * C interface to the initdecomp.
+ *
+ * @param  iosysid @copydoc iosystem_desc_t (input)
+ * @param  basetype the basic PIO data type used (input)
+ * @param  ndims the number of dimensions in the variable (input)
+ * @param  dims[] the global size of each dimension (input)
+ * @param  maplen the local length of the compmap array (input)
+ * @param compmap[] a 1 based array of offsets into the array record
+ * on file.  A 0 in this array indicates a value which should not be
+ * transfered. (input)
+ * @param ioidp  the io description pointer (output)
+ * @param rearranger the rearranger to be used for this decomp or NULL
+ * to use the default (optional input)
+ * @param iostart An optional array of start values for block cyclic
+ * decompositions (optional input)
+ * @param iocount An optional array of count values for block cyclic
+ * decompositions (optional input)
+ * @returns 0 on success, error code otherwise
  */
 int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const int dims[],
                     const int maplen, const PIO_Offset *compmap, int *ioidp,const int *rearranger,
@@ -289,13 +314,22 @@ int PIOc_InitDecomp(const int iosysid, const int basetype,const int ndims, const
     return PIO_NOERR;
 }
 
-/**
- ** @ingroup PIO_initdecomp
- ** This is a simplified initdecomp which can be used if the memory order of the data can be
- ** expressed in terms of start and count on the file.
- ** in this case we compute the compdof and use the subset rearranger
+/** @ingroup PIO_initdecomp
+ * This is a simplified initdecomp which can be used if the memory
+ * order of the data can be expressed in terms of start and count on
+ * the file.  In this case we compute the compdof and use the subset
+ * rearranger.
+ *
+ * @param iosysid the IO system ID
+ * @param basetype
+ * @param ndims the number of dimensions
+ * @param dims array of dimensions
+ * @param start start array
+ * @param count count array
+ * @param pointer that gets the IO ID.
+ * @returns 0 for success, error code otherwise
  */
-int PIOc_InitDecomp_bc(const int iosysid, const int basetype,const int ndims, const int dims[],
+int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, const int dims[],
                        const long int start[], const long int count[], int *ioidp)
 
 {
@@ -500,9 +534,17 @@ int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
 }
 
 /**
- ** @internal
- ** interface to call from pio_init from fortran
- ** @endinternal
+ * @internal
+ * Interface to call from pio_init from fortran.
+ *
+ * @param f90_comp_comm
+ * @param num_iotasks the number of IO tasks
+ * @param stride the stride to use assigning tasks
+ * @param base the starting point when assigning tasks
+ * @param rearr the rearranger
+ * @param iosysidp a pointer that gets the IO system ID
+ * @returns 0 for success, error code otherwise
+ * @endinternal
  */
 int PIOc_Init_Intracomm_from_F90(int f90_comp_comm,
                                  const int num_iotasks, const int stride,
@@ -510,9 +552,12 @@ int PIOc_Init_Intracomm_from_F90(int f90_comp_comm,
     return PIOc_Init_Intracomm(MPI_Comm_f2c(f90_comp_comm), num_iotasks, stride,base,rearr, iosysidp);
 }
 
-/**
- ** @brief Send a hint to the MPI-IO library
- **
+/** Send a hint to the MPI-IO library.
+ *
+ * @param iosysid the IO system ID
+ * @param hint the hint for MPI
+ * @param hintval the value of the hint
+ * @returns 0 for success, or PIO_BADID if iosysid can't be found. 
  */
 int PIOc_set_hint(const int iosysid, char hint[], const char hintval[])
 {
@@ -533,7 +578,6 @@ int PIOc_set_hint(const int iosysid, char hint[], const char hintval[])
  * pio library.
  *
  * @param iosysid: the io system ID provided by PIOc_Init_Intracomm().
- *
  * @returns 0 for success or non-zero for error.
  */
 int PIOc_finalize(const int iosysid)
@@ -558,7 +602,6 @@ int PIOc_finalize(const int iosysid)
     if (ios->async_interface && ios->union_comm != MPI_COMM_NULL)
     {
         int msg = PIO_MSG_EXIT;
-        LOG((3, "async"));
 
         if (!ios->ioproc)
         {
@@ -568,8 +611,6 @@ int PIOc_finalize(const int iosysid)
             /* Send the message to the message handler. */
             if (ios->compmaster)
                 mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-
-            LOG((2, "sending iosysid = %d", iosysid));
 
             /* Send the parameters of the function call. */
             if (!mpierr)
@@ -608,102 +649,98 @@ int PIOc_finalize(const int iosysid)
         MPI_Group_free(&ios->compgroup);
 
     if (ios->iogroup != MPI_GROUP_NULL)
-    {
         MPI_Group_free(&(ios->iogroup));
-        LOG((2, "Freed MPI groups."));
-    }
 
     /* Free the MPI communicators. my_comm is just a copy (but not an
      * MPI copy), so does not have to have an MPI_Comm_free()
      * call. comp_comm and io_comm are MPI duplicates of the comms
      * handed into init_intercomm. So they need to be freed by MPI. */
     if (ios->intercomm != MPI_COMM_NULL)
-    {
-        LOG((3, "freeing intercomm %d", ios->intercomm));
         MPI_Comm_free(&ios->intercomm);
-    }
     if (ios->union_comm != MPI_COMM_NULL)
-    {
-        LOG((3, "freeing union_comm %d", ios->union_comm));
         MPI_Comm_free(&ios->union_comm);
-    }
     if (ios->io_comm != MPI_COMM_NULL)
-    {
-        LOG((3, "freeing io_comm %d", ios->io_comm));
         MPI_Comm_free(&ios->io_comm);
-    }
     if (ios->comp_comm != MPI_COMM_NULL)
-    {
-        LOG((3, "freeing comp_comm %d", ios->comp_comm));
         MPI_Comm_free(&ios->comp_comm);
-    }
     if (ios->my_comm != MPI_COMM_NULL)
         ios->my_comm = MPI_COMM_NULL;
 
     /* Delete the iosystem_desc_t data associated with this id. */
     LOG((2, "About to delete iosysid %d.", iosysid));
     ierr = pio_delete_iosystem_from_list(iosysid);
-    LOG((2, "Deleted iosysid %d ierr = %d", iosysid, ierr));
     LOG((2, "PIOc_finalize completed successfully"));
 
     return ierr;
 }
 
-/**
- ** @brief return a logical indicating whether this task is an iotask
+/** Return a logical indicating whether this task is an IO task.
+ *
+ * @param iosysid the io system ID
+ * @param ioproc a pointer that gets 1 if task is an IO task, 0
+ * otherwise. Ignored if NULL.
+ * @returns 0 for success, or PIO_BADID if iosysid can't be found. 
  */
 int PIOc_iam_iotask(const int iosysid, bool *ioproc)
 {
     iosystem_desc_t *ios;
-    ios = pio_get_iosystem_from_id(iosysid);
-    if(ios == NULL)
+    
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
 
-    *ioproc = ios->ioproc;
+    if (ioproc)
+	*ioproc = ios->ioproc;
+    
     return PIO_NOERR;
 }
 
-/**
- ** @brief return the rank of this task in the io comm or
- ** -1 if this task is not in the comm
+/** Return the rank of this task in the IO communicator or -1 if this
+ * task is not in the communicator.
+ *
+ * @param iosysid the io system ID
+ * @param iorank a pointer that gets the io rank, or -1 if task is not
+ * in the IO communicator. Ignored if NULL.
+ * @returns 0 for success, or PIO_BADID if iosysid can't be found.
  */
 int PIOc_iotask_rank(const int iosysid, int *iorank)
 {
     iosystem_desc_t *ios;
-    ios = pio_get_iosystem_from_id(iosysid);
-    if(ios == NULL)
+    
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return PIO_EBADID;
 
-    *iorank = ios->io_rank;
+    if (iorank)
+	*iorank = ios->io_rank;
 
     return PIO_NOERR;
-
 }
 
-/**
- ** @brief return true if this iotype is supported in the build, 0 otherwise
+/** Return true if this iotype is supported in the build, 0 otherwise.
+ *
+ * @param iotype the io type to check
+ * @returns 1 if iotype is in build, 0 if not.
  */
 
 int PIOc_iotype_available(const int iotype)
 {
 
-    switch(iotype){
+    switch(iotype)
+    {
 #ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
     case PIO_IOTYPE_NETCDF4C:
-        return(1);
+        return 1;
 #endif
     case PIO_IOTYPE_NETCDF:
-        return(1);
+        return 1;
 #endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
-        return(1);
+        return 1;
         break;
 #endif
     default:
-        return(0);
+        return 0;
     }
-
 }

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -579,7 +579,6 @@ int PIOc_set_hint(const int iosysid, char hint[], const char hintval[])
         CheckMPIReturn(MPI_Info_set(ios->info, hint, hintval), __FILE__,__LINE__);
 
     return PIO_NOERR;
-
 }
 
 /**

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -175,7 +175,7 @@ void pio_log(int severity, const char *fmt, ...)
 static pio_swapm_defaults swapm_defaults;
 bool PIO_Save_Decomps=false;
 
-/* Get PIO environment variables.
+/** Get PIO environment variables.
  */
 void pio_get_env(void)
 {

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -10,8 +10,10 @@
 #include <pio_internal.h>
 
 #include <execinfo.h>
+
 #define versno 2001
 
+/* Some logging constants. */
 #if PIO_ENABLE_LOGGING
 #define MAX_LOG_MSG 1024
 #define MAX_RANK_STR 12
@@ -32,7 +34,6 @@ FILE *LOG_FILE;
  */
 int PIOc_strerror(int pioerr, char *errmsg)
 {
-
     /* System error? */
     if(pioerr > 0)
     {
@@ -57,7 +58,8 @@ int PIOc_strerror(int pioerr, char *errmsg)
     else
     {
         /* Handle PIO errors. */
-        switch(pioerr) {
+        switch(pioerr)
+	{
         case PIO_EBADIOTYPE:
             strcpy(errmsg, "Bad IO type");
             break;
@@ -69,10 +71,21 @@ int PIOc_strerror(int pioerr, char *errmsg)
     return PIO_NOERR;
 }
 
-/** Set the logging level. Set to -1 for nothing, 0 for errors only, 1
- * for important logging, and so on. Log levels below 1 are only
- * printed on the io/component root. If the library is not built with
- * logging, this function does nothing. */
+/** Set the logging level if PIO was built with
+ * PIO_ENABLE_LOGGING. Set to -1 for nothing, 0 for errors only, 1 for
+ * important logging, and so on. Log levels below 1 are only printed
+ * on the io/component root.
+ *
+ * A log file is also produced for each task. The file is called
+ * pio_log_X.txt, where X is the (0-based) task number.
+ *
+ * If the library is not built with logging, this function does
+ * nothing.
+ *
+ * @param level the logging level, 0 for errors only, 5 for max
+ * verbosity. 
+ * @returns 0 on success, error code otherwise. 
+ */
 int PIOc_set_log_level(int level)
 {
 #if PIO_ENABLE_LOGGING
@@ -89,15 +102,22 @@ int PIOc_set_log_level(int level)
 
 #if PIO_ENABLE_LOGGING
 /** This function prints out a message, if the severity of the message
-    is lower than the global pio_log_level. To use it, do something
-    like this:
-
-    pio_log(0, "this computer will explode in %d seconds", i);
-
-    After the first arg (the severity), use the rest like a normal
-    printf statement. Output will appear on stdout.
-    This function is heavily based on the function in section 15.5 of
-    the C FAQ.
+ * is lower than the global pio_log_level. To use it, do something
+ * like this:
+ *
+ * pio_log(0, "this computer will explode in %d seconds", i);
+ *
+ * After the first arg (the severity), use the rest like a normal
+ * printf statement. Output will appear on stdout.
+ * This function is heavily based on the function in section 15.5 of
+ * the C FAQ.
+ *
+ * In code this functions should be wrapped in the LOG(()) macro.
+ *
+ * @param severity the severity of the message, 0 for error messages,
+ * then increasing levels of verbosity.
+ * @param fmt the format string.
+ * @param ... the arguments used in format string.
 */
 void pio_log(int severity, const char *fmt, ...)
 {
@@ -154,10 +174,9 @@ void pio_log(int severity, const char *fmt, ...)
 
 static pio_swapm_defaults swapm_defaults;
 bool PIO_Save_Decomps=false;
-/**
- ** @brief Get PIO environment variables
- **
- **/
+
+/* Get PIO environment variables.
+ */
 void pio_get_env(void)
 {
     char *envptr;


### PR DESCRIPTION
This PR contains documentation fixes to pioc.c and pioc_support.c.

It also includes some whitespace changes, and some removal of detailed logging that I put in when hunting for recent iosystem bugs.

Unfortunately, the doxygen internal flag does not do what we were hoping it did. We must come up with a different way of documenting some functions for developers, and some for the user. I will address that in a new github issue.