### PR TITLE
removed use of environmental vars

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -528,9 +528,6 @@ int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
         /* Add this iosys struct to the list in the PIO library. */
         *iosysidp = pio_add_to_iosystem_list(iosys);
 
-        /* Get some info from the environment. */
-        pio_get_env();
-
         /* Allocate buffer space for compute nodes. */
         compute_buffer_init(*iosys);
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -177,51 +177,6 @@ void pio_log(int severity, const char *fmt, ...)
 static pio_swapm_defaults swapm_defaults;
 bool PIO_Save_Decomps=false;
 
-/** Get PIO environment variables.
- */
-void pio_get_env(void)
-{
-    char *envptr;
-    extern bufsize pio_cnbuffer_limit;
-    envptr = getenv("PIO_Save_Decomps");
-
-    if(envptr != NULL && (strcmp(envptr,"true")==0)){
-        PIO_Save_Decomps=true;
-    }
-    swapm_defaults.nreqs = 0;
-    swapm_defaults.handshake=false;
-    swapm_defaults.isend=false;
-
-    envptr = getenv("PIO_SWAPM");
-    if(envptr != NULL){
-        char *token = strtok(envptr, ":");
-
-        swapm_defaults.nreqs = atoi(token);
-
-        token = strtok(NULL, ":");
-
-        if((token!=NULL) && strcmp(token,"t")==0){
-            swapm_defaults.handshake = true;
-        }
-        token = strtok(NULL, ":");
-
-        if((token!=NULL) && strcmp(token,"t")==0){
-            swapm_defaults.isend = true;
-        }
-        //printf("nreqs %d handshake %d isend %d\n",swapm_defaults.nreqs, swapm_defaults.handshake, swapm_defaults.isend);
-    }
-    envptr = getenv("PIO_CNBUFFER_LIMIT");
-    if(envptr != NULL){
-        int mult=1;
-        if(strchr(envptr,"M") != NULL){
-            mult = 1000000;
-        }else if(strchr(envptr,"K") != NULL){
-            mult = 1000;
-        }
-        pio_cnbuffer_limit = (bufsize) atoll(envptr) * mult;
-    }
-}
-
 /* Obtain a backtrace and print it to stderr. */
 void print_trace (FILE *fp)
 {


### PR DESCRIPTION
From discussion with Jim, it seemed that the use of environment variables in Init_Intracomm() was an old feature, no longer used.

Environment variables are not a good way to control our library functions, so that is probably why their use was abandoned. 

There was never any reference to the environment vars in Init_Intercomm().

This pull request removes this old code.

Fixes #143 
Fixes #138 