### PR TITLE
Making sure we free buffers only after using them

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -487,7 +487,8 @@ int PIOc_sync(int ncid)
                 brel(twmb);
             }
         }
-        flush_output_buffer(file, true, 0);
+        if(file->iotype == PIO_IOTYPE_PNETCDF)
+            flush_output_buffer(file, true, 0);
 
         if (ios->ioproc){
             switch(file->iotype){


### PR DESCRIPTION
This change ensures that we don't free the iobuf and fillbuf
, for PNETCDF iotype, before waiting on the pending io request.
Also see c0884e57a25e283768b451d4a1bcefb676c6ac8a

Also making sure that flush_output_buffer() is only called for
PNETCDF iotype.

Fixes #179 