### PR TITLE
Modify test_darray and test_darray_async to use test_common.c

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -79,7 +79,7 @@ if (NOT PIO_USE_MPI_SERIAL)
   add_executable (test_iosystem3 EXCLUDE_FROM_ALL test_iosystem3.c test_common.c)
   target_link_libraries (test_iosystem3 pioc)
   add_dependencies (tests test_iosystem3)
-  add_executable (test_darray_async EXCLUDE_FROM_ALL test_darray_async.c)
+  add_executable (test_darray_async EXCLUDE_FROM_ALL test_darray_async.c test_common.c)
   target_link_libraries (test_darray_async pioc)
   add_dependencies (tests test_darray_async)
   add_executable (test_file EXCLUDE_FROM_ALL test_file.c)
@@ -90,7 +90,7 @@ add_executable (test_names EXCLUDE_FROM_ALL test_names.c)
 target_link_libraries (test_names pioc)
 add_executable (test_nc4 EXCLUDE_FROM_ALL test_nc4.c)
 target_link_libraries (test_nc4 pioc)
-add_executable (test_darray EXCLUDE_FROM_ALL test_darray.c)
+add_executable (test_darray EXCLUDE_FROM_ALL test_darray.c test_common.c)
 target_link_libraries (test_darray pioc)
 
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
@@ -119,6 +119,10 @@ if (PIO_USE_MPISERIAL)
 else ()
     add_mpi_test(test_darray
         EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_darray
+        NUMPROCS 4
+        TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+    add_mpi_test(test_darray_async
+        EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_darray_async
         NUMPROCS 4
         TIMEOUT ${DEFAULT_TEST_TIMEOUT})
     add_mpi_test(test_file

--- a/tests/unit/test_darray.c
+++ b/tests/unit/test_darray.c
@@ -4,9 +4,13 @@
  *
  */
 #include <pio.h>
-#ifdef TIMING
-#include <gptl.h>
-#endif
+#include <pio_tests.h>
+
+/* The number of tasks this test should run on. */
+#define TARGET_NTASKS 4
+
+/* The name of this test. */
+#define TEST_NAME "test_darray"
 
 #define NUM_NETCDF_FLAVORS 4
 #define NDIM 3
@@ -28,14 +32,6 @@
         fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
         MPI_Finalize();                                                 \
         return ERR_AWFUL;                                               \
-    } while (0)
-
-/** Handle non-MPI errors by finalizing the MPI library and exiting
- * with an exit code. */
-#define ERR(e) do {                                                     \
-        fprintf(stderr, "Error %d in %s, line %d\n", e, __FILE__, __LINE__); \
-        MPI_Finalize();                                                 \
-        return e;                                                       \
     } while (0)
 
 /** Global err buffer for MPI. */

--- a/tests/unit/test_darray.c
+++ b/tests/unit/test_darray.c
@@ -92,7 +92,7 @@ main(int argc, char **argv)
 	for (fmt = 0; fmt < num_flavors; fmt++)
 	{
 	    /* Create the filename. */
-	    sprintf(filename, "%s_%d", TEST_NAME, flavor[fmt]);
+	    sprintf(filename, "%s_%d.nc", TEST_NAME, flavor[fmt]);
 	    
 	    /* Create the netCDF output file. */
 	    printf("rank: %d Creating sample file %s with format %d...\n", my_rank, filename,

--- a/tests/unit/test_darray.c
+++ b/tests/unit/test_darray.c
@@ -113,8 +113,19 @@ main(int argc, char **argv)
 	    if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM, dimids, &varid)))
 		ERR(ret);
 
+	    /* End define mode. */
 	    if ((ret = PIOc_enddef(ncid)))
 		ERR(ret);
+
+	    /* Write some data. */
+	    float fillvalue = 0.0;
+	    PIO_Offset arraylen = 4;
+	    float test_data[arraylen];
+	    for (int f = 0; f < arraylen; f++)
+		test_data[f] = my_rank * 10 + f;
+	    /* if ((ret = PIOc_write_darray(ncid, varid, iosysid, arraylen, test_data, */
+	    /* 				 &fillvalue))) */
+	    /* 	ERR(ret); */
 
 	    /* Close the netCDF file. */
 	    printf("rank: %d Closing the sample data file...\n", my_rank);

--- a/tests/unit/test_darray.c
+++ b/tests/unit/test_darray.c
@@ -12,31 +12,10 @@
 /* The name of this test. */
 #define TEST_NAME "test_darray"
 
-#define NUM_NETCDF_FLAVORS 4
 #define NDIM 3
 #define X_DIM_LEN 400
 #define Y_DIM_LEN 400
-#define NUM_TIMESTEPS 6
 #define VAR_NAME "foo"
-#define ATT_NAME "bar"
-#define START_DATA_VAL 42
-#define ERR_AWFUL 1111
-#define VAR_CACHE_SIZE (1024 * 1024)
-#define VAR_CACHE_NELEMS 10
-#define VAR_CACHE_PREEMPTION 0.5
-
-/** Handle MPI errors. This should only be used with MPI library
- * function calls. */
-#define MPIERR(e) do {                                                  \
-        MPI_Error_string(e, err_buffer, &resultlen);                    \
-        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
-        MPI_Finalize();                                                 \
-        return ERR_AWFUL;                                               \
-    } while (0)
-
-/** Global err buffer for MPI. */
-char err_buffer[MPI_MAX_ERROR_STRING];
-int resultlen;
 
 /** The dimension names. */
 char dim_name[NDIM][NC_MAX_NAME + 1] = {"timestep", "x", "y"};
@@ -52,205 +31,115 @@ int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
 int
 main(int argc, char **argv)
 {
-    int verbose = 1;
-
-    /** Zero-based rank of processor. */
-    int my_rank;
-
-    /** Number of processors involved in current execution. */
-    int ntasks;
-
-    /** Specifies the flavor of netCDF output format. */
-    int iotype;
-
-    /** Different output flavors. */
-    int format[NUM_NETCDF_FLAVORS] = {PIO_IOTYPE_PNETCDF,
-                                      PIO_IOTYPE_NETCDF,
-                                      PIO_IOTYPE_NETCDF4C,
-                                      PIO_IOTYPE_NETCDF4P};
-
-    /** Names for the output files. */
-    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"test_darray_pnetcdf.nc",
-                                                          "test_darray_classic.nc",
-                                                          "test_darray_serial4.nc",
-                                                          "test_darray_parallel4.nc"};
-
-    /** Number of processors that will do IO. In this test we
-     * will do IO from all processors. */
-    int niotasks;
-
-    /** Stride in the mpi rank between io tasks. Always 1 in this
-     * test. */
-    int ioproc_stride = 1;
-
-    /** Number of the aggregator? Always 0 in this test. */
-    int numAggregator = 0;
-
-    /** Zero based rank of first processor to be used for I/O. */
-    int ioproc_start = 0;
-
-    /** The dimension IDs. */
-    int dimids[NDIM];
-
-    /** Array index per processing unit. */
-    PIO_Offset elements_per_pe;
-
-    /** The ID for the parallel I/O system. */
-    int iosysid;
-
-    /** The ncid of the netCDF file. */
-    int ncid;
-
-    /** The ID of the netCDF varable. */
-    int varid;
-
-    /** The I/O description ID. */
-    int ioid;
-
-    /** A buffer for sample data. */
-    float *buffer;
-
-    /** A buffer for reading data back from the file. */
-    int *read_buffer;
-
-    /** The decomposition mapping. */
-    PIO_Offset *compdof;
-
-    /** Return code. */
-    int ret;
-
-    /** Index for loops. */
-    int fmt, d, d1, i;
-
-#ifdef TIMING
-    /* Initialize the GPTL timing library. */
-    if ((ret = GPTLinitialize ()))
-        return ret;
-#endif
-
-    /* Initialize MPI. */
-    if ((ret = MPI_Init(&argc, &argv)))
-        MPIERR(ret);
-
-    /* Learn my rank and the total number of processors. */
-    if ((ret = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
-        MPIERR(ret);
-    if ((ret = MPI_Comm_size(MPI_COMM_WORLD, &ntasks)))
-        MPIERR(ret);
-
-    /* Check that a valid number of processors was specified. */
-    if (!(ntasks == 1 || ntasks == 2 || ntasks == 4 ||
-          ntasks == 8 || ntasks == 16))
-        fprintf(stderr, "Number of processors must be 1, 2, 4, 8, or 16!\n");
-    if (verbose)
-        printf("%d: ParallelIO Library example1 running on %d processors.\n",
-               my_rank, ntasks);
-
-    /* keep things simple - 1 iotask per MPI process */
-    niotasks = ntasks;
-
-    /* Initialize the PIO IO system. This specifies how
-     * many and which processors are involved in I/O. */
-    if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, niotasks, ioproc_stride,
-                                   ioproc_start, PIO_REARR_SUBSET, &iosysid)))
-        ERR(ret);
-
-    /* Describe the decomposition. This is a 1-based array, so add 1! */
-    elements_per_pe = X_DIM_LEN * Y_DIM_LEN / ntasks;
-    if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
-        return PIO_ENOMEM;
-    for (i = 0; i < elements_per_pe; i++) {
-        compdof[i] = my_rank * elements_per_pe + i + 1;
-    }
-
-    /* Create the PIO decomposition for this test. */
-    if (verbose)
-        printf("rank: %d Creating decomposition...\n", my_rank);
-    if ((ret = PIOc_InitDecomp(iosysid, PIO_FLOAT, 2, &dim_len[1], (PIO_Offset)elements_per_pe,
-                               compdof, &ioid, NULL, NULL, NULL)))
-        ERR(ret);
-    free(compdof);
-
-    /* How many flavors will we be running for? */
-    int num_flavors = 0;
-    int fmtidx = 0;
-#ifdef _PNETCDF
-    num_flavors++;
-    format[fmtidx++] = PIO_IOTYPE_PNETCDF;
-#endif
-#ifdef _NETCDF
-    num_flavors++;
-    format[fmtidx++] = PIO_IOTYPE_NETCDF;
-#endif
-#ifdef _NETCDF4
-    num_flavors += 2;
-    format[fmtidx++] = PIO_IOTYPE_NETCDF4C;
-    format[fmtidx] = PIO_IOTYPE_NETCDF4P;
-#endif
-
-    /* Use PIO to create the example file in each of the four
-     * available ways. */
-    for (fmt = 0; fmt < num_flavors; fmt++)
+    int my_rank;     /* Zero-based rank of processor. */
+    int ntasks;      /* Number of processors involved in current execution. */
+    int iotype;      /* Specifies the flavor of netCDF output format. */
+    char filename[NC_MAX_NAME + 1]; /* Name for the output files. */
+    int niotasks;    /* Number of processors that will do IO. */
+    int ioproc_stride = 1; /* Stride in the mpi rank between io tasks. */
+    int numAggregator = 0; /* Number of the aggregator? */
+    int ioproc_start = 0;  /* Zero based rank of first I/O processor. */
+    int dimids[NDIM];      /* The dimension IDs. */
+    PIO_Offset elements_per_pe;     /* Array index per processing unit. */
+    int iosysid;   /* The ID for the parallel I/O system. */
+    int ncid;      /* The ncid of the netCDF file. */
+    int varid;     /* The ID of the netCDF varable. */
+    int ioid;      /* The I/O description ID. */
+    float *buffer; /* A buffer for sample data. */
+    int *read_buffer;     /* A buffer for reading data back from the file. */
+    PIO_Offset *compdof;  /* The decomposition mapping. */
+    int fmt, d, d1, i;    /* Index for loops. */
+    MPI_Comm test_comm;   /* Contains all tasks running test. */
+    int num_flavors;      /* Number of PIO netCDF flavors in this build. */
+    int flavor[NUM_FLAVORS]; /* iotypes for the supported netCDF IO flavors. */
+    int ret;              /* Return code. */
+	
+    /* Initialize test. */
+    if ((ret = pio_test_init(argc, argv, &my_rank, &ntasks, TARGET_NTASKS, &test_comm)))
+        ERR(ERR_INIT);
+    if (my_rank < TARGET_NTASKS)
     {
-        /* Create the netCDF output file. */
-        if (verbose)
-            printf("rank: %d Creating sample file %s with format %d...\n",
-                   my_rank, filename[fmt], format[fmt]);
-        if ((ret = PIOc_createfile(iosysid, &ncid, &(format[fmt]), filename[fmt],
-                                   PIO_CLOBBER)))
+        /* Figure out iotypes. */
+        if ((ret = get_iotypes(&num_flavors, flavor)))
             ERR(ret);
 
-        /* Define netCDF dimensions and variable. */
-        if (verbose)
-            printf("rank: %d Defining netCDF metadata...\n", my_rank);
-        for (d = 0; d < NDIM; d++) {
-            if (verbose)
-                printf("rank: %d Defining netCDF dimension %s, length %d\n", my_rank,
-                       dim_name[d], dim_len[d]);
-            if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
-                ERR(ret);
-        }
+	/* keep things simple - 1 iotask per MPI process */
+	niotasks = ntasks;
 
-        /* Define a variable. */
-        if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM, dimids, &varid)))
-            ERR(ret);
+	/* Initialize the PIO IO system. This specifies how
+	 * many and which processors are involved in I/O. */
+	if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, niotasks, ioproc_stride,
+				       ioproc_start, PIO_REARR_SUBSET, &iosysid)))
+	    ERR(ret);
 
-        if ((ret = PIOc_enddef(ncid)))
-            ERR(ret);
+	/* Describe the decomposition. This is a 1-based array, so add 1! */
+	elements_per_pe = X_DIM_LEN * Y_DIM_LEN / ntasks;
+	if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
+	    return PIO_ENOMEM;
+	for (i = 0; i < elements_per_pe; i++) {
+	    compdof[i] = my_rank * elements_per_pe + i + 1;
+	}
 
-        /* Close the netCDF file. */
-        if (verbose)
-            printf("rank: %d Closing the sample data file...\n", my_rank);
-        if ((ret = PIOc_closefile(ncid)))
-            ERR(ret);
+	/* Create the PIO decomposition for this test. */
+	printf("rank: %d Creating decomposition...\n", my_rank);
+	if ((ret = PIOc_InitDecomp(iosysid, PIO_FLOAT, 2, &dim_len[1], (PIO_Offset)elements_per_pe,
+				   compdof, &ioid, NULL, NULL, NULL)))
+	    ERR(ret);
+	free(compdof);
 
-        /* Put a barrier here to make verbose output look better. */
-        if ((ret = MPI_Barrier(MPI_COMM_WORLD)))
-            MPIERR(ret);
+	/* Use PIO to create the example file in each of the four
+	 * available ways. */
+	for (fmt = 0; fmt < num_flavors; fmt++)
+	{
+	    /* Create the filename. */
+	    sprintf(filename, "%s_%d", TEST_NAME, flavor[fmt]);
+	    
+	    /* Create the netCDF output file. */
+	    printf("rank: %d Creating sample file %s with format %d...\n", my_rank, filename,
+		   flavor[fmt]);
+	    if ((ret = PIOc_createfile(iosysid, &ncid, &(flavor[fmt]), filename, PIO_CLOBBER)))
+		ERR(ret);
 
-    }
+	    /* Define netCDF dimensions and variable. */
+	    printf("rank: %d Defining netCDF metadata...\n", my_rank);
+	    for (d = 0; d < NDIM; d++) {
+		printf("rank: %d Defining netCDF dimension %s, length %d\n", my_rank,
+		       dim_name[d], dim_len[d]);
+		if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
+		    ERR(ret);
+	    }
 
-    /* Free the PIO decomposition. */
-    if (verbose)
-        printf("rank: %d Freeing PIO decomposition...\n", my_rank);
-    if ((ret = PIOc_freedecomp(iosysid, ioid)))
-        ERR(ret);
+	    /* Define a variable. */
+	    if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM, dimids, &varid)))
+		ERR(ret);
 
-    /* Finalize the IO system. */
-    if (verbose)
-        printf("rank: %d Freeing PIO resources...\n", my_rank);
-    if ((ret = PIOc_finalize(iosysid)))
-        ERR(ret);
+	    if ((ret = PIOc_enddef(ncid)))
+		ERR(ret);
 
-    /* Finalize the MPI library. */
-    MPI_Finalize();
+	    /* Close the netCDF file. */
+	    printf("rank: %d Closing the sample data file...\n", my_rank);
+	    if ((ret = PIOc_closefile(ncid)))
+		ERR(ret);
 
-#ifdef TIMING
-    /* Finalize the GPTL timing library. */
-    if ((ret = GPTLfinalize ()))
-        return ret;
-#endif
+	    /* Put a barrier here to make output look better. */
+	    if ((ret = MPI_Barrier(MPI_COMM_WORLD)))
+		MPIERR(ret);
 
+	}
+
+	/* Free the PIO decomposition. */
+	printf("rank: %d Freeing PIO decomposition...\n", my_rank);
+	if ((ret = PIOc_freedecomp(iosysid, ioid)))
+	    ERR(ret);
+
+    } /* my_rank < TARGET_NTASKS */
+
+    /* Finalize test. */
+    printf("%d %s finalizing...\n", my_rank, TEST_NAME);
+    if ((ret = pio_test_finalize()))
+        return ERR_AWFUL;
+
+    printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
 
     return 0;
 }

--- a/tests/unit/test_darray_async.c
+++ b/tests/unit/test_darray_async.c
@@ -1,5 +1,4 @@
-/**
- * @file
+/*
  * Tests for darray functions.
  * @author Ed Hartnett
  *
@@ -7,225 +6,135 @@
 #include <pio.h>
 #include <pio_tests.h>
 
-#define NUM_NETCDF_FLAVORS 4
+/* The number of tasks this test should run on. */
+#define TARGET_NTASKS 4
+
+/* The name of this test. */
+#define TEST_NAME "test_darray_async"
+
 #define NDIM 3
 #define X_DIM_LEN 400
 #define Y_DIM_LEN 400
 #define VAR_NAME "foo"
 
-/** The dimension names. */
+/* The dimension names. */
 char dim_name[NDIM][NC_MAX_NAME + 1] = {"timestep", "x", "y"};
 
-/** Length of the dimensions in the sample data. */
+/* Length of the dimensions in the sample data. */
 int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
 
-/** Run Tests for darray Functions.
- *
- * @param argc argument count
- * @param argv array of arguments
- */
-int
-main(int argc, char **argv)
+/* Run Tests for darray Functions. */
+int main(int argc, char **argv)
 {
-    int verbose = 1;
+    int my_rank;  /* Zero-based rank of processor. */
+    int ntasks;   /* Number of processors involved in current execution. */    
+    int iotype;   /* Specifies the flavor of netCDF output format. */
+    char filename[NC_MAX_NAME + 1]; /* Name for output file. */
+    int niotasks;    /* Number of processors that will do IO. */
+    int ioproc_stride = 1; /* Stride in the mpi rank between io tasks. */
+    int numAggregator = 0; /* Number of the aggregator? */
+    int ioproc_start = 0;  /* Zero based rank of first processor to be used for I/O. */
+    int dimids[NDIM];      /* The dimension IDs. */
+    PIO_Offset elements_per_pe;  /* Array index per processing unit. */    
+    int iosysid; /* The ID for the parallel I/O system. */
+    int ncid;    /* The ncid of the netCDF file. */
+    int varid;   /* The ncid of the netCDF file. */
+    int ioid;    /* The I/O description ID. */
+    float *buffer;     /* A buffer for sample data. */
+    int *read_buffer;  /* A buffer for reading data back from the file. */
+    PIO_Offset *compdof;  /* The decomposition mapping. */
+    MPI_Comm test_comm;   /* Contains all tasks running test. */
+    int num_flavors;      /* Number of PIO netCDF flavors in this build. */
+    int flavor[NUM_FLAVORS]; /* iotypes for the supported netCDF IO flavors. */
+    int fmt, d, d1, i;    /* Index for loops. */
+    int ret;     /* Return code. */
 
-    /** Zero-based rank of processor. */
-    int my_rank;
-
-    /** Number of processors involved in current execution. */
-    int ntasks;
-
-    /** Specifies the flavor of netCDF output format. */
-    int iotype;
-
-    /** Different output flavors. */
-    int format[NUM_NETCDF_FLAVORS] = {PIO_IOTYPE_PNETCDF,
-                                      PIO_IOTYPE_NETCDF,
-                                      PIO_IOTYPE_NETCDF4C,
-                                      PIO_IOTYPE_NETCDF4P};
-
-    /** Names for the output files. */
-    char filename[NUM_NETCDF_FLAVORS][NC_MAX_NAME + 1] = {"test_darray_pnetcdf.nc",
-                                                          "test_darray_classic.nc",
-                                                          "test_darray_serial4.nc",
-                                                          "test_darray_parallel4.nc"};
-
-    /** Number of processors that will do IO. In this test we
-     * will do IO from all processors. */
-    int niotasks;
-
-    /** Stride in the mpi rank between io tasks. Always 1 in this
-     * test. */
-    int ioproc_stride = 1;
-
-    /** Number of the aggregator? Always 0 in this test. */
-    int numAggregator = 0;
-
-    /** Zero based rank of first processor to be used for I/O. */
-    int ioproc_start = 0;
-
-    /** The dimension IDs. */
-    int dimids[NDIM];
-
-    /** Array index per processing unit. */
-    PIO_Offset elements_per_pe;
-
-    /** The ID for the parallel I/O system. */
-    int iosysid;
-
-    /** The ncid of the netCDF file. */
-    int ncid;
-
-    /** The ID of the netCDF varable. */
-    int varid;
-
-    /** The I/O description ID. */
-    int ioid;
-
-    /** A buffer for sample data. */
-    float *buffer;
-
-    /** A buffer for reading data back from the file. */
-    int *read_buffer;
-
-    /** The decomposition mapping. */
-    PIO_Offset *compdof;
-
-    /** Return code. */
-    int ret;
-
-    /** Index for loops. */
-    int fmt, d, d1, i;
-
-#ifdef TIMING
-    /* Initialize the GPTL timing library. */
-    if ((ret = GPTLinitialize ()))
-        return ret;
-#endif
-
-    /* Initialize MPI. */
-    if ((ret = MPI_Init(&argc, &argv)))
-        MPIERR(ret);
-
-    /* Learn my rank and the total number of processors. */
-    if ((ret = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
-        MPIERR(ret);
-    if ((ret = MPI_Comm_size(MPI_COMM_WORLD, &ntasks)))
-        MPIERR(ret);
-
-    /* Check that a valid number of processors was specified. */
-    if (!(ntasks == 1 || ntasks == 2 || ntasks == 4 ||
-          ntasks == 8 || ntasks == 16))
-        fprintf(stderr, "Number of processors must be 1, 2, 4, 8, or 16!\n");
-    if (verbose)
-        printf("%d: ParallelIO Library example1 running on %d processors.\n",
-               my_rank, ntasks);
-
-    /* keep things simple - 1 iotask per MPI process */
-    niotasks = ntasks;
-
-    /* Initialize the PIO IO system. This specifies how
-     * many and which processors are involved in I/O. */
-    if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, niotasks, ioproc_stride,
-                                   ioproc_start, PIO_REARR_SUBSET, &iosysid)))
-        ERR(ret);
-
-    /* Describe the decomposition. This is a 1-based array, so add 1! */
-    elements_per_pe = X_DIM_LEN * Y_DIM_LEN / ntasks;
-    if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
-        return PIO_ENOMEM;
-    for (i = 0; i < elements_per_pe; i++) {
-        compdof[i] = my_rank * elements_per_pe + i + 1;
-    }
-
-    /* Create the PIO decomposition for this test. */
-    if (verbose)
-        printf("rank: %d Creating decomposition...\n", my_rank);
-    if ((ret = PIOc_InitDecomp(iosysid, PIO_FLOAT, 2, &dim_len[1], (PIO_Offset)elements_per_pe,
-                               compdof, &ioid, NULL, NULL, NULL)))
-        ERR(ret);
-    free(compdof);
-
-    /* How many flavors will we be running for? */
-    int num_flavors = 0;
-    int fmtidx = 0;
-#ifdef _PNETCDF
-    num_flavors++;
-    format[fmtidx++] = PIO_IOTYPE_PNETCDF;
-#endif
-#ifdef _NETCDF
-    num_flavors++;
-    format[fmtidx++] = PIO_IOTYPE_NETCDF;
-#endif
-#ifdef _NETCDF4
-    num_flavors += 2;
-    format[fmtidx++] = PIO_IOTYPE_NETCDF4C;
-    format[fmtidx] = PIO_IOTYPE_NETCDF4P;
-#endif
-
-    /* Use PIO to create the example file in each of the four
-     * available ways. */
-    for (fmt = 0; fmt < num_flavors; fmt++)
+    /* Initialize test. */
+    if ((ret = pio_test_init(argc, argv, &my_rank, &ntasks, TARGET_NTASKS, &test_comm)))
+        ERR(ERR_INIT);
+    if (my_rank < TARGET_NTASKS)
     {
-        /* Create the netCDF output file. */
-        if (verbose)
-            printf("rank: %d Creating sample file %s with format %d...\n",
-                   my_rank, filename[fmt], format[fmt]);
-        if ((ret = PIOc_createfile(iosysid, &ncid, &(format[fmt]), filename[fmt],
-                                   PIO_CLOBBER)))
+        /* Figure out iotypes. */
+        if ((ret = get_iotypes(&num_flavors, flavor)))
             ERR(ret);
 
-        /* Define netCDF dimensions and variable. */
-        if (verbose)
-            printf("rank: %d Defining netCDF metadata...\n", my_rank);
-        for (d = 0; d < NDIM; d++) {
-            if (verbose)
-                printf("rank: %d Defining netCDF dimension %s, length %d\n", my_rank,
-                       dim_name[d], dim_len[d]);
-            if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
-                ERR(ret);
-        }
+	/* keep things simple - 1 iotask per MPI process */
+	niotasks = ntasks;
 
-        /* Define a variable. */
-        if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM, dimids, &varid)))
-            ERR(ret);
+	/* Initialize the PIO IO system. This specifies how
+	 * many and which processors are involved in I/O. */
+	if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, niotasks, ioproc_stride,
+				       ioproc_start, PIO_REARR_SUBSET, &iosysid)))
+	    ERR(ret);
 
-        if ((ret = PIOc_enddef(ncid)))
-            ERR(ret);
+	/* Describe the decomposition. This is a 1-based array, so add 1! */
+	elements_per_pe = X_DIM_LEN * Y_DIM_LEN / ntasks;
+	if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
+	    return PIO_ENOMEM;
+	for (i = 0; i < elements_per_pe; i++) {
+	    compdof[i] = my_rank * elements_per_pe + i + 1;
+	}
 
-        /* Close the netCDF file. */
-        if (verbose)
-            printf("rank: %d Closing the sample data file...\n", my_rank);
-        if ((ret = PIOc_closefile(ncid)))
-            ERR(ret);
+	/* Create the PIO decomposition for this test. */
+	printf("rank: %d Creating decomposition...\n", my_rank);
+	if ((ret = PIOc_InitDecomp(iosysid, PIO_FLOAT, 2, &dim_len[1], (PIO_Offset)elements_per_pe,
+				   compdof, &ioid, NULL, NULL, NULL)))
+	    ERR(ret);
+	free(compdof);
 
-        /* Put a barrier here to make verbose output look better. */
-        if ((ret = MPI_Barrier(MPI_COMM_WORLD)))
-            MPIERR(ret);
+	/* Use PIO to create the example file in each of the four
+	 * available ways. */
+	for (fmt = 0; fmt < num_flavors; fmt++)
+	{
+	    /* Create the filename. */
+	    sprintf(filename, "%s_%d.nc", TEST_NAME, flavor[fmt]);
+	
+	    /* Create the netCDF output file. */
+	    printf("rank: %d Creating sample file %s with format %d...\n",
+		   my_rank, filename, flavor[fmt]);
+	    if ((ret = PIOc_createfile(iosysid, &ncid, &(flavor[fmt]), filename,
+				       PIO_CLOBBER)))
+		ERR(ret);
 
-    }
+	    /* Define netCDF dimensions and variable. */
+	    printf("rank: %d Defining netCDF metadata...\n", my_rank);
+	    for (d = 0; d < NDIM; d++) {
+		printf("rank: %d Defining netCDF dimension %s, length %d\n", my_rank,
+		       dim_name[d], dim_len[d]);
+		if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
+		    ERR(ret);
+	    }
 
-    /* Free the PIO decomposition. */
-    if (verbose)
-        printf("rank: %d Freeing PIO decomposition...\n", my_rank);
-    if ((ret = PIOc_freedecomp(iosysid, ioid)))
-        ERR(ret);
+	    /* Define a variable. */
+	    if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM, dimids, &varid)))
+		ERR(ret);
 
-    /* Finalize the IO system. */
-    if (verbose)
-        printf("rank: %d Freeing PIO resources...\n", my_rank);
-    if ((ret = PIOc_finalize(iosysid)))
-        ERR(ret);
+	    if ((ret = PIOc_enddef(ncid)))
+		ERR(ret);
 
-    /* Finalize the MPI library. */
-    MPI_Finalize();
+	    /* Close the netCDF file. */
+	    printf("rank: %d Closing the sample data file...\n", my_rank);
+	    if ((ret = PIOc_closefile(ncid)))
+		ERR(ret);
 
-#ifdef TIMING
-    /* Finalize the GPTL timing library. */
-    if ((ret = GPTLfinalize ()))
-        return ret;
-#endif
+	    /* Put a barrier here to make verbose output look better. */
+	    if ((ret = MPI_Barrier(MPI_COMM_WORLD)))
+		MPIERR(ret);
 
+	}
+
+	/* Free the PIO decomposition. */
+	printf("rank: %d Freeing PIO decomposition...\n", my_rank);
+	if ((ret = PIOc_freedecomp(iosysid, ioid)))
+	    ERR(ret);
+    } /* my_rank < TARGET_NTASKS */
+
+    /* Finalize test. */
+    printf("%d %s finalizing...\n", my_rank, TEST_NAME);
+    if ((ret = pio_test_finalize()))
+        return ERR_AWFUL;
+
+    printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
 
     return 0;
 }

--- a/tests/unit/test_darray_async.c
+++ b/tests/unit/test_darray_async.c
@@ -5,43 +5,13 @@
  *
  */
 #include <pio.h>
-#ifdef TIMING
-#include <gptl.h>
-#endif
+#include <pio_tests.h>
 
 #define NUM_NETCDF_FLAVORS 4
 #define NDIM 3
 #define X_DIM_LEN 400
 #define Y_DIM_LEN 400
-#define NUM_TIMESTEPS 6
 #define VAR_NAME "foo"
-#define ATT_NAME "bar"
-#define START_DATA_VAL 42
-#define ERR_AWFUL 1111
-#define VAR_CACHE_SIZE (1024 * 1024)
-#define VAR_CACHE_NELEMS 10
-#define VAR_CACHE_PREEMPTION 0.5
-
-/** Handle MPI errors. This should only be used with MPI library
- * function calls. */
-#define MPIERR(e) do {                                                  \
-        MPI_Error_string(e, err_buffer, &resultlen);                    \
-        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
-        MPI_Finalize();                                                 \
-        return ERR_AWFUL;                                               \
-    } while (0)
-
-/** Handle non-MPI errors by finalizing the MPI library and exiting
- * with an exit code. */
-#define ERR(e) do {                                                     \
-        fprintf(stderr, "Error %d in %s, line %d\n", e, __FILE__, __LINE__); \
-        MPI_Finalize();                                                 \
-        return e;                                                       \
-    } while (0)
-
-/** Global err buffer for MPI. */
-char err_buffer[MPI_MAX_ERROR_STRING];
-int resultlen;
 
 /** The dimension names. */
 char dim_name[NDIM][NC_MAX_NAME + 1] = {"timestep", "x", "y"};


### PR DESCRIPTION
As a prelude for putting some meat on these tests, I have updated them to use the test_common.c, and pio_test.h. This eliminates a bunch of code that was repeated in every C test.

No changes to library functionality in this PR - just test code. This is a prelude to working on #89.
