### PR TITLE
Allow OLCF users to run ctest via batch scripts or interactive jobs on Eos/Titan

### DIFF
--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -44,6 +44,12 @@ function (platform_name RETURN_VARIABLE)
     elseif (SITENAME MATCHES "^h2ologin")
 
         set (${RETURN_VARIABLE} "ncsa" PARENT_SCOPE)
+
+    # OLCF/Oak Ridge Machines
+    elseif (SITENAME MATCHES "^eos" OR
+            SITENAME MATCHES "^titan")
+
+        set (${RETURN_VARIABLE} "olcf" PARENT_SCOPE)
         
     else ()
 

--- a/cmake/mpiexec.olcf
+++ b/cmake/mpiexec.olcf
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Arguments:
+#
+#   $1  - Number of MPI Tasks
+#   $2+ - Executable and its arguments
+#
+
+NP=$1
+shift
+
+aprun -n $NP $@


### PR DESCRIPTION
Tested on both Eos and Titan, with all unit tests passed.

Fixes #182. If there is a need to create CDash ctest run scripts for OLCF platform as well, we can do it later.