### PR TITLE
update modules for yellowstone intel

### DIFF
--- a/ctest/runcdash-nwsc-intel.sh
+++ b/ctest/runcdash-nwsc-intel.sh
@@ -9,11 +9,11 @@ fi
 
 module reset
 module unload netcdf
-module swap intel intel/16.0.0
+module swap intel intel/16.0.3
 module load git/2.3.0
 module load cmake/3.0.2
-module load netcdf-mpi/4.3.3.1
-module load pnetcdf/1.6.1
+module load netcdf-mpi/4.4.1
+module load pnetcdf/1.7.0
 
 export CC=mpicc
 export FC=mpif90


### PR DESCRIPTION
This fixes testing for intel on yellowstone by updating to netcdf-mpi/4.4.1
