### PR TITLE
Changes to support async tests on Laramie - needed different indexes …

### DIFF
--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -2064,7 +2064,7 @@ PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
 		    LOG((3, "about to create intercomm for IO component to cmp = %d "
 			 "my_iosys->io_comm = %d", cmp, my_iosys->io_comm));
 		    if ((ret = MPI_Intercomm_create(my_iosys->io_comm, 0, my_iosys->union_comm,
-						    num_procs_per_comp[0], my_rank,
+						    my_proc_list[cmp][0], 0,
 						    &my_iosys->intercomm)))
 			return check_mpi(NULL, ret, __FILE__, __LINE__);
 		}
@@ -2073,8 +2073,9 @@ PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
 		    /* Create the intercomm from computation component to IO component. */
 		    LOG((3, "about to create intercomm for cmp = %d my_iosys->comp_comm = %d", cmp,
 			 my_iosys->comp_comm));
-		    if ((ret = MPI_Intercomm_create(my_iosys->comp_comm, 0, my_iosys->union_comm, 0,
-						    my_rank, &my_iosys->intercomm)))
+		    if ((ret = MPI_Intercomm_create(my_iosys->comp_comm, 0, my_iosys->union_comm, 
+						    my_proc_list[0][0], 0,
+						    &my_iosys->intercomm)))
 			return check_mpi(NULL, ret, __FILE__, __LINE__);
 		}
 		LOG((3, "intercomm created for cmp = %d", cmp));


### PR DESCRIPTION
…and tags in the create_intercomm call in init. @edhartnett Please take a look at these changes. The Laramie test cluster wanted some changes to the MPI_Intercomm_create call to get it to work. I changed the index of the second comm root to be relative to the peer comm (union_comm) and the tag to be a single value (rather than all different).  