### PR TITLE
Fix compiler warnings in pio_nc4.c

### DIFF
--- a/doc/source/code_style.txt
+++ b/doc/source/code_style.txt
@@ -25,6 +25,11 @@ contributes to code quality.
 
 # C Code #
 
+## Warnings ##
+
+<p>The C library compiles under GNU gcc without warnings. No code will
+be merged with the C library which causes warnings during compile.
+
 ## Backward Compatibility ##
 
 <p>We cannot remove or change a function in the public C API. We can

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -129,21 +129,14 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
         /* Free tmp resources. */
         if (start_present)
-        {
             free(rstart);
-        }
         else
-        {
             start = rstart;
-        }
+
         if (count_present)
-        {
             free(rcount);
-        }
         else
-        {
             count = rcount;
-        }
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -282,7 +275,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 break;
             case NC_CHAR:
                 ierr = nc_get_vars_text(file->fh, varid, (size_t *)start, (size_t *)count,
-                                         (ptrdiff_t *)stride, buf);
+                                        (ptrdiff_t *)stride, buf);
                 break;
             case NC_SHORT:
                 ierr = nc_get_vars_short(file->fh, varid, (size_t *)start, (size_t *)count,
@@ -677,7 +670,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 break;
             case NC_CHAR:
                 ierr = nc_put_vars_text(file->fh, varid, (size_t *)start, (size_t *)count,
-                                         (ptrdiff_t *)stride, buf);
+                                        (ptrdiff_t *)stride, buf);
                 break;
             case NC_SHORT:
                 ierr = nc_put_vars_short(file->fh, varid, (size_t *)start, (size_t *)count,

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -9,7 +9,6 @@
 #include <pio_internal.h>
 
 /**
- * @ingroup PIO_def_var
  * Set deflate (zlib) settings for a variable.
  *
  * This function only applies to netCDF-4 files. When used with netCDF
@@ -29,6 +28,7 @@
  * @param deflate_level 1 to 9, with 1 being faster and 9 being more
  * compressed.
  * @return PIO_NOERR for success, otherwise an error code.
+ * @ingroup PIO_def_var
  */
 int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
                          int deflate_level)
@@ -45,21 +45,21 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
         if (!ios->ioproc)
         {
-	    int msg = PIO_MSG_DEF_VAR_DEFLATE;
+            int msg = PIO_MSG_DEF_VAR_DEFLATE;
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
@@ -70,11 +70,11 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
 
     if (ios->ioproc)
     {
-#ifdef _NETCDF4	
-	if (file->iotype == PIO_IOTYPE_NETCDF4P)
+#ifdef _NETCDF4
+        if (file->iotype == PIO_IOTYPE_NETCDF4P)
             ierr = NC_EINVAL;
-	else
-	    if (file->do_io)
+        else
+            if (file->do_io)
                 ierr = nc_def_var_deflate(file->fh, varid, shuffle, deflate, deflate_level);
 #endif
     }
@@ -129,7 +129,7 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     msg = PIO_MSG_INQ_VAR_DEFLATE;
 
@@ -139,12 +139,12 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
         if (!ios->ioproc)
         {
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
@@ -156,7 +156,7 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep,
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-	if (file->do_io)
+        if (file->do_io)
             ierr = nc_inq_var_deflate(file->fh, varid, shufflep, deflatep, deflate_levelp);
 #endif
     }
@@ -218,7 +218,7 @@ int PIOc_def_var_chunking(int ncid, int varid, int storage,
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
@@ -245,7 +245,7 @@ int PIOc_def_var_chunking(int ncid, int varid, int storage,
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-	if (file->do_io)
+        if (file->do_io)
             ierr = nc_def_var_chunking(file->fh, varid, storage, chunksizesp);
 #endif
     }
@@ -297,16 +297,16 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* Run these on all tasks if async is not in use, but only on
      * non-IO tasks if async is in use. */
     if (!ios->async_interface || !ios->ioproc)
     {
-	/* Find the number of dimensions of this variable. */
-	if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
-	    return ierr;
-	LOG((2, "ndims = %d", ndims));
+        /* Find the number of dimensions of this variable. */
+        if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
+            return ierr;
+        LOG((2, "ndims = %d", ndims));
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -314,14 +314,14 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
     {
         if (!ios->ioproc)
         {
-	    int msg = PIO_MSG_INQ_VAR_CHUNKING;
+            int msg = PIO_MSG_INQ_VAR_CHUNKING;
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
@@ -338,10 +338,10 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-	if (file->do_io)
-	    ierr = nc_inq_var_chunking(file->fh, varid, storagep, chunksizesp);
+        if (file->do_io)
+            ierr = nc_inq_var_chunking(file->fh, varid, storagep, chunksizesp);
 #endif
-	LOG((2, "ierr = %d", ierr));
+        LOG((2, "ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -397,21 +397,21 @@ int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
         if (!ios->ioproc)
         {
-	    int msg = PIO_MSG_SET_FILL;
+            int msg = PIO_MSG_SET_FILL;
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
@@ -423,8 +423,8 @@ int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-	if (file->do_io)
-	    ierr = nc_def_var_fill(file->fh, varid, no_fill, fill_value);
+        if (file->do_io)
+            ierr = nc_def_var_fill(file->fh, varid, no_fill, fill_value);
 #endif
     }
 
@@ -474,20 +474,20 @@ int PIOc_def_var_endian(int ncid, int varid, int endian)
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
         if (!ios->ioproc)
         {
-	    int msg = PIO_MSG_DEF_VAR_ENDIAN;
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            int msg = PIO_MSG_DEF_VAR_ENDIAN;
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
@@ -499,8 +499,8 @@ int PIOc_def_var_endian(int ncid, int varid, int endian)
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-	if (file->do_io)
-	    ierr = nc_def_var_endian(file->fh, varid, endian);
+        if (file->do_io)
+            ierr = nc_def_var_endian(file->fh, varid, endian);
 #endif
     }
 
@@ -547,21 +547,21 @@ int PIOc_inq_var_endian(int ncid, int varid, int *endianp)
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
         if (!ios->ioproc)
         {
-	    int msg = PIO_MSG_INQ_VAR_CHUNKING;
+            int msg = PIO_MSG_INQ_VAR_CHUNKING;
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
@@ -574,8 +574,8 @@ int PIOc_inq_var_endian(int ncid, int varid, int *endianp)
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-	if (file->do_io)
-	    ierr = nc_inq_var_endian(file->fh, varid, endianp);
+        if (file->do_io)
+            ierr = nc_inq_var_endian(file->fh, varid, endianp);
 #endif
     }
 
@@ -632,7 +632,7 @@ int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size,
 
     /* Only netCDF-4 files can use this feature. */
     if (iotype != PIO_IOTYPE_NETCDF4P && iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     int msg;
     msg = PIO_MSG_SET_CHUNK_CACHE;
@@ -700,7 +700,7 @@ int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep,
 
     /* Only netCDF-4 files can use this feature. */
     if (iotype != PIO_IOTYPE_NETCDF4P && iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* Since this is a property of the running HDF5 instance, not the
      * file, it's not clear if this message passing will apply. For
@@ -779,21 +779,21 @@ int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset ne
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async_interface)
     {
         if (!ios->ioproc)
         {
-	    int msg = PIO_MSG_SET_VAR_CHUNK_CACHE;
+            int msg = PIO_MSG_SET_VAR_CHUNK_CACHE;
 
-	    if (ios->compmaster)
-		mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster)
+                mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm);
+        }
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
@@ -805,8 +805,8 @@ int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset ne
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-	if (file->do_io)
-	    ierr = nc_set_var_chunk_cache(file->fh, varid, size, nelems, preemption);
+        if (file->do_io)
+            ierr = nc_set_var_chunk_cache(file->fh, varid, size, nelems, preemption);
 #endif
     }
 
@@ -859,7 +859,7 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset 
 
     /* Only netCDF-4 files can use this feature. */
     if (file->iotype != PIO_IOTYPE_NETCDF4P && file->iotype != PIO_IOTYPE_NETCDF4C)
-	return PIO_ENOTNC4;
+        return PIO_ENOTNC4;
 
     /* Since this is a property of the running HDF5 instance, not the
      * file, it's not clear if this message passing will apply. For
@@ -875,9 +875,9 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset 
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-	if (file->do_io)
-	    ierr = nc_get_var_chunk_cache(file->fh, varid, (size_t *)sizep, (size_t *)nelemsp,
-					  preemptionp);
+        if (file->do_io)
+            ierr = nc_get_var_chunk_cache(file->fh, varid, (size_t *)sizep, (size_t *)nelemsp,
+                                          preemptionp);
 #endif
     }
 
@@ -890,12 +890,12 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset 
     /* Broadcast results to all tasks. */
     if (!ierr)
     {
-	if (sizep && !ierr)
-	    ierr = MPI_Bcast(sizep, 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
-	if (nelemsp && !ierr)
-	    ierr = MPI_Bcast(nelemsp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
-	if (preemptionp && !ierr)
-	    ierr = MPI_Bcast(preemptionp, 1, MPI_FLOAT, ios->ioroot, ios->my_comm);
+        if (sizep && !ierr)
+            ierr = MPI_Bcast(sizep, 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
+        if (nelemsp && !ierr)
+            ierr = MPI_Bcast(nelemsp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm);
+        if (preemptionp && !ierr)
+            ierr = MPI_Bcast(preemptionp, 1, MPI_FLOAT, ios->ioroot, ios->my_comm);
     }
 
     return ierr;

--- a/tests/unit/test_nc4.c
+++ b/tests/unit/test_nc4.c
@@ -6,6 +6,7 @@
  * functions are called on non-netCDF-4 files, and that is tested in
  * this code as well.
  *
+ * Ed Hartnett
  */
 #include <pio.h>
 #include <pio_tests.h>


### PR DESCRIPTION
Fixes #130.

Now the C library builds without warnings. I have added a section to the code style document indicating that no code with warnings will be checked into the C library.

I also have discovered that I didn't have the correct .emacs settings for whitespace on my new machine, which may account for the continuing whitespace issues I keep finding. What I now have, and what we should all have, is:

```
; Set the style for C programming.
(setq c-default-style "linux"
      c-basic-offset 4)
(setq-default indent-tabs-mode nil)

```