### PR TITLE
now freeing test_comm communicator in C tests

### DIFF
--- a/tests/unit/README
+++ b/tests/unit/README
@@ -1,5 +1,0 @@
-1) Make sure pio is built in ../pio
-
-3) Determine what tests to run by setting namelist values in input.nl
-
-4) Use your machine's mpirun to launch "piotest" with the desired number of tasks 

--- a/tests/unit/pio_tests.h
+++ b/tests/unit/pio_tests.h
@@ -29,6 +29,7 @@
 #define ERR_AWFUL 1111
 #define ERR_WRONG 1112
 #define ERR_GPTL 1113
+#define ERR_MPI 1114
 
 /** Handle MPI errors. This should only be used with MPI library
  * function calls. */
@@ -68,6 +69,6 @@ int create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int
 int check_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *ncid);
 int get_iotypes(int *num_flavors, int *flavors);
 int get_iotype_name(int iotype, char *name);
-int pio_test_finalize();
+int pio_test_finalize(MPI_Comm *test_comm);
 
 #endif /* _PIO_TESTS_H */

--- a/tests/unit/test_async_2comp.c
+++ b/tests/unit/test_async_2comp.c
@@ -123,7 +123,7 @@ main(int argc, char **argv)
 
     /* Finalize the MPI library. */
     printf("%d %s Finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_async_3proc.c
+++ b/tests/unit/test_async_3proc.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_async_4proc.c
+++ b/tests/unit/test_async_4proc.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_async_simple.c
+++ b/tests/unit/test_async_simple.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_common.c
+++ b/tests/unit/test_common.c
@@ -1,46 +1,47 @@
-/**
- * @file Common test code for some PIO tests.
+/*
+ * Common test code for PIO C tests.
  *
+ * Ed Hartnett
  */
 #include <pio.h>
 #include <pio_tests.h>
 
-/** The number of dimensions in the test data. */
+/* The number of dimensions in the test data. */
 #define NDIM_S1 1
 
-/** The length of our test data. */
+/* The length of our test data. */
 #define DIM_LEN_S1 4
 
-/** The name of the dimension in the netCDF output file. */
+/* The name of the dimension in the netCDF output file. */
 #define FIRST_DIM_NAME_S1 "jojo"
 #define DIM_NAME_S1 "dim_sample_s1"
 
-/** The name of the variable in the netCDF output file. */
+/* The name of the variable in the netCDF output file. */
 #define FIRST_VAR_NAME_S1 "bill"
 #define VAR_NAME_S1 "var_sample_s1"
 
-/** The number of dimensions in the sample 2 test data. */
+/* The number of dimensions in the sample 2 test data. */
 #define NDIM_S2 1
 
-/** The length of our sample 2 test data. */
+/* The length of our sample 2 test data. */
 #define DIM_LEN_S2 4
 
-/** The name of the dimension in the sample 2 output file. */
+/* The name of the dimension in the sample 2 output file. */
 #define FIRST_DIM_NAME_S2 "jojo"
 #define DIM_NAME_S2 "dim_sample_s2"
 
-/** The name of the variable in the sample 2 output file. */
+/* The name of the variable in the sample 2 output file. */
 #define FIRST_VAR_NAME_S2 "bill"
 #define VAR_NAME_S2 "var_sample_s2"
 
-/** The name of the global attribute in the sample 2 output file. */
+/* The name of the global attribute in the sample 2 output file. */
 #define FIRST_ATT_NAME_S2 "willy_gatt_sample s2"
 #define ATT_NAME_S2 "gatt_sample s2"
 #define SHORT_ATT_NAME_S2 "short_gatt_sample s2"
 #define FLOAT_ATT_NAME_S2 "float_gatt_sample s2"
 #define DOUBLE_ATT_NAME_S2 "double_gatt_sample s2"
 
-/** The value of the global attribute in the sample 2 output file. */
+/* The value of the global attribute in the sample 2 output file. */
 #define ATT_VALUE_S2 42
 
 /* How many flavors of netCDF are available? */
@@ -175,10 +176,18 @@ int pio_test_init(int argc, char **argv, int *my_rank, int *ntasks,
     return PIO_NOERR;
 }
 
-/* Finalize a test. */
-int pio_test_finalize()
+/* Finalize a PIO C test. 
+*
+* @param test_comm pointer to the test communicator.
+* @returns 0 for success, error code otherwise.
+*/
+int pio_test_finalize(MPI_Comm *test_comm)
 {
     int ret = PIO_NOERR; /* Return value. */
+
+    /* Free communicator. */
+    if (MPI_Comm_free(test_comm))
+        return ERR_MPI;
 
     /* Finalize MPI. */
     MPI_Finalize();
@@ -192,7 +201,7 @@ int pio_test_finalize()
     return ret;
 }
 
-/** Test the inq_format function. */
+/* Test the inq_format function. */
 int
 test_inq_format(int ncid, int format)
 {
@@ -213,7 +222,7 @@ test_inq_format(int ncid, int format)
     return PIO_NOERR;
 }
 
-/** Test the inq_type function for atomic types. */
+/* Test the inq_type function for atomic types. */
 int
 test_inq_type(int ncid, int format)
 {
@@ -238,7 +247,7 @@ test_inq_type(int ncid, int format)
     return PIO_NOERR;
 }
 
-/** This creates a netCDF sample file in the specified format. */
+/* This creates a netCDF sample file in the specified format. */
 int
 create_nc_sample(int sample, int iosysid, int format, char *filename, int my_rank, int *ncid)
 {
@@ -257,7 +266,7 @@ create_nc_sample(int sample, int iosysid, int format, char *filename, int my_ran
     return PIO_EINVAL;
 }
 
-/** This checks a netCDF sample file in the specified format. */
+/* This checks a netCDF sample file in the specified format. */
 int
 check_nc_sample(int sample, int iosysid, int format, char *filename, int my_rank, int *ncid)
 {
@@ -276,7 +285,7 @@ check_nc_sample(int sample, int iosysid, int format, char *filename, int my_rank
     return PIO_EINVAL;
 }
 
-/** This creates an empty netCDF file in the specified format. */
+/* This creates an empty netCDF file in the specified format. */
 int
 create_nc_sample_0(int iosysid, int format, char *filename, int my_rank, int *ncidp)
 {
@@ -366,7 +375,7 @@ check_nc_sample_0(int iosysid, int format, char *filename, int my_rank, int *nci
     return 0;
 }
 
-/** This creates a netCDF file in the specified format, with some
+/* This creates a netCDF file in the specified format, with some
  * sample values. */
 int
 create_nc_sample_1(int iosysid, int format, char *filename, int my_rank, int *ncidp)
@@ -550,7 +559,7 @@ check_nc_sample_1(int iosysid, int format, char *filename, int my_rank, int *nci
     return 0;
 }
 
-/** This creates a netCDF file in the specified format, with some
+/* This creates a netCDF file in the specified format, with some
  * sample values. */
 int
 create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *ncidp)

--- a/tests/unit/test_darray.c
+++ b/tests/unit/test_darray.c
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_darray_async.c
+++ b/tests/unit/test_darray_async.c
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_file.c
+++ b/tests/unit/test_file.c
@@ -219,7 +219,7 @@ int main(int argc, char **argv)
 
     /* Finalize the MPI library. */
     printf("%d %s Finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ret;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_intercomm2.c
+++ b/tests/unit/test_intercomm2.c
@@ -461,7 +461,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_iosystem2.c
+++ b/tests/unit/test_iosystem2.c
@@ -203,7 +203,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_iosystem2_simple.c
+++ b/tests/unit/test_iosystem2_simple.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_iosystem2_simple2.c
+++ b/tests/unit/test_iosystem2_simple2.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_iosystem3.c
+++ b/tests/unit/test_iosystem3.c
@@ -344,7 +344,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_iosystem3_simple.c
+++ b/tests/unit/test_iosystem3_simple.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_iosystem3_simple2.c
+++ b/tests/unit/test_iosystem3_simple2.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
 
     /* Finalize test. */
     printf("%d %s finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ERR_AWFUL;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_names.c
+++ b/tests/unit/test_names.c
@@ -340,7 +340,7 @@ main(int argc, char **argv)
 
     /* Finalize the MPI library. */
     printf("%d %s Finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ret;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_nc4.c
+++ b/tests/unit/test_nc4.c
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
 
     /* Finalize the MPI library. */
     printf("%d %s Finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ret;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/unit/test_spmd.c
+++ b/tests/unit/test_spmd.c
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
 
     /* Finalize the MPI library. */
     printf("%d %s Finalizing...\n", my_rank, TEST_NAME);
-    if ((ret = pio_test_finalize()))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ret;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);


### PR DESCRIPTION
Fixes #223.

This PR has test code changes only - no library code.

The C tests were not freeing the test communicator at the end of the test. Now they do.