### PR TITLE
Change 2 C tests so they work with 1 to 4 tasks, and will pass under MPI_SERIAL

### DIFF
--- a/tests/unit/pio_tests.h
+++ b/tests/unit/pio_tests.h
@@ -59,6 +59,8 @@ int resultlen;
 
 /* Function prototypes. */
 int pio_test_init(int argc, char **argv, int *my_rank, int *ntasks, int target_ntasks, MPI_Comm *test_comm);
+int pio_test_init2(int argc, char **argv, int *my_rank, int *ntasks, int min_ntasks,
+                   int max_ntasks, MPI_Comm *test_comm);
 int create_nc_sample(int sample, int iosysid, int format, char *filename, int my_rank, int *ncid);
 int check_nc_sample(int sample, int iosysid, int format, char *filename, int my_rank, int *ncid);
 int create_nc_sample_0(int iosysid, int format, char *filename, int my_rank, int *ncid);

--- a/tests/unit/test_names.c
+++ b/tests/unit/test_names.c
@@ -2,6 +2,7 @@
  * Tests for names of vars, atts, and dims. Also test the
  * PIOc_strerror() function.
  *
+ * Ed Hartnett
  */
 #include <pio.h>
 #include <pio_tests.h>

--- a/tests/unit/test_names.c
+++ b/tests/unit/test_names.c
@@ -9,6 +9,9 @@
 /* The number of tasks this test should run on. */
 #define TARGET_NTASKS 4
 
+/* The minimum number of tasks this test should run on. */
+#define MIN_NTASKS 1
+
 /* The name of this test. */
 #define TEST_NAME "test_names"
 
@@ -221,8 +224,8 @@ main(int argc, char **argv)
     MPI_Comm test_comm; /* A communicator for this test. */
 
     /* Initialize test. */
-    if ((ret = pio_test_init(argc, argv, &my_rank, &ntasks, TARGET_NTASKS,
-			     &test_comm)))
+    if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, MIN_NTASKS, TARGET_NTASKS,
+                              &test_comm)))
         ERR(ERR_INIT);
 
     /* Test code runs on TARGET_NTASKS tasks. The left over tasks do

--- a/tests/unit/test_nc4.c
+++ b/tests/unit/test_nc4.c
@@ -96,8 +96,8 @@ int main(int argc, char **argv)
     MPI_Comm test_comm; /* A communicator for this test. */
 
     /* Initialize test. */
-    if ((ret = pio_test_init(argc, argv, &my_rank, &ntasks, TARGET_NTASKS,
-                             &test_comm)))
+    if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, 1, TARGET_NTASKS,
+                              &test_comm)))
         ERR(ERR_INIT);
 
     /* Only do something on TARGET_NTASKS tasks. */

--- a/tests/unit/test_nc4.c
+++ b/tests/unit/test_nc4.c
@@ -14,6 +14,9 @@
 /* The number of tasks this test should run on. */
 #define TARGET_NTASKS 4
 
+/* The minimum number of tasks this test should run on. */
+#define MIN_NTASKS 1
+
 /* The name of this test. */
 #define TEST_NAME "test_nc4"
 
@@ -96,8 +99,8 @@ int main(int argc, char **argv)
     MPI_Comm test_comm; /* A communicator for this test. */
 
     /* Initialize test. */
-    if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, 1, TARGET_NTASKS,
-                              &test_comm)))
+    if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, MIN_NTASKS,
+                              TARGET_NTASKS, &test_comm)))
         ERR(ERR_INIT);
 
     /* Only do something on TARGET_NTASKS tasks. */


### PR DESCRIPTION
Fixes #220.

Only test code changes in the PR.

These tests were made to run on exactly 4 tasks, so are failing when run with 1 task.

I have changed test_names and test_nc4 so that they can run on any number of tasks between 1 and 4. This should cause them to pass on cdash tonight.

Once they do, I will apply these changes to other tests that should be running under MPI_SERIAL but currently are not.