### PR TITLE
removed const from scalar parameters in function prototypes

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -556,62 +556,54 @@ extern "C" {
     int PIOc_set_log_level(int level);
 
     /* Decomposition. */
-    int PIOc_InitDecomp(const int iosysid, const int basetype, const int ndims, const int *dims,
-                        const int maplen, const PIO_Offset *compmap, int *ioidp, const int *rearr,
-                        const PIO_Offset *iostart,const PIO_Offset *iocount);
+    int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int maplen,
+                        const PIO_Offset *compmap, int *ioidp, const int *rearr,
+                        const PIO_Offset *iostart, const PIO_Offset *iocount);
     int PIOc_freedecomp(int iosysid, int ioid);
-    int PIOc_readmap(const char file[], int *ndims, int *gdims[], PIO_Offset *fmaplen,
-		     PIO_Offset *map[], const MPI_Comm comm);
-    int PIOc_readmap_from_f90(const char file[],int *ndims, int *gdims[], PIO_Offset *maplen,
-			      PIO_Offset *map[], const int f90_comm);
-    int PIOc_writemap(const char file[], const int ndims, const int gdims[], PIO_Offset maplen,
-		      PIO_Offset map[], const MPI_Comm comm);
-    int PIOc_writemap_from_f90(const char file[], const int ndims, const int gdims[],
-			       const PIO_Offset maplen, const PIO_Offset map[], const int f90_comm);
+    int PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
+		     PIO_Offset **map, MPI_Comm comm);
+    int PIOc_readmap_from_f90(const char *file,int *ndims, int **gdims, PIO_Offset *maplen,
+			      PIO_Offset **map, int f90_comm);
+    int PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
+		      PIO_Offset *map, MPI_Comm comm);
+    int PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
+			       const PIO_Offset maplen, const PIO_Offset *map, int f90_comm);
 
     /* Initializing IO system. */
-    int PIOc_Init_Intracomm(const MPI_Comm comp_comm,
-                            const int num_iotasks, const int stride,
-                            const int base, const int rearr, int *iosysidp);
     int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
                         int *num_procs_per_comp, int **proc_list, int *iosysidp);
     int PIOc_Init_Intercomm(int component_count, MPI_Comm peer_comm, MPI_Comm *comp_comms,
                             MPI_Comm io_comm, int *iosysidp);
     int PIOc_get_numiotasks(int iosysid, int *numiotasks);
-    int PIOc_Init_Intracomm(const MPI_Comm comp_comm,
-                            const int num_iotasks, const int stride,
-                            const int base,const int rearr, int *iosysidp);
-    int PIOc_finalize(const int iosysid);
+    int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
+                            int *iosysidp);
+    int PIOc_finalize(int iosysid);
     int PIOc_get_iorank(int iosysid, int *iorank);
     int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method);
-    int PIOc_iam_iotask(const int iosysid, bool *ioproc);
-    int PIOc_iotask_rank(const int iosysid, int *iorank);
-    int PIOc_iosystem_is_active(const int iosysid, bool *active);
-    int PIOc_iotype_available(const int iotype);
+    int PIOc_iam_iotask(int iosysid, bool *ioproc);
+    int PIOc_iotask_rank(int iosysid, int *iorank);
+    int PIOc_iosystem_is_active(int iosysid, bool *active);
+    int PIOc_iotype_available(int iotype);
 
     /* Distributed data. */
     int PIOc_advanceframe(int ncid, int varid);
-    int PIOc_setframe(const int ncid, const int varid,const int frame);
-    int PIOc_write_darray(const int ncid, const int vid, const int ioid, const PIO_Offset arraylen,
-                          void *array, void *fillvalue);
-    int PIOc_write_darray_multi(const int ncid, const int vid[], const int ioid, const int nvars,
-				const PIO_Offset arraylen, void *array, const int frame[],
-				void *fillvalue[], bool flushtodisk);
-    int PIOc_read_darray(const int ncid, const int vid, const int ioid, const PIO_Offset arraylen,
-			 void *array);
+    int PIOc_setframe(int ncid, int varid, int frame);
+    int PIOc_write_darray(int ncid, int vid, int ioid, PIO_Offset arraylen, void *array,
+                          void *fillvalue);
+    int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_Offset arraylen,
+                                void *array, const int *frame, void **fillvalue, bool flushtodisk);
+    int PIOc_read_darray(int ncid, int vid, int ioid, PIO_Offset arraylen, void *array);
     int PIOc_get_local_array_size(int ioid);    
 
     /* Handling files. */
     int PIOc_redef(int ncid);
     int PIOc_enddef(int ncid);
     int PIOc_sync(int ncid);
-    int PIOc_deletefile(const int iosysid, const char filename[]);
-    int PIOc_createfile(const int iosysid, int *ncidp,  int *iotype,
-                        const char *fname, const int mode);
+    int PIOc_deletefile(int iosysid, const char *filename);
+    int PIOc_createfile(int iosysid, int *ncidp,  int *iotype, const char *fname, int mode);
     int PIOc_create(int iosysid, const char *path, int cmode, int *ncidp);
-    int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
-                      const char *fname, const int mode);
-    int PIOc_open(const int iosysid, const char *path, int mode, int *ncidp);
+    int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *fname, int mode);
+    int PIOc_open(int iosysid, const char *path, int mode, int *ncidp);
     int PIOc_closefile(int ncid);
     int PIOc_inq_format(int ncid, int *formatp);
     int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp);
@@ -620,7 +612,7 @@ extern "C" {
     int PIOc_inq_natts(int ncid, int *ngattsp);
     int PIOc_inq_unlimdim(int ncid, int *unlimdimidp);
     int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep);
-    int PIOc_set_blocksize(const int newblocksize);
+    int PIOc_set_blocksize(int newblocksize);
     int PIOc_File_is_Open(int ncid);
     int PIOc_Set_File_Error_Handling(int ncid, int method);
     int PIOc_set_hint(int iosysid, const char *hint, const char *hintval);
@@ -720,44 +712,44 @@ extern "C" {
 			   const unsigned char *op);
 
     /* Data reads and writes. */
-    int PIOc_put_vars_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], const unsigned char *op);
-    int PIOc_get_var1_schar(int ncid, int varid, const PIO_Offset index[], signed char *buf);
-    int PIOc_put_vars_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			     const PIO_Offset stride[], const unsigned short *op);
-    int PIOc_put_vars_ulonglong(int ncid, int varid, const PIO_Offset start[],
-				const PIO_Offset count[], const PIO_Offset stride[],
+    int PIOc_put_vars_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, const unsigned char *op);
+    int PIOc_get_var1_schar(int ncid, int varid, const PIO_Offset *index, signed char *buf);
+    int PIOc_put_vars_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			     const PIO_Offset *stride, const unsigned short *op);
+    int PIOc_put_vars_ulonglong(int ncid, int varid, const PIO_Offset *start,
+				const PIO_Offset *count, const PIO_Offset *stride,
 				const unsigned long long *op);
-    int PIOc_get_vars_ulonglong(int ncid, int varid, const PIO_Offset start[],
-				const PIO_Offset count[], const PIO_Offset stride[],
+    int PIOc_get_vars_ulonglong(int ncid, int varid, const PIO_Offset *start,
+				const PIO_Offset *count, const PIO_Offset *stride,
 				unsigned long long *buf);
-    int PIOc_put_vars_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			   const PIO_Offset stride[], const unsigned int *op);
+    int PIOc_put_vars_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			   const PIO_Offset *stride, const unsigned int *op);
 
 
     int PIOc_put_var_ushort(int ncid, int varid, const unsigned short *op);
-    int PIOc_get_vars_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], short *buf);
-    int PIOc_put_var1_longlong(int ncid, int varid, const PIO_Offset index[], const long long *op);
+    int PIOc_get_vars_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, short *buf);
+    int PIOc_put_var1_longlong(int ncid, int varid, const PIO_Offset *index, const long long *op);
     int PIOc_get_var_double(int ncid, int varid, double *buf);
-    int PIOc_put_vara_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_put_vara_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			    const unsigned char *op);
-    int PIOc_get_vara_double(int ncid, int varid, const PIO_Offset start[],
-			     const PIO_Offset count[], double *buf);
-    int PIOc_put_var1_long(int ncid, int varid, const PIO_Offset index[], const long *ip);
+    int PIOc_get_vara_double(int ncid, int varid, const PIO_Offset *start,
+			     const PIO_Offset *count, double *buf);
+    int PIOc_put_var1_long(int ncid, int varid, const PIO_Offset *index, const long *ip);
     int PIOc_get_var_int(int ncid, int varid, int *buf);
-    int PIOc_put_vars_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			   const PIO_Offset stride[], const long *op);
+    int PIOc_put_vars_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			   const PIO_Offset *stride, const long *op);
     int PIOc_put_var_short(int ncid, int varid, const short *op);
-    int PIOc_get_vara_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_vara_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			   char *buf);
-    int PIOc_put_vara_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_put_vara_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			  const int *op);
 
-    int PIOc_put_var1_ushort(int ncid, int varid, const PIO_Offset index[],
+    int PIOc_put_var1_ushort(int ncid, int varid, const PIO_Offset *index,
 			     const unsigned short *op);
-    int PIOc_put_vara_text(int ncid, int varid, const PIO_Offset start[],
-			   const PIO_Offset count[], const char *op);
+    int PIOc_put_vara_text(int ncid, int varid, const PIO_Offset *start,
+			   const PIO_Offset *count, const char *op);
     int PIOc_put_var_ulonglong(int ncid, int varid, const unsigned long long *op);
     int PIOc_put_var_int(int ncid, int varid, const int *op);
     int PIOc_put_var_longlong(int ncid, int varid, const long long *op);
@@ -765,196 +757,196 @@ extern "C" {
     int PIOc_put_var_uint(int ncid, int varid, const unsigned int *op);
     int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
 		     MPI_Datatype buftype);
-    int PIOc_put_vara_ushort(int ncid, int varid, const PIO_Offset start[],
-			     const PIO_Offset count[], const unsigned short *op);
-    int PIOc_put_vars_short(int ncid, int varid, const PIO_Offset start[],
-			    const PIO_Offset count[], const PIO_Offset stride[], const short *op);
-    int PIOc_put_vara_uint(int ncid, int varid, const PIO_Offset start[],
-			   const PIO_Offset count[], const unsigned int *op);
-    int PIOc_put_vara_schar(int ncid, int varid, const PIO_Offset start[],
-			    const PIO_Offset count[], const signed char *op);
-    int PIOc_put_var1_uchar(int ncid, int varid, const PIO_Offset index[],
+    int PIOc_put_vara_ushort(int ncid, int varid, const PIO_Offset *start,
+			     const PIO_Offset *count, const unsigned short *op);
+    int PIOc_put_vars_short(int ncid, int varid, const PIO_Offset *start,
+			    const PIO_Offset *count, const PIO_Offset *stride, const short *op);
+    int PIOc_put_vara_uint(int ncid, int varid, const PIO_Offset *start,
+			   const PIO_Offset *count, const unsigned int *op);
+    int PIOc_put_vara_schar(int ncid, int varid, const PIO_Offset *start,
+			    const PIO_Offset *count, const signed char *op);
+    int PIOc_put_var1_uchar(int ncid, int varid, const PIO_Offset *index,
 			    const unsigned char *op);
-    int PIOc_put_vars_schar(int ncid, int varid, const PIO_Offset start[],
-			    const PIO_Offset count[], const PIO_Offset stride[],
+    int PIOc_put_vars_schar(int ncid, int varid, const PIO_Offset *start,
+			    const PIO_Offset *count, const PIO_Offset *stride,
 			    const signed char *op);
-    int PIOc_put_var1(int ncid, int varid, const PIO_Offset index[], const void *buf,
+    int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
 		      PIO_Offset bufcount, MPI_Datatype buftype);
-    int PIOc_put_vara_float(int ncid, int varid, const PIO_Offset start[],
-			    const PIO_Offset count[], const float *op);
-    int PIOc_put_var1_float(int ncid, int varid, const PIO_Offset index[], const float *op);
-    int PIOc_put_var1_text(int ncid, int varid, const PIO_Offset index[], const char *op);
-    int PIOc_put_vars_text(int ncid, int varid, const PIO_Offset start[],
-			   const PIO_Offset count[], const PIO_Offset stride[], const char *op);
-    int PIOc_put_vars_double(int ncid, int varid, const PIO_Offset start[],
-			     const PIO_Offset count[], const PIO_Offset stride[], const double *op);
-    int PIOc_put_vara_longlong(int ncid, int varid, const PIO_Offset start[],
-			       const PIO_Offset count[], const long long *op);
+    int PIOc_put_vara_float(int ncid, int varid, const PIO_Offset *start,
+			    const PIO_Offset *count, const float *op);
+    int PIOc_put_var1_float(int ncid, int varid, const PIO_Offset *index, const float *op);
+    int PIOc_put_var1_text(int ncid, int varid, const PIO_Offset *index, const char *op);
+    int PIOc_put_vars_text(int ncid, int varid, const PIO_Offset *start,
+			   const PIO_Offset *count, const PIO_Offset *stride, const char *op);
+    int PIOc_put_vars_double(int ncid, int varid, const PIO_Offset *start,
+			     const PIO_Offset *count, const PIO_Offset *stride, const double *op);
+    int PIOc_put_vara_longlong(int ncid, int varid, const PIO_Offset *start,
+			       const PIO_Offset *count, const long long *op);
     int PIOc_put_var_double(int ncid, int varid, const double *op);
     int PIOc_put_var_float(int ncid, int varid, const float *op);
-    int PIOc_put_var1_ulonglong(int ncid, int varid, const PIO_Offset index[],
+    int PIOc_put_var1_ulonglong(int ncid, int varid, const PIO_Offset *index,
 				const unsigned long long *op);
-    int PIOc_put_var1_uint(int ncid, int varid, const PIO_Offset index[],
+    int PIOc_put_var1_uint(int ncid, int varid, const PIO_Offset *index,
 			   const unsigned int *op);
-    int PIOc_put_var1_int(int ncid, int varid, const PIO_Offset index[], const int *op);
-    int PIOc_put_vars_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], const float *op);
-    int PIOc_put_vara_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_put_var1_int(int ncid, int varid, const PIO_Offset *index, const int *op);
+    int PIOc_put_vars_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, const float *op);
+    int PIOc_put_vara_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			    const short *op);
-    int PIOc_put_var1_schar(int ncid, int varid, const PIO_Offset index[], const signed char *op);
-    int PIOc_put_vara_ulonglong(int ncid, int varid, const PIO_Offset start[],
-				const PIO_Offset count[], const unsigned long long *op);
-    int PIOc_put_vara(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_put_var1_schar(int ncid, int varid, const PIO_Offset *index, const signed char *op);
+    int PIOc_put_vara_ulonglong(int ncid, int varid, const PIO_Offset *start,
+				const PIO_Offset *count, const unsigned long long *op);
+    int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 		      const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
-    int PIOc_put_vara_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_put_vara_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			   const long *op);
-    int PIOc_put_var1_double(int ncid, int varid, const PIO_Offset index[], const double *op);
+    int PIOc_put_var1_double(int ncid, int varid, const PIO_Offset *index, const double *op);
     int PIOc_put_var_text(int ncid, int varid, const char *op);
-    int PIOc_put_vars_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			  const PIO_Offset stride[], const int *op);
-    int PIOc_put_var1_short(int ncid, int varid, const PIO_Offset index[], const short *op);
-    int PIOc_put_vars_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			       const PIO_Offset stride[], const long long *op);
-    int PIOc_put_vara_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_put_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			  const PIO_Offset *stride, const int *op);
+    int PIOc_put_var1_short(int ncid, int varid, const PIO_Offset *index, const short *op);
+    int PIOc_put_vars_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			       const PIO_Offset *stride, const long long *op);
+    int PIOc_put_vara_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			     const double *op);
-    int PIOc_put_vars(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-		      const PIO_Offset stride[], const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
-    int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			 const PIO_Offset stride[], nc_type xtype, const void *buf);
+    int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+		      const PIO_Offset *stride, const void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			 const PIO_Offset *stride, nc_type xtype, const void *buf);
     int PIOc_put_var_uchar(int ncid, int varid, const unsigned char *op);
     int PIOc_put_var_long(int ncid, int varid, const long *op);
-    int PIOc_get_vara_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_vara_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			  int *buf);
-    int PIOc_get_var1_float(int ncid, int varid, const PIO_Offset index[], float *buf);
-    int PIOc_get_var1_short(int ncid, int varid, const PIO_Offset index[], short *buf);
-    int PIOc_get_vars_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			  const PIO_Offset stride[], int *buf);
+    int PIOc_get_var1_float(int ncid, int varid, const PIO_Offset *index, float *buf);
+    int PIOc_get_var1_short(int ncid, int varid, const PIO_Offset *index, short *buf);
+    int PIOc_get_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			  const PIO_Offset *stride, int *buf);
     int PIOc_get_var_text(int ncid, int varid, char *buf);
-    int PIOc_get_vars_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], signed char *buf);
-    int PIOc_get_vara_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_vars_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, signed char *buf);
+    int PIOc_get_vara_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			     unsigned short *buf);
-    int PIOc_get_var1_ushort(int ncid, int varid, const PIO_Offset index[], unsigned short *buf);
+    int PIOc_get_var1_ushort(int ncid, int varid, const PIO_Offset *index, unsigned short *buf);
     int PIOc_get_var_float(int ncid, int varid, float *buf);
-    int PIOc_get_vars_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], unsigned char *buf);
+    int PIOc_get_vars_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, unsigned char *buf);
     int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
-    int PIOc_get_var1_longlong(int ncid, int varid, const PIO_Offset index[], long long *buf);
-    int PIOc_get_vars_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			     const PIO_Offset stride[], unsigned short *buf);
+    int PIOc_get_var1_longlong(int ncid, int varid, const PIO_Offset *index, long long *buf);
+    int PIOc_get_vars_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			     const PIO_Offset *stride, unsigned short *buf);
     int PIOc_get_var_long(int ncid, int varid, long *buf);
-    int PIOc_get_var1_double(int ncid, int varid, const PIO_Offset index[], double *buf);
-    int PIOc_get_vara_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_var1_double(int ncid, int varid, const PIO_Offset *index, double *buf);
+    int PIOc_get_vara_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			   unsigned int *buf);
-    int PIOc_get_vars_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			       const PIO_Offset stride[], long long *buf);
+    int PIOc_get_vars_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			       const PIO_Offset *stride, long long *buf);
     int PIOc_get_var_longlong(int ncid, int varid, long long *buf);
-    int PIOc_get_vara_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_vara_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			    short *buf);
-    int PIOc_get_vara_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_vara_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			   long *buf);
-    int PIOc_get_var1_int(int ncid, int varid, const PIO_Offset index[], int *buf);
-    int PIOc_get_var1_ulonglong(int ncid, int varid, const PIO_Offset index[], unsigned long long *buf);
+    int PIOc_get_var1_int(int ncid, int varid, const PIO_Offset *index, int *buf);
+    int PIOc_get_var1_ulonglong(int ncid, int varid, const PIO_Offset *index, unsigned long long *buf);
     int PIOc_get_var_uchar(int ncid, int varid, unsigned char *buf);
-    int PIOc_get_vara_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_vara_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			    unsigned char *buf);
-    int PIOc_get_vars_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], float *buf);
-    int PIOc_get_vars_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			   const PIO_Offset stride[], long *buf);
-    int PIOc_get_var1(int ncid, int varid, const PIO_Offset index[], void *buf, PIO_Offset bufcount,
+    int PIOc_get_vars_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, float *buf);
+    int PIOc_get_vars_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			   const PIO_Offset *stride, long *buf);
+    int PIOc_get_var1(int ncid, int varid, const PIO_Offset *index, void *buf, PIO_Offset bufcount,
 		      MPI_Datatype buftype);
     int PIOc_get_var_uint(int ncid, int varid, unsigned int *buf);
-    int PIOc_get_vara(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[], void *buf,
+    int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count, void *buf,
 		      PIO_Offset bufcount, MPI_Datatype buftype);
-    int PIOc_get_vara_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_vara_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			    signed char *buf);
-    int PIOc_get_var1_uint(int ncid, int varid, const PIO_Offset index[], unsigned int *buf);
-    int PIOc_get_vars_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			   const PIO_Offset stride[], unsigned int *buf);
-    int PIOc_get_vara_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_var1_uint(int ncid, int varid, const PIO_Offset *index, unsigned int *buf);
+    int PIOc_get_vars_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			   const PIO_Offset *stride, unsigned int *buf);
+    int PIOc_get_vara_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			    float *buf);
-    int PIOc_get_var1_text(int ncid, int varid, const PIO_Offset index[], char *buf);
-    int PIOc_get_vars_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			     const PIO_Offset stride[], double *buf);
-    int PIOc_get_vara_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_var1_text(int ncid, int varid, const PIO_Offset *index, char *buf);
+    int PIOc_get_vars_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			     const PIO_Offset *stride, double *buf);
+    int PIOc_get_vara_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 			       long long *buf);
     int PIOc_get_var_ulonglong(int ncid, int varid, unsigned long long *buf);
-    int PIOc_get_vara_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
+    int PIOc_get_vara_ulonglong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
 				unsigned long long *buf);
     int PIOc_get_var_short(int ncid, int varid, short *buf);
-    int PIOc_get_var1_long(int ncid, int varid, const PIO_Offset index[], long *buf);
-    int PIOc_get_vars_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			   const PIO_Offset stride[], char *buf);
-    int PIOc_get_var1_uchar(int ncid, int varid, const PIO_Offset index[], unsigned char *buf);
-    int PIOc_get_vars(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-		      const PIO_Offset stride[], void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
-    int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			 const PIO_Offset stride[], nc_type xtype, void *buf);
+    int PIOc_get_var1_long(int ncid, int varid, const PIO_Offset *index, long *buf);
+    int PIOc_get_vars_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			   const PIO_Offset *stride, char *buf);
+    int PIOc_get_var1_uchar(int ncid, int varid, const PIO_Offset *index, unsigned char *buf);
+    int PIOc_get_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+		      const PIO_Offset *stride, void *buf, PIO_Offset bufcount, MPI_Datatype buftype);
+    int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			 const PIO_Offset *stride, nc_type xtype, void *buf);
     int PIOc_get_var_schar(int ncid, int varid, signed char *buf);
 
     /* Varm functions are deprecated and should be used with extreme
      * caution or not at all. Varm functions are not supported in
      * async mode. */
-    int PIOc_put_varm(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-		      const PIO_Offset stride[], const PIO_Offset imap[], const void *buf,
+    int PIOc_put_varm(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+		      const PIO_Offset *stride, const PIO_Offset *imap, const void *buf,
 		      PIO_Offset bufcount, MPI_Datatype buftype);
-    int PIOc_get_varm_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], const PIO_Offset imap[], signed char *buf);
-    int PIOc_put_varm_uchar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], const PIO_Offset imap[],
+    int PIOc_get_varm_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, const PIO_Offset *imap, signed char *buf);
+    int PIOc_put_varm_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, const PIO_Offset *imap,
 			    const unsigned char *op);
-    int PIOc_put_varm_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], const PIO_Offset imap[], const short *op);
-    int PIOc_get_varm_short(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], const PIO_Offset imap[], short *buf);
-    int PIOc_get_varm_ulonglong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-				const PIO_Offset stride[], const PIO_Offset imap[], unsigned long long *buf);
-    int PIOc_get_varm_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			     const PIO_Offset stride[], const PIO_Offset imap[], unsigned short *buf);
-    int PIOc_get_varm_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			       const PIO_Offset stride[], const PIO_Offset imap[], long long *buf);
-    int PIOc_put_varm_text(int ncid, int varid, const PIO_Offset start[],
-			   const PIO_Offset count[], const PIO_Offset stride[],
-			   const PIO_Offset imap[], const char *op);
-    int PIOc_put_varm_ushort(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			     const PIO_Offset stride[], const PIO_Offset imap[], const unsigned short *op);
-    int PIOc_put_varm_ulonglong(int ncid, int varid, const PIO_Offset start[],
-				const PIO_Offset count[], const PIO_Offset stride[],
-				const PIO_Offset imap[], const unsigned long long *op);
-    int PIOc_put_varm_int(int ncid, int varid, const PIO_Offset start[],
-			  const PIO_Offset count[], const PIO_Offset stride[],
-			  const PIO_Offset imap[], const int *op);
-    int PIOc_put_varm_float(int ncid, int varid, const PIO_Offset start[],
-			    const PIO_Offset count[], const PIO_Offset stride[],
-			    const PIO_Offset imap[], const float *op);
-    int PIOc_put_varm_long(int ncid, int varid, const PIO_Offset start[],
-			   const PIO_Offset count[], const PIO_Offset stride[],
-			   const PIO_Offset imap[], const long *op);
-    int PIOc_put_varm_uint(int ncid, int varid, const PIO_Offset start[],
-			   const PIO_Offset count[], const PIO_Offset stride[],
-			   const PIO_Offset imap[], const unsigned int *op);
-    int PIOc_put_varm_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			     const PIO_Offset stride[], const PIO_Offset imap[], const double *op);
-    int PIOc_put_varm_schar(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], const PIO_Offset imap[], const signed char *op);
-    int PIOc_put_varm_longlong(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			       const PIO_Offset stride[], const PIO_Offset imap[], const long long *op);
-    int PIOc_get_varm_double(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			     const PIO_Offset stride[], const PIO_Offset imap[], double *buf);
-    int PIOc_get_varm_text(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			   const PIO_Offset stride[], const PIO_Offset imap[], char *buf);
-    int PIOc_get_varm_int(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			  const PIO_Offset stride[], const PIO_Offset imap[], int *buf);
-    int PIOc_get_varm_uint(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			   const PIO_Offset stride[], const PIO_Offset imap[], unsigned int *buf);
-    int PIOc_get_varm(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-		      const PIO_Offset stride[], const PIO_Offset imap[], void *buf,
+    int PIOc_put_varm_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, const PIO_Offset *imap, const short *op);
+    int PIOc_get_varm_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, const PIO_Offset *imap, short *buf);
+    int PIOc_get_varm_ulonglong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+				const PIO_Offset *stride, const PIO_Offset *imap, unsigned long long *buf);
+    int PIOc_get_varm_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			     const PIO_Offset *stride, const PIO_Offset *imap, unsigned short *buf);
+    int PIOc_get_varm_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			       const PIO_Offset *stride, const PIO_Offset *imap, long long *buf);
+    int PIOc_put_varm_text(int ncid, int varid, const PIO_Offset *start,
+			   const PIO_Offset *count, const PIO_Offset *stride,
+			   const PIO_Offset *imap, const char *op);
+    int PIOc_put_varm_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			     const PIO_Offset *stride, const PIO_Offset *imap, const unsigned short *op);
+    int PIOc_put_varm_ulonglong(int ncid, int varid, const PIO_Offset *start,
+				const PIO_Offset *count, const PIO_Offset *stride,
+				const PIO_Offset *imap, const unsigned long long *op);
+    int PIOc_put_varm_int(int ncid, int varid, const PIO_Offset *start,
+			  const PIO_Offset *count, const PIO_Offset *stride,
+			  const PIO_Offset *imap, const int *op);
+    int PIOc_put_varm_float(int ncid, int varid, const PIO_Offset *start,
+			    const PIO_Offset *count, const PIO_Offset *stride,
+			    const PIO_Offset *imap, const float *op);
+    int PIOc_put_varm_long(int ncid, int varid, const PIO_Offset *start,
+			   const PIO_Offset *count, const PIO_Offset *stride,
+			   const PIO_Offset *imap, const long *op);
+    int PIOc_put_varm_uint(int ncid, int varid, const PIO_Offset *start,
+			   const PIO_Offset *count, const PIO_Offset *stride,
+			   const PIO_Offset *imap, const unsigned int *op);
+    int PIOc_put_varm_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			     const PIO_Offset *stride, const PIO_Offset *imap, const double *op);
+    int PIOc_put_varm_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, const PIO_Offset *imap, const signed char *op);
+    int PIOc_put_varm_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			       const PIO_Offset *stride, const PIO_Offset *imap, const long long *op);
+    int PIOc_get_varm_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			     const PIO_Offset *stride, const PIO_Offset *imap, double *buf);
+    int PIOc_get_varm_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			   const PIO_Offset *stride, const PIO_Offset *imap, char *buf);
+    int PIOc_get_varm_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			  const PIO_Offset *stride, const PIO_Offset *imap, int *buf);
+    int PIOc_get_varm_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			   const PIO_Offset *stride, const PIO_Offset *imap, unsigned int *buf);
+    int PIOc_get_varm(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+		      const PIO_Offset *stride, const PIO_Offset *imap, void *buf,
 		      PIO_Offset bufcount, MPI_Datatype buftype);
-    int PIOc_get_varm_float(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			    const PIO_Offset stride[], const PIO_Offset imap[], float *buf);
-    int PIOc_get_varm_long(int ncid, int varid, const PIO_Offset start[], const PIO_Offset count[],
-			   const PIO_Offset stride[], const PIO_Offset imap[], long *buf);
+    int PIOc_get_varm_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			    const PIO_Offset *stride, const PIO_Offset *imap, float *buf);
+    int PIOc_get_varm_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
+			   const PIO_Offset *stride, const PIO_Offset *imap, long *buf);
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -74,6 +74,7 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
     int vsize;             /* size in bytes of the given data. */
     int rlen;              /* total data buffer size. */
     var_desc_t *vdesc0;    /* pointer to var_desc structure for each var. */
+    int mpierr;            /* Return code from MPI functions. */
     int ierr = PIO_NOERR;  /* Return code. */
 
     /* Check inputs. */
@@ -102,12 +103,12 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
 
     /* ??? */
     /*   rlen = iodesc->llen*nvars; */
-    rlen=0;
+    rlen = 0;
     if (iodesc->llen > 0)
-        rlen = iodesc->maxiobuflen*nvars;
+        rlen = iodesc->maxiobuflen * nvars;
 
     if (vdesc0->iobuf)
-        piodie("Attempt to overwrite existing io buffer",__FILE__,__LINE__);
+        piodie("Attempt to overwrite existing io buffer",__FILE__, __LINE__);
 
     /* Currently there are two rearrangers box=1 and subset=2. There
      * is never a case where rearranger==0. */
@@ -115,7 +116,8 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
     {
         if (rlen > 0)
         {
-            MPI_Type_size(iodesc->basetype, &vsize);
+            if ((mpierr = MPI_Type_size(iodesc->basetype, &vsize)))
+                return check_mpi(file, mpierr, __FILE__, __LINE__);
 
 	    /* Allocate memory for the variable buffer. */
             if (!(vdesc0->iobuf = bget((size_t)vsize * (size_t)rlen)))
@@ -284,7 +286,7 @@ int PIOc_write_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
     bufsize totfree;       /* Amount of free space in the buffer. */
     bufsize maxfree;       /* Max amount of free space in buffer. */
     int ierr = PIO_NOERR;  /* Return code. */
-    int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
+    int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI functions. */
 
     LOG((1, "PIOc_write_darray ncid = %d vid = %d ioid = %d arraylen = %d",
 	 ncid, vid, ioid, arraylen));
@@ -526,6 +528,7 @@ int PIOc_read_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
     size_t rlen = 0;       /* the length of data in iobuf. */
     int tsize;          /* Total size. */
     MPI_Datatype vtype; /* MPI type of this var. */
+    int mpierr;         /* Return code from MPI functions. */
     int ierr;           /* Return code. */
 
     /* Get the file info. */
@@ -549,7 +552,8 @@ int PIOc_read_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
         if (ios->ioproc && rlen > 0)
         {
             /* Get the MPI type size. */
-            MPI_Type_size(iodesc->basetype, &tsize);
+            if ((mpierr = MPI_Type_size(iodesc->basetype, &tsize)))
+                return check_mpi(file, mpierr, __FILE__, __LINE__);
 
             /* Allocate a buffer for one record. */
             if (!(iobuf = bget((size_t)tsize * rlen)))

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -65,10 +65,8 @@ PIO_Offset PIOc_set_buffer_size_limit(const PIO_Offset limit)
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_write_darray
  */
-int PIOc_write_darray_multi(const int ncid, const int *vid, const int ioid,
-                            const int nvars, const PIO_Offset arraylen,
-                            void *array, const int *frame, void **fillvalue,
-                            bool flushtodisk)
+int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_Offset arraylen,
+                            void *array, const int *frame, void **fillvalue, bool flushtodisk)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -270,8 +268,8 @@ int PIOc_write_darray_multi(const int ncid, const int *vid, const int ioid,
  * @returns 0 for success, non-zero error code for failure.
  * @ingroup PIO_write_darray
  */
-int PIOc_write_darray(const int ncid, const int vid, const int ioid,
-                      const PIO_Offset arraylen, void *array, void *fillvalue)
+int PIOc_write_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
+                      void *array, void *fillvalue)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Info about file we are writing to. */
@@ -518,8 +516,8 @@ int PIOc_write_darray(const int ncid, const int vid, const int ioid,
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_read_darray
  */
-int PIOc_read_darray(const int ncid, const int vid, const int ioid,
-                     const PIO_Offset arraylen, void *array)
+int PIOc_read_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
+                     void *array)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -26,8 +26,8 @@ int pio_next_ncid = 16;
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_openfile
  */
-int PIOc_openfile(const int iosysid, int *ncidp, int *iotype,
-                  const char *filename, const int mode)
+int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
+                  int mode)
 {
     LOG((1, "PIOc_openfile iosysid = %d iotype = %d filename = %s mode = %d",
          iosysid, *iotype, filename, mode));
@@ -86,8 +86,7 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
  * @returns 0 for success, error code otherwise.
  * @ingroup PIO_createfile
  */
-int PIOc_createfile(const int iosysid, int *ncidp, int *iotype,
-                    const char *filename, const int mode)
+int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, int mode)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -384,7 +383,7 @@ int PIOc_closefile(int ncid)
  * @param filename a filename.
  * @returns PIO_NOERR for success, error code otherwise.
  */
-int PIOc_deletefile(const int iosysid, const char filename[])
+int PIOc_deletefile(int iosysid, const char *filename)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -1829,7 +1829,6 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
 }
 
 /**
- * @ingroup PIO_def_var
  * The PIO-C interface for the NetCDF function nc_def_var.
  *
  * This routine is called collectively by all tasks in the communicator
@@ -1842,6 +1841,7 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
  * @param varid the variable ID.
  * @param varidp a pointer that will get the variable id
  * @return PIO_NOERR for success, error code otherwise.
+ * @ingroup PIO_def_var
  */
 int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 		 const int *dimidsp, int *varidp)

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -21,7 +21,7 @@ static int counter = 0;
  * otherwise.
  * @returns 0 on success, error code otherwise
  */
-int PIOc_iosystem_is_active(const int iosysid, bool *active)
+int PIOc_iosystem_is_active(int iosysid, bool *active)
 {
     iosystem_desc_t *ios;
 
@@ -99,17 +99,16 @@ int PIOc_advanceframe(int ncid, int varid)
 }
 
 /**
- * @ingroup PIO_setframe
  * Set the unlimited dimension of the given variable
  *
  * @param ncid the ncid of the file.
  * @param varid the varid of the variable
  * @param frame the value of the unlimited dimension.  In c 0 for the
  * first record, 1 for the second
- *
  * @return PIO_NOERR for no error, or error code.
+ * @ingroup PIO_setframe
  */
-int PIOc_setframe(const int ncid, const int varid, const int frame)
+int PIOc_setframe(int ncid, int varid, int frame)
 {
     file_desc_t *file;
     int ret;
@@ -233,10 +232,9 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
  * @returns 0 on success, error code otherwise
  * @ingroup PIO_initdecomp
  */
-int PIOc_InitDecomp(const int iosysid, const int basetype, const int ndims,
-		    const int *dims, const int maplen, const PIO_Offset *compmap,
-		    int *ioidp, const int *rearranger, const PIO_Offset *iostart,
-		    const PIO_Offset *iocount)
+int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int maplen,
+                    const PIO_Offset *compmap, int *ioidp, const int *rearranger,
+                    const PIO_Offset *iostart, const PIO_Offset *iocount)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     io_desc_t *iodesc;     /* The IO description. */
@@ -451,9 +449,8 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
  * @param iosysidp index of the defined system descriptor
  * @return 0 on success, otherwise a PIO error code.
  */
-int PIOc_Init_Intracomm(const MPI_Comm comp_comm, const int num_iotasks,
-                        const int stride, const int base, const int rearr,
-                        int *iosysidp)
+int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base,
+                        int rearr, int *iosysidp)
 {
     iosystem_desc_t *iosys;
     int ierr = PIO_NOERR;
@@ -625,7 +622,7 @@ int PIOc_set_hint(int iosysid, const char *hint, const char *hintval)
  * @returns 0 for success or non-zero for error.
  * @ingroup PIO_finalize
  */
-int PIOc_finalize(const int iosysid)
+int PIOc_finalize(int iosysid)
 {
     iosystem_desc_t *ios, *nios;
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
@@ -729,7 +726,7 @@ int PIOc_finalize(const int iosysid)
  * otherwise. Ignored if NULL.
  * @returns 0 for success, or PIO_BADID if iosysid can't be found.
  */
-int PIOc_iam_iotask(const int iosysid, bool *ioproc)
+int PIOc_iam_iotask(int iosysid, bool *ioproc)
 {
     iosystem_desc_t *ios;
 
@@ -751,7 +748,7 @@ int PIOc_iam_iotask(const int iosysid, bool *ioproc)
  * in the IO communicator. Ignored if NULL.
  * @returns 0 for success, or PIO_BADID if iosysid can't be found.
  */
-int PIOc_iotask_rank(const int iosysid, int *iorank)
+int PIOc_iotask_rank(int iosysid, int *iorank)
 {
     iosystem_desc_t *ios;
 
@@ -770,7 +767,7 @@ int PIOc_iotask_rank(const int iosysid, int *iorank)
  * @param iotype the io type to check
  * @returns 1 if iotype is in build, 0 if not.
  */
-int PIOc_iotype_available(const int iotype)
+int PIOc_iotype_available(int iotype)
 {
     switch(iotype)
     {

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -357,7 +357,6 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
 }
 
 /**
- * @ingroup PIO_initdecomp
  * This is a simplified initdecomp which can be used if the memory
  * order of the data can be expressed in terms of start and count on
  * the file.  In this case we compute the compdof and use the subset
@@ -371,6 +370,7 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
  * @param count count array
  * @param pointer that gets the IO ID.
  * @returns 0 for success, error code otherwise
+ * @ingroup PIO_initdecomp
  */
 int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, const int dims[],
                        const long int start[], const long int count[], int *ioidp)
@@ -430,7 +430,6 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
 }
 
 /**
- * @ingroup PIO_init
  * Library initialization used when IO tasks are a subset of compute
  * tasks.
  *
@@ -448,6 +447,7 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
  * overriden in the @ref PIO_initdecomp
  * @param iosysidp index of the defined system descriptor
  * @return 0 on success, otherwise a PIO error code.
+ * @ingroup PIO_init
  */
 int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base,
                         int rearr, int *iosysidp)

--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -50,7 +50,7 @@ int blocksize = default_blocksize;
  ** @brief Set the target blocksize for the box rearranger.
  **
  */
-int PIOc_set_blocksize(const int newblocksize)
+int PIOc_set_blocksize(int newblocksize)
 {
     if(newblocksize > 0)
         blocksize = newblocksize;

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -568,7 +568,7 @@ int PIOc_freedecomp(int iosysid, int ioid)
  * @param file the filename
  */
 int PIOc_readmap(const char *file, int *ndims, int *gdims[], PIO_Offset *fmaplen,
-		 PIO_Offset *map[], const MPI_Comm comm)
+		 PIO_Offset *map[], MPI_Comm comm)
 {
     int npes, myrank;
     int rnpes, rversno;
@@ -671,7 +671,7 @@ int PIOc_readmap(const char *file, int *ndims, int *gdims[], PIO_Offset *fmaplen
  * @returns 0 for success, error code otherwise.
  */
 int PIOc_readmap_from_f90(const char *file, int *ndims, int *gdims[], PIO_Offset *maplen,
-			  PIO_Offset *map[], const int f90_comm)
+			  PIO_Offset *map[], int f90_comm)
 {
     return PIOc_readmap(file, ndims, gdims, maplen, map, MPI_Comm_f2c(f90_comm));
 }
@@ -687,8 +687,8 @@ int PIOc_readmap_from_f90(const char *file, int *ndims, int *gdims[], PIO_Offset
  * @param comm an MPI communicator.
  * @returns 0 for success, error code otherwise.
  */
-int PIOc_writemap(const char *file, const int ndims, const int *gdims, PIO_Offset maplen,
-		  PIO_Offset *map, const MPI_Comm comm)
+int PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
+		  PIO_Offset *map, MPI_Comm comm)
 {
     int npes, myrank;
     PIO_Offset *nmaplen = NULL;


### PR DESCRIPTION
Fixes #234.

This removes the unneeded "const"s before scalar paramters in the C function prototypes.

For example: 

`PIOc_closefile(const int ncid)`
becomes
`PIOc_closefile(int ncid)`

As far a C compilers are concerned this is not an important change, and it should go unnoticed everywhere.