### PR TITLE
Adding a new CMake option to perform valgrind memory check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set (PIO_FILESYSTEM_HINTS IGNORE CACHE STRING "Filesystem hints (lustre or gpfs)
 #===== Testing Options =====
 option (PIO_ENABLE_TESTS  "Enable the testing builds"                           ON)
 option (PIO_HDF5_LOGGING  "Enable hdf5 logging (requires instrumented netcdf4)" OFF)
+option (PIO_VALGRIND_CHECK  "Enable memory leak check using valgrind"           OFF)
 
 #==============================================================================
 #  BACKWARDS COMPATIBILITY

--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -1,5 +1,16 @@
 include (CMakeParseArguments)
 
+# Find Valgrind to perform memory leak check
+if (PIO_VALGRIND_CHECK)
+    find_program (VALGRIND_COMMAND NAMES valgrind)
+    if (VALGRIND_COMMAND)
+        set (VALGRIND_COMMAND_OPTIONS --leak-check=full --show-reachable=yes)
+    else ()
+        message (WARNING "Valgrind not found: memory leak check could not be performed")
+        set (VALGRIND_COMMAND "")
+    endif ()
+endif ()
+
 #
 # - Functions for parallel testing with CTest
 #
@@ -89,14 +100,14 @@ function (add_mpi_test TESTNAME)
 
         # Run tests directly from the command line
         set(EXE_CMD ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} 
-                    ${MPIEXEC_PREFLAGS} ${exec_file} 
+                    ${MPIEXEC_PREFLAGS} ${VALGRIND_COMMAND} ${VALGRIND_COMMAND_OPTIONS} ${exec_file} 
                     ${MPIEXEC_POSTFLAGS} ${exec_args})
 
     else ()
                         
         # Run tests from the platform-specific executable
         set (EXE_CMD ${CMAKE_SOURCE_DIR}/cmake/mpiexec.${PLATFORM} 
-                     ${num_procs} ${exec_file} ${exec_args})
+                     ${num_procs} ${VALGRIND_COMMAND} ${VALGRIND_COMMAND_OPTIONS} ${exec_file} ${exec_args})
                      
     endif ()
     


### PR DESCRIPTION
This feature branch has been tested on ANL's Jenkins server to generate nightly valgrind check reports. Some memory leaks are confirmed in #245.