### PR TITLE
adding pio_err() function to handle PIO errors

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -374,6 +374,10 @@ typedef struct file_desc_t
      * the same communication pattern prior to a write. */
     struct wmulti_buffer buffer;
 
+    /** Controls handling errors. Overrides the IO system error
+     * handler if set. */
+    int error_handler;
+
     /** Pointer to the next file_desc_t in the list of open files. */
     struct file_desc_t *next;
 

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -102,11 +102,11 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return PIO_EBADID;
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Allocate space for the file info. */
     if (!(file = (file_desc_t *)malloc(sizeof(file_desc_t))))
-        return PIO_ENOMEM;
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Fill in some file values. */
     file->fh = -1;

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -95,7 +95,7 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
 
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename || strlen(filename) > NC_MAX_NAME)
-        return PIO_EINVAL;
+        return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     LOG((1, "PIOc_createfile iosysid = %d iotype = %d filename = %s mode = %d",
          iosysid, *iotype, filename, mode));

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -78,11 +78,15 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
  * Create a new file using pio. Input parameters are read on comp task
  * 0 and ignored elsewhere.
  *
- * @param iosysid A defined pio system descriptor (input)
- * @param ncidp A pio file descriptor (output)
- * @param iotype A pio output format (input)
- * @param filename The filename to open
- * @param mode The netcdf mode for the open operation
+ * @param iosysid A defined pio system ID, obtained from
+ * PIOc_InitIntercomm() or PIOc_InitAsync().
+ * @param ncidp A pointer that gets the ncid of the newly created
+ * file.
+ * @param iotype A pointer to a pio output format. Must be one of
+ * PIO_IOTYPE_PNETCDF, PIO_IOTYPE_NETCDF, PIO_IOTYPE_NETCDF4C, or
+ * PIO_IOTYPE_NETCDF4P.
+ * @param filename The filename to create.
+ * @param mode The netcdf mode for the create operation.
  * @returns 0 for success, error code otherwise.
  * @ingroup PIO_createfile
  */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -113,6 +113,7 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
     file->next = NULL;
     file->iosystem = ios;
     file->iotype = *iotype;
+    file->error_handler = 0;
 
     file->buffer.validvars = 0;
     file->buffer.data = NULL;

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -77,7 +77,7 @@ extern "C" {
         bool isend;
     } pio_swapm_defaults;
 
-    /* Handle are error in the PIO library. */
+    /* Handle an error in the PIO library. */
     int pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fname,
                 int line);
     

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -77,6 +77,10 @@ extern "C" {
         bool isend;
     } pio_swapm_defaults;
 
+    /* Handle are error in the PIO library. */
+    int pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fname,
+                int line);
+    
     void pio_get_env(void);
     int  pio_add_to_iodesc_list(io_desc_t *iodesc);
     io_desc_t *pio_get_iodesc_from_id(int ioid);

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -451,9 +451,6 @@ int pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fn
     /* If logging is in use, log an error message. */
     LOG((0, "%s err_num = %d fname = %s line = %d", err_msg, err_num, fname ? fname : '\0', line));
 
-    /* ??? */
-    print_trace(stderr);
-
     /* What error handler should we use? */
     if (file)
         err_handler = file->error_handler ? file->error_handler : file->iosystem->error_handler;
@@ -463,6 +460,9 @@ int pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fn
     /* Should we abort? */
     if (err_handler == PIO_INTERNAL_ERROR)
     {
+        /* For debugging only, this will print a traceback of the call tree.  */
+        print_trace(stderr);
+
 #ifdef MPI_SERIAL
         /* Why the special abort() call for MPI_SERIAL??? */
         abort();


### PR DESCRIPTION
Working on #238, need to clear #225.

In this PR I add pio_err(), the function that will handled errors in the PIO library. It checks with the file and iosystem error handlers (in that order) to decide what to do with the error.

Also I note that setting the file error_handler actually just changes the iosystem error handler for that file, which is not right. So I have added an error_handler field to file_desc_t, it is initialized to 0 when a new file_desc_t is created.

