### PR TITLE
fixed returns in pio_file.c to use pio_err(), working out code merge procedure

### DIFF
--- a/doc/source/contributing_code.txt
+++ b/doc/source/contributing_code.txt
@@ -145,8 +145,8 @@ test cycles. (???)
 hours).
 
 <li>After all jenkins and Cdash builds complete successfully, with all
-tests passing, and no warnings, the PR is merged into master by Jim
-(???)
+tests passing, and no warnings, the PR is merged into master by the
+integrator.
 
 <li>Multiple PRs may be merged to master between test cycles. (???)
 

--- a/doc/source/contributing_code.txt
+++ b/doc/source/contributing_code.txt
@@ -136,7 +136,16 @@ develop.
 <li>When code review is complete, and the changes are approved, the PR
 is merged into the develop branch.
 
-<li> ???
+<li>The develop branch is tested automatically by Jenkins.
+
+<li>The develop branch is tested periodically by CDash (every ~6
+hours).
+
+<li>After all jenkins and Cdash builds complete successfully, with all
+tests passing, and no warnings, the PR is merged into master by Jim
+(???)
+
+<li>The branch is then deleted by whomever merged it to master.
 
 </ul>
 

--- a/doc/source/contributing_code.txt
+++ b/doc/source/contributing_code.txt
@@ -131,10 +131,13 @@ all issues have been resolved.
 <li>Programmers begin work on a feature or fix by branching from
 develop.
 
-<li>When branch is ready, it is submitted to code review.
+<li>When a branch is ready, it is submitted to code review.
 
 <li>When code review is complete, and the changes are approved, the PR
 is merged into the develop branch.
+
+<li>Mutliple merges into the develop branch may take place between
+test cycles. (???)
 
 <li>The develop branch is tested automatically by Jenkins.
 
@@ -145,7 +148,16 @@ hours).
 tests passing, and no warnings, the PR is merged into master by Jim
 (???)
 
+<li>Commit comments are squished, to come comment per merged PR.
+
+<li>Multiple PRs may be merged to master between test cycles. (???)
+
 <li>The branch is then deleted by whomever merged it to master.
+
+<li>The master branch is then tested on Jenkins.
+
+<li>The master branch is tested on CDash. Any test failures and the
+merge to master will be rolled back.
 
 </ul>
 

--- a/doc/source/contributing_code.txt
+++ b/doc/source/contributing_code.txt
@@ -148,8 +148,6 @@ hours).
 tests passing, and no warnings, the PR is merged into master by Jim
 (???)
 
-<li>Commit comments are squished, to come comment per merged PR.
-
 <li>Multiple PRs may be merged to master between test cycles. (???)
 
 <li>The branch is then deleted by whomever merged it to master.

--- a/doc/source/contributing_code.txt
+++ b/doc/source/contributing_code.txt
@@ -124,7 +124,23 @@ all issues have been resolved.
 
 </ul>
 
-## Example ##
+## Merge Proceedure
+
+<ul>
+
+<li>Programmers begin work on a feature or fix by branching from
+develop.
+
+<li>When branch is ready, it is submitted to code review.
+
+<li>When code review is complete, and the changes are approved, the PR
+is merged into the develop branch.
+
+<li> ???
+
+</ul>
+
+## Formatting Example ##
 
 <pre>
 /** 

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -306,7 +306,7 @@ int PIOc_closefile(int ncid)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-        return ierr;
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
     ios = file->iosystem;
 
     /* Sync changes before closing. */
@@ -400,7 +400,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
 
     /* Get the IO system info from the id. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return PIO_EBADID;
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* If async is in use, send message to IO master task. */
     if (ios->async_interface)
@@ -480,7 +480,7 @@ int PIOc_sync(int ncid)
 
     /* Get the file info from the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
-        return ierr;
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
     ios = file->iosystem;
 
     /* If async is in use, send message to IO master tasks. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -109,7 +109,7 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Allocate space for the file info. */
-    if (!(file = (file_desc_t *)malloc(sizeof(file_desc_t))))
+    if (!(file = malloc(sizeof(file_desc_t))))
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Fill in some file values. */
@@ -306,7 +306,7 @@ int PIOc_closefile(int ncid)
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
     /* Sync changes before closing. */
@@ -480,7 +480,7 @@ int PIOc_sync(int ncid)
 
     /* Get the file info from the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
     /* If async is in use, send message to IO master tasks. */


### PR DESCRIPTION
A very simple PR to take us through our first merge with the develop branch.

This PR uses the pio_err() function in the rest of pio_file.c. (See issue #225.)

I have also started to document our merge procedure, which is being discussed in email and other place. Please take a look at what I have put in the contributions document.
