### PR TITLE
Update nersc cdash

### DIFF
--- a/ctest/runcdash-nersc-cray.sh
+++ b/ctest/runcdash-nersc-cray.sh
@@ -12,12 +12,12 @@ module load PrgEnv-cray
 module load craype-haswell
 module load cray-shmem
 module load cray-mpich
-module swap cce cce/8.4.2
+module swap cce cce/8.5.1
 module load git/2.6.3
 module load cmake/3.3.2
-module load cray-hdf5-parallel/1.8.14
+module load cray-hdf5-parallel/1.8.16
 module load cray-netcdf-hdf5parallel/4.3.3.1
-module load cray-parallel-netcdf/1.6.1
+module load cray-parallel-netcdf/1.7.0
 
 export CC=cc
 export FC=ftn

--- a/ctest/runcdash-nersc-intel.sh
+++ b/ctest/runcdash-nersc-intel.sh
@@ -7,17 +7,33 @@ else
 	model=$1
 fi
 
-module purge
+
+
+module rm PrgEnv-intel
+module rm PrgEnv-cray
+module rm PrgEnv-gnu
+module rm intel
+module rm cce
+module rm cray-parallel-netcdf
+module rm cray-parallel-hdf5
+module rm pmi
+module rm cray-libsci
+module rm cray-mpich2
+module rm cray-mpich
+module rm cray-netcdf
+module rm cray-hdf5
+module rm cray-netcdf-hdf5parallel
+module rm craype-sandybridge
+module rm craype-ivybridge
+module rm craype
 module load PrgEnv-intel
-module load craype-ivybridge
-module load cray-shmem
-module load cray-mpich
-module load torque
+module switch intel intel/16.0.0.109
+
 module load git/2.4.6
-module load cmake/3.0.0
-module load cray-hdf5-parallel/1.8.14
-module load cray-netcdf-hdf5parallel/4.3.3.1
-module load cray-parallel-netcdf/1.6.0
+module load cmake/3.3.2
+module load cray-hdf5-parallel/1.10.0
+module load cray-netcdf-hdf5parallel/4.4.0
+module load cray-parallel-netcdf/1.7.0
 
 export CC=cc
 export FC=ftn
@@ -34,6 +50,7 @@ if [ ! -d src ]; then
   git clone --branch develop https://github.com/PARALLELIO/ParallelIO src
   cd src
 else
+  cd src
   git fetch origin
   git checkout develop
 fi

--- a/ctest/runcdash-nersc-intel.sh
+++ b/ctest/runcdash-nersc-intel.sh
@@ -7,8 +7,6 @@ else
 	model=$1
 fi
 
-
-
 module rm PrgEnv-intel
 module rm PrgEnv-cray
 module rm PrgEnv-gnu
@@ -25,15 +23,31 @@ module rm cray-hdf5
 module rm cray-netcdf-hdf5parallel
 module rm craype-sandybridge
 module rm craype-ivybridge
+module rm craype-haswell
 module rm craype
 module load PrgEnv-intel
-module switch intel intel/16.0.0.109
 
-module load git/2.4.6
-module load cmake/3.3.2
-module load cray-hdf5-parallel/1.10.0
-module load cray-netcdf-hdf5parallel/4.4.0
-module load cray-parallel-netcdf/1.7.0
+case "$NERSC_HOST" in
+    edison)
+	module switch intel intel/16.0.0.109
+	module load craype-ivybridge
+	module load git/2.4.6
+	module load cmake/3.3.2
+	module load cray-hdf5-parallel/1.8.16 
+	module load cray-netcdf-hdf5parallel/4.3.3.1
+	module load cray-parallel-netcdf/1.7.0
+	;;
+    cori)
+	module switch intel intel/17.0.1.132
+	module load craype-mic-knl
+	module load git/2.9.1
+	module load cmake/3.3.2
+	module load cray-hdf5-parallel/1.8.16
+	module load cray-netcdf-hdf5parallel/4.3.3.1
+	module load cray-parallel-netcdf/1.7.0
+	;;
+	
+esac
 
 export CC=cc
 export FC=ftn

--- a/ctest/runctest-nersc.sh
+++ b/ctest/runctest-nersc.sh
@@ -38,7 +38,13 @@ echo "\$CTEST_CMD -S ${scrdir}/CTestScript-Test.cmake,${model} -V" >> runctest.s
 chmod +x runctest.slurm
 # Submit the job to the queue
 #jobid=`sbatch runctest.slurm| egrep -o -e "\b[0-9]+$"`
-salloc -N 1 ./runctest.slurm
+case "$NERSC_HOST" in
+    edison)
+	salloc -N 1 ./runctest.slurm
+	;;
+    cori)
+	salloc -N 1 -C knl ./runctest.slurm
+esac
 # Wait for the job to complete before exiting
 #while true; do
 #	status=`squeue -j $jobid`

--- a/ctest/runctest-nersc.sh
+++ b/ctest/runctest-nersc.sh
@@ -19,7 +19,16 @@ model=$2
 echo "#!/bin/sh" > runctest.slurm
 echo "#SBATCH --partition debug" >> runctest.slurm
 echo "#SBATCH --nodes=1" >> runctest.slurm
-echo "#SBATCH --ntasks-per-node=32" >> runctest.slurm
+case "$NERSC_HOST" in
+    edison)
+	echo "#SBATCH --ntasks-per-node=32" >> runctest.slurm
+	;;
+    cori)
+	echo "#SBATCH --ntasks-per-node=68" >> runctest.slurm
+	echo "#SBATCH -C knl" >> runctest.slurm
+	;;
+esac
+
 echo "#SBATCH --time=00:15:00" >> runctest.slurm
 
 echo "#SBATCH --export PIO_DASHBOARD_SITE,PIO_DASHBOARD_BUILD_NAME,PIO_DASHBOARD_SOURCE_DIR,PIO_DASHBOARD_BINARY_DIR" >> runctest.slurm

--- a/ctest/runctest-nersc.sh
+++ b/ctest/runctest-nersc.sh
@@ -44,7 +44,8 @@ case "$NERSC_HOST" in
 	;;
     cori)
 	salloc -N 1 -C knl ./runctest.slurm
-esac
+	;;
+esac 
 # Wait for the job to complete before exiting
 #while true; do
 #	status=`squeue -j $jobid`


### PR DESCRIPTION
Still having timeout problems on cori but this is a step in the right direction.
Something is currently wrong with the netcdf 4.4.1 and hdf5 1.10.0 modules, this has
been reported to nersc support. 