### PR TITLE
Make sure a test driver fail is signaled as a fail

### DIFF
--- a/tests/general/util/pio_tf_f90gen.pl
+++ b/tests/general/util/pio_tf_f90gen.pl
@@ -623,6 +623,7 @@ sub get_default_test_main
   $out_line = $out_line . "          WRITE(*,PIO_TF_TEST_RES_FMT) \"PIO_TF: \",&\n";
   $out_line = $out_line . "           \"All tests\", \"---------\", \"PASSED\"\n";
   $out_line = $out_line . "        ELSE\n";
+  $out_line = $out_line . "          pio_tf_nerrs_total_ = pio_tf_nerrs_total_ + 1\n";
   $out_line = $out_line . "          WRITE(*,PIO_TF_TEST_RES_FMT) \"PIO_TF: \",&\n";
   $out_line = $out_line . "           \"Test driver\", \"---------\", \"FAILED\"\n";
   $out_line = $out_line . "        END IF\n";


### PR DESCRIPTION
If the test driver fails make sure that we report an error. Without
this fix failures in the test driver is not signaled as an error.

Fixes Issue #284 