### PR TITLE
Ejh check netcdf2

### DIFF
--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -421,7 +421,7 @@ int pio_write_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
 #ifdef TIMING
     /* Stop timing this function. */
@@ -696,7 +696,7 @@ int pio_write_darray_multi_nc(file_desc_t *file, int nvars, const int *vid, int 
         } /* next regioncnt */
     } /* endif (ios->ioproc) */
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
 #ifdef TIMING
     /* Stop timing this function. */
@@ -962,7 +962,7 @@ int pio_write_darray_multi_nc_serial(file_desc_t *file, int nvars, const int *vi
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
 #ifdef TIMING
     /* Stop timing this function. */
@@ -1154,7 +1154,7 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *IOBU
         } /* next regioncnt */
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
 #ifdef TIMING
     /* Stop timing this function. */
@@ -1387,7 +1387,7 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__, __LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
 #ifdef TIMING
     /* Stop timing this function. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -441,7 +441,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
 #else
 #ifdef _PNETCDF
         if (!mpierr && !delete_called)
-            ierr = ncmpi_delete(filename, ios->info);
+            ierr = ncmpi_delete((char *)filename, ios->info);
 #endif
 #endif
         if (!mpierr)

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -226,7 +226,7 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
@@ -371,7 +371,7 @@ int PIOc_closefile(int ncid)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Delete file from our list of open files. */
     pio_delete_file_from_list(ncid);
@@ -453,7 +453,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(NULL, mpierr2, __FILE__, __LINE__);        
     if (ierr)
-        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, NULL, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -545,7 +545,7 @@ int PIOc_sync(int ncid)
             }
         }
 
-        ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+        ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
     }
     return ierr;
 }

--- a/src/clib/pio_get_nc.c
+++ b/src/clib/pio_get_nc.c
@@ -1091,7 +1091,7 @@ int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Dataty
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1165,7 +1165,7 @@ int PIOc_get_var1(int ncid, int varid, const PIO_Offset *index, void *buf, PIO_O
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1239,7 +1239,7 @@ int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1313,7 +1313,7 @@ int PIOc_get_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -110,9 +110,9 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
          * user may have passed in NULLs.) */
         /* Allocate memory for these arrays, now that we know ndims. */
         if (!(rstart = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
         if (!(rcount = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
         PIO_Offset rstride[ndims];
         for (int vd = 0; vd < ndims; vd++)
@@ -486,11 +486,11 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
         /* Allocate memory for these arrays, now that we know ndims. */
         if (!(rstart = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
         if (!(rcount = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
         if (!(rstride = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
         /* Figure out the real start, count, and stride arrays. (The
          * user may have passed in NULLs.) */
@@ -591,7 +591,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             {
                 LOG((2, "stride not present"));
                 if (!(fake_stride = malloc(ndims * sizeof(PIO_Offset))))
-                    return PIO_ENOMEM;
+                    return check_netcdf(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
                 for (int d = 0; d < ndims; d++)
                     fake_stride[d] = 1;
             }

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -81,11 +81,11 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     {
         /* Get the length of the data type. */
         if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
         /* Get the number of dims for this var. */
         if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
         PIO_Offset dimlen[ndims];
 
@@ -98,21 +98,21 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
             /* Get the dimids for this var. */
             if ((ierr = PIOc_inq_vardimid(ncid, varid, dimid)))
-                return check_netcdf(file, ierr, __FILE__, __LINE__);
+                return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
             /* Get the length of each dimension. */
             for (int vd = 0; vd < ndims; vd++)
                 if ((ierr = PIOc_inq_dimlen(ncid, dimid[vd], &dimlen[vd])))
-                    return check_netcdf(file, ierr, __FILE__, __LINE__);
+                    return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
         }
 
         /* Figure out the real start, count, and stride arrays. (The
          * user may have passed in NULLs.) */
         /* Allocate memory for these arrays, now that we know ndims. */
         if (!(rstart = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
         if (!(rcount = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
         PIO_Offset rstride[ndims];
         for (int vd = 0; vd < ndims; vd++)
@@ -339,7 +339,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Send the data. */
     LOG((2, "PIOc_get_vars_tc bcasting data num_elem = %d typelen = %d", num_elem,
@@ -454,11 +454,11 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     {
         /* Get the number of dims for this var. */
         if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
         /* Get the length of the data type. */
         if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
         LOG((2, "ndims = %d typelen = %d", ndims, typelen));
 
@@ -473,24 +473,24 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
             /* Get the dimids for this var. */
             if ((ierr = PIOc_inq_vardimid(ncid, varid, dimid)))
-                return check_netcdf(file, ierr, __FILE__, __LINE__);
+                return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
             /* Get the length of each dimension. */
             for (int vd = 0; vd < ndims; vd++)
             {
                 if ((ierr = PIOc_inq_dimlen(ncid, dimid[vd], &dimlen[vd])))
-                    return check_netcdf(file, ierr, __FILE__, __LINE__);
+                    return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
                 LOG((3, "dimlen[%d] = %d", vd, dimlen[vd]));
             }
         }
 
         /* Allocate memory for these arrays, now that we know ndims. */
         if (!(rstart = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
         if (!(rcount = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
         if (!(rstride = malloc(ndims * sizeof(PIO_Offset))))
-            return check_netcdf(file, PIO_ENOMEM, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
         /* Figure out the real start, count, and stride arrays. (The
          * user may have passed in NULLs.) */
@@ -729,7 +729,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
     LOG((2, "PIOc_put_vars_tc bcast netcdf return code %d complete", ierr));
 
     return ierr;

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -98,9 +98,10 @@ extern "C" {
     iosystem_desc_t *pio_get_iosystem_from_id(int iosysid);
     int pio_add_to_iosystem_list(iosystem_desc_t *ios);
 
-    int check_netcdf(file_desc_t *file,const int status, const char *fname, const int line);
-    int check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
+    /* Check the return code from a netCDF call. */
+    int check_netcdf(iosystem_desc_t *ios, file_desc_t *file, int status,
                       const char *fname, const int line);
+    
     int iotype_error(const int iotype, const char *fname, const int line);
     void piodie(const char *msg,const char *fname, const int line);
     void pioassert(bool exp, const char *msg,const char *fname, const int line);

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -133,7 +133,7 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (ndimsp)
@@ -282,7 +282,7 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (name)
@@ -367,7 +367,7 @@ int PIOc_inq_format(int ncid, int *formatp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (formatp)
@@ -460,7 +460,7 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (name)
@@ -594,7 +594,7 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results. */
     if (idp)
@@ -724,7 +724,7 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast the results for non-null pointers. */
     if (name)
@@ -914,7 +914,7 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (varidp)
@@ -1012,7 +1012,7 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results. */
     if (xtypep)
@@ -1133,7 +1133,7 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (name)
@@ -1231,7 +1231,7 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results. */
     if (idp)
@@ -1321,7 +1321,7 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -1407,7 +1407,7 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -1498,7 +1498,7 @@ int PIOc_rename_att(int ncid, int varid, const char *name,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     LOG((2, "PIOc_rename_att succeeded"));
     return ierr;
@@ -1582,7 +1582,7 @@ int PIOc_del_att(int ncid, int varid, const char *name)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -1653,7 +1653,7 @@ int PIOc_set_fill(int ncid, int fillmode, int *old_modep)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     LOG((2, "PIOc_set_fill succeeded"));
     return ierr;
@@ -1774,7 +1774,7 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (idp)
@@ -1811,7 +1811,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     /* User must provide name and storage for varid. */
     if (!name || !varidp || strlen(name) > NC_MAX_NAME)
     {
-        check_netcdf(file, PIO_EINVAL, __FILE__, __LINE__);
+        check_netcdf(ios, file, PIO_EINVAL, __FILE__, __LINE__);
         return PIO_EINVAL;
     }
 
@@ -1881,7 +1881,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results. */
     if (varidp)
@@ -1957,7 +1957,7 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (fill_valuep)
@@ -2008,7 +2008,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
         /* Get the type and length of the attribute. */
         if ((ierr = PIOc_inq_att(ncid, varid, name, &atttype, &attlen)))
         {
-            check_netcdf(file, ierr, __FILE__, __LINE__);
+            check_netcdf(ios, file, ierr, __FILE__, __LINE__);
             return ierr;
         }
         LOG((2, "atttype = %d attlen = %d", atttype, attlen));
@@ -2016,7 +2016,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
         /* Get the length (in bytes) of the type. */
         if ((ierr = PIOc_inq_type(ncid, atttype, NULL, &typelen)))
         {
-            check_netcdf(file, ierr, __FILE__, __LINE__);
+            check_netcdf(ios, file, ierr, __FILE__, __LINE__);
             return ierr;
         }
         LOG((2, "typelen = %d", typelen));
@@ -2094,7 +2094,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. */
     if ((mpierr = MPI_Bcast(ip, (int)attlen * typelen, MPI_BYTE, ios->ioroot,
@@ -2144,7 +2144,7 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
         /* Get the length (in bytes) of the type. */
         if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
         {
-            check_netcdf(file, ierr, __FILE__, __LINE__);
+            check_netcdf(ios, file, ierr, __FILE__, __LINE__);
             return ierr;
         }
         LOG((2, "PIOc_put_att typelen = %d", ncid, typelen));
@@ -2211,7 +2211,7 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -83,7 +83,7 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -182,7 +182,7 @@ int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep, int *deflatep,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. */
     if (shufflep)
@@ -247,7 +247,7 @@ int PIOc_def_var_chunking(int ncid, int varid, int storage,
      * dimensions. */
     if (!ios->async_interface || !ios->ioproc)
         if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+            return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
     LOG((2, "PIOc_def_var_chunking first ndims = %d", ndims));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -317,7 +317,7 @@ int PIOc_def_var_chunking(int ncid, int varid, int storage,
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -435,7 +435,7 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. */
     if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->ioroot, ios->my_comm)))
@@ -522,7 +522,7 @@ int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -602,7 +602,7 @@ int PIOc_def_var_endian(int ncid, int varid, int endian)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -682,7 +682,7 @@ int PIOc_inq_var_endian(int ncid, int varid, int *endianp)
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. */
     if (endianp)
@@ -781,7 +781,7 @@ int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset ne
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        check_netcdf(file, ierr, __FILE__, __LINE__);
+        check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     LOG((2, "PIOc_set_chunk_cache complete!"));
     return ierr;
@@ -886,7 +886,7 @@ int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset 
         return check_mpi(NULL, mpierr, __FILE__, __LINE__);
     LOG((2, "bcast complete ierr = %d sizep = %d", ierr, sizep));
     if (ierr)
-        return check_netcdf(NULL, ierr, __FILE__, __LINE__);        
+        return check_netcdf(ios, NULL, ierr, __FILE__, __LINE__);        
 
     if (sizep)
     {
@@ -992,7 +992,7 @@ int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset ne
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     return ierr;
 }
@@ -1088,7 +1088,7 @@ int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset 
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(ios, file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. */
     if (sizep && !ierr)

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -1175,7 +1175,7 @@ int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -1261,7 +1261,7 @@ int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -1336,7 +1336,7 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -1411,7 +1411,7 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -76,7 +76,7 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -151,7 +151,7 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -226,7 +226,7 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -302,7 +302,7 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -379,7 +379,7 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -456,7 +456,7 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -532,7 +532,7 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -609,7 +609,7 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -685,7 +685,7 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -762,7 +762,7 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -839,7 +839,7 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -915,7 +915,7 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -990,7 +990,7 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     return ierr;
 }
@@ -1062,7 +1062,7 @@ int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1139,7 +1139,7 @@ int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1216,7 +1216,7 @@ int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const P
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1293,7 +1293,7 @@ int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1370,7 +1370,7 @@ int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1447,7 +1447,7 @@ int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1520,7 +1520,7 @@ int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1597,7 +1597,7 @@ int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1674,7 +1674,7 @@ int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1751,7 +1751,7 @@ int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1828,7 +1828,7 @@ int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1905,7 +1905,7 @@ int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){
@@ -1982,7 +1982,7 @@ int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
         }
     }
 
-    ierr = check_netcdf(file, ierr, __FILE__,__LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__,__LINE__);
 
     if(ios->async_interface || bcast ||
        (ios->num_iotasks < ios->num_comptasks)){


### PR DESCRIPTION
Here are changes to use the new check_netcdf() function, and remove the old one.

The new function, as you may recall, accepts the iosystem_desc_t for those cases where we have an ios but not a file to decide what error handling to use.