### PR TITLE
free MPI communicator newcomm

### DIFF
--- a/tests/unit/test_iosystem2.c
+++ b/tests/unit/test_iosystem2.c
@@ -192,6 +192,9 @@ int main(int argc, char **argv)
             if ((ret = PIOc_closefile(ncid2)))
                 ERR(ret);
         } /* next iotype */
+        if ((ret = MPI_Comm_free(&newcomm)))
+            MPIERR(ret);
+
         /* Finalize PIO system. */
         if ((ret = PIOc_finalize(iosysid)))
             ERR(ret);


### PR DESCRIPTION
because of the following MPI warning message.

In direct memory block for handle type COMM, 1 handles are still allocated
...