### PR TITLE
added check_mpi that accepts ios, for use in deletefile function

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -402,9 +402,9 @@ int PIOc_deletefile(int iosysid, const char *filename)
 
         /* Handle MPI errors. */
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            return check_mpi(NULL, mpierr2, __FILE__, __LINE__);
+            return check_mpi2(ios, NULL, mpierr2, __FILE__, __LINE__);
         if (mpierr)
-            return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+            return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. The
@@ -433,7 +433,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(NULL, mpierr2, __FILE__, __LINE__);        
+        return check_mpi2(ios, NULL, mpierr2, __FILE__, __LINE__);        
     if (ierr)
         return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
 

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -92,8 +92,10 @@ extern "C" {
     void pio_add_to_file_list(file_desc_t *file);
     void pio_push_request(file_desc_t *file, int request);
 
+    /* Open a file with PIO. Optionally retry with classic netCDF if
+     * first iotype doesn't work. */
     int PIOc_openfile_retry(const int iosysid, int *ncidp, int *iotype,
-                            const char *filename, const int mode, int retry);
+                            const char *filename, int mode, int retry);
 
     iosystem_desc_t *pio_get_iosystem_from_id(int iosysid);
     int pio_add_to_iosystem_list(iosystem_desc_t *ios);

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -164,8 +164,13 @@ extern "C" {
     void flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk);
     void piomemerror(iosystem_desc_t ios, size_t req, char *fname, const int line);
     void compute_maxaggregate_bytes(const iosystem_desc_t ios, io_desc_t *iodesc);
-    int check_mpi(file_desc_t *file, const int mpierr, const char *filename,
-                  const int line);
+
+    /* Check the return code from an MPI function call. */
+    int check_mpi(file_desc_t *file, int mpierr, const char *filename, int line);
+
+    /* Check the return code from an MPI function call. */
+    int check_mpi2(iosystem_desc_t *ios, file_desc_t *file, int mpierr, const char *filename,
+                   int line);
 
     /* Darray support functions. */
     int pio_write_darray_multi_nc(file_desc_t *file, const int nvars, const int *vid,

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -993,7 +993,7 @@ int PIOc_writemap_from_f90(const char *file, const int ndims, const int *gdims,
  * @ingroup PIO_openfile
  */
 int PIOc_openfile_retry(const int iosysid, int *ncidp, int *iotype,
-                        const char *filename, const int mode, int retry)
+                        const char *filename, int mode, int retry)
 {
     iosystem_desc_t *ios;  /** Pointer to io system information. */
     file_desc_t *file;     /** Pointer to file information. */


### PR DESCRIPTION
There is one case (at least) where there is an ios but not a file pointer, and that is in deletefile.

This PR adds a check_mpi2() which can be used in those cases to make sure the correct error handler is used.
