### PR TITLE
Fixing some memory leaks on pio_decomp_fillval test

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -699,6 +699,9 @@ int PIOc_freedecomp(int iosysid, int ioid)
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
         return PIO_EBADID;
 
+    if (iodesc->gsize)
+        brel(iodesc->gsize);
+
     if (iodesc->rfrom)
         brel(iodesc->rfrom);
     
@@ -734,6 +737,9 @@ int PIOc_freedecomp(int iosysid, int ioid)
 
     if (iodesc->firstregion)
         free_region_list(iodesc->firstregion);
+
+    if (iodesc->fillregion)
+        free_region_list(iodesc->fillregion);
 
     if (iodesc->rearranger == PIO_REARR_SUBSET)
         MPI_Comm_free(&(iodesc->subset_comm));


### PR DESCRIPTION
Some memory leaks are reported by both Valgrind and LeakSanitizer on pio_decomp_fillval test. In PIOc_freedecomp(), we should clean gsize array and fillregion linked list in io_desc. Before it goes to master, this fix will be merged to the develop branch to be tested by some nightly builds. Fixes #305.