### PR TITLE
added PIO_ENABLE_EXAMPLES, also now run C examples as extra tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option (PIO_ENABLE_TIMING    "Enable the use of the GPTL timing library"    ON)
 option (PIO_ENABLE_LOGGING   "Enable debug logging (large output possible)" OFF)
 option (PIO_ENABLE_DOC       "Enable building PIO documentation"            ON)
 option (PIO_ENABLE_COVERAGE  "Enable code coverage"                         OFF)
+option (PIO_ENABLE_EXAMPLES  "Enable PIO examples"                          ON)
 option (PIO_INTERNAL_DOC     "Enable PIO developer documentation"           OFF)
 option (PIO_TEST_BIG_ENDIAN  "Enable test to see if machine is big endian"  ON)
 option (PIO_USE_MPIIO        "Enable support for MPI-IO auto detect"        ON)
@@ -154,12 +155,25 @@ endif ()
 # Libraries
 add_subdirectory (src)
 
+#==============================================================================
+#  TESTING TARGET
+#==============================================================================
+
+# Custom "piotests" target (builds the test executables)
+add_custom_target (tests)
+
+# Custom "check" target that depends upon "tests"
+add_custom_target (check COMMAND ${CMAKE_CTEST_COMMAND})
+add_dependencies (check tests)
+
 # Tests
 if (PIO_ENABLE_TESTS)
   enable_testing()
   include (CTest)
   add_subdirectory (tests)
-  add_subdirectory (examples)
+  if (PIO_ENABLE_EXAMPLES)
+    add_subdirectory (examples)
+  endif ()
 endif ()
 
 # Documentation

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 # Include PIO include and lib directories
 INCLUDE_DIRECTORIES(${PIO_INCLUDE_DIRS})
+include_directories("${CMAKE_SOURCE_DIR}/examples/c")
 LINK_DIRECTORIES(${PIO_LIB_DIR})
 
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -O0")
@@ -24,13 +25,22 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
 
-SET(SRC examplePio.c)
-ADD_EXECUTABLE(examplePio_c ${SRC})
-TARGET_LINK_LIBRARIES(examplePio_c pioc)
+ADD_EXECUTABLE(examplePio EXCLUDE_FROM_ALL examplePio.c)
+TARGET_LINK_LIBRARIES(examplePio pioc)
+add_dependencies(tests examplePio)
 
-SET(SRC example1.c)
-ADD_EXECUTABLE(example1 ${SRC})
+ADD_EXECUTABLE(example1 example1.c)
 TARGET_LINK_LIBRARIES(example1 pioc)
+add_dependencies(tests example1)
+
+if (PIO_USE_MPISERIAL)
+  add_test(NAME examplePio COMMAND examplePio)
+  add_test(NAME example1 COMMAND example1)
+else ()
+  add_mpi_test(examplePio EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/examplePio NUMPROCS 4 TIMEOUT 60)
+  add_mpi_test(example1 EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/example1 NUMPROCS 4 TIMEOUT 60)
+endif ()
+
 
 #===== MPE =====
 find_package (MPE "2.4.8" COMPONENTS C)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,12 +5,12 @@ project (PIOTests C Fortran)
 #  TESTING TARGET
 #==============================================================================
 
-# Custom "piotests" target (builds the test executables)
-add_custom_target (tests)
+# # Custom "piotests" target (builds the test executables)
+# add_custom_target (tests)
 
-# Custom "check" target that depends upon "tests"
-add_custom_target (check COMMAND ${CMAKE_CTEST_COMMAND})
-add_dependencies (check tests)
+# # Custom "check" target that depends upon "tests"
+# add_custom_target (check COMMAND ${CMAKE_CTEST_COMMAND})
+# add_dependencies (check tests)
 
 #==============================================================================
 #  INCLUDE SOURCE DIRECTORIES


### PR DESCRIPTION
This adds the C examples as extra tests.

It also allows users to disable building the examples. By default examples are built and run as tests.

Previously they were built, but not run as tests.

Fixes #322.

I have merged this to develop for testing.
