### PR TITLE
silence compile warnings caused by the use of qsort

### DIFF
--- a/src/gptl/gptl.c
+++ b/src/gptl/gptl.c
@@ -195,8 +195,8 @@ static int update_ll_hash (Timer *, const int, const unsigned int);
 static inline int update_ptr (Timer *, const int);
 static int construct_tree (Timer *, Method);
 
-static int cmp (const char **, const char **);
-static int ncmp (const char **, const char **);
+static int cmp (const void *, const void *);
+static int ncmp (const void *, const void *);
 static int get_index ( const char *, const char *);
 
 typedef struct {
@@ -2933,9 +2933,9 @@ int get_index( const char * list,
 ** cmp: returns value from strcmp. for use with qsort
 */
 
-static int cmp(const char **x, const char **y)
+static int cmp(const void *x, const void *y)
 {
-  return strcmp(*x, *y);
+  return strcmp(*(char**)x, *(char**)y);
 }
 
 
@@ -2943,15 +2943,17 @@ static int cmp(const char **x, const char **y)
 ** ncmp: compares values of memory adresses pointed to by a pointer. for use with qsort
 */
 
-static int ncmp( const char **x, const char **y )
+static int ncmp( const void *x, const void *y )
 {
   static const char *thisfunc = "GPTLsetoption";
+  const char **ix = (const char **)x;
+  const char **iy = (const char **)y;
 
-  if( *x > *y )
+  if( *ix > *iy )
     return 1;
-  if( *x < *y )
+  if( *ix < *iy )
     return -1;
-  if( *x == *y )
+  if( *ix == *iy )
     GPTLerror("%s: shared memory address between timers\n", thisfunc);
 }
 


### PR DESCRIPTION
Got the following compile-time warning messages.

src/gptl/gptl.c: In function 'merge_thread_data':
src/gptl/gptl.c:2578: warning: passing argument 4 of 'qsort' from incompatible pointer type
/usr/include/stdlib.h:761: note: expected '__compar_fn_t' but argument is of type 'int (*)(const char **, const char **)'
src/gptl/gptl.c:2625: warning: passing argument 4 of 'qsort' from incompatible pointer type
/usr/include/stdlib.h:761: note: expected '__compar_fn_t' but argument is of type 'int (*)(const char **, const char **)'
src/gptl/gptl.c:2648: warning: passing argument 4 of 'qsort' from incompatible pointer type
/usr/include/stdlib.h:761: note: expected '__compar_fn_t' but argument is of type 'int (*)(const char **, const char **)'
src/gptl/gptl.c: In function 'collect_data':
src/gptl/gptl.c:2802: warning: passing argument 4 of 'qsort' from incompatible pointer type
/usr/include/stdlib.h:761: note: expected '__compar_fn_t' but argument is of type 'int (*)(const char **, const char **)'
/src/gptl/gptl.c:2803: warning: passing argument 4 of 'qsort' from incompatible pointer type
/usr/include/stdlib.h:761: note: expected '__compar_fn_t' but argument is of type 'int (*)(const char **, const char **)'
src/gptl/gptl.c:2845: warning: passing argument 4 of 'qsort' from incompatible pointer type
/usr/include/stdlib.h:761: note: expected '__compar_fn_t' but argument is of type 'int (*)(const char **, const char **)'
