### PR TITLE
fix setting of iosystem error handler with no file_desc_t present for non-async cases

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -581,7 +581,13 @@ extern "C" {
                             int *iosysidp);
     int PIOc_finalize(int iosysid);
     int PIOc_get_iorank(int iosysid, int *iorank);
+
+    /* Set error handling for entire io system. */
     int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method);
+
+    /* Set error handling for entire io system. */
+    int PIOc_set_iosystem_error(int iosysid, int method);
+    
     int PIOc_iam_iotask(int iosysid, bool *ioproc);
     int PIOc_iotask_rank(int iosysid, int *iorank);
     int PIOc_iosystem_is_active(int iosysid, bool *active);
@@ -616,7 +622,13 @@ extern "C" {
     int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep);
     int PIOc_set_blocksize(int newblocksize);
     int PIOc_File_is_Open(int ncid);
+
+    /* Set the error hanlding for a file. */
     int PIOc_Set_File_Error_Handling(int ncid, int method);
+
+    /* Set the error hanlding for a file. */
+    int PIOc_set_file_error(int ncid, int method);
+    
     int PIOc_set_hint(int iosysid, const char *hint, const char *hintval);
     int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems,
 			     float preemption);

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -586,7 +586,7 @@ extern "C" {
     int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method);
 
     /* Set error handling for entire io system. */
-    int PIOc_set_iosystem_error(int iosysid, int method);
+    int PIOc_set_iosystem_error_handling(int iosysid, int method, int *old_method);
     
     int PIOc_iam_iotask(int iosysid, bool *ioproc);
     int PIOc_iotask_rank(int iosysid, int *iorank);
@@ -627,7 +627,7 @@ extern "C" {
     int PIOc_Set_File_Error_Handling(int ncid, int method);
 
     /* Set the error hanlding for a file. */
-    int PIOc_set_file_error(int ncid, int method);
+    int PIOc_set_file_error_handling(int ncid, int method, int *old_method);
     
     int PIOc_set_hint(int iosysid, const char *hint, const char *hintval);
     int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems,

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -117,6 +117,7 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
     file->iosystem = ios;
     file->iotype = *iotype;
     file->buffer.ioid = -1;
+    file->error_handler = ios->error_handler;
     for (int i = 0; i < PIO_MAX_VARS; i++)
     {
         file->varlist[i].record = -1;

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -30,6 +30,13 @@ FILE *LOG_FILE = NULL;
 */
 extern int pio_next_ncid;
 
+/** Default settings for swap memory. */
+static pio_swapm_defaults swapm_defaults;
+
+/** If this is set to true, then InitDecomp() will save the
+ * decomposition to file. */
+bool PIO_Save_Decomps = false;
+
 /**
  * Return a string description of an error code. If zero is passed,
  * the errmsg will be "No error".
@@ -233,13 +240,6 @@ void pio_log(int severity, const char *fmt, ...)
         fflush(LOG_FILE);
 }
 #endif /* PIO_ENABLE_LOGGING */
-
-/** Default settings for swap memory. */
-static pio_swapm_defaults swapm_defaults;
-
-/** If this is set to true, then InitDecomp() will save the
- * decomposition to file. */
-bool PIO_Save_Decomps = false;
 
 /**
  * Obtain a backtrace and print it to stderr.

--- a/tests/cunit/test_iosystem3.c
+++ b/tests/cunit/test_iosystem3.c
@@ -49,12 +49,16 @@ int create_file(MPI_Comm comm, int iosysid, int format, char *filename,
     printf("%d file created ncid = %d\n", my_rank, ncid);
 
     /* Set the error handler. */
-    if ((ret = PIOc_set_file_error(ncid, PIO_BCAST_ERROR)))
+    int old_method;
+    if ((ret = PIOc_set_file_error_handling(ncid, PIO_RETURN_ERROR, &old_method)))
         return ret;
+    printf("old_method = %d\n", old_method);
+    if (old_method != PIO_BCAST_ERROR) /* the default */
+        return ERR_WRONG;
 
     /* Set the error handler the old-fashioned way. */
-    int old_method = PIOc_Set_File_Error_Handling(ncid, PIO_BCAST_ERROR);
-    if (old_method != PIO_BCAST_ERROR)
+    old_method = PIOc_Set_File_Error_Handling(ncid, PIO_BCAST_ERROR);
+    if (old_method != PIO_RETURN_ERROR)
         return ERR_WRONG;
 
     /* Define a dimension. */
@@ -189,7 +193,7 @@ int main(int argc, char **argv)
         /* Set the error handler. */
         /*PIOc_Set_IOSystem_Error_Handling(iosysid_world, PIO_BCAST_ERROR);*/
         printf("%d about to set iosystem error hanlder for world\n", my_rank);
-        if ((ret = PIOc_set_iosystem_error(iosysid_world, PIO_BCAST_ERROR)))
+        if ((ret = PIOc_set_iosystem_error_handling(iosysid_world, PIO_BCAST_ERROR, NULL)))
             ERR(ret);
         printf("%d done setting iosystem error hanlder for world\n", my_rank);
 
@@ -248,7 +252,7 @@ int main(int argc, char **argv)
             /* Set the error handler. */
             /*PIOc_Set_IOSystem_Error_Handling(even_iosysid, PIO_BCAST_ERROR);*/
             printf("%d about to set iosystem error hanlder for even\n", my_rank);
-            if ((ret = PIOc_set_iosystem_error(even_iosysid, PIO_BCAST_ERROR)))
+            if ((ret = PIOc_set_iosystem_error_handling(even_iosysid, PIO_BCAST_ERROR, NULL)))
                 ERR(ret);
             printf("%d done setting iosystem error hanlder for even\n", my_rank);
         }
@@ -262,7 +266,7 @@ int main(int argc, char **argv)
 
             printf("%d about to set iosystem error hanlder for overlap\n", my_rank);
             /* Set the error handler. */
-            /* if ((ret = PIOc_set_iosystem_error(overlap_iosysid, PIO_BCAST_ERROR))) */
+            /* if ((ret = PIOc_set_iosystem_error_handling(overlap_iosysid, PIO_BCAST_ERROR))) */
             /*     ERR(ret); */
             PIOc_Set_IOSystem_Error_Handling(overlap_iosysid, PIO_BCAST_ERROR);
             printf("%d done setting iosystem error hanlder for overlap\n", my_rank);

--- a/tests/cunit/test_nc4.c
+++ b/tests/cunit/test_nc4.c
@@ -97,11 +97,10 @@ int test_deletefile(int iosysid, int num_flavors, int *flavor, int my_rank)
         if ((ret = PIOc_deletefile(iosysid, filename)))
             ERR(ret);
 
-        /* Make sure it is gone. */
-        /* if ((ret = PIOc_openfile(iosysid, &ncid, &(flavor[fmt]), filename, */
-        /*                          PIO_NOWRITE)) != PIO_ENFILE) */
-        /*     ERR(ret); */
-        
+        /* Make sure it is gone. Openfile will now return an error
+         * code when I try to open the file. */
+        if (!PIOc_openfile(iosysid, &ncid, &(flavor[fmt]), filename, PIO_NOWRITE))
+            ERR(ret);
     }
 
     return PIO_NOERR;

--- a/tests/cunit/test_nc4.c
+++ b/tests/cunit/test_nc4.c
@@ -70,7 +70,8 @@ int test_deletefile(int iosysid, int num_flavors, int *flavor, int my_rank)
         char iotype_name[NC_MAX_NAME + 1];
 
         /* Set error handling. */
-        PIOc_Set_IOSystem_Error_Handling(ncid, PIO_RETURN_ERROR);
+        if ((ret = PIOc_set_iosystem_error(iosysid, PIO_RETURN_ERROR)))
+            return ret;
 
         /* Create a filename. */
         if ((ret = get_iotype_name(flavor[fmt], iotype_name)))
@@ -326,10 +327,12 @@ int test_all(int iosysid, int num_flavors, int *flavor, int my_rank)
     int ret; /* Return code. */
     
     /* Test file deletes. */
+    printf("%d Testing deletefile...\n", my_rank);
     if ((ret = test_deletefile(iosysid, num_flavors, flavor, my_rank)))
         return ret;
 
     /* Test netCDF-4 functions. */
+    printf("%d Testing nc4 functions...\n", my_rank);
     if ((ret = test_nc4(iosysid, num_flavors, flavor, my_rank)))
         return ret;
 
@@ -380,6 +383,7 @@ int test_no_async(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm)
     free(compdof);
 
     /* Run tests. */
+    printf("%d Running tests...\n", my_rank);
     if ((ret = test_all(iosysid, num_flavors, flavor, my_rank)))
         return ret;
         

--- a/tests/cunit/test_nc4.c
+++ b/tests/cunit/test_nc4.c
@@ -68,10 +68,13 @@ int test_deletefile(int iosysid, int num_flavors, int *flavor, int my_rank)
     {
         char filename[NC_MAX_NAME + 1]; /* Test filename. */
         char iotype_name[NC_MAX_NAME + 1];
+        int old_method;
 
         /* Set error handling. */
-        if ((ret = PIOc_set_iosystem_error(iosysid, PIO_RETURN_ERROR)))
+        if ((ret = PIOc_set_iosystem_error_handling(iosysid, PIO_RETURN_ERROR, &old_method)))
             return ret;
+        if (old_method != PIO_INTERNAL_ERROR && old_method != PIO_RETURN_ERROR)
+            return ERR_WRONG;
 
         /* Create a filename. */
         if ((ret = get_iotype_name(flavor[fmt], iotype_name)))

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -154,6 +154,8 @@ CONTAINS
     !    pio_tf_num_aggregators_
     !END IF
 
+    ierr = PIO_set_log_level(3)
+
     ! FIXME: Do we need to test with different types of aggregators?
     ! Initialize PIO
     CALL PIO_init(pio_tf_world_rank_, &

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -154,8 +154,6 @@ CONTAINS
     !    pio_tf_num_aggregators_
     !END IF
 
-    ierr = PIO_set_log_level(3)
-
     ! FIXME: Do we need to test with different types of aggregators?
     ! Initialize PIO
     CALL PIO_init(pio_tf_world_rank_, &


### PR DESCRIPTION
Fixes #330.

Fixes #268.

Part of #238, part of #225.

Setting the iosystem error handler was not working (even for non-async cases). This was tested in test_nc4, where I delete a file, and then try to reopen it, only to get an error code.

This was causing an abort, because it was not accepting my setting of the iosystem error handler to RETURN. (Which I need for this test to work.)

I have introduced new functions PIOc_set_file_error() and PIOc_set_iosystem_error() because I need all API functions to return an error code on failure, and the existing PIOc_Set_File_Error_Handling() and PIOc_Set_IOSystem_Error_Handling() return the previous setting and have no way to return errors.

The old functions are still there and still supported, but I guess they should be removed, and the new ones used from the fortran API.

