### PR TITLE
Fixing some memory leaks on test_darray test

### DIFF
--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -99,6 +99,10 @@ int check_file(int iosysid, int ntasks, int my_rank, char *filename)
     if ((ret = PIOc_closefile(ncid)))
         return ret;
 
+    /* Free the PIO decomposition. */
+    if ((ret = PIOc_freedecomp(iosysid, ioid)))
+        ERR(ret);
+
     return PIO_NOERR;
 }
 


### PR DESCRIPTION
In check_file() of test_darray.c, we call create_decomposition() which calls PIOc_InitDecomp(), but there is no call to PIOc_freedecomp() at the end of this function. This PR is related to issue #245, which partially fix the memory leaks of test_darray. More PRs are needed to fix remaining leaks in test_darray and other C tests. Before it goes to master, this fix will be merged to the develop branch to be tested by some nightly builds.