### PR TITLE
error handling for MPI call

### DIFF
--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -12,27 +12,6 @@
 #include <pio_internal.h>
 
 /**
- * Wrapper for MPI calls to print the Error string on error.
- *
- * @param ierr the error code to check.
- * @param file the code file where the error happened.
- * @param line the line of code (near) where the error happened.
- */
-void CheckMPIReturn(const int ierr, const char *file, const int line)
-{
-
-    if (ierr != MPI_SUCCESS)
-    {
-        char errstring[MPI_MAX_ERROR_STRING];
-        int errstrlen;
-        int mpierr = MPI_Error_string(ierr, errstring, &errstrlen);
-
-        fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n", errstring, file,
-                line);
-    }
-}
-
-/**
  * Returns the smallest power of 2 greater than i.
  *
  * @param i input number

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -641,7 +641,10 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
      * communicator. For some reason when I check the return value of
      * this MPI call, all tests start to fail! */
     if (iosys->ioproc)
-        CheckMPIReturn(MPI_Comm_rank(iosys->io_comm, &iosys->io_rank),__FILE__,__LINE__);
+    {
+        if ((mpierr = MPI_Comm_rank(iosys->io_comm, &iosys->io_rank)))
+            return check_mpi(NULL, mpierr, __FILE__, __LINE__);                            
+    }
     else
         iosys->io_rank = -1;
     LOG((3, "iosys->io_comm = %d iosys->io_rank = %d", iosys->io_comm, iosys->io_rank));

--- a/src/gptl/gptl.c
+++ b/src/gptl/gptl.c
@@ -195,8 +195,8 @@ static int update_ll_hash (Timer *, const int, const unsigned int);
 static inline int update_ptr (Timer *, const int);
 static int construct_tree (Timer *, Method);
 
-static int cmp (const char **, const char **);
-static int ncmp (const char **, const char **);
+static int cmp (const void *, const void *);
+static int ncmp (const void *, const void *);
 static int get_index ( const char *, const char *);
 
 typedef struct {
@@ -2933,9 +2933,9 @@ int get_index( const char * list,
 ** cmp: returns value from strcmp. for use with qsort
 */
 
-static int cmp(const char **x, const char **y)
+static int cmp(const void *x, const void *y)
 {
-  return strcmp(*x, *y);
+  return strcmp(*(char**)x, *(char**)y);
 }
 
 
@@ -2943,15 +2943,17 @@ static int cmp(const char **x, const char **y)
 ** ncmp: compares values of memory adresses pointed to by a pointer. for use with qsort
 */
 
-static int ncmp( const char **x, const char **y )
+static int ncmp( const void *x, const void *y )
 {
   static const char *thisfunc = "GPTLsetoption";
+  const char **ix = (const char **)x;
+  const char **iy = (const char **)y;
 
-  if( *x > *y )
+  if( *ix > *iy )
     return 1;
-  if( *x < *y )
+  if( *ix < *iy )
     return -1;
-  if( *x == *y )
+  if( *ix == *iy )
     GPTLerror("%s: shared memory address between timers\n", thisfunc);
 }
 

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -99,6 +99,10 @@ int check_file(int iosysid, int ntasks, int my_rank, char *filename)
     if ((ret = PIOc_closefile(ncid)))
         return ret;
 
+    /* Free the PIO decomposition. */
+    if ((ret = PIOc_freedecomp(iosysid, ioid)))
+        ERR(ret);
+
     return PIO_NOERR;
 }
 


### PR DESCRIPTION
Fixes #232.

Part of #225.

In this PR I add checking to an MPI function call. Also I remove CheckMPIReturn() because it has now been replaced with check_mpi().

I have merged this into develop for testing.