### PR TITLE
Fixing memory leaks on several C unit tests

### DIFF
--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -211,6 +211,11 @@ int test_no_async(int my_rank, int ntasks, int num_flavors, int *flavor,
     printf("rank: %d Freeing PIO decomposition...\n", my_rank);
     if ((ret = PIOc_freedecomp(iosysid, ioid)))
         ERR(ret);
+
+    /* Finalize PIO system. */
+    if ((ret = PIOc_finalize(iosysid)))
+        ERR(ret);
+
     return PIO_NOERR;
 }
 

--- a/tests/cunit/test_file.c
+++ b/tests/cunit/test_file.c
@@ -211,6 +211,10 @@ int main(int argc, char **argv)
         printf("rank: %d Freeing PIO decomposition...\n", my_rank);
         if ((ret = PIOc_freedecomp(iosysid, ioid)))
             ERR(ret);
+
+        /* Finalize PIO system. */
+        if ((ret = PIOc_finalize(iosysid)))
+            ERR(ret);
     } /* endif my_rank < TARGET_NTASKS */
 
     /* Wait for everyone to catch up. */

--- a/tests/cunit/test_names.c
+++ b/tests/cunit/test_names.c
@@ -424,6 +424,9 @@ int main(int argc, char **argv)
         if ((ret = PIOc_freedecomp(iosysid, ioid)))
             ERR(ret);
 
+        /* Finalize PIO system. */
+        if ((ret = PIOc_finalize(iosysid)))
+            ERR(ret);
     } /* endif my_rank < TARGET_NTASKS */
 
     /* Wait for everyone to catch up. */

--- a/tests/cunit/test_nc4.c
+++ b/tests/cunit/test_nc4.c
@@ -393,6 +393,11 @@ int test_no_async(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm)
     printf("%d Freeing PIO decomposition...\n", my_rank);
     if ((ret = PIOc_freedecomp(iosysid, ioid)))
         ERR(ret);
+
+    /* Finalize PIO system. */
+    if ((ret = PIOc_finalize(iosysid)))
+        ERR(ret);
+
     return PIO_NOERR;
 }
 


### PR DESCRIPTION
A few C unit tests (test_darray, test_file, test_names, test_nc4) have memory leaks due to missing necessary PIOc_finalize() calls. This fix will be merged to the develop branch to be tested by some nightly builds.