### PR TITLE
update compiler and netcdf libraries

### DIFF
--- a/ctest/runcdash-nwsc-gnu.sh
+++ b/ctest/runcdash-nwsc-gnu.sh
@@ -9,11 +9,11 @@ fi
 
 module reset
 module unload netcdf
-module swap intel gnu/5.3.0
+module swap intel gnu/6.1.0
 module load git/2.3.0
 module load cmake/3.0.2
-module load netcdf-mpi/4.3.3.1
-module load pnetcdf/1.6.1
+module load netcdf-mpi/4.4.1
+module load pnetcdf/1.7.0
 
 export CC=mpicc
 export FC=mpif90


### PR DESCRIPTION
Fixes issues with tests failing in cdash. netcdf 4.3.3.1 has known problems, updated to netcdf 4.4.1
also updated gnu to 6.1.0 and pnetcdf to 1.7.0.

Already merged to develop.