### PR TITLE
Remove hardcoded string lens in unit test

### DIFF
--- a/tests/unit/driver.F90
+++ b/tests/unit/driver.F90
@@ -27,8 +27,8 @@ Program pio_unit_test_driver
   integer, external :: nc_set_log_level2
 #endif
   integer ret_val
-  character(len=80) :: errmsg
-  character(len=80) :: expected
+  character(len=pio_max_name) :: errmsg
+  character(len=pio_max_name) :: expected
   
   ! Set up MPI
   call MPI_Init(ierr)

--- a/tests/unit/global_vars.F90
+++ b/tests/unit/global_vars.F90
@@ -12,7 +12,7 @@ module global_vars
 
   include 'mpif.h' ! _EXTERNAL
 
-  integer, parameter :: str_len = 255, ntest=4
+  integer, parameter :: str_len = pio_max_name, ntest=4
    integer, parameter ::NETCDF =1, &
                         NETCDF4P=2, &
                         NETCDF4C=3, &


### PR DESCRIPTION
The old fortran unit test used hardcoded lengths for strings used
to retrieve pio error messages. Now using pio_max_name instead.

See Issue #319