### PR TITLE
fixed leaks if createfile or openfile fails, fix test problem

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -208,10 +208,15 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
-    if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
 
-    /* Broadcast results to all tasks. Ignore NULL parameters. */
+    /* If there was an error, free the memory we allocated and handle error. */
+    if (ierr)
+    {
+        free(file);
+        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+    }
+
+    /* Broadcast mode to all tasks. */
     if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1112,8 +1112,13 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,
          ios->my_comm));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
+
+    /* If there was an error, free allocated memory and deal with the error. */
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+    {
+        free(file);
+        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+    }
     LOG((2, "error code Bcast complete ierr = %d ios->my_comm = %d", ierr, ios->my_comm));
 
     /* Broadcast results to all tasks. Ignore NULL parameters. */

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -581,7 +581,7 @@ int test_deletefile(int iosysid, int num_flavors, int *flavor, int my_rank)
         /* Make sure it is gone. Openfile will now return an error
          * code when I try to open the file. */
         if (!PIOc_openfile(iosysid, &ncid, &(flavor[fmt]), filename, PIO_NOWRITE))
-            ERR(ret);
+            ERR(ERR_WRONG);
     }
 
     return PIO_NOERR;


### PR DESCRIPTION
Fixes #357.

Fixes #356.

This PR fixes two leaks and an incorrect return in a test. Thanks to @dqwu for pointing these out.

I will merge this to develop for testing.