### PR TITLE
fixed MPI group leak in pio_msg.c

### DIFF
--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -2688,6 +2688,9 @@ PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
                 return check_mpi(NULL, ret, __FILE__, __LINE__);
     }
 
+    if ((ret = MPI_Group_free(&world_group)))
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
+
     LOG((2, "successfully done with PIO_Init_Async"));
     return PIO_NOERR;
 }


### PR DESCRIPTION
Part of #245.

Fix a leak of a group that was created but never freed.

I have merged this to develop for testing.