### PR TITLE
turn on nc_set_log_level if PIOc_set_log_level with level > 3 is called

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -106,6 +106,9 @@ if (NetCDF_C_FOUND)
   if (${NetCDF_C_LOGGING_ENABLED})
     target_compile_definitions (pioc
       PUBLIC NETCDF_C_LOGGING_ENABLED)
+    # netcdf.h needs this to be defined to use netCDF logging.
+    target_compile_definitions (pioc
+      PUBLIC LOGGING)
   endif()
 else ()
   target_compile_definitions (pioc

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -18,6 +18,7 @@
 #define MAX_LOG_MSG 1024
 #define MAX_RANK_STR 12
 #define ERROR_PREFIX "ERROR: "
+#define NC_LEVEL_DIFF 3
 int pio_log_level = 0;
 int pio_log_ref_cnt = 0;
 int my_rank;
@@ -104,11 +105,20 @@ int PIOc_strerror(int pioerr, char *errmsg)
  */
 int PIOc_set_log_level(int level)
 {
+    int ret = PIO_NOERR;
 #if PIO_ENABLE_LOGGING
     /* Set the log level. */
     pio_log_level = level;
+
+#if NETCDF_C_LOGGING_ENABLED
+    /* If netcdf logging is available turn it on starting at level = 4. */
+    if (level > NC_LEVEL_DIFF)
+        if ((ret = nc_set_log_level(level - NC_LEVEL_DIFF)))
+            return ret;
+#endif /* NETCDF_C_LOGGING_ENABLED */
 #endif /* PIO_ENABLE_LOGGING */
-    return PIO_NOERR;
+
+    return ret;
 }
 
 /**


### PR DESCRIPTION
Fixes #355.

This has been merged to develop for testing.