### PR TITLE
Remove incorrect file-level error handling

### DIFF
--- a/doc/source/mach_walkthrough.txt
+++ b/doc/source/mach_walkthrough.txt
@@ -426,7 +426,7 @@ build from the command line, including tests:
 
 <pre>
 cd build
-rm -rf * && CFLAGS=-g FFLAGS=-g CC=mpicc FC=mpifort cmake -DNetCDF_C_PATH=/usr/local/netcdf-c-4.4.1 -DNetCDF_Fortran_PATH=/usr/local/netcdf-fortran-4.4.3 -DPnetCDF_PATH=/usr/local/pnetcdf-1.7.0 -DPIO_ENABLE_LOGGING=On -DPIO_HDF5_LOGGING=On .. && make VERBOSE=1 all tests check
+rm -rf * && CFLAGS=-g FFLAGS=-g CC=mpicc FC=mpifort cmake -DNetCDF_C_PATH=/usr/local/netcdf-4.4.1 -DNetCDF_Fortran_PATH=/usr/local/netcdf-fortran-4.4.4 -DPnetCDF_PATH=/usr/local/pnetcdf-1.7.0 -DPIO_ENABLE_LOGGING=On -DPIO_HDF5_LOGGING=On .. && make VERBOSE=1 all tests check
 </pre>
 
 <p>Note the optional CFLAGS=-g which allows the use of a debugger

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -371,10 +371,6 @@ typedef struct file_desc_t
      * the same communication pattern prior to a write. */
     struct wmulti_buffer buffer;
 
-    /** Controls handling errors. Overrides the IO system error
-     * handler if set. */
-    int error_handler;
-
     /** Pointer to the next file_desc_t in the list of open files. */
     struct file_desc_t *next;
 
@@ -626,9 +622,6 @@ extern "C" {
     /* Set the error hanlding for a file. */
     int PIOc_Set_File_Error_Handling(int ncid, int method);
 
-    /* Set the error hanlding for a file. */
-    int PIOc_set_file_error_handling(int ncid, int method, int *old_method);
-    
     int PIOc_set_hint(int iosysid, const char *hint, const char *hintval);
     int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems,
 			     float preemption);

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -117,7 +117,6 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
     file->iosystem = ios;
     file->iotype = *iotype;
     file->buffer.ioid = -1;
-    file->error_handler = ios->error_handler;
     for (int i = 0; i < PIO_MAX_VARS; i++)
     {
         file->varlist[i].record = -1;

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -56,10 +56,13 @@ int PIOc_File_is_Open(int ncid)
 
 /**
  * Set the error handling method to be used for subsequent pio library
- * calls, returns the previous method setting. This function is
- * supported but deprecated. New code should use
- * PIOc_set_file_error_handling().  This method has no way to return
- * an error, so any failure will result in MPI_Abort.
+ * calls, returns the previous method setting. Note that this changes
+ * error handling for the IO system that was used when this file was
+ * opened. Other files opened with the same IO system will also he
+ * affected by this call. This function is supported but
+ * deprecated. New code should use PIOc_set_iosystem_error_handling().
+ * This method has no way to return an error, so any failure will
+ * result in MPI_Abort.
  *
  * @param ncid the ncid of an open file
  * @param method the error handling method
@@ -230,12 +233,12 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
 
 /**
  * Set the error handling method used for subsequent calls for this IO
- * system. This may be overridden for individual files by
- * PIOc_set_file_error_handling().
+ * system.
  *
  * @param iosysid the IO system ID
  * @param method the error handling method
- * @param old_method pointer to int that will get old method. Ignored if NULL.
+ * @param old_method pointer to int that will get old method. Ignored
+ * if NULL.
  * @returns 0 for success, error code otherwise.
  * @ingroup PIO_error_method
  */

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -76,50 +76,18 @@ int PIOc_Set_File_Error_Handling(int ncid, int method)
     if (pio_get_file(ncid, &file))
         piodie("Could not find file", __FILE__, __LINE__);                
 
-    /* Get the old method. */
-    oldmethod = file->iosystem->error_handler;
-
-    /* Set the file error handler. */
-    if (PIOc_set_file_error_handling(ncid, method, &oldmethod))
-        piodie("Could not set the file error hanlder", __FILE__, __LINE__);        
-
-    return oldmethod;
-}
-
-/**
- * Set the error handling method to be used for subsequent pio
- * library calls on this file.
- *
- * @param ncid the ncid of an open file
- * @param method the error handling method
- * @param old_method pointer to int that will get old method. Ignored if NULL.
- * @returns 0 for success, error code otherwise.
- * @ingroup PIO_error_method
- */
-int PIOc_set_file_error_handling(int ncid, int method, int *old_method)
-{
-    file_desc_t *file;
-    int ret;
-
-    LOG((1, "PIOc_set_file_error_handling ncid = %d method = %d", ncid, method));
-
-    /* Find info for this file. */
-    if ((ret = pio_get_file(ncid, &file)))
-        return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
-
     /* Check that valid error handler was provided. */
     if (method != PIO_INTERNAL_ERROR && method != PIO_BCAST_ERROR &&
         method != PIO_RETURN_ERROR)
         return pio_err(file->iosystem, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    /* Return the current handler. */
-    if (old_method)
-        *old_method = file->error_handler;
+    /* Get the old method. */
+    oldmethod = file->iosystem->error_handler;
 
     /* Set the error hanlder. */
-    file->error_handler = method;
-    
-    return PIO_NOERR;
+    file->iosystem->error_handler = method;
+
+    return oldmethod;
 }
 
 /**

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -429,7 +429,7 @@ int check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
     if (ios)
         eh = ios->error_handler;
     if (file)
-        eh = file->error_handler;
+        eh = file->iosystem->error_handler;
     pioassert(eh == PIO_INTERNAL_ERROR || eh == PIO_BCAST_ERROR || eh == PIO_RETURN_ERROR,
               "invalid error handler", __FILE__, __LINE__);
 
@@ -499,7 +499,7 @@ int pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fn
 
     /* What error handler should we use? */
     if (file)
-        err_handler = file->error_handler ? file->error_handler : file->iosystem->error_handler;
+        err_handler = file->iosystem->error_handler;
     else if (ios)
         err_handler = ios->error_handler;
 
@@ -1029,7 +1029,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,
     file->iotype = *iotype;
     file->iosystem = ios;
     file->mode = mode;
-    file->error_handler = ios->error_handler;
 
     for (int i = 0; i < PIO_MAX_VARS; i++)
     {

--- a/tests/cunit/test_iosystem3.c
+++ b/tests/cunit/test_iosystem3.c
@@ -48,19 +48,6 @@ int create_file(MPI_Comm comm, int iosysid, int format, char *filename,
         return ret;
     printf("%d file created ncid = %d\n", my_rank, ncid);
 
-    /* Set the error handler. */
-    int old_method;
-    if ((ret = PIOc_set_file_error_handling(ncid, PIO_RETURN_ERROR, &old_method)))
-        return ret;
-    printf("old_method = %d\n", old_method);
-    if (old_method != PIO_BCAST_ERROR) /* the default */
-        return ERR_WRONG;
-
-    /* Set the error handler the old-fashioned way. */
-    old_method = PIOc_Set_File_Error_Handling(ncid, PIO_BCAST_ERROR);
-    if (old_method != PIO_RETURN_ERROR)
-        return ERR_WRONG;
-
     /* Define a dimension. */
     printf("%d defining dimension %s\n", my_rank, dimname);
     if ((ret = PIOc_def_dim(ncid, dimname, PIO_TF_MAX_STR_LEN, &dimid)))

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -675,9 +675,6 @@ int test_nc4(int iosysid, int num_flavors, int *flavor, int my_rank)
         if ((ret = PIOc_createfile(iosysid, &ncid, &(flavor[fmt]), filename, PIO_CLOBBER)))
             ERR(ret);
 
-        /* Set error handling. */
-        /* PIOc_Set_File_Error_Handling(ncid, PIO_BCAST_ERROR); */
-
         /* Define netCDF dimensions and variable. */
         printf("%d Defining netCDF metadata...\n", my_rank);
         for (int d = 0; d < NDIM; d++)


### PR DESCRIPTION
Based on discussions with Jim I realized that the file-based error handling I was using was not correct.

Here's the fixes to remove it and make the error handling work as expected.

I will merge to develop for testing.