### PR TITLE
this cannot be collective

### DIFF
--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1621,7 +1621,7 @@ void free_cn_buffer_pool(iosystem_desc_t ios)
     LOG((2, "free_cn_buffer_pool CN_bpool = %d", CN_bpool));
     if (CN_bpool)
     {
-        cn_buffer_report(ios, true);
+        cn_buffer_report(ios, false);
         bpoolrelease(CN_bpool);
         LOG((2, "free_cn_buffer_pool done!"));
         free(CN_bpool);


### PR DESCRIPTION
Since we are calling this on the last iosystem on each task and these iosystems do not necessarily reflect a common communicator we cannot use collective calls.

Fixes #118  