### PR TITLE
add PIO_DATATYPE_NULL with switch depending on MPI variety

### DIFF
--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -23,6 +23,14 @@
 #define MPI_Offset long long
 #endif
 
+#if defined(MPT_VERSION) || defined(OPEN_MPI)
+/* Some MPI implementations do not allow passing MPI_DATATYPE_NULL to comm functions 
+ * even though the send or recv length is 0, in these cases we use MPI_CHAR */
+#define PIO_DATATYPE_NULL MPI_CHAR
+#else
+#define PIO_DATATYPE_NULL MPI_DATATYPE_NULL
+#endif
+
 #include <bget.h>
 #include <limits.h>
 #include <math.h>

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -251,7 +251,7 @@ int create_mpi_datatypes(const MPI_Datatype basetype, const int msgcnt,
     }
 
     bsizeT[0] = 0;
-    mtype[0] = MPI_DATATYPE_NULL;
+    mtype[0] = PIO_DATATYPE_NULL;
     int pos = 0;
     int ii = 0;
 
@@ -312,7 +312,7 @@ int create_mpi_datatypes(const MPI_Datatype basetype, const int msgcnt,
                 if ((mpierr = MPI_Type_create_indexed_block(len, blocksize, displace, basetype, mtype + i)))
                     return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
-                if (mtype[i] == MPI_DATATYPE_NULL)
+                if (mtype[i] == PIO_DATATYPE_NULL)
                     piodie("Unexpected NULL MPI DATATYPE", __FILE__, __LINE__);
 
                 /* Commit the MPI data type. */
@@ -362,7 +362,7 @@ int define_iodesc_datatypes(const iosystem_desc_t ios, io_desc_t *iodesc)
 
                 /* Initialize data types to NULL. */
                 for (int i = 0; i < iodesc->nrecvs; i++)
-                    iodesc->rtype[i] = MPI_DATATYPE_NULL;
+                    iodesc->rtype[i] = PIO_DATATYPE_NULL;
 
                 /* Create the datatypes, which will be used both to
                  * receive and to send data. */
@@ -408,7 +408,7 @@ int define_iodesc_datatypes(const iosystem_desc_t ios, io_desc_t *iodesc)
 
         /* Initialize send types to NULL. */
         for (int i = 0; i < ntypes; i++)
-            iodesc->stype[i] = MPI_DATATYPE_NULL;
+            iodesc->stype[i] = PIO_DATATYPE_NULL;
 
         iodesc->num_stypes = ntypes;
 
@@ -759,8 +759,8 @@ int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
         recvcounts[i] = 0;
         sdispls[i] = 0;
         rdispls[i] = 0;
-        recvtypes[i] = MPI_DATATYPE_NULL;
-        sendtypes[i] =  MPI_DATATYPE_NULL;
+        recvtypes[i] = PIO_DATATYPE_NULL;
+        sendtypes[i] =  PIO_DATATYPE_NULL;
     }
 
     /* If this io proc will exchange data with compute tasks create a
@@ -769,7 +769,7 @@ int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
     {
         for (i = 0; i < iodesc->nrecvs; i++)
         {
-            if (iodesc->rtype[i] != MPI_DATATYPE_NULL)
+            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
             {
                 if (iodesc->rearranger == PIO_REARR_SUBSET)
                 {
@@ -781,7 +781,7 @@ int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
                                                    recvtypes + i)))
                         return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
-                    if (recvtypes[i] == MPI_DATATYPE_NULL)
+                    if (recvtypes[i] == PIO_DATATYPE_NULL)
                         piodie("Unexpected NULL MPI DATATYPE", __FILE__, __LINE__);
 
                     if ((mpierr = MPI_Type_commit(recvtypes + i)))
@@ -797,7 +797,7 @@ int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
                                                    recvtypes + iodesc->rfrom[i])))
                         return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
-                    if (recvtypes[iodesc->rfrom[i]] == MPI_DATATYPE_NULL)
+                    if (recvtypes[iodesc->rfrom[i]] == PIO_DATATYPE_NULL)
                         piodie("Unexpected NULL MPI DATATYPE", __FILE__, __LINE__);
 
                     if ((mpierr = MPI_Type_commit(recvtypes+iodesc->rfrom[i])))
@@ -825,7 +825,7 @@ int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
                                            sendtypes + io_comprank)))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
-            if (sendtypes[io_comprank] == MPI_DATATYPE_NULL)
+            if (sendtypes[io_comprank] == PIO_DATATYPE_NULL)
                 piodie("Unexpected NULL MPI DATATYPE",__FILE__,__LINE__);
 
             if ((mpierr = MPI_Type_commit(sendtypes + io_comprank)))
@@ -836,19 +836,17 @@ int rearrange_comp2io(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
             sendcounts[io_comprank]=0;
         }
     }
-
     /* Data in sbuf on the compute nodes is sent to rbuf on the ionodes */
     pio_swapm(sbuf, sendcounts, sdispls, sendtypes, rbuf, recvcounts, rdispls, recvtypes,
               mycomm, iodesc->handshake, iodesc->isend, iodesc->max_requests);
-
     /* Free the MPI types. */
     for (i = 0; i < ntasks; i++)
     {
-        if (sendtypes[i] != MPI_DATATYPE_NULL)
+        if (sendtypes[i] != PIO_DATATYPE_NULL)
             if ((mpierr = MPI_Type_free(sendtypes + i)))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
-        if (recvtypes[i] != MPI_DATATYPE_NULL)
+        if (recvtypes[i] != PIO_DATATYPE_NULL)
             if ((mpierr = MPI_Type_free(recvtypes + i)))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
     }
@@ -946,14 +944,14 @@ int rearrange_io2comp(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
         recvcounts[i] = 0;
         sdispls[i] = 0;
         rdispls[i] = 0;
-        sendtypes[i] = MPI_DATATYPE_NULL;
-        recvtypes[i] = MPI_DATATYPE_NULL;
+        sendtypes[i] = PIO_DATATYPE_NULL;
+        recvtypes[i] = PIO_DATATYPE_NULL;
     }
 
     /* In IO tasks ??? */
     if (ios.ioproc)
         for (i = 0; i < iodesc->nrecvs; i++)
-            if (iodesc->rtype[i] != MPI_DATATYPE_NULL)
+            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
                 if (iodesc->rearranger == PIO_REARR_SUBSET)
                 {
                     if (sbuf)
@@ -978,7 +976,7 @@ int rearrange_io2comp(const iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
         if (iodesc->rearranger == PIO_REARR_SUBSET)
             io_comprank = 0;
 
-        if (scount[i] > 0 && iodesc->stype[i] != MPI_DATATYPE_NULL)
+        if (scount[i] > 0 && iodesc->stype[i] != PIO_DATATYPE_NULL)
         {
             recvcounts[io_comprank] = 1;
             recvtypes[io_comprank] = iodesc->stype[i];

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -137,40 +137,11 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
      * mpi_alltoallw function is used. */
     if (max_requests == 0)
     {
-#ifdef OPEN_MPI
-        /* OPEN_MPI developers determined that MPI_DATATYPE_NULL was
-           not a valid argument to MPI_Alltoallw according to the
-           standard. The standard is a little vague on this issue and
-           other mpi vendors disagree. In my opinion it just makes
-           sense that if an argument expects an mpi datatype then
-           MPI_DATATYPE_NULL should be valid. For each task it's
-           possible that either sendlength or receive length is 0 it
-           is in this case that the datatype null makes sense. */
-        for (int i = 0; i < ntasks; i++)
-        {
-            if (sendtypes[i] == MPI_DATATYPE_NULL)
-                sendtypes[i] = MPI_CHAR;
-            if (recvtypes[i] == MPI_DATATYPE_NULL)
-                recvtypes[i] = MPI_CHAR;
-        }
-#endif
-
         /* Call the MPI alltoall without flow control. */
         LOG((3, "Calling MPI_Alltoallw without flow control."));
         if ((mpierr = MPI_Alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                     recvcounts, rdispls, recvtypes, comm)))
             return check_mpi(NULL, mpierr, __FILE__, __LINE__);
-
-#ifdef OPEN_MPI
-        /* OPEN_MPI has problems with MPI_DATATYPE_NULL. */
-        for (int i = 0; i < ntasks; i++)
-        {
-            if (sendtypes[i] == MPI_CHAR)
-                sendtypes[i] = MPI_DATATYPE_NULL;
-            if (recvtypes[i] == MPI_CHAR)
-                recvtypes[i] = MPI_DATATYPE_NULL;
-        }
-#endif
         return PIO_NOERR;
     }
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -692,7 +692,7 @@ int PIOc_freedecomp(int iosysid, int ioid)
     if (iodesc->rtype)
     {
         for (i = 0; i < iodesc->nrecvs; i++)
-            if (iodesc->rtype[i] != MPI_DATATYPE_NULL)
+            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
                 if ((mpierr = MPI_Type_free(iodesc->rtype + i)))
                     return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
 
@@ -702,7 +702,7 @@ int PIOc_freedecomp(int iosysid, int ioid)
     if (iodesc->stype)
     {
         for (i = 0; i < iodesc->num_stypes; i++)
-            if (iodesc->stype[i] != MPI_DATATYPE_NULL)
+            if (iodesc->stype[i] != PIO_DATATYPE_NULL)
                 if ((mpierr = MPI_Type_free(iodesc->stype + i)))
                     return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
 


### PR DESCRIPTION
We had a workaround for MPI_DATATYPE_NULL for OPEN_MPI in pio_spmd.c, it turns out that SGI's MPT also needs this workaround.  So I added a PIO_DATATYPE_NULL macro and moved the definition to pio_internal.h OPEN_MPI and MPT_VERSION are macros defined in the respective MPI libraries so no further changes to the build are required.  