### PR TITLE
removed unneeded code for saving decomp

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -336,28 +336,6 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
-    /* If desired, save the computed decompositions to
-     * files. PIO_Save_Decomps is a global var set in
-     * pioc_support.c. This used to be set by environment variable and
-     * needs to be settable for debug purposes. */
-    if (PIO_Save_Decomps)
-    {
-        char filename[NC_MAX_NAME];
-        if (ios->num_comptasks < 100)
-            sprintf(filename, "piodecomp%2.2dtasks%2.2ddims%2.2d.dat", ios->num_comptasks,
-		    ndims, counter);
-        else if (ios->num_comptasks < 10000)
-            sprintf(filename, "piodecomp%4.4dtasks%2.2ddims%2.2d.dat", ios->num_comptasks,
-		    ndims, counter);
-        else
-            sprintf(filename, "piodecomp%6.6dtasks%2.2ddims%2.2d.dat", ios->num_comptasks,
-		    ndims, counter);
-
-	LOG((2, "saving decomp map to %s", filename));
-        PIOc_writemap(filename, ndims, dims, maplen, (PIO_Offset *)compmap, ios->comp_comm);
-        counter++;
-    }
-
     /* Allocate space for the iodesc info. */
     if (!(iodesc = malloc_iodesc(basetype, ndims)))
 	piodie("Out of memory", __FILE__, __LINE__);

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -34,10 +34,6 @@ extern int pio_next_ncid;
 /** Default settings for swap memory. */
 static pio_swapm_defaults swapm_defaults;
 
-/** If this is set to true, then InitDecomp() will save the
- * decomposition to file. */
-bool PIO_Save_Decomps = false;
-
 /**
  * Return a string description of an error code. If zero is passed,
  * the errmsg will be "No error".


### PR DESCRIPTION
Saving of the decomp can now be achieved by calling PIOc_write_decomp().

The code removed in this PR is left over from the environment variable method of saving decomps.

I will merge to develop for testing.

Fixes #442.