### PR TITLE
allow changes to default error handler, some tests for invalid parameters

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -40,6 +40,10 @@
 /** The maximum number of variables allowed in a netCDF file. */
 #define PIO_MAX_VARS NC_MAX_VARS
 
+/** Pass this to PIOc_set_iosystem_error_handling() as the iosysid in
+ * order to set default error handling. */
+#define PIO_DEFAULT (-1)
+
 /**
  * Variable description structure.
  */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -121,7 +121,6 @@ extern "C" {
 
     /* Check whether an IO type is valid for this build. */
     int iotype_is_valid(int iotype);    
-    int check_iotype(int iotype, int *valid_iotype);
     
     int iotype_error(int iotype, const char *fname, int line);
     void piodie(const char *msg, const char *fname, int line);

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -118,6 +118,11 @@ extern "C" {
     /* Check the return code from a netCDF call, with ios pointer. */
     int check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
                       const char *fname, int line);
+
+    /* Check whether an IO type is valid for this build. */
+    int iotype_is_valid(int iotype);    
+    int check_iotype(int iotype, int *valid_iotype);
+    
     int iotype_error(int iotype, const char *fname, int line);
     void piodie(const char *msg, const char *fname, int line);
     void pioassert(bool exp, const char *msg,const char *fname, const int line);

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1218,9 +1218,8 @@ int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         }
 
 
-        /* If this is the IO component, remember the
-         * comm. Otherwise make a copy of the comm for each
-         * component. */
+        /* If this is the IO component, make a copy of the IO comm for
+         * each computational component. */
         if (in_io)
             if (cmp)
             {

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -13,6 +13,9 @@
 
 static int counter = 0;
 
+/** The default error handler used when iosystem cannot be located. */
+int default_error_handler = PIO_INTERNAL_ERROR;
+
 /**
  * Check to see if PIO has been initialized.
  *
@@ -235,7 +238,8 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
  * Set the error handling method used for subsequent calls for this IO
  * system.
  *
- * @param iosysid the IO system ID
+ * @param iosysid the IO system ID. Passing PIO_DEFAULT instead
+ * changes the default error handling for the library.
  * @param method the error handling method
  * @param old_method pointer to int that will get old method. Ignored
  * if NULL.
@@ -244,14 +248,16 @@ int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method)
  */
 int PIOc_set_iosystem_error_handling(int iosysid, int method, int *old_method)
 {
-    iosystem_desc_t *ios;
+    iosystem_desc_t *ios = NULL;
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_set_iosystem_error_handling iosysid = %d method = %d", iosysid, method));
+    LOG((1, "PIOc_set_iosystem_error_handling iosysid = %d method = %d", iosysid,
+         method));
 
     /* Find info about this iosystem. */
-    if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+    if (iosysid != PIO_DEFAULT)
+        if (!(ios = pio_get_iosystem_from_id(iosysid)))
+            return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Check that valid error handler was provided. */
     if (method != PIO_INTERNAL_ERROR && method != PIO_BCAST_ERROR &&
@@ -259,35 +265,39 @@ int PIOc_set_iosystem_error_handling(int iosysid, int method, int *old_method)
         return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* If using async, and not an IO task, then send parameters. */
-    if (ios->async_interface)
-    {
-        if (!ios->ioproc)
+    if (iosysid != PIO_DEFAULT)
+        if (ios->async_interface)
         {
-            int msg = PIO_MSG_SETERRORHANDLING;
-            char old_method_present = old_method ? true : false;
+            if (!ios->ioproc)
+            {
+                int msg = PIO_MSG_SETERRORHANDLING;
+                char old_method_present = old_method ? true : false;
+                
+                if (ios->compmaster == MPI_ROOT)
+                    mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+                
+                if (!mpierr)
+                    mpierr = MPI_Bcast(&method, 1, MPI_INT, ios->compmaster, ios->intercomm);
+                if (!mpierr)
+                    mpierr = MPI_Bcast(&old_method_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            }
 
-          if (ios->compmaster == MPI_ROOT)
-                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-
-            if (!mpierr)
-                mpierr = MPI_Bcast(&method, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&old_method_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            /* Handle MPI errors. */
+            if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+                check_mpi2(ios, NULL, mpierr2, __FILE__, __LINE__);
+            if (mpierr)
+                return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
         }
-
-        /* Handle MPI errors. */
-        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi2(ios, NULL, mpierr2, __FILE__, __LINE__);
-        if (mpierr)
-            return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
-    }
 
     /* Return the current handler. */
     if (old_method)
-        *old_method = ios->error_handler;
+        *old_method = iosysid == PIO_DEFAULT ? default_error_handler : ios->error_handler;
 
     /* Set new error handler. */
-    ios->error_handler = method;
+    if (iosysid == PIO_DEFAULT)
+        default_error_handler = method;
+    else
+        ios->error_handler = method;
 
     return PIO_NOERR;
 }
@@ -546,7 +556,7 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
 
     ios->io_comm = MPI_COMM_NULL;
     ios->intercomm = MPI_COMM_NULL;
-    ios->error_handler = PIO_INTERNAL_ERROR;
+    ios->error_handler = default_error_handler;
     ios->default_rearranger = rearr;
     ios->num_iotasks = num_iotasks;
 
@@ -1109,7 +1119,7 @@ int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
             my_iosys->intercomm = MPI_COMM_NULL;
             my_iosys->my_comm = MPI_COMM_NULL;
             my_iosys->async_interface = 1;
-            my_iosys->error_handler = PIO_INTERNAL_ERROR;
+            my_iosys->error_handler = default_error_handler;
             my_iosys->num_comptasks = num_procs_per_comp[cmp];
             my_iosys->num_iotasks = num_procs_per_comp[0];
             my_iosys->compgroup = MPI_GROUP_NULL;

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1361,43 +1361,6 @@ int pioc_change_def(int ncid, int is_enddef)
  * Check whether an IO type is valid for the build. 
  *
  * @param iotype the IO type to check
- * @param valid_iotype pointer to an int that gets set to 1 if the IO
- * type is valid, 0 otherwise.
- * @returns 0 for success.
- */
-int check_iotype(int iotype, int *valid_iotype)
-{
-    int ret;
-
-    pioassert(valid_iotype, "pointer to int must be provided", __FILE__, __LINE__);
-    LOG((1, "check_iotype iotype = %d", iotype));
-
-    /* Assume it's not valid. */
-    *valid_iotype = 0;
-
-    /* All builds include netCDF. */
-    if (iotype == PIO_IOTYPE_NETCDF)
-        *valid_iotype++;
-
-    /* Some builds include netCDF-4. */
-#ifdef _NETCDF4
-    if (iotype == PIO_IOTYPE_NETCDF4C || iotype == PIO_IOTYPE_NETCDF4P)
-        *valid_iotype++;
-#endif /* _NETCDF4 */
-
-    /* Some builds include pnetcdf. */
-    if (iotype == PIO_IOTYPE_PNETCDF)
-        *valid_iotype++;
-#ifdef _PNETCDF
-#endif /* _PNETCDF */
-
-    return PIO_NOERR;
-}
-
-/**
- * Check whether an IO type is valid for the build. 
- *
- * @param iotype the IO type to check
  * @returns 0 if valid, non-zero otherwise.
  */
 int iotype_is_valid(int iotype)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -31,6 +31,9 @@ FILE *LOG_FILE = NULL;
 */
 extern int pio_next_ncid;
 
+/** The default error handler used when iosystem cannot be located. */
+extern int default_error_handler;
+
 /** Default settings for swap memory. */
 static pio_swapm_defaults swapm_defaults;
 
@@ -408,7 +411,7 @@ int check_netcdf(file_desc_t *file, int status, const char *fname, int line)
 int check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
                   const char *fname, int line)
 {
-    int eh = PIO_INTERNAL_ERROR; /* Default error handler. */
+    int eh = default_error_handler; /* Default error handler. */
     int ierr;
 
     /* User must provide this. */
@@ -429,6 +432,8 @@ int check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
     LOG((1, "check_netcdf2 eh = %d", eh));
     pioassert(eh == PIO_INTERNAL_ERROR || eh == PIO_BCAST_ERROR || eh == PIO_RETURN_ERROR,
               "invalid error handler", __FILE__, __LINE__);
+
+    LOG((2, "check_netcdf2 chose error handler = %d", eh));
 
     /* Decide what to do based on the error handler. */
     if (eh == PIO_INTERNAL_ERROR)
@@ -477,7 +482,7 @@ int pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fn
             int line)
 {
     char err_msg[PIO_MAX_NAME + 1];
-    int err_handler = PIO_INTERNAL_ERROR; /* Default error handler. */
+    int err_handler = default_error_handler; /* Default error handler. */
     int ret;
 
     /* User must provide this. */
@@ -499,6 +504,8 @@ int pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fn
         err_handler = file->iosystem->error_handler;
     else if (ios)
         err_handler = ios->error_handler;
+
+    LOG((2, "pio_err chose error handler = %d", err_handler));
 
     /* Should we abort? */
     if (err_handler == PIO_INTERNAL_ERROR)
@@ -1348,4 +1355,71 @@ int pioc_change_def(int ncid, int is_enddef)
     LOG((3, "pioc_change_def succeeded"));
 
     return ierr;
+}
+
+/**
+ * Check whether an IO type is valid for the build. 
+ *
+ * @param iotype the IO type to check
+ * @param valid_iotype pointer to an int that gets set to 1 if the IO
+ * type is valid, 0 otherwise.
+ * @returns 0 for success.
+ */
+int check_iotype(int iotype, int *valid_iotype)
+{
+    int ret;
+
+    pioassert(valid_iotype, "pointer to int must be provided", __FILE__, __LINE__);
+    LOG((1, "check_iotype iotype = %d", iotype));
+
+    /* Assume it's not valid. */
+    *valid_iotype = 0;
+
+    /* All builds include netCDF. */
+    if (iotype == PIO_IOTYPE_NETCDF)
+        *valid_iotype++;
+
+    /* Some builds include netCDF-4. */
+#ifdef _NETCDF4
+    if (iotype == PIO_IOTYPE_NETCDF4C || iotype == PIO_IOTYPE_NETCDF4P)
+        *valid_iotype++;
+#endif /* _NETCDF4 */
+
+    /* Some builds include pnetcdf. */
+    if (iotype == PIO_IOTYPE_PNETCDF)
+        *valid_iotype++;
+#ifdef _PNETCDF
+#endif /* _PNETCDF */
+
+    return PIO_NOERR;
+}
+
+/**
+ * Check whether an IO type is valid for the build. 
+ *
+ * @param iotype the IO type to check
+ * @returns 0 if valid, non-zero otherwise.
+ */
+int iotype_is_valid(int iotype)
+{
+    /* Assume it's not valid. */
+    int ret = 0;
+
+    /* All builds include netCDF. */
+    if (iotype == PIO_IOTYPE_NETCDF)
+        ret++;
+
+    /* Some builds include netCDF-4. */
+#ifdef _NETCDF4
+    if (iotype == PIO_IOTYPE_NETCDF4C || iotype == PIO_IOTYPE_NETCDF4P)
+        ret++;
+#endif /* _NETCDF4 */
+
+    /* Some builds include pnetcdf. */
+    if (iotype == PIO_IOTYPE_PNETCDF)
+        ret++;
+#ifdef _PNETCDF
+#endif /* _PNETCDF */
+
+    return ret;
 }

--- a/tests/cunit/test_pioc_putget.c
+++ b/tests/cunit/test_pioc_putget.c
@@ -717,6 +717,10 @@ int test_putget(int iosysid, int num_flavors, int *flavor, int my_rank,
                     break;
                 }
 
+                /* Check for bad input handling. */
+                if (PIOc_sync(ncid + 42) != PIO_EBADID)
+                    return ret;
+                
                 /* Make sure all data are written (pnetcdf needs this). */
                 if ((ret = PIOc_sync(ncid)))
                     return ret;

--- a/tests/cunit/test_shared.c
+++ b/tests/cunit/test_shared.c
@@ -173,6 +173,9 @@ int run_test_main(int argc, char **argv, int min_ntasks, int max_ntasks,
                               max_ntasks, log_level, &test_comm)))
         ERR(ERR_INIT);
 
+    if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))
+        return ret;
+
     /* Only do something on max_ntasks tasks. */
     if (my_rank < max_ntasks)
     {


### PR DESCRIPTION
In order to test checking for invalid parameters, I need to be able to change the default error handling. This PR includes the introduction of constant macro PIO_DEFAULT. When passed as the iosysid into int PIOc_set_iosystem_error_handling(), this will change the default error handling for the library. (That is, the error handling that is used to initialize io systems, and when an io system cannot be located at the time of error.)

Also added a bunch of tests to test_pioc.c for invalid parameter handling. Turned on some old test code I wrote but could not use before.

Fixes #412.
Fixes #458.
Fixes #421.
Fixes #422.
This is all part of #205.

I will merge to develop for testing.