### PR TITLE
More error handling cleanup, moved PIOc_set_blocksize

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -145,7 +145,7 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
          } */
 
     /* Write the darray based on the iotype. */
-    switch(file->iotype)
+    switch (file->iotype)
     {
     case PIO_IOTYPE_NETCDF4P:
     case PIO_IOTYPE_PNETCDF:
@@ -164,6 +164,8 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
                                                 vdesc0->iobuf, frame);
 
         break;
+    default:
+        return pio_err(NULL, NULL, PIO_EBADIOTYPE, __FILE__, __LINE__);
     }
 
     /* For PNETCDF the iobuf is freed in flush_output_buffer() */
@@ -210,7 +212,7 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
                     ((double *)vdesc0->fillbuf)[i + nv * iodesc->holegridsize] = ((double *)fillvalue)[nv];
 
         /* Write the darray based on the iotype. */
-        switch(file->iotype)
+        switch (file->iotype)
         {
         case PIO_IOTYPE_PNETCDF:
         case PIO_IOTYPE_NETCDF4P:
@@ -228,6 +230,8 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
                                                     iodesc->holegridsize, iodesc->num_aiotasks,
                                                     vdesc0->fillbuf, frame);
             break;
+        default:
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
 
         /* For PNETCDF fillbuf is freed in flush_output_buffer() */
@@ -566,7 +570,7 @@ int PIOc_read_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
     }
 
     /* Call the correct darray read function based on iotype. */
-    switch(file->iotype)
+    switch (file->iotype)
     {
     case PIO_IOTYPE_NETCDF:
     case PIO_IOTYPE_NETCDF4C:
@@ -577,7 +581,7 @@ int PIOc_read_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
         ierr = pio_read_darray_nc(file, iodesc, vid, iobuf);
         break;
     default:
-        ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+        return pio_err(NULL, NULL, PIO_EBADIOTYPE, __FILE__, __LINE__);
     }
 
     /* If a rearranger was specified, rearrange the data. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -352,7 +352,7 @@ int PIOc_closefile(int ncid)
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -531,7 +531,7 @@ int PIOc_sync(int ncid)
                 break;
 #endif
             default:
-                ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+                return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
             }
         }
 

--- a/src/clib/pio_get_nc.c
+++ b/src/clib/pio_get_nc.c
@@ -1102,7 +1102,7 @@ int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Dataty
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1193,7 +1193,7 @@ int PIOc_get_var1(int ncid, int varid, const PIO_Offset *index, void *buf,
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1285,7 +1285,7 @@ int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1381,7 +1381,7 @@ int PIOc_get_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -121,10 +121,13 @@ extern "C" {
 
     /* Check whether an IO type is valid for this build. */
     int iotype_is_valid(int iotype);    
-    
-    int iotype_error(int iotype, const char *fname, int line);
+
+    /* Print error message and abort. */
     void piodie(const char *msg, const char *fname, int line);
+
+    /* Assert that an expression is true. */
     void pioassert(bool exp, const char *msg,const char *fname, const int line);
+    
     int CalcStartandCount(const int basetype, const int ndims, const int *gdims, const int num_io_procs,
                           const int myiorank, PIO_Offset *start, PIO_Offset *kount);
 
@@ -180,7 +183,10 @@ extern "C" {
                                 const int gsize[], const int ndims, io_desc_t *iodesc);
     void print_trace (FILE *fp);
     void cn_buffer_report(iosystem_desc_t ios, bool collective);
-    void compute_buffer_init(iosystem_desc_t ios);
+
+    /* Initialize the compute buffer. */
+    int compute_buffer_init(iosystem_desc_t ios);
+    
     void free_cn_buffer_pool(iosystem_desc_t ios);
     void flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk);
     void piomemerror(iosystem_desc_t ios, size_t req, char *fname, int line);

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -79,6 +79,9 @@ int pio_get_file(int ncid, file_desc_t **cfile1)
     if (!cfile->iosystem)
         return PIO_EINVAL;
 
+    /* Let's just ensure we have a valid IO type. */
+    pioassert(iotype_is_valid(cfile->iotype), "invalid IO type", __FILE__, __LINE__);
+
     /* Copy pointer to file info. */
     *cfile1 = cfile;
 

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -1154,13 +1154,13 @@ int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-            ierr = nc_put_var(file->fh, varid,   buf);
+            ierr = nc_put_var(file->fh, varid, buf);
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
         case PIO_IOTYPE_NETCDF:
             if (ios->io_rank == 0)
-                ierr = nc_put_var(file->fh, varid,   buf);
+                ierr = nc_put_var(file->fh, varid, buf);
             break;
 #endif
 #ifdef _PNETCDF

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -1346,13 +1346,13 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-            ierr = nc_put_var1(file->fh, varid, (size_t *) index, buf);
+            ierr = nc_put_var1(file->fh, varid, (size_t *)index, buf);
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
         case PIO_IOTYPE_NETCDF:
             if(ios->io_rank==0)
-                ierr = nc_put_var1(file->fh, varid, (size_t *) index, buf);
+                ierr = nc_put_var1(file->fh, varid, (size_t *)index, buf);
             break;
 #endif
 #ifdef _PNETCDF

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -1167,13 +1167,13 @@ int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
 
-            if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 )
+            if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0 )
             {
                 if (!(vdesc->request = realloc(vdesc->request,
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                     return PIO_ENOMEM;
             }
-            request = vdesc->request+vdesc->nreqs;
+            request = vdesc->request + vdesc->nreqs;
 
             if (ios->io_rank == 0)
                 ierr = ncmpi_bput_var(file->fh, varid, buf, bufcount, buftype, request);
@@ -1239,7 +1239,7 @@ int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     if (ios->async_interface && !ios->ioproc)
     {
-        if (ios->compmaster)
+        if (ios->compmaster == MPI_ROOT)
             mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
         mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
@@ -1272,7 +1272,7 @@ int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                     return PIO_ENOMEM;
             }
-            request = vdesc->request+vdesc->nreqs;
+            request = vdesc->request + vdesc->nreqs;
 
             if(ios->io_rank == 0)
                 ierr = ncmpi_bput_vars(file->fh, varid, start, count, stride, buf,
@@ -1332,7 +1332,7 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
 
     if (ios->async_interface && !ios->ioproc)
     {
-        if (ios->compmaster)
+        if (ios->compmaster == MPI_ROOT)
             mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
         mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
@@ -1359,13 +1359,13 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
 
-            if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0)
+            if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
             {
                 if (!(vdesc->request = realloc(vdesc->request,
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                     return PIO_ENOMEM;
             }
-            request = vdesc->request+vdesc->nreqs;
+            request = vdesc->request + vdesc->nreqs;
 
             if (ios->io_rank==0)
                 ierr = ncmpi_bput_var1(file->fh, varid, index, buf, bufcount, buftype, request);
@@ -1427,8 +1427,8 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     if (ios->async_interface && !ios->ioproc)
     {
-        if (ios->compmaster)
-            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+        if (ios->compmaster == MPI_ROOT)
+            mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
         mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
@@ -1446,7 +1446,7 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
         case PIO_IOTYPE_NETCDF4C:
 #endif
         case PIO_IOTYPE_NETCDF:
-            if(ios->io_rank == 0)
+            if (ios->io_rank == 0)
                 ierr = nc_put_vara(file->fh, varid, (size_t *)start, (size_t *)count, buf);
             break;
 #endif
@@ -1454,7 +1454,7 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
 
-            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 )
+            if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0 )
             {
                 if (!(vdesc->request = realloc(vdesc->request,
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
@@ -1462,11 +1462,10 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
             }
             request = vdesc->request + vdesc->nreqs;
 
-            if(ios->io_rank==0){
+            if (ios->io_rank == 0)
                 ierr = ncmpi_bput_vara(file->fh, varid, start, count, buf, bufcount, buftype, request);
-            }else{
+            else
                 *request = PIO_REQ_NULL;
-            }
             vdesc->nreqs++;
             flush_output_buffer(file, false, 0);
             break;

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -1139,51 +1139,52 @@ int PIOc_put_var(int ncid, int varid, const void *buf, PIO_Offset bufcount,
 
     msg = PIO_MSG_PUT_VAR;
 
-    if(ios->async_interface && ! ios->ioproc){
-        if(ios->compmaster)
-            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    if (ios->async_interface && !ios->ioproc)
+    {
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
         mpierr = MPI_Bcast(&ncid,1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
-
-    if(ios->ioproc){
-        switch(file->iotype){
+    if (ios->ioproc)
+    {
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-            ierr = nc_put_var(file->fh, varid,   buf);;
+            ierr = nc_put_var(file->fh, varid,   buf);
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
         case PIO_IOTYPE_NETCDF:
-            if(ios->io_rank==0){
-                ierr = nc_put_var(file->fh, varid,   buf);;
-            }
+            if (ios->io_rank == 0)
+                ierr = nc_put_var(file->fh, varid,   buf);
             break;
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
 
-            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+            if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 )
+            {
                 if (!(vdesc->request = realloc(vdesc->request,
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                     return PIO_ENOMEM;
             }
             request = vdesc->request+vdesc->nreqs;
 
-            if(ios->io_rank==0){
-                ierr = ncmpi_bput_var(file->fh, varid, buf, bufcount, buftype, request);;
-            }else{
+            if (ios->io_rank == 0)
+                ierr = ncmpi_bput_var(file->fh, varid, buf, bufcount, buftype, request);
+            else
                 *request = PIO_REQ_NULL;
-            }
             vdesc->nreqs++;
             flush_output_buffer(file, false, 0);
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1236,53 +1237,54 @@ int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     msg = PIO_MSG_PUT_VARS;
 
-    if(ios->async_interface && ! ios->ioproc){
-        if(ios->compmaster)
-            mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
+    if (ios->async_interface && !ios->ioproc)
+    {
+        if (ios->compmaster)
+            mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
         mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
-
-    if(ios->ioproc){
-        switch(file->iotype){
+    if (ios->ioproc)
+    {
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-            ierr = nc_put_vars(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride,   buf);;
+            ierr = nc_put_vars(file->fh, varid, (size_t *)start, (size_t *)count, (ptrdiff_t *)stride, buf);
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
         case PIO_IOTYPE_NETCDF:
-            if(ios->io_rank==0){
+            if (ios->io_rank == 0)
                 ierr = nc_put_vars(file->fh, varid, (size_t *)start, (size_t *)count,
-                                   (ptrdiff_t *)stride,   buf);;
-            }
+                                   (ptrdiff_t *)stride, buf);
             break;
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
 
-            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+            if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
+            {
                 if (!(vdesc->request = realloc(vdesc->request,
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                     return PIO_ENOMEM;
             }
             request = vdesc->request+vdesc->nreqs;
 
-            if(ios->io_rank==0){
+            if(ios->io_rank == 0)
                 ierr = ncmpi_bput_vars(file->fh, varid, start, count, stride, buf,
-                                       bufcount, buftype, request);;
-            }else{
+                                       bufcount, buftype, request);
+            else
                 *request = PIO_REQ_NULL;
-            }
             vdesc->nreqs++;
             flush_output_buffer(file, false, 0);
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1328,51 +1330,53 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *buf,
 
     msg = PIO_MSG_PUT_VAR1;
 
-    if(ios->async_interface && ! ios->ioproc){
-        if(ios->compmaster)
+    if (ios->async_interface && !ios->ioproc)
+    {
+        if (ios->compmaster)
             mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
         mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
 
-    if(ios->ioproc){
-        switch(file->iotype){
+    if (ios->ioproc)
+    {
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-            ierr = nc_put_var1(file->fh, varid, (size_t *) index,   buf);;
+            ierr = nc_put_var1(file->fh, varid, (size_t *) index, buf);
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
         case PIO_IOTYPE_NETCDF:
-            if(ios->io_rank==0){
-                ierr = nc_put_var1(file->fh, varid, (size_t *) index,   buf);;
-            }
+            if(ios->io_rank==0)
+                ierr = nc_put_var1(file->fh, varid, (size_t *) index, buf);
             break;
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
 
-            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+            if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0)
+            {
                 if (!(vdesc->request = realloc(vdesc->request,
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                     return PIO_ENOMEM;
             }
             request = vdesc->request+vdesc->nreqs;
 
-            if(ios->io_rank==0){
-                ierr = ncmpi_bput_var1(file->fh, varid, index, buf, bufcount, buftype, request);;
-            }else{
+            if (ios->io_rank==0)
+                ierr = ncmpi_bput_var1(file->fh, varid, index, buf, bufcount, buftype, request);
+            else
                 *request = PIO_REQ_NULL;
-            }
             vdesc->nreqs++;
             flush_output_buffer(file, false, 0);
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1421,42 +1425,45 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 
     msg = PIO_MSG_PUT_VARA;
 
-    if(ios->async_interface && ! ios->ioproc){
-        if(ios->compmaster)
+    if (ios->async_interface && !ios->ioproc)
+    {
+        if (ios->compmaster)
             mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
         mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
     }
 
 
-    if(ios->ioproc){
-        switch(file->iotype){
+    if (ios->ioproc)
+    {
+        switch (file->iotype)
+        {
 #ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
-            ierr = nc_put_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
+            ierr = nc_put_vara(file->fh, varid, (size_t *)start, (size_t *)count, buf);
             break;
         case PIO_IOTYPE_NETCDF4C:
 #endif
         case PIO_IOTYPE_NETCDF:
-            if(ios->io_rank==0){
-                ierr = nc_put_vara(file->fh, varid, (size_t *) start, (size_t *) count,   buf);;
-            }
+            if(ios->io_rank == 0)
+                ierr = nc_put_vara(file->fh, varid, (size_t *)start, (size_t *)count, buf);
             break;
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
 
-            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
+            if(vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 )
+            {
                 if (!(vdesc->request = realloc(vdesc->request,
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                     return PIO_ENOMEM;
             }
-            request = vdesc->request+vdesc->nreqs;
+            request = vdesc->request + vdesc->nreqs;
 
             if(ios->io_rank==0){
-                ierr = ncmpi_bput_vara(file->fh, varid, start, count, buf, bufcount, buftype, request);;
+                ierr = ncmpi_bput_vara(file->fh, varid, start, count, buf, bufcount, buftype, request);
             }else{
                 *request = PIO_REQ_NULL;
             }
@@ -1465,7 +1472,7 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -72,7 +72,7 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -147,7 +147,7 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -222,7 +222,7 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -298,7 +298,7 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -375,7 +375,7 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -452,7 +452,7 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -528,7 +528,7 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -605,7 +605,7 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -681,7 +681,7 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -758,7 +758,7 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -835,7 +835,7 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -911,7 +911,7 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -986,7 +986,7 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1058,7 +1058,7 @@ int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1135,7 +1135,7 @@ int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1212,7 +1212,7 @@ int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const P
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1289,7 +1289,7 @@ int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1366,7 +1366,7 @@ int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1443,7 +1443,7 @@ int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1516,7 +1516,7 @@ int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1593,7 +1593,7 @@ int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1670,7 +1670,7 @@ int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1747,7 +1747,7 @@ int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1824,7 +1824,7 @@ int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1901,7 +1901,7 @@ int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 
@@ -1978,7 +1978,7 @@ int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
             break;
 #endif
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
     }
 

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -16,6 +16,10 @@ static int counter = 0;
 /** The default error handler used when iosystem cannot be located. */
 int default_error_handler = PIO_INTERNAL_ERROR;
 
+/** The target blocksize for each io task when the box rearranger is
+ * used (see pio_sc.c). */
+extern int blocksize;
+
 /**
  * Check to see if PIO has been initialized.
  *
@@ -1332,3 +1336,18 @@ int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
     LOG((2, "successfully done with PIO_Init_Async"));
     return PIO_NOERR;
 }
+
+/**
+ * Set the target blocksize for the box rearranger.
+ *
+ * @param newblocksize the new blocksize.
+ * @returns 0 for success.
+ * @ingroup PIO_set_blocksize
+ */
+int PIOc_set_blocksize(int newblocksize)
+{
+    if (newblocksize > 0)
+        blocksize = newblocksize;
+    return PIO_NOERR;
+}
+

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -544,6 +544,7 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
     int lbase;
     int num_comptasks; /* The size of the comp_comm. */
     int mpierr;        /* Return value for MPI calls. */
+    int ret;           /* Return code for function calls. */
 
     /* Turn on the logging system. */
     pio_init_logging();
@@ -645,7 +646,8 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
     *iosysidp = pio_add_to_iosystem_list(ios);
 
     /* Allocate buffer space for compute nodes. */
-    compute_buffer_init(*ios);
+    if ((ret = compute_buffer_init(*ios)))
+        return ret;
 
     LOG((2, "Init_Intracomm complete iosysid = %d", *iosysidp));
 

--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -17,20 +17,6 @@
  * used. */
 int blocksize = DEFAULT_BLOCKSIZE;
 
-/**
- * Set the target blocksize for the box rearranger.
- *
- * @param newblocksize the new blocksize.
- * @returns 0 for success.
- * @ingroup PIO_set_blocksize
- */
-int PIOc_set_blocksize(int newblocksize)
-{
-    if (newblocksize > 0)
-        blocksize = newblocksize;
-    return PIO_NOERR;
-}
-
 /* Recursive Standard C Function: Greatest Common Divisor.
  *
  * @param a

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -525,21 +525,6 @@ int pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fn
 }
 
 /**
- * Handle IO type error.
- *
- * @param iotype the undefined IO type
- * @param fname name of code file where error occured
- * @param line the line of code where the error occurred.
- * @returns PIO_EBADIOTYPE
- */
-int iotype_error(int iotype, const char *fname, int line)
-{
-    fprintf(stderr, "ERROR: iotype %d not defined in build %s %d\n",
-            iotype, fname ? fname : "_", line);
-    return PIO_EBADIOTYPE;
-}
-
-/**
  * Allocate an region.
  *
  * ndims the number of dimensions for the data in this region.
@@ -1160,8 +1145,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,
 #endif
 
         default:
-            ierr = iotype_error(file->iotype,__FILE__,__LINE__);
-            break;
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
         }
 
         /* If the caller requested a retry, and we failed to open a

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -634,8 +634,6 @@ create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nc
     if ((ret = PIOc_rename_var(ncid, 0, VAR_NAME_S2)))
         return ret;
 
-    /* char *buf111 = malloc(19999); */
-
     /* Add a global attribute. */
     printf("%d writing attributes %s\n", my_rank, ATT_NAME_S2);
     int att_data = ATT_VALUE_S2;

--- a/tests/cunit/test_intercomm2.c
+++ b/tests/cunit/test_intercomm2.c
@@ -377,8 +377,6 @@ int main(int argc, char **argv)
                 if ((ret = PIOc_rename_var(ncid, 0, VAR_NAME)))
                     ERR(ret);
 
-                char *buf111 = malloc(19999);
-
                 /* Add a global attribute. */
 		printf("%d test_intercomm2 writing attributes %s\n", my_rank, ATT_NAME);
                 int att_data = ATT_VALUE;

--- a/tests/cunit/test_iosystem2_simple.c
+++ b/tests/cunit/test_iosystem2_simple.c
@@ -46,6 +46,10 @@ int main(int argc, char **argv)
      * nothing. */
     if(my_rank < TARGET_NTASKS)
     {
+        /* Try setting the blocksize. */
+        if ((ret = PIOc_set_blocksize(2048)))
+            ERR(ret);
+        
         /* Figure out iotypes. */
         if ((ret = get_iotypes(&num_flavors, flavor)))
             ERR(ret);


### PR DESCRIPTION
More error handling cleanup and additional tests. Moved PIOc_set_blocksize to a file where it will be included in public documentation; also added a test for it. Removed the now unneeded function iotype_error().

Fixes #462.
Fixes #454.
Fixes #452.
Fixes #449.
Fixes #446.

I will merge to develop for testing.