### PR TITLE
attribute read/write tests

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -688,56 +688,58 @@ extern "C" {
     int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nelemsp,
                                  float *preemptionp);
 
-    /* Attributes. */
+    /* Attributes - misc. */
     int PIOc_rename_att(int ncid, int varid, const char *name, const char *newname);
     int PIOc_del_att(int ncid, int varid, const char *name);
+
+    /* Attributes - inquiry functions. */
     int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
 		     PIO_Offset *lenp);
     int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp);
     int PIOc_inq_attlen(int ncid, int varid, const char *name, PIO_Offset *lenp);
     int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep);
     int PIOc_inq_attname(int ncid, int varid, int attnum, char *name);
+
+    /* Attributes - writing. */
     int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const void *op);
-    int PIOc_get_att(int ncid, int varid, const char *name, void *ip);
-    int PIOc_put_att_double(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			    const double *op);
-    int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			 const int *op);
-    int PIOc_get_att_text(int ncid, int varid, const char *name, char *ip);
-    int PIOc_get_att_short(int ncid, int varid, const char *name, short *ip);
-    int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			  const long *op);
-    int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			   const short *op);
     int PIOc_put_att_text(int ncid, int varid, const char *name, PIO_Offset len, const char *op);
-    int PIOc_get_att_ulonglong(int ncid, int varid, const char *name, unsigned long long *ip);
-    int PIOc_get_att_ushort(int ncid, int varid, const char *name, unsigned short *ip);
-    int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype,
-			       PIO_Offset len, const unsigned long long *op);
-    int PIOc_get_att_uint(int ncid, int varid, const char *name, unsigned int *ip);
-    int PIOc_get_att_longlong(int ncid, int varid, const char *name, long long *ip);
     int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
 			   const signed char *op);
+    int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
+			   const short *op);
+    int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
+			 const int *op);
+    int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
+			  const long *op);
     int PIOc_put_att_float(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
 			   const float *op);
-    int PIOc_get_att_long(int ncid, int varid, const char *name, long *ip);
-    int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			    const unsigned short *op);
-    int PIOc_get_att_float(int ncid, int varid, const char *name, float *ip);
-    int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			      const long long *op);
-    int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			  const unsigned int *op);
-    int PIOc_get_att_schar(int ncid, int varid, const char *name, signed char *ip);
-    int PIOc_get_att_int(int ncid, int varid, const char *name, int *ip);
-    int PIOc_get_att_double(int ncid, int varid, const char *name, double *ip);
+    int PIOc_put_att_double(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
+			    const double *op);
     int PIOc_put_att_uchar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
 			   const unsigned char *op);
-    int PIOc_get_att_uchar(int ncid, int varid, const char *name, unsigned char *ip);
+    int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
+			    const unsigned short *op);
+    int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
+			  const unsigned int *op);
+    int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
+			      const long long *op);
+    int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype,
+			       PIO_Offset len, const unsigned long long *op);
 
-    int PIOc_get_att_ubyte(int ncid, int varid, const char *name, unsigned char *ip);
-    int PIOc_put_att_ubyte(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			   const unsigned char *op);
+    /* Attributes - reading. */
+    int PIOc_get_att(int ncid, int varid, const char *name, void *ip);
+    int PIOc_get_att_text(int ncid, int varid, const char *name, char *ip);
+    int PIOc_get_att_schar(int ncid, int varid, const char *name, signed char *ip);
+    int PIOc_get_att_short(int ncid, int varid, const char *name, short *ip);
+    int PIOc_get_att_int(int ncid, int varid, const char *name, int *ip);
+    int PIOc_get_att_long(int ncid, int varid, const char *name, long *ip);
+    int PIOc_get_att_float(int ncid, int varid, const char *name, float *ip);
+    int PIOc_get_att_double(int ncid, int varid, const char *name, double *ip);
+    int PIOc_get_att_uchar(int ncid, int varid, const char *name, unsigned char *ip);
+    int PIOc_get_att_ushort(int ncid, int varid, const char *name, unsigned short *ip);
+    int PIOc_get_att_uint(int ncid, int varid, const char *name, unsigned int *ip);
+    int PIOc_get_att_longlong(int ncid, int varid, const char *name, long long *ip);
+    int PIOc_get_att_ulonglong(int ncid, int varid, const char *name, unsigned long long *ip);
 
     /* Data reads - var. */
     int PIOc_get_var(int ncid, int varid, void *buf, PIO_Offset bufcount, MPI_Datatype buftype);

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2265,7 +2265,6 @@ int PIOc_get_att_ushort(int ncid, int varid, const char *name, unsigned short *i
 }
 
 /**
- * @ingroup PIO_get_att
  * Get the value of an 32-bit unsigned integer array attribute.
  *
  * This routine is called collectively by all tasks in the communicator
@@ -2277,6 +2276,7 @@ int PIOc_get_att_ushort(int ncid, int varid, const char *name, unsigned short *i
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @ingroup PIO_get_att
  */
 int PIOc_get_att_uint(int ncid, int varid, const char *name, unsigned int *ip)
 {

--- a/tests/cunit/test_pioc_putget.c
+++ b/tests/cunit/test_pioc_putget.c
@@ -55,7 +55,11 @@
 /* Length of the attributes for each type. */
 #define ATT_LEN 3
 
+/* Text att (must be two chars long to fit in ATT_LEN with a NULL). */
+#define TEXT_ATT_VALUE "hi"
+
 /* Names for each type attribute. */
+#define TEXT_ATT_NAME "text_att"
 #define SCHAR_ATT_NAME "schar_att"
 #define SHORT_ATT_NAME "short_att"
 #define INT_ATT_NAME "int_att"
@@ -223,9 +227,9 @@ int test_write_atts(int ncid, int *varid, int flavor)
     /*                        ATT_LEN, (signed char *)byte_array) != PIO_EBADID) */
     /*     return ERR_WRONG; */
 
-    /* if ((ret = PIOc_put_var_text(ncid, varid[2], &char_array))) */
-    /*     ERR(ret); */
-
+    if ((ret = PIOc_put_att_text(ncid, varid[0], TEXT_ATT_NAME, ATT_LEN,
+                                 TEXT_ATT_VALUE)))
+        return ret;
     if ((ret = PIOc_put_att_schar(ncid, varid[0], SCHAR_ATT_NAME, PIO_BYTE,
                                   ATT_LEN, (signed char *)byte_array)))
         return ret;
@@ -283,6 +287,7 @@ int test_write_atts(int ncid, int *varid, int flavor)
  */
 int test_read_att(int ncid, int *varid, int flavor)
 {
+    char text_in[ATT_LEN];
     signed char byte_array_in[ATT_LEN];
     short short_array_in[ATT_LEN];
     unsigned char ubyte_array_in[ATT_LEN];
@@ -296,18 +301,22 @@ int test_read_att(int ncid, int *varid, int flavor)
     int x, y;
     int ret;
 
-    if ((ret = PIOc_get_att_schar(ncid, varid[0], SCHAR_ATT_NAME, (signed char *)byte_array_in)))
+    if ((ret = PIOc_get_att_text(ncid, varid[0], TEXT_ATT_NAME, text_in)))
         return ret;
-    if ((ret = PIOc_get_att_short(ncid, varid[2], SHORT_ATT_NAME, (short *)short_array_in)))
+    if ((ret = PIOc_get_att_schar(ncid, varid[0], SCHAR_ATT_NAME, byte_array_in)))
         return ret;
-    if ((ret = PIOc_get_att_int(ncid, varid[3], INT_ATT_NAME, (int *)int_array_in)))
+    if ((ret = PIOc_get_att_short(ncid, varid[2], SHORT_ATT_NAME, short_array_in)))
         return ret;
-    if ((ret = PIOc_get_att_float(ncid, varid[4], FLOAT_ATT_NAME, (float *)float_array_in)))
+    if ((ret = PIOc_get_att_int(ncid, varid[3], INT_ATT_NAME, int_array_in)))
         return ret;
-    if ((ret = PIOc_get_att_double(ncid, varid[5], DOUBLE_ATT_NAME, (double *)double_array_in)))
+    if ((ret = PIOc_get_att_float(ncid, varid[4], FLOAT_ATT_NAME, float_array_in)))
+        return ret;
+    if ((ret = PIOc_get_att_double(ncid, varid[5], DOUBLE_ATT_NAME, double_array_in)))
         return ret;
     for (x = 0; x < ATT_LEN; x++)
     {
+        if (strncmp(text_in, TEXT_ATT_VALUE, ATT_LEN))
+            return ERR_WRONG;
         if (byte_array_in[x] != byte_array[x][0])
             return ERR_WRONG;
         if (short_array_in[x] != short_array[x][0])
@@ -322,15 +331,15 @@ int test_read_att(int ncid, int *varid, int flavor)
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_get_att_uchar(ncid, varid[6], UCHAR_ATT_NAME, (unsigned char *)ubyte_array_in)))
+        if ((ret = PIOc_get_att_uchar(ncid, varid[6], UCHAR_ATT_NAME, ubyte_array_in)))
             return ret;
-        if ((ret = PIOc_get_att_ushort(ncid, varid[7], USHORT_ATT_NAME, (unsigned short *)ushort_array_in)))
+        if ((ret = PIOc_get_att_ushort(ncid, varid[7], USHORT_ATT_NAME, ushort_array_in)))
             return ret;
-        if ((ret = PIOc_get_att_uint(ncid, varid[8], UINT_ATT_NAME, (unsigned int *)uint_array_in)))
+        if ((ret = PIOc_get_att_uint(ncid, varid[8], UINT_ATT_NAME, uint_array_in)))
             return ret;
-        if ((ret = PIOc_get_att_longlong(ncid, varid[9], INT64_ATT_NAME, (long long *)int64_array_in)))
+        if ((ret = PIOc_get_att_longlong(ncid, varid[9], INT64_ATT_NAME, int64_array_in)))
             return ret;
-        if ((ret = PIOc_get_att_ulonglong(ncid, varid[10], UINT64_ATT_NAME, (unsigned long long *)uint64_array_in)))
+        if ((ret = PIOc_get_att_ulonglong(ncid, varid[10], UINT64_ATT_NAME, uint64_array_in)))
             return ret;
         for (x = 0; x < ATT_LEN; x++)
         {
@@ -991,7 +1000,7 @@ int main(int argc, char **argv)
     /* Initialize data arrays with sample data. */
     init_arrays();
 
-    return run_test_main(argc, argv, MIN_NTASKS, TARGET_NTASKS, 3,
+    return run_test_main(argc, argv, MIN_NTASKS, TARGET_NTASKS, 0,
                          TEST_NAME, dim_len, COMPONENT_COUNT, NUM_IO_PROCS);
 
     return 0;

--- a/tests/cunit/test_pioc_putget.c
+++ b/tests/cunit/test_pioc_putget.c
@@ -52,6 +52,22 @@
 /* Number of NetCDF-4 types. */
 #define NUM_NETCDF4_TYPES 12
 
+/* Length of the attributes for each type. */
+#define ATT_LEN 3
+
+/* Names for each type attribute. */
+#define SCHAR_ATT_NAME "schar_att"
+#define SHORT_ATT_NAME "short_att"
+#define INT_ATT_NAME "int_att"
+#define LONG_ATT_NAME "long_att"
+#define FLOAT_ATT_NAME "float_att"
+#define DOUBLE_ATT_NAME "double_att"
+#define UCHAR_ATT_NAME "uchar_att"
+#define USHORT_ATT_NAME "ushort_att"
+#define UINT_ATT_NAME "uint_att"
+#define INT64_ATT_NAME "int64_att"
+#define UINT64_ATT_NAME "unit64_att"
+
 /* The dimension names. */
 char dim_name[NDIM][PIO_MAX_NAME + 1] = {"timestep", "x", "y"};
 
@@ -185,6 +201,150 @@ int putget_write_var(int ncid, int *varid, int flavor)
             return ret;
         if ((ret = PIOc_put_var_ulonglong(ncid, varid[10], (unsigned long long *)uint64_array)))
             return ret;
+    }
+
+    return 0;
+}
+
+/* Use the att functions to write some data to attributes in an open
+ * test file. 
+ *
+ * @param ncid the ncid of the test file to read.
+ * @param varid an array of varids in the file.
+ * @param flavor the PIO IO type of the test file.
+ * @returns 0 for success, error code otherwise.
+*/
+int test_write_atts(int ncid, int *varid, int flavor)
+{
+    int ret;
+
+    /* Test some invalid parameters. (Type is irrelevant here.) */
+    /* if (PIOc_put_att_schar(ncid + 1, varid[0], SCHAR_ATT_NAME, PIO_BYTE, */
+    /*                        ATT_LEN, (signed char *)byte_array) != PIO_EBADID) */
+    /*     return ERR_WRONG; */
+
+    /* if ((ret = PIOc_put_var_text(ncid, varid[2], &char_array))) */
+    /*     ERR(ret); */
+
+    if ((ret = PIOc_put_att_schar(ncid, varid[0], SCHAR_ATT_NAME, PIO_BYTE,
+                                  ATT_LEN, (signed char *)byte_array)))
+        return ret;
+
+    if ((ret = PIOc_put_att_short(ncid, varid[2], SHORT_ATT_NAME, PIO_SHORT,
+                                  ATT_LEN, (short *)short_array)))
+        return ret;
+
+    if ((ret = PIOc_put_att_int(ncid, varid[3], INT_ATT_NAME, PIO_INT,
+                                  ATT_LEN, (int *)int_array)))
+        return ret;
+
+    /* Use long on same int var. */
+    /* if ((ret = PIOc_put_att_long(ncid, varid[3], LONG_ATT_NAME, PIO_INT, */
+    /*                              ATT_LEN, (long int *)int_array))) */
+    /*     return ret; */
+
+    if ((ret = PIOc_put_att_float(ncid, varid[4], FLOAT_ATT_NAME, PIO_FLOAT,
+                                  ATT_LEN, (float *)float_array)))
+        return ret;
+
+    if ((ret = PIOc_put_att_double(ncid, varid[5], DOUBLE_ATT_NAME, PIO_DOUBLE,
+                                  ATT_LEN, (double *)double_array)))
+        return ret;
+
+    if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
+    {
+        if ((ret = PIOc_put_att_uchar(ncid, varid[6], UCHAR_ATT_NAME, PIO_UBYTE,
+                                      ATT_LEN, (unsigned char *)ubyte_array)))
+            return ret;
+        if ((ret = PIOc_put_att_ushort(ncid, varid[7], USHORT_ATT_NAME, PIO_SHORT,
+                                       ATT_LEN, (unsigned short *)ushort_array)))
+            return ret;
+        if ((ret = PIOc_put_att_uint(ncid, varid[8], UINT_ATT_NAME, PIO_UINT,
+                                     ATT_LEN, (unsigned int *)uint_array)))
+            return ret;
+        if ((ret = PIOc_put_att_longlong(ncid, varid[9], INT64_ATT_NAME, PIO_INT64,
+                                         ATT_LEN, (long long *)int64_array)))
+            return ret;
+        if ((ret = PIOc_put_att_ulonglong(ncid, varid[10], UINT64_ATT_NAME, PIO_UINT64,
+                                          ATT_LEN, (unsigned long long *)uint64_array)))
+            return ret;
+    }
+
+    return 0;
+}
+
+/* Use the att functions to read some attributes from an open test
+ * file.
+ *
+ * @param ncid the ncid of the test file to read.
+ * @param varid an array of varids in the file.
+ * @param flavor the PIO IO type of the test file.
+ * @returns 0 for success, error code otherwise.
+ */
+int test_read_att(int ncid, int *varid, int flavor)
+{
+    signed char byte_array_in[ATT_LEN];
+    short short_array_in[ATT_LEN];
+    unsigned char ubyte_array_in[ATT_LEN];
+    int int_array_in[ATT_LEN];
+    float float_array_in[ATT_LEN];
+    double double_array_in[ATT_LEN];
+    unsigned short ushort_array_in[ATT_LEN];
+    unsigned int uint_array_in[ATT_LEN];
+    long long int64_array_in[ATT_LEN];
+    unsigned long long uint64_array_in[ATT_LEN];
+    int x, y;
+    int ret;
+
+    if ((ret = PIOc_get_att_schar(ncid, varid[0], SCHAR_ATT_NAME, (signed char *)byte_array_in)))
+        return ret;
+    if ((ret = PIOc_get_att_short(ncid, varid[2], SHORT_ATT_NAME, (short *)short_array_in)))
+        return ret;
+    if ((ret = PIOc_get_att_int(ncid, varid[3], INT_ATT_NAME, (int *)int_array_in)))
+        return ret;
+    if ((ret = PIOc_get_att_float(ncid, varid[4], FLOAT_ATT_NAME, (float *)float_array_in)))
+        return ret;
+    if ((ret = PIOc_get_att_double(ncid, varid[5], DOUBLE_ATT_NAME, (double *)double_array_in)))
+        return ret;
+    for (x = 0; x < ATT_LEN; x++)
+    {
+        if (byte_array_in[x] != byte_array[x][0])
+            return ERR_WRONG;
+        if (short_array_in[x] != short_array[x][0])
+            return ERR_WRONG;
+        if (int_array_in[x] != int_array[x][0])
+            return ERR_WRONG;
+        if (float_array_in[x] != float_array[x][0])
+            return ERR_WRONG;
+        if (double_array_in[x] != double_array[x][0])
+            return ERR_WRONG;
+    }
+
+    if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
+    {
+        if ((ret = PIOc_get_att_uchar(ncid, varid[6], UCHAR_ATT_NAME, (unsigned char *)ubyte_array_in)))
+            return ret;
+        if ((ret = PIOc_get_att_ushort(ncid, varid[7], USHORT_ATT_NAME, (unsigned short *)ushort_array_in)))
+            return ret;
+        if ((ret = PIOc_get_att_uint(ncid, varid[8], UINT_ATT_NAME, (unsigned int *)uint_array_in)))
+            return ret;
+        if ((ret = PIOc_get_att_longlong(ncid, varid[9], INT64_ATT_NAME, (long long *)int64_array_in)))
+            return ret;
+        if ((ret = PIOc_get_att_ulonglong(ncid, varid[10], UINT64_ATT_NAME, (unsigned long long *)uint64_array_in)))
+            return ret;
+        for (x = 0; x < ATT_LEN; x++)
+        {
+            if (ubyte_array_in[x] != ubyte_array[x][0])
+                return ERR_WRONG;
+            if (ushort_array_in[x] != ushort_array[x][0])
+                return ERR_WRONG;
+            if (uint_array_in[x] != uint_array[x][0])
+                return ERR_WRONG;
+            if (int64_array_in[x] != int64_array[x][0])
+                return ERR_WRONG;
+            if (uint64_array_in[x] != uint64_array[x][0])
+                return ERR_WRONG;
+        }
     }
 
     return 0;
@@ -636,6 +796,11 @@ int create_putget_file(int iosysid, int access, int unlim, int flavor, int *dim_
             return ret;
     }
 
+    /* For the first access, also test attributes. */
+    if (access == 0)
+        if ((ret = test_write_atts(ncid, varid, flavor)))
+            return ret;
+
     if ((ret = PIOc_enddef(ncid)))
         return ret;
 
@@ -728,6 +893,10 @@ int test_putget(int iosysid, int num_flavors, int *flavor, int my_rank,
                 switch (access)
                 {
                 case 0:
+                    /* Use the att functions to read some data. */
+                    if ((ret = test_read_att(ncid, varid, flavor[fmt])))
+                        return ret;
+                    
                     /* Use the vara functions to read some data. */
                     if ((ret = putget_read_var(ncid, varid, unlim, flavor[fmt])))
                         return ret;


### PR DESCRIPTION
Added tests for attribute writes/reads of all types.

Also changed check_netcdf2() so that the netCDF error message is logged. (It is only printed if PIO_ERROR_INTERNAL is being used and there is an abort.)

Also re-ordered the attribute functions in pio.h.

Fixes #431.

I will merge with develop for testing.