### PR TITLE
more tests

### DIFF
--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -144,6 +144,9 @@ extern "C" {
     void PIO_Offset_size(MPI_Datatype *dtype, int *tsize);
     PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in);
 
+    /* Initialize the rearranger options. */
+    void init_rearr_opts(iosystem_desc_t *iosys);
+
     /* Create a subset rearranger. */
     int subset_rearrange_create(iosystem_desc_t ios, int maplen, PIO_Offset *compmap, const int *gsize,
                                 int ndim, io_desc_t *iodesc);

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2489,28 +2489,6 @@ int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype,
 
 /**
  * @ingroup PIO_put_att
- * Write a netCDF attribute array of 8-bit unsigned bytes.
- *
- * This routine is called collectively by all tasks in the communicator
- * ios.union_comm.
- *
- * @param ncid the ncid of the open file, obtained from
- * PIOc_openfile() or PIOc_createfile().
- * @param varid the variable ID.
- * @param name the name of the attribute.
- * @param xtype the nc_type of the attribute.
- * @param len the length of the attribute array.
- * @param op a pointer with the attribute data.
- * @return PIO_NOERR for success, error code otherwise.
- */
-int PIOc_put_att_ubyte(int ncid, int varid, const char *name, nc_type xtype,
-                       PIO_Offset len, const unsigned char *op)
-{
-    return PIOc_put_att_tc(ncid, varid, name, xtype, len, PIO_UBYTE, op);
-}
-
-/**
- * @ingroup PIO_put_att
  * Write a netCDF attribute array of 32-bit floating points.
  *
  * This routine is called collectively by all tasks in the communicator

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -233,7 +233,7 @@ int create_mpi_datatypes(MPI_Datatype basetype, int msgcnt, PIO_Offset dlen,
     for (int j = 0; j < msgcnt; j++)
         numinds += mcount[j];
 
-    pioassert(dlen >= 0,"dlen < 0", __FILE__, __LINE__);
+    pioassert(dlen >= 0, "dlen < 0", __FILE__, __LINE__);
     pioassert(numinds >= 0, "num inds < 0", __FILE__, __LINE__);
 
     if (mindex)
@@ -444,9 +444,8 @@ int compute_counts(iosystem_desc_t ios, io_desc_t *iodesc, int maplen,
     int send_displs[ntasks];
     int recv_counts[ntasks];
     int recv_displs[ntasks];
-    int *recv_buf=NULL;
+    int *recv_buf = NULL;
     int nrecvs;
-    int maxreq = MAX_GATHER_BLOCK_SIZE;
     int ierr;
     int io_comprank;
     int ioindex;
@@ -1119,7 +1118,6 @@ int box_rearrange_create(iosystem_desc_t ios, int maplen, const PIO_Offset *comp
     int rdispls[nprocs];
     MPI_Datatype dtypes[nprocs];
     PIO_Offset iomaplen[nioprocs];
-    int maxreq = MAX_GATHER_BLOCK_SIZE;
     int mpierr; /* Return code from MPI functions. */
     int ret;
 

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -8,6 +8,27 @@
 #include <pio_internal.h>
 
 /**
+ * Internal library util function to initialize rearranger options.
+ *
+ * @param iosys pointer to iosystem descriptor
+ */
+void init_rearr_opts(iosystem_desc_t *iosys)
+{
+    /* The old default for max pending requests was 64 - we no longer use it*/
+
+    /* Disable handshake /isend and set max_pend_req = 0 to turn of throttling */
+    const rearr_comm_fc_opt_t def_coll_comm_fc_opts = { false, false, 0 };
+
+    assert(iosys);
+    
+    /* Default to coll - i.e., no flow control */
+    iosys->rearr_opts.comm_type = PIO_REARR_COMM_COLL;
+    iosys->rearr_opts.fcd = PIO_REARR_COMM_FC_2D_DISABLE;
+    iosys->rearr_opts.comm_fc_opts_comp2io = def_coll_comm_fc_opts;
+    iosys->rearr_opts.comm_fc_opts_io2comp = def_coll_comm_fc_opts;
+}
+
+/**
  * Convert an index into a list of dimensions. E.g., for index 4 into a
  * array defined as a[3][2], will return 1 1.
  *

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -496,27 +496,6 @@ int PIOc_InitDecomp_bc(int iosysid, int basetype, int ndims, const int *dims,
 }
 
 /**
- * Internal library util function to initialize rearranger options
- * @param iosys pointer to iosystem descriptor
- */
-
-static void init_rearr_opts(iosystem_desc_t *iosys)
-{
-    /* The old default for max pending requests was 64 - we no longer use it*/
-
-    /* Disable handshake /isend and set max_pend_req = 0 to turn of throttling */
-    const rearr_comm_fc_opt_t def_coll_comm_fc_opts = { false, false, 0 };
-
-    assert(iosys);
-    
-    /* Default to coll - i.e., no flow control */
-    iosys->rearr_opts.comm_type = PIO_REARR_COMM_COLL;
-    iosys->rearr_opts.fcd = PIO_REARR_COMM_FC_2D_DISABLE;
-    iosys->rearr_opts.comm_fc_opts_comp2io = def_coll_comm_fc_opts;
-    iosys->rearr_opts.comm_fc_opts_io2comp = def_coll_comm_fc_opts;
-}
-
-/**
  * Library initialization used when IO tasks are a subset of compute
  * tasks.
  *
@@ -569,6 +548,8 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
     ios->default_rearranger = rearr;
     ios->num_iotasks = num_iotasks;
     ios->num_comptasks = num_comptasks;
+
+    /* Initialize the rearranger options. */
     init_rearr_opts(ios);
 
     /* Copy the computation communicator into union_comm. */
@@ -709,13 +690,25 @@ int PIOc_set_hint(int iosysid, const char *hint, const char *hintval)
     iosystem_desc_t *ios;
     int mpierr; /* Return value for MPI calls. */
 
+    /* Get the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
+    /* User must provide these. */
+    if (!hint || !hintval)
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+
+    LOG((1, "PIOc_set_hint hint = %s hintval = %s", hint, hintval));
+
+    /* Make sure we have an info object. */
+    if (ios->info == MPI_INFO_NULL)
+        if ((mpierr = MPI_Info_create(&ios->info)))
+            return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);            
+    
     /* Set the MPI hint. */
     if (ios->ioproc)
         if ((mpierr = MPI_Info_set(ios->info, hint, hintval)))
-            return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+            return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -1142,9 +1135,8 @@ int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
             my_iosys->comproot = num_procs_per_comp[0];
             LOG((3, "my_iosys->comproot = %d", my_iosys->comproot));
 
-            /* Create an MPI info object. */
-            if ((ret = MPI_Info_create(&my_iosys->info)))
-                return check_mpi(NULL, ret, __FILE__, __LINE__);
+            /* We are not providing an info object. */
+            my_iosys->info = MPI_INFO_NULL;
         }
 
         /* Create a group for this component. */

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -321,7 +321,7 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
     /* Check the dim lengths. */
     for (int i = 0; i < ndims; i++)
         if (dims[i] <= 0)
-            piodie("Invalid dims argument", __FILE__, __LINE__);
+            return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* Get IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
@@ -502,12 +502,13 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
 
 static void init_rearr_opts(iosystem_desc_t *iosys)
 {
-    /* The old default for max pending requests - we no longer use it*/
-    const int DEF_P2P_MAXREQ = 64;
+    /* The old default for max pending requests was 64 - we no longer use it*/
+
     /* Disable handshake /isend and set max_pend_req = 0 to turn of throttling */
     const rearr_comm_fc_opt_t def_coll_comm_fc_opts = { false, false, 0 };
 
-    assert(iosys != NULL);
+    assert(iosys);
+    
     /* Default to coll - i.e., no flow control */
     iosys->rearr_opts.comm_type = PIO_REARR_COMM_COLL;
     iosys->rearr_opts.fcd = PIO_REARR_COMM_FC_2D_DISABLE;

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -329,7 +329,7 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
 
     /* Allocate space for the iodesc info. */
     if (!(iodesc = malloc_iodesc(ios, basetype, ndims)))
-	piodie("Out of memory", __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Remember the maplen. */
     iodesc->maplen = maplen;
@@ -441,8 +441,8 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
  * @returns 0 for success, error code otherwise
  * @ingroup PIO_initdecomp
  */
-int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, const int dims[],
-                       const long int start[], const long int count[], int *ioidp)
+int PIOc_InitDecomp_bc(int iosysid, int basetype, int ndims, const int *dims,
+                       const long int *start, const long int *count, int *ioidp)
 
 {
     iosystem_desc_t *ios;
@@ -452,10 +452,10 @@ int PIOc_InitDecomp_bc(const int iosysid, const int basetype, const int ndims, c
     for (int i = 0; i < ndims; i++)
     {
         if (dims[i] <= 0)
-            piodie("Invalid dims argument",__FILE__,__LINE__);
+            return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
         if (start[i] < 0 || count[i] < 0 || (start[i] + count[i]) > dims[i])
-            piodie("Invalid start or count argument ",__FILE__,__LINE__);
+            return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
     }
 
     /* Get the info about the io system. */

--- a/tests/cunit/test_iosystem2.c
+++ b/tests/cunit/test_iosystem2.c
@@ -145,6 +145,10 @@ int main(int argc, char **argv)
         if ((ret = PIOc_Init_Intracomm(newcomm, 2, 1, 0, 1, &iosysid)))
             ERR(ret);
 
+        /* This should fail. */
+        if (PIOc_finalize(iosysid + 42) != PIO_EBADID)
+            ERR(ERR_WRONG);
+
         /* Initialize another PIO system. */
         if ((ret = PIOc_Init_Intracomm(test_comm, 4, 1, 0, 1, &iosysid_world)))
             ERR(ret);

--- a/tests/cunit/test_iosystem3.c
+++ b/tests/cunit/test_iosystem3.c
@@ -234,6 +234,16 @@ int main(int argc, char **argv)
             if ((ret = PIOc_Init_Intracomm(even_comm, NUM_IO1, STRIDE1, BASE1, REARRANGER, &even_iosysid)))
                 ERR(ret);
 
+            /* These should not work. */
+            if (PIOc_set_hint(even_iosysid + 42, NULL, NULL) != PIO_EBADID)
+                ERR(ERR_WRONG);
+            if (PIOc_set_hint(even_iosysid, NULL, NULL) != PIO_EINVAL)
+                ERR(ERR_WRONG);
+
+            /* Set the hint (which will be ignored). */
+            if ((ret = PIOc_set_hint(even_iosysid, "hint", "hint_value")))
+                ERR(ret);
+
             /* Set the error handler. */
             /*PIOc_Set_IOSystem_Error_Handling(even_iosysid, PIO_BCAST_ERROR);*/
             printf("%d about to set iosystem error hanlder for even\n", my_rank);

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -85,6 +85,7 @@ int create_decomposition(int ntasks, int my_rank, int iosysid, int dim1_len, int
     PIO_Offset elements_per_pe;     /* Array elements per processing unit. */
     PIO_Offset *compdof;  /* The decomposition mapping. */
     int dim_len[NDIM1] = {dim1_len};
+    int bad_dim_len[NDIM1] = {-50};
     int ret;
 
     /* How many data elements per task? */
@@ -97,6 +98,14 @@ int create_decomposition(int ntasks, int my_rank, int iosysid, int dim1_len, int
     /* Describe the decomposition. This is a 1-based array, so add 1! */
     for (int i = 0; i < elements_per_pe; i++)
         compdof[i] = my_rank * elements_per_pe + i + 1;
+
+    /* These should fail. */
+    if (PIOc_InitDecomp(iosysid + 42, PIO_FLOAT, NDIM1, dim_len, elements_per_pe,
+                        compdof, ioid, NULL, NULL, NULL) != PIO_EBADID)
+        ERR(ERR_WRONG);
+    if (PIOc_InitDecomp(iosysid, PIO_FLOAT, NDIM1, bad_dim_len, elements_per_pe,
+                        compdof, ioid, NULL, NULL, NULL) != PIO_EINVAL)
+        ERR(ERR_WRONG);
 
     /* Create the PIO decomposition for this test. */
     printf("%d Creating decomposition elements_per_pe = %lld\n", my_rank, elements_per_pe);

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -909,6 +909,12 @@ int test_deletefile(int iosysid, int num_flavors, int *flavor, int my_rank)
         char iotype_name[PIO_MAX_NAME + 1];
         int old_method;
 
+        /* These should fail. */
+        if (PIOc_set_iosystem_error_handling(iosysid + 42, PIO_RETURN_ERROR, &old_method) != PIO_EBADID)
+            return ERR_WRONG;
+        if (PIOc_set_iosystem_error_handling(iosysid, PIO_RETURN_ERROR + 42, &old_method) != PIO_EINVAL)
+            return ERR_WRONG;
+        
         /* Set error handling. */
         if ((ret = PIOc_set_iosystem_error_handling(iosysid, PIO_RETURN_ERROR, &old_method)))
             return ret;


### PR DESCRIPTION
Fixes #507.
Fixes #506.
Fixes #505.
Part of #441.
Fixes #510.
Fixes #430.
Part of #205 (of course).

Filling in lots of missing test cases, mostly checking that invalid parameters are properly rejected.

PIOc_set_hint() was not actually working because the info object was not always present. That's fixed in this PR.

Also fixed a few cases of bad error handling. We usually don't want to call piodie(). Instead call pio_err() which checks the error handler and only dies if it should.

I will merge to develop for testing.