### PR TITLE
fixed _long() problems with new internal type

### DIFF
--- a/src/clib/pio_get_nc.c
+++ b/src/clib/pio_get_nc.c
@@ -218,7 +218,7 @@ int PIOc_get_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Of
 int PIOc_get_vars_long(int ncid, int varid, const PIO_Offset *start,
                        const PIO_Offset *count, const PIO_Offset *stride, long *buf)
 {
-    return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_LONG, buf);
+    return PIOc_get_vars_tc(ncid, varid, start, count, stride, PIO_LONG_INTERNAL, buf);
 }
 
 /**
@@ -299,7 +299,7 @@ int PIOc_get_vars_ulonglong(int ncid, int varid, const PIO_Offset *start,
                             const PIO_Offset *count, const PIO_Offset *stride,
                             unsigned long long *buf)
 {
-    return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_UINT64, buf);
+    return PIOc_get_vars_tc(ncid, varid, start, count, stride, PIO_LONG_INTERNAL, buf);
 }
 
 /**
@@ -464,7 +464,7 @@ int PIOc_get_vara_short(int ncid, int varid, const PIO_Offset *start,
 int PIOc_get_vara_long(int ncid, int varid, const PIO_Offset *start,
                        const PIO_Offset *count, long *buf)
 {
-    return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_LONG, buf);
+    return PIOc_get_vars_tc(ncid, varid, start, count, NULL, PIO_LONG_INTERNAL, buf);
 }
 
 /**
@@ -731,7 +731,7 @@ int PIOc_get_var_int(int ncid, int varid, int *buf)
  */
 int PIOc_get_var_long (int ncid, int varid, long *buf)
 {
-    return PIOc_get_vars_tc(ncid, varid, NULL, NULL, NULL, NC_LONG, buf);
+    return PIOc_get_vars_tc(ncid, varid, NULL, NULL, NULL, PIO_LONG_INTERNAL, buf);
 }
 
 /**
@@ -930,7 +930,7 @@ int PIOc_get_var1_uint(int ncid, int varid, const PIO_Offset *index, unsigned in
  */
 int PIOc_get_var1_long (int ncid, int varid, const PIO_Offset *index, long *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_LONG, buf);
+    return PIOc_get_var1_tc(ncid, varid, index, PIO_LONG_INTERNAL, buf);
 }
 
 /**

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -59,8 +59,13 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             return check_netcdf(file, ierr, __FILE__, __LINE__);
 
         /* Get the length (in bytes) of the type in memory. */
-        if ((ierr = PIOc_inq_type(ncid, memtype, NULL, &memtype_len)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+        if (memtype == PIO_LONG_INTERNAL)
+            memtype_len = sizeof(long int);
+        else
+        {
+            if ((ierr = PIOc_inq_type(ncid, memtype, NULL, &memtype_len)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+        }
         LOG((2, "PIOc_put_att atttype_len = %d memtype_len = %d", ncid, atttype_len, memtype_len));
     }
 
@@ -136,6 +141,9 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             case NC_INT:
                 ierr = ncmpi_put_att_int(file->fh, varid, name, atttype, len, op);
                 break;
+            case PIO_LONG_INTERNAL:
+                ierr = ncmpi_put_att_long(file->fh, varid, name, atttype, len, op);
+                break;
             case NC_FLOAT:
                 ierr = ncmpi_put_att_float(file->fh, varid, name, atttype, len, op);
                 break;
@@ -166,6 +174,9 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                 break;
             case NC_INT:
                 ierr = nc_put_att_int(file->fh, varid, name, atttype, len, op);
+                break;
+            case PIO_LONG_INTERNAL:
+                ierr = nc_put_att_long(file->fh, varid, name, atttype, len, op);
                 break;
             case NC_FLOAT:
                 ierr = nc_put_att_float(file->fh, varid, name, atttype, len, op);
@@ -264,8 +275,13 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
 
         /* Get the length (in bytes) of the type that the user wants
          * the data converted to. */
-        if ((ierr = PIOc_inq_type(ncid, memtype, NULL, &memtype_len)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+        if (memtype == PIO_LONG_INTERNAL)
+            memtype_len = sizeof(long int);
+        else
+        {
+            if ((ierr = PIOc_inq_type(ncid, memtype, NULL, &memtype_len)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+        }
     }
     LOG((2, "atttype_len = %d memtype_len = %d", atttype_len, memtype_len));
 
@@ -349,6 +365,9 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
             case NC_INT:
                 ierr = ncmpi_get_att_int(file->fh, varid, name, ip);
                 break;
+            case PIO_LONG_INTERNAL:
+                ierr = ncmpi_get_att_long(file->fh, varid, name, ip);
+                break;
             case NC_FLOAT:
                 ierr = ncmpi_get_att_float(file->fh, varid, name, ip);
                 break;
@@ -379,6 +398,9 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
                 break;
             case NC_INT:
                 ierr = nc_get_att_int(file->fh, varid, name, ip);
+                break;
+            case PIO_LONG_INTERNAL:
+                ierr = nc_get_att_long(file->fh, varid, name, ip);
                 break;
             case NC_FLOAT:
                 ierr = nc_get_att_float(file->fh, varid, name, ip);
@@ -495,9 +517,13 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
      * non-IO tasks if async is in use. */
     if (!ios->async_interface || !ios->ioproc)
     {
-        /* Get the length of the data type. */
-        if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+        if (xtype == PIO_LONG_INTERNAL)
+            typelen = sizeof(long int);
+        else
+        {
+            if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+        }
 
         /* Get the number of dims for this var. */
         if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
@@ -636,6 +662,9 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 case NC_INT:
                     ierr = ncmpi_get_vars_int(file->fh, varid, start, count, stride, buf);
                     break;
+                case PIO_LONG_INTERNAL:
+                    ierr = ncmpi_get_vars_long(file->fh, varid, start, count, stride, buf);
+                    break;
                 case NC_FLOAT:
                     ierr = ncmpi_get_vars_float(file->fh, varid, start, count, stride, buf);
                     break;
@@ -663,6 +692,9 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 break;
             case NC_INT:
                 ierr = ncmpi_get_vars_int_all(file->fh, varid, start, count, stride, buf);
+                break;
+            case PIO_LONG_INTERNAL:
+                ierr = ncmpi_get_vars_long_all(file->fh, varid, start, count, stride, buf);
                 break;
             case NC_FLOAT:
                 ierr = ncmpi_get_vars_float_all(file->fh, varid, start, count, stride, buf);
@@ -695,6 +727,10 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             case NC_INT:
                 ierr = nc_get_vars_int(file->fh, varid, (size_t *)start, (size_t *)count,
                                        (ptrdiff_t *)stride, buf);
+                break;
+            case PIO_LONG_INTERNAL:
+                ierr = nc_get_vars_long(file->fh, varid, (size_t *)start, (size_t *)count,
+                                        (ptrdiff_t *)stride, buf);
                 break;
             case NC_FLOAT:
                 ierr = nc_get_vars_float(file->fh, varid, (size_t *)start, (size_t *)count,
@@ -874,8 +910,13 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             return check_netcdf(file, ierr, __FILE__, __LINE__);
 
         /* Get the length of the data type. */
-        if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
+        if (xtype == PIO_LONG_INTERNAL)
+            typelen = sizeof(long int);
+        else
+        {
+            if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+        }
 
         LOG((2, "ndims = %d typelen = %d", ndims, typelen));
 
@@ -1041,6 +1082,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 case NC_INT:
                     ierr = ncmpi_bput_vars_int(file->fh, varid, start, count, fake_stride, buf, request);
                     break;
+                case PIO_LONG_INTERNAL:
+                    ierr = ncmpi_bput_vars_long(file->fh, varid, start, count, fake_stride, buf, request);
+                    break;
                 case NC_FLOAT:
                     ierr = ncmpi_bput_vars_float(file->fh, varid, start, count, fake_stride, buf, request);
                     break;
@@ -1086,6 +1130,10 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             case NC_INT:
                 ierr = nc_put_vars_int(file->fh, varid, (size_t *)start, (size_t *)count,
                                        (ptrdiff_t *)stride, buf);
+                break;
+            case PIO_LONG_INTERNAL:
+                ierr = nc_put_vars_long(file->fh, varid, (size_t *)start, (size_t *)count,
+                                        (ptrdiff_t *)stride, buf);
                 break;
             case NC_FLOAT:
                 ierr = nc_put_vars_float(file->fh, varid, (size_t *)start, (size_t *)count,

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -59,6 +59,11 @@ void pio_log(int severity, const char *fmt, ...);
 #define MAX_GATHER_BLOCK_SIZE 0
 #define PIO_REQUEST_ALLOC_CHUNK 16
 
+/** This is needed to handle _long() functions. It may not be used as
+ * a data type when creating attributes or varaibles, it is only used
+ * internally. */
+#define PIO_LONG_INTERNAL 13
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2153,7 +2153,7 @@ int PIOc_get_att_uint(int ncid, int varid, const char *name, unsigned int *ip)
  */
 int PIOc_get_att_long(int ncid, int varid, const char *name, long *ip)
 {
-    return PIOc_get_att_tc(ncid, varid, name, PIO_INT64, (void *)ip);
+    return PIOc_get_att_tc(ncid, varid, name, PIO_LONG_INTERNAL, (void *)ip);
 }
 
 /**
@@ -2332,7 +2332,7 @@ int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype,
 int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype,
                       PIO_Offset len, const long *op)
 {
-    return PIOc_put_att_tc(ncid, varid, name, xtype, len, PIO_INT64, op);
+    return PIOc_put_att_tc(ncid, varid, name, xtype, len, PIO_LONG_INTERNAL, op);
 }
 
 /**

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -219,7 +219,7 @@ int PIOc_put_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Of
 int PIOc_put_vars_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
                        const PIO_Offset *stride, const long *op)
 {
-    return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_INT, op);
+    return PIOc_put_vars_tc(ncid, varid, start, count, stride, PIO_LONG_INTERNAL, op);
 }
 
 /**
@@ -502,7 +502,7 @@ int PIOc_put_var1_float(int ncid, int varid, const PIO_Offset *index, const floa
  */
 int PIOc_put_var1_long(int ncid, int varid, const PIO_Offset *index, const long *op)
 {
-    return PIOc_put_var1_tc(ncid, varid, index, NC_LONG, op);
+    return PIOc_put_var1_tc(ncid, varid, index, PIO_LONG_INTERNAL, op);
 }
 
 /**

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -650,6 +650,8 @@ int define_metadata(int ncid, int my_rank)
         return ERR_WRONG;
     if (PIOc_def_var(ncid, too_long_name, PIO_INT, NDIM, dimids, NULL) != PIO_EINVAL)
         return ERR_WRONG;
+    if (PIOc_def_var(ncid, too_long_name, 42, NDIM, dimids, &varid) != PIO_EINVAL)
+        return ERR_WRONG;
 
     /* Define a variable. */
     if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_INT, NDIM, dimids, &varid)))
@@ -789,6 +791,8 @@ int test_names(int iosysid, int num_flavors, int *flavor, int my_rank,
         if (PIOc_put_att_int(ncid, NC_GLOBAL, too_long_name, PIO_INT, 1, &att_val) != PIO_EINVAL)
             ERR(ERR_WRONG);
         if (PIOc_put_att_int(ncid, NC_GLOBAL, ATT_NAME, PIO_INT, -1, &att_val) != PIO_EINVAL)
+            ERR(ERR_WRONG);
+        if (PIOc_put_att_int(ncid, NC_GLOBAL, ATT_NAME, 42, 1, &att_val) != PIO_EBADTYPE)
             ERR(ERR_WRONG);
 
         /* Define a global attribute. */

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -4,6 +4,7 @@
  * Ed Hartnett
  */
 #include <pio.h>
+#include <pio_internal.h>
 #include <pio_tests.h>
 
 /* The number of tasks this test should run on. */
@@ -652,6 +653,8 @@ int define_metadata(int ncid, int my_rank)
         return ERR_WRONG;
     if (PIOc_def_var(ncid, too_long_name, 42, NDIM, dimids, &varid) != PIO_EINVAL)
         return ERR_WRONG;
+    if (PIOc_def_var(ncid, too_long_name, PIO_LONG_INTERNAL, NDIM, dimids, &varid) != PIO_EINVAL)
+        return ERR_WRONG;
 
     /* Define a variable. */
     if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_INT, NDIM, dimids, &varid)))
@@ -793,6 +796,8 @@ int test_names(int iosysid, int num_flavors, int *flavor, int my_rank,
         if (PIOc_put_att_int(ncid, NC_GLOBAL, ATT_NAME, PIO_INT, -1, &att_val) != PIO_EINVAL)
             ERR(ERR_WRONG);
         if (PIOc_put_att_int(ncid, NC_GLOBAL, ATT_NAME, 42, 1, &att_val) != PIO_EBADTYPE)
+            ERR(ERR_WRONG);
+        if (PIOc_put_att_int(ncid, NC_GLOBAL, ATT_NAME, PIO_LONG_INTERNAL, 1, &att_val) != PIO_EBADTYPE)
             ERR(ERR_WRONG);
 
         /* Define a global attribute. */

--- a/tests/cunit/test_pioc_putget.c
+++ b/tests/cunit/test_pioc_putget.c
@@ -4,6 +4,7 @@
  * Ed Hartnett
  */
 #include <pio.h>
+#include <pio_internal.h>
 #include <pio_tests.h>
 
 /* The number of tasks this test should run on. */
@@ -87,6 +88,7 @@ char char_data = 2;
 signed char byte_data = -42;
 short short_data = -300;
 int int_data = -10000;
+long int long_data = -20000;
 float float_data = -42.42;
 double double_data = -420000000000.5;
 unsigned char ubyte_data = 43;
@@ -531,23 +533,26 @@ int putget_write_var1(int ncid, int *varid, PIO_Offset *index, int flavor)
     if ((ret = PIOc_put_var1_int(ncid, varid[3], index, &int_data)))
         return ret;
 
-    if ((ret = PIOc_put_var1_float(ncid, varid[4], index, &float_data)))
+    if ((ret = PIOc_put_var1_long(ncid, varid[4], index, &long_data)))
         return ret;
 
-    if ((ret = PIOc_put_var1_double(ncid, varid[5], index, &double_data)))
+    if ((ret = PIOc_put_var1_float(ncid, varid[5], index, &float_data)))
+        return ret;
+
+    if ((ret = PIOc_put_var1_double(ncid, varid[6], index, &double_data)))
         return ret;
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_put_var1_uchar(ncid, varid[6], index, &ubyte_data)))
+        if ((ret = PIOc_put_var1_uchar(ncid, varid[7], index, &ubyte_data)))
             return ret;
-        if ((ret = PIOc_put_var1_ushort(ncid, varid[7], index, &ushort_data)))
+        if ((ret = PIOc_put_var1_ushort(ncid, varid[8], index, &ushort_data)))
             return ret;
-        if ((ret = PIOc_put_var1_uint(ncid, varid[8], index, &uint_data)))
+        if ((ret = PIOc_put_var1_uint(ncid, varid[9], index, &uint_data)))
             return ret;
-        if ((ret = PIOc_put_var1_longlong(ncid, varid[9], index, &int64_data)))
+        if ((ret = PIOc_put_var1_longlong(ncid, varid[10], index, &int64_data)))
             return ret;
-        if ((ret = PIOc_put_var1_ulonglong(ncid, varid[10], index, &uint64_data)))
+        if ((ret = PIOc_put_var1_ulonglong(ncid, varid[11], index, &uint64_data)))
             return ret;
     }
 
@@ -571,23 +576,26 @@ int putget_write_var(int ncid, int *varid, int flavor)
     if ((ret = PIOc_put_var_int(ncid, varid[3], (int *)int_array)))
         return ret;
 
-    if ((ret = PIOc_put_var_float(ncid, varid[4], (float *)float_array)))
+    if ((ret = PIOc_put_var_long(ncid, varid[4], (long int *)long_array)))
         return ret;
 
-    if ((ret = PIOc_put_var_double(ncid, varid[5], (double *)double_array)))
+    if ((ret = PIOc_put_var_float(ncid, varid[5], (float *)float_array)))
+        return ret;
+
+    if ((ret = PIOc_put_var_double(ncid, varid[6], (double *)double_array)))
         return ret;
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_put_var_uchar(ncid, varid[6], (unsigned char *)ubyte_array)))
+        if ((ret = PIOc_put_var_uchar(ncid, varid[7], (unsigned char *)ubyte_array)))
             return ret;
-        if ((ret = PIOc_put_var_ushort(ncid, varid[7], (unsigned short *)ushort_array)))
+        if ((ret = PIOc_put_var_ushort(ncid, varid[8], (unsigned short *)ushort_array)))
             return ret;
-        if ((ret = PIOc_put_var_uint(ncid, varid[8], (unsigned int *)uint_array)))
+        if ((ret = PIOc_put_var_uint(ncid, varid[9], (unsigned int *)uint_array)))
             return ret;
-        if ((ret = PIOc_put_var_longlong(ncid, varid[9], (long long *)int64_array)))
+        if ((ret = PIOc_put_var_longlong(ncid, varid[10], (long long *)int64_array)))
             return ret;
-        if ((ret = PIOc_put_var_ulonglong(ncid, varid[10], (unsigned long long *)uint64_array)))
+        if ((ret = PIOc_put_var_ulonglong(ncid, varid[11], (unsigned long long *)uint64_array)))
             return ret;
     }
 
@@ -632,34 +640,33 @@ int test_write_atts(int ncid, int *varid, int flavor)
                                   ATT_LEN, (int *)int_array)))
         return ret;
 
-    /* Use long on same int var. */
-    if ((ret = PIOc_put_att_long(ncid, varid[3], LONG_ATT_NAME, PIO_INT,
+    if ((ret = PIOc_put_att_long(ncid, varid[4], LONG_ATT_NAME, PIO_INT,
                                  ATT_LEN, (long int *)long_array)))
         return ret;
 
-    if ((ret = PIOc_put_att_float(ncid, varid[4], FLOAT_ATT_NAME, PIO_FLOAT,
+    if ((ret = PIOc_put_att_float(ncid, varid[5], FLOAT_ATT_NAME, PIO_FLOAT,
                                   ATT_LEN, (float *)float_array)))
         return ret;
 
-    if ((ret = PIOc_put_att_double(ncid, varid[5], DOUBLE_ATT_NAME, PIO_DOUBLE,
+    if ((ret = PIOc_put_att_double(ncid, varid[6], DOUBLE_ATT_NAME, PIO_DOUBLE,
                                   ATT_LEN, (double *)double_array)))
         return ret;
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_put_att_uchar(ncid, varid[6], UCHAR_ATT_NAME, PIO_UBYTE,
+        if ((ret = PIOc_put_att_uchar(ncid, varid[7], UCHAR_ATT_NAME, PIO_UBYTE,
                                       ATT_LEN, (unsigned char *)ubyte_array)))
             return ret;
-        if ((ret = PIOc_put_att_ushort(ncid, varid[7], USHORT_ATT_NAME, PIO_SHORT,
+        if ((ret = PIOc_put_att_ushort(ncid, varid[8], USHORT_ATT_NAME, PIO_SHORT,
                                        ATT_LEN, (unsigned short *)ushort_array)))
             return ret;
-        if ((ret = PIOc_put_att_uint(ncid, varid[8], UINT_ATT_NAME, PIO_UINT,
+        if ((ret = PIOc_put_att_uint(ncid, varid[9], UINT_ATT_NAME, PIO_UINT,
                                      ATT_LEN, (unsigned int *)uint_array)))
             return ret;
-        if ((ret = PIOc_put_att_longlong(ncid, varid[9], INT64_ATT_NAME, PIO_INT64,
+        if ((ret = PIOc_put_att_longlong(ncid, varid[10], INT64_ATT_NAME, PIO_INT64,
                                          ATT_LEN, (long long *)int64_array)))
             return ret;
-        if ((ret = PIOc_put_att_ulonglong(ncid, varid[10], UINT64_ATT_NAME, PIO_UINT64,
+        if ((ret = PIOc_put_att_ulonglong(ncid, varid[11], UINT64_ATT_NAME, PIO_UINT64,
                                           ATT_LEN, (unsigned long long *)uint64_array)))
             return ret;
     }
@@ -682,6 +689,7 @@ int test_read_att(int ncid, int *varid, int flavor)
     short short_array_in[ATT_LEN];
     unsigned char ubyte_array_in[ATT_LEN];
     int int_array_in[ATT_LEN];
+    long int long_array_in[ATT_LEN];
     float float_array_in[ATT_LEN];
     double double_array_in[ATT_LEN];
     unsigned short ushort_array_in[ATT_LEN];
@@ -699,9 +707,11 @@ int test_read_att(int ncid, int *varid, int flavor)
         return ret;
     if ((ret = PIOc_get_att_int(ncid, varid[3], INT_ATT_NAME, int_array_in)))
         return ret;
-    if ((ret = PIOc_get_att_float(ncid, varid[4], FLOAT_ATT_NAME, float_array_in)))
+    if ((ret = PIOc_get_att_long(ncid, varid[4], LONG_ATT_NAME, long_array_in)))
         return ret;
-    if ((ret = PIOc_get_att_double(ncid, varid[5], DOUBLE_ATT_NAME, double_array_in)))
+    if ((ret = PIOc_get_att_float(ncid, varid[5], FLOAT_ATT_NAME, float_array_in)))
+        return ret;
+    if ((ret = PIOc_get_att_double(ncid, varid[6], DOUBLE_ATT_NAME, double_array_in)))
         return ret;
     for (x = 0; x < ATT_LEN; x++)
     {
@@ -713,6 +723,8 @@ int test_read_att(int ncid, int *varid, int flavor)
             return ERR_WRONG;
         if (int_array_in[x] != int_array[x][0])
             return ERR_WRONG;
+        if (long_array_in[x] != long_array[x][0])
+            return ERR_WRONG;
         if (float_array_in[x] != float_array[x][0])
             return ERR_WRONG;
         if (double_array_in[x] != double_array[x][0])
@@ -721,15 +733,15 @@ int test_read_att(int ncid, int *varid, int flavor)
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_get_att_uchar(ncid, varid[6], UCHAR_ATT_NAME, ubyte_array_in)))
+        if ((ret = PIOc_get_att_uchar(ncid, varid[7], UCHAR_ATT_NAME, ubyte_array_in)))
             return ret;
-        if ((ret = PIOc_get_att_ushort(ncid, varid[7], USHORT_ATT_NAME, ushort_array_in)))
+        if ((ret = PIOc_get_att_ushort(ncid, varid[8], USHORT_ATT_NAME, ushort_array_in)))
             return ret;
-        if ((ret = PIOc_get_att_uint(ncid, varid[8], UINT_ATT_NAME, uint_array_in)))
+        if ((ret = PIOc_get_att_uint(ncid, varid[9], UINT_ATT_NAME, uint_array_in)))
             return ret;
-        if ((ret = PIOc_get_att_longlong(ncid, varid[9], INT64_ATT_NAME, int64_array_in)))
+        if ((ret = PIOc_get_att_longlong(ncid, varid[10], INT64_ATT_NAME, int64_array_in)))
             return ret;
-        if ((ret = PIOc_get_att_ulonglong(ncid, varid[10], UINT64_ATT_NAME, uint64_array_in)))
+        if ((ret = PIOc_get_att_ulonglong(ncid, varid[11], UINT64_ATT_NAME, uint64_array_in)))
             return ret;
         for (x = 0; x < ATT_LEN; x++)
         {
@@ -767,23 +779,26 @@ int putget_write_vara(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count
     if ((ret = PIOc_put_vara_int(ncid, varid[3], start, count, (int *)int_array)))
         return ret;
 
-    if ((ret = PIOc_put_vara_float(ncid, varid[4], start, count, (float *)float_array)))
+    if ((ret = PIOc_put_vara_long(ncid, varid[4], start, count, (long int *)long_array)))
         return ret;
 
-    if ((ret = PIOc_put_vara_double(ncid, varid[5], start, count, (double *)double_array)))
+    if ((ret = PIOc_put_vara_float(ncid, varid[5], start, count, (float *)float_array)))
+        return ret;
+
+    if ((ret = PIOc_put_vara_double(ncid, varid[6], start, count, (double *)double_array)))
         return ret;
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_put_vara_uchar(ncid, varid[6], start, count, (unsigned char *)ubyte_array)))
+        if ((ret = PIOc_put_vara_uchar(ncid, varid[7], start, count, (unsigned char *)ubyte_array)))
             return ret;
-        if ((ret = PIOc_put_vara_ushort(ncid, varid[7], start, count, (unsigned short *)ushort_array)))
+        if ((ret = PIOc_put_vara_ushort(ncid, varid[8], start, count, (unsigned short *)ushort_array)))
             return ret;
-        if ((ret = PIOc_put_vara_uint(ncid, varid[8], start, count, (unsigned int *)uint_array)))
+        if ((ret = PIOc_put_vara_uint(ncid, varid[9], start, count, (unsigned int *)uint_array)))
             return ret;
-        if ((ret = PIOc_put_vara_longlong(ncid, varid[9], start, count, (long long *)int64_array)))
+        if ((ret = PIOc_put_vara_longlong(ncid, varid[10], start, count, (long long *)int64_array)))
             return ret;
-        if ((ret = PIOc_put_vara_ulonglong(ncid, varid[10], start, count, (unsigned long long *)uint64_array)))
+        if ((ret = PIOc_put_vara_ulonglong(ncid, varid[11], start, count, (unsigned long long *)uint64_array)))
             return ret;
     }
 
@@ -808,23 +823,26 @@ int putget_write_vars(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count
     if ((ret = PIOc_put_vars_int(ncid, varid[3], start, count, stride, (int *)int_array)))
         return ret;
 
-    if ((ret = PIOc_put_vars_float(ncid, varid[4], start, count, stride, (float *)float_array)))
+    if ((ret = PIOc_put_vars_long(ncid, varid[4], start, count, stride, (long int *)long_array)))
         return ret;
 
-    if ((ret = PIOc_put_vars_double(ncid, varid[5], start, count, stride, (double *)double_array)))
+    if ((ret = PIOc_put_vars_float(ncid, varid[5], start, count, stride, (float *)float_array)))
+        return ret;
+
+    if ((ret = PIOc_put_vars_double(ncid, varid[6], start, count, stride, (double *)double_array)))
         return ret;
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_put_vars_uchar(ncid, varid[6], start, count, stride, (unsigned char *)ubyte_array)))
+        if ((ret = PIOc_put_vars_uchar(ncid, varid[7], start, count, stride, (unsigned char *)ubyte_array)))
             return ret;
-        if ((ret = PIOc_put_vars_ushort(ncid, varid[7], start, count, stride, (unsigned short *)ushort_array)))
+        if ((ret = PIOc_put_vars_ushort(ncid, varid[8], start, count, stride, (unsigned short *)ushort_array)))
             return ret;
-        if ((ret = PIOc_put_vars_uint(ncid, varid[8], start, count, stride, (unsigned int *)uint_array)))
+        if ((ret = PIOc_put_vars_uint(ncid, varid[9], start, count, stride, (unsigned int *)uint_array)))
             return ret;
-        if ((ret = PIOc_put_vars_longlong(ncid, varid[9], start, count, stride, (long long *)int64_array)))
+        if ((ret = PIOc_put_vars_longlong(ncid, varid[10], start, count, stride, (long long *)int64_array)))
             return ret;
-        if ((ret = PIOc_put_vars_ulonglong(ncid, varid[10], start, count, stride, (unsigned long long *)uint64_array)))
+        if ((ret = PIOc_put_vars_ulonglong(ncid, varid[11], start, count, stride, (unsigned long long *)uint64_array)))
             return ret;
     }
 
@@ -839,6 +857,7 @@ int putget_read_var1(int ncid, int *varid, PIO_Offset *index, int flavor)
     short short_data_in;
     unsigned char ubyte_data_in;
     int int_data_in;
+    long int long_data_in;
     float float_data_in;
     double double_data_in;
     unsigned short ushort_data_in;
@@ -877,35 +896,40 @@ int putget_read_var1(int ncid, int *varid, PIO_Offset *index, int flavor)
     if (int_data_in != int_data)
         return ERR_WRONG;
 
-    if ((ret = PIOc_get_var1_float(ncid, varid[4], index, &float_data_in)))
+    if ((ret = PIOc_get_var1_long(ncid, varid[4], index, &long_data_in)))
+        return ret;
+    if (long_data_in != long_data)
+        return ERR_WRONG;
+
+    if ((ret = PIOc_get_var1_float(ncid, varid[5], index, &float_data_in)))
         return ret;
     if (float_data_in != float_data)
         return ERR_WRONG;
 
-    if ((ret = PIOc_get_var1_double(ncid, varid[5], index, &double_data_in)))
+    if ((ret = PIOc_get_var1_double(ncid, varid[6], index, &double_data_in)))
         return ret;
     if (double_data_in != double_data)
         return ERR_WRONG;
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_get_var1_uchar(ncid, varid[6], index, &ubyte_data_in)))
+        if ((ret = PIOc_get_var1_uchar(ncid, varid[7], index, &ubyte_data_in)))
             return ret;
         if (ubyte_data_in != ubyte_data)
             return ERR_WRONG;
-        if ((ret = PIOc_get_var1_ushort(ncid, varid[7], index, &ushort_data_in)))
+        if ((ret = PIOc_get_var1_ushort(ncid, varid[8], index, &ushort_data_in)))
             return ret;
         if (ushort_data_in != ushort_data)
             return ERR_WRONG;
-        if ((ret = PIOc_get_var1_uint(ncid, varid[8], index, &uint_data_in)))
+        if ((ret = PIOc_get_var1_uint(ncid, varid[9], index, &uint_data_in)))
             return ret;
         if (uint_data_in != uint_data)
             return ERR_WRONG;
-        if ((ret = PIOc_get_var1_longlong(ncid, varid[9], index, &int64_data_in)))
+        if ((ret = PIOc_get_var1_longlong(ncid, varid[10], index, &int64_data_in)))
             return ret;
         if (int64_data_in != int64_data)
             return ERR_WRONG;
-        if ((ret = PIOc_get_var1_ulonglong(ncid, varid[10], index, &uint64_data_in)))
+        if ((ret = PIOc_get_var1_ulonglong(ncid, varid[11], index, &uint64_data_in)))
             return ret;
         if (uint64_data_in != uint64_data)
             return ERR_WRONG;
@@ -929,6 +953,7 @@ int putget_read_var(int ncid, int *varid, int unlim, int flavor)
     short short_array_in[X_DIM_LEN][Y_DIM_LEN];
     unsigned char ubyte_array_in[X_DIM_LEN][Y_DIM_LEN];
     int int_array_in[X_DIM_LEN][Y_DIM_LEN];
+    long int long_array_in[X_DIM_LEN][Y_DIM_LEN];
     float float_array_in[X_DIM_LEN][Y_DIM_LEN];
     double double_array_in[X_DIM_LEN][Y_DIM_LEN];
     unsigned short ushort_array_in[X_DIM_LEN][Y_DIM_LEN];
@@ -954,9 +979,11 @@ int putget_read_var(int ncid, int *varid, int unlim, int flavor)
         return ret;
     if ((ret = PIOc_get_var_int(ncid, varid[3], (int *)int_array_in)))
         return ret;
-    if ((ret = PIOc_get_var_float(ncid, varid[4], (float *)float_array_in)))
+    if ((ret = PIOc_get_var_long(ncid, varid[4], (long int *)long_array_in)))
         return ret;
-    if ((ret = PIOc_get_var_double(ncid, varid[5], (double *)double_array_in)))
+    if ((ret = PIOc_get_var_float(ncid, varid[5], (float *)float_array_in)))
+        return ret;
+    if ((ret = PIOc_get_var_double(ncid, varid[6], (double *)double_array_in)))
         return ret;
     for (x = 0; x < X_DIM_LEN; x++)
     {
@@ -970,6 +997,8 @@ int putget_read_var(int ncid, int *varid, int unlim, int flavor)
                 return ERR_WRONG;
             if (int_array_in[x][y] != int_array[x][y])
                 return ERR_WRONG;
+            if (long_array_in[x][y] != long_array[x][y])
+                return ERR_WRONG;
             if (float_array_in[x][y] != float_array[x][y])
                 return ERR_WRONG;
             if (double_array_in[x][y] != double_array[x][y])
@@ -979,15 +1008,15 @@ int putget_read_var(int ncid, int *varid, int unlim, int flavor)
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_get_var_uchar(ncid, varid[6], (unsigned char *)ubyte_array_in)))
+        if ((ret = PIOc_get_var_uchar(ncid, varid[7], (unsigned char *)ubyte_array_in)))
             return ret;
-        if ((ret = PIOc_get_var_ushort(ncid, varid[7], (unsigned short *)ushort_array_in)))
+        if ((ret = PIOc_get_var_ushort(ncid, varid[8], (unsigned short *)ushort_array_in)))
             return ret;
-        if ((ret = PIOc_get_var_uint(ncid, varid[8], (unsigned int *)uint_array_in)))
+        if ((ret = PIOc_get_var_uint(ncid, varid[9], (unsigned int *)uint_array_in)))
             return ret;
-        if ((ret = PIOc_get_var_longlong(ncid, varid[9], (long long *)int64_array_in)))
+        if ((ret = PIOc_get_var_longlong(ncid, varid[10], (long long *)int64_array_in)))
             return ret;
-        if ((ret = PIOc_get_var_ulonglong(ncid, varid[10], (unsigned long long *)uint64_array_in)))
+        if ((ret = PIOc_get_var_ulonglong(ncid, varid[11], (unsigned long long *)uint64_array_in)))
             return ret;
         for (x = 0; x < X_DIM_LEN; x++)
             for (y = 0; y < Y_DIM_LEN; y++)
@@ -1017,6 +1046,7 @@ int putget_read_vara(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
     short short_array_in[X_DIM_LEN][Y_DIM_LEN];
     unsigned char ubyte_array_in[X_DIM_LEN][Y_DIM_LEN];
     int int_array_in[X_DIM_LEN][Y_DIM_LEN];
+    long int long_array_in[X_DIM_LEN][Y_DIM_LEN];
     float float_array_in[X_DIM_LEN][Y_DIM_LEN];
     double double_array_in[X_DIM_LEN][Y_DIM_LEN];
     unsigned short ushort_array_in[X_DIM_LEN][Y_DIM_LEN];
@@ -1034,9 +1064,11 @@ int putget_read_vara(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
         return ret;
     if ((ret = PIOc_get_vara_int(ncid, varid[3], start, count, (int *)int_array_in)))
         return ret;
-    if ((ret = PIOc_get_vara_float(ncid, varid[4], start, count, (float *)float_array_in)))
+    if ((ret = PIOc_get_vara_long(ncid, varid[4], start, count, (long int *)long_array_in)))
         return ret;
-    if ((ret = PIOc_get_vara_double(ncid, varid[5], start, count, (double *)double_array_in)))
+    if ((ret = PIOc_get_vara_float(ncid, varid[5], start, count, (float *)float_array_in)))
+        return ret;
+    if ((ret = PIOc_get_vara_double(ncid, varid[6], start, count, (double *)double_array_in)))
         return ret;
 
     for (x = 0; x < X_DIM_LEN; x++)
@@ -1051,6 +1083,8 @@ int putget_read_vara(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
                 return ERR_WRONG;
             if (int_array_in[x][y] != int_array[x][y])
                 return ERR_WRONG;
+            if (long_array_in[x][y] != long_array[x][y])
+                return ERR_WRONG;
             if (float_array_in[x][y] != float_array[x][y])
                 return ERR_WRONG;
             if (double_array_in[x][y] != double_array[x][y])
@@ -1060,16 +1094,16 @@ int putget_read_vara(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_get_vara_uchar(ncid, varid[6], start, count, (unsigned char *)ubyte_array_in)))
+        if ((ret = PIOc_get_vara_uchar(ncid, varid[7], start, count, (unsigned char *)ubyte_array_in)))
             return ret;
 
-        if ((ret = PIOc_get_vara_ushort(ncid, varid[7], start, count, (unsigned short *)ushort_array_in)))
+        if ((ret = PIOc_get_vara_ushort(ncid, varid[8], start, count, (unsigned short *)ushort_array_in)))
             return ret;
-        if ((ret = PIOc_get_vara_uint(ncid, varid[8], start, count, (unsigned int *)uint_array_in)))
+        if ((ret = PIOc_get_vara_uint(ncid, varid[9], start, count, (unsigned int *)uint_array_in)))
             return ret;
-        if ((ret = PIOc_get_vara_longlong(ncid, varid[9], start, count, (long long *)int64_array_in)))
+        if ((ret = PIOc_get_vara_longlong(ncid, varid[10], start, count, (long long *)int64_array_in)))
             return ret;
-        if ((ret = PIOc_get_vara_ulonglong(ncid, varid[10], start, count, (unsigned long long *)uint64_array_in)))
+        if ((ret = PIOc_get_vara_ulonglong(ncid, varid[11], start, count, (unsigned long long *)uint64_array_in)))
             return ret;
         for (x = 0; x < X_DIM_LEN; x++)
             for (y = 0; y < Y_DIM_LEN; y++)
@@ -1099,6 +1133,7 @@ int putget_read_vars(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
     short short_array_in[X_DIM_LEN][Y_DIM_LEN];
     unsigned char ubyte_array_in[X_DIM_LEN][Y_DIM_LEN];
     int int_array_in[X_DIM_LEN][Y_DIM_LEN];
+    long int long_array_in[X_DIM_LEN][Y_DIM_LEN];
     float float_array_in[X_DIM_LEN][Y_DIM_LEN];
     double double_array_in[X_DIM_LEN][Y_DIM_LEN];
     unsigned short ushort_array_in[X_DIM_LEN][Y_DIM_LEN];
@@ -1116,9 +1151,11 @@ int putget_read_vars(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
         return ret;
     if ((ret = PIOc_get_vars_int(ncid, varid[3], start, count, stride, (int *)int_array_in)))
         return ret;
-    if ((ret = PIOc_get_vars_float(ncid, varid[4], start, count, stride, (float *)float_array_in)))
+    if ((ret = PIOc_get_vars_long(ncid, varid[4], start, count, stride, (long int *)long_array_in)))
         return ret;
-    if ((ret = PIOc_get_vars_double(ncid, varid[5], start, count, stride, (double *)double_array_in)))
+    if ((ret = PIOc_get_vars_float(ncid, varid[5], start, count, stride, (float *)float_array_in)))
+        return ret;
+    if ((ret = PIOc_get_vars_double(ncid, varid[6], start, count, stride, (double *)double_array_in)))
         return ret;
 
     for (x = 0; x < X_DIM_LEN; x++)
@@ -1133,6 +1170,8 @@ int putget_read_vars(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
                 return ERR_WRONG;
             if (int_array_in[x][y] != int_array[x][y])
                 return ERR_WRONG;
+            if (long_array_in[x][y] != long_array[x][y])
+                return ERR_WRONG;
             if (float_array_in[x][y] != float_array[x][y])
                 return ERR_WRONG;
             if (double_array_in[x][y] != double_array[x][y])
@@ -1142,16 +1181,16 @@ int putget_read_vars(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
 
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
     {
-        if ((ret = PIOc_get_vars_uchar(ncid, varid[6], start, count, stride, (unsigned char *)ubyte_array_in)))
+        if ((ret = PIOc_get_vars_uchar(ncid, varid[7], start, count, stride, (unsigned char *)ubyte_array_in)))
             return ret;
 
-        if ((ret = PIOc_get_vars_ushort(ncid, varid[7], start, count, stride, (unsigned short *)ushort_array_in)))
+        if ((ret = PIOc_get_vars_ushort(ncid, varid[8], start, count, stride, (unsigned short *)ushort_array_in)))
             return ret;
-        if ((ret = PIOc_get_vars_uint(ncid, varid[8], start, count, stride, (unsigned int *)uint_array_in)))
+        if ((ret = PIOc_get_vars_uint(ncid, varid[9], start, count, stride, (unsigned int *)uint_array_in)))
             return ret;
-        if ((ret = PIOc_get_vars_longlong(ncid, varid[9], start, count, stride, (long long *)int64_array_in)))
+        if ((ret = PIOc_get_vars_longlong(ncid, varid[10], start, count, stride, (long long *)int64_array_in)))
             return ret;
-        if ((ret = PIOc_get_vars_ulonglong(ncid, varid[10], start, count, stride, (unsigned long long *)uint64_array_in)))
+        if ((ret = PIOc_get_vars_ulonglong(ncid, varid[11], start, count, stride, (unsigned long long *)uint64_array_in)))
             return ret;
         for (x = 0; x < X_DIM_LEN; x++)
             for (y = 0; y < Y_DIM_LEN; y++)
@@ -1192,10 +1231,10 @@ int create_putget_file(int iosysid, int access, int unlim, int flavor, int *dim_
 {
     char iotype_name[PIO_MAX_NAME + 1];
     int dimids[NDIM];        /* The dimension IDs. */
-    int num_vars = NUM_CLASSIC_TYPES;
-    int xtype[NUM_NETCDF4_TYPES] = {PIO_BYTE, PIO_CHAR, PIO_SHORT, PIO_INT, PIO_FLOAT,
-                                    PIO_DOUBLE, PIO_UBYTE, PIO_USHORT, PIO_UINT, PIO_INT64,
-                                    PIO_UINT64, PIO_STRING};
+    int num_vars = NUM_CLASSIC_TYPES + 1;
+    int xtype[NUM_NETCDF4_TYPES + 1] = {PIO_BYTE, PIO_CHAR, PIO_SHORT, PIO_INT, PIO_LONG_INTERNAL,
+                                        PIO_FLOAT, PIO_DOUBLE, PIO_UBYTE, PIO_USHORT, PIO_UINT, PIO_INT64,
+                                        PIO_UINT64, PIO_STRING};
     int ncid;
     int ret;
 
@@ -1220,14 +1259,15 @@ int create_putget_file(int iosysid, int access, int unlim, int flavor, int *dim_
 
     /* For netcdf-4, there are extra types. */
     if (flavor == PIO_IOTYPE_NETCDF4C || flavor == PIO_IOTYPE_NETCDF4P)
-        num_vars = NUM_NETCDF4_TYPES;
+        num_vars = NUM_NETCDF4_TYPES + 1;
 
     /* Define variables. */
     for (int v = 0; v < num_vars; v++)
     {
         char var_name[PIO_MAX_NAME + 1];
         snprintf(var_name, PIO_MAX_NAME, "%s_%d", VAR_NAME, xtype[v]);
-        if ((ret = PIOc_def_var(ncid, var_name, xtype[v], NDIM, dimids, &varid[v])))
+        nc_type my_type = xtype[v] == PIO_LONG_INTERNAL ? PIO_INT : xtype[v];
+        if ((ret = PIOc_def_var(ncid, var_name, my_type, NDIM, dimids, &varid[v])))
             return ret;
     }
 
@@ -1434,7 +1474,7 @@ int main(int argc, char **argv)
     /* Initialize data arrays with sample data. */
     init_arrays();
 
-    return run_test_main(argc, argv, MIN_NTASKS, TARGET_NTASKS, 0,
+    return run_test_main(argc, argv, MIN_NTASKS, TARGET_NTASKS, 3,
                          TEST_NAME, dim_len, COMPONENT_COUNT, NUM_IO_PROCS);
 
     return 0;


### PR DESCRIPTION
Fixes #555.
Fixes #550.
Fixes #528.
Fixes #420.
Fixes #557.

In netCDF the handling of long ints was a momentary lapse in judgement. The netcdf.h file assumes that long ints are the same as ints. (NC_INT = NC_LONG). However, that is no longer true.

To handle this I needed to add an internal type, PIO_LONG_INTERNAL. This type may not be used to create variables or attributes, but is used internally when one of the _long() functions are called, to indicated that the buffer is allocated in terms of long int (whatever that size is on that machine).

Also added tests relating to these changes.

I will merge to develop after my local jenkins builds all it's variants on my branch on my machine.

I have merged to develop for testing.

