### PR TITLE
fix issue in openfile_retry

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -498,7 +498,7 @@ int PIOc_sync(int ncid)
     if (file->mode & PIO_WRITE)
     {
         LOG((3, "PIOc_sync checking buffers"));
-        
+
         /*  cn_buffer_report( *ios, true); */
         wmb = &file->buffer;
         while (wmb)
@@ -545,7 +545,7 @@ int PIOc_sync(int ncid)
                 return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
             }
         }
-        LOG((2, "PIOc_sync ierr = %d", ierr));        
+        LOG((2, "PIOc_sync ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -20,7 +20,7 @@ void init_rearr_opts(iosystem_desc_t *iosys)
     const rearr_comm_fc_opt_t def_coll_comm_fc_opts = { false, false, 0 };
 
     assert(iosys);
-    
+
     /* Default to coll - i.e., no flow control */
     iosys->rearr_opts.comm_type = PIO_REARR_COMM_COLL;
     iosys->rearr_opts.fcd = PIO_REARR_COMM_FC_2D_DISABLE;
@@ -524,7 +524,7 @@ int compute_counts(iosystem_desc_t ios, io_desc_t *iodesc, int maplen,
         /* Allocate memory to hold array of tasks that have recieved
          * data ??? */
         if (!(recv_buf = calloc(ntasks, sizeof(int))))
-            return pio_err(&ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);            
+            return pio_err(&ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
         /* Initialize arrays that keep track of receives. */
         for (i = 0; i < ntasks; i++)
@@ -1522,7 +1522,7 @@ int subset_rearrange_create(iosystem_desc_t ios, int maplen, PIO_Offset *compmap
         if (iodesc->llen > 0)
         {
             if (!(srcindex = calloc(iodesc->llen, sizeof(PIO_Offset))))
-                return pio_err(&ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);                
+                return pio_err(&ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
             for (i = 0; i < iodesc->llen; i++)
                 srcindex[i] = 0;
@@ -1537,7 +1537,7 @@ int subset_rearrange_create(iosystem_desc_t ios, int maplen, PIO_Offset *compmap
         }
     }
     if ((ret = determine_fill(ios, iodesc, gsize, compmap)))
-        return pio_err(&ios, NULL, ret, __FILE__, __LINE__);        
+        return pio_err(&ios, NULL, ret, __FILE__, __LINE__);
 
     /* Pass the sindex from each compute task to its associated IO task. */
     if ((mpierr = MPI_Gatherv(iodesc->sindex, iodesc->scount[0], PIO_OFFSET,
@@ -1559,7 +1559,7 @@ int subset_rearrange_create(iosystem_desc_t ios, int maplen, PIO_Offset *compmap
     if (maplen>iodesc->scount[0] && iodesc->scount[0] > 0)
     {
         if (!(shrtmap = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
-            return pio_err(&ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);            
+            return pio_err(&ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
         j = 0;
         for (i = 0; i < maplen; i++)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -250,9 +250,9 @@ void pio_log(int severity, const char *fmt, ...)
 
 /**
  * Obtain a backtrace and print it to stderr. This is appended to the
- * text decomposition file. 
+ * text decomposition file.
  *
- * Note from Jim: 
+ * Note from Jim:
  *
  * The stack trace can be used to identify the usage in
  * the model code of the particular decomposition in question and so
@@ -1107,6 +1107,8 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,
 #else
             file->mode = file->mode |  NC_MPIIO;
             ierr = nc_open_par(filename, file->mode, ios->io_comm, ios->info, &file->fh);
+	    LOG((2, "PIOc_openfile_retry:nc_open_par filename = %s mode = %d ierr = %d",
+		 filename, file->mode, ierr));
 #endif
             break;
 
@@ -1161,6 +1163,10 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,
                 if (ios->io_rank == 0)
                     ierr = nc_open(filename, file->mode, &file->fh);
             }
+            LOG((2, "retry nc_open(%s) : fd = %d, ierr = %d", filename, file->fh, ierr));
+	    if (ios->io_rank != 0)
+		file->do_io = 0;
+
 #endif
         }
     }
@@ -1436,7 +1442,7 @@ static bool cmp_rearr_opts(const rearr_opt_t *rearr_opts,
 static void check_and_reset_rearr_opts(iosystem_desc_t *ios)
 {
     /* Disable handshake/isend and set max_pend_req to unlimited */
-    const rearr_comm_fc_opt_t def_comm_nofc_opts = 
+    const rearr_comm_fc_opt_t def_comm_nofc_opts =
         { false, false, PIO_REARR_COMM_UNLIMITED_PEND_REQ };
     /* Disable handshake /isend and set max_pend_req = 0 to turn off throttling */
     const rearr_comm_fc_opt_t def_coll_comm_fc_opts = { false, false, 0 };


### PR DESCRIPTION
The retry portion of openfile_retry was not working because file->do_io needed to be reset to the 
correct serial netcdf value.     There are several whitespace changes in this PR indicating that someone is still committing files with white space additions.

Will merge to develop for testing. 