### PR TITLE
change default fill mode for PIOc_createfile()

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -18,6 +18,9 @@ int pio_next_ncid = 16;
  * If the open fails, try again as netCDF serial before giving
  * up. Input parameters are read on comp task 0 and ignored elsewhere.
  *
+ * Note that the file is opened with default fill mode, NOFILL for
+ * pnetcdf, and FILL for netCDF classic and netCDF-4 files.
+ *
  * @param iosysid : A defined pio system descriptor (input)
  * @param ncidp : A pio file descriptor (output)
  * @param iotype : A pio output format (input)
@@ -83,7 +86,8 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
 
 /**
  * Create a new file using pio. Input parameters are read on comp task
- * 0 and ignored elsewhere. NOFILL will be turned on in all cases.
+ * 0 and ignored elsewhere. NOFILL mode will be turned on in all
+ * cases.
  *
  * @param iosysid A defined pio system ID, obtained from
  * PIOc_InitIntercomm() or PIOc_InitAsync().
@@ -97,7 +101,8 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
  * @returns 0 for success, error code otherwise.
  * @ingroup PIO_createfile
  */
-int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, int mode)
+int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
+                    int mode)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -29,7 +29,17 @@ int pio_next_ncid = 16;
 int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
                   int mode)
 {
-    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1);
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    int ret;               /* Return code from function calls. */
+
+    /* Get the IO system info from the id. */
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+    if ((ret = PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+
+    return PIO_NOERR;
 }
 
 /**
@@ -93,14 +103,13 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
     file_desc_t *file;     /* Pointer to file information. */
     int ret;               /* Return code from function calls. */
 
+    /* Get the IO system info from the id. */
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
     /* Create the file. */
     if ((ret = PIOc_createfile_int(iosysid, ncidp, iotype, filename, mode)))
-        return ret;
-
-    /* Find the info about this file. */
-    if ((ret = pio_get_file(*ncidp, &file)))
-        return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
-    ios = file->iosystem;
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Run this on all tasks if async is not in use, but only on
      * non-IO tasks if async is in use. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -32,17 +32,7 @@ int pio_next_ncid = 16;
 int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
                   int mode)
 {
-    iosystem_desc_t *ios;  /* Pointer to io system information. */
-    int ret;               /* Return code from function calls. */
-
-    /* Get the IO system info from the id. */
-    if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
-
-    if ((ret = PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-
-    return PIO_NOERR;
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1);
 }
 
 /**

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -73,7 +73,7 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
 
 /**
  * Create a new file using pio. Input parameters are read on comp task
- * 0 and ignored elsewhere.
+ * 0 and ignored elsewhere. NOFILL will be turned on in all cases.
  *
  * @param iosysid A defined pio system ID, obtained from
  * PIOc_InitIntercomm() or PIOc_InitAsync().
@@ -91,162 +91,36 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename, 
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
-    int ierr;              /* Return code from function calls. */
-    int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
+    int ret;               /* Return code from function calls. */
 
-    /* Get the IO system info from the iosysid. */
-    if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+    /* Create the file. */
+    if ((ret = PIOc_createfile_int(iosysid, ncidp, iotype, filename, mode)))
+        return ret;
 
-    /* User must provide valid input for these parameters. */
-    if (!ncidp || !iotype || !filename || strlen(filename) > NC_MAX_NAME)
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+    /* Find the info about this file. */
+    if ((ret = pio_get_file(*ncidp, &file)))
+        return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
+    ios = file->iosystem;
 
-    /* A valid iotype must be specified. */
-    if (!iotype_is_valid(*iotype))
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
-
-    LOG((1, "PIOc_createfile iosysid = %d iotype = %d filename = %s mode = %d",
-         iosysid, *iotype, filename, mode));
-
-    /* Allocate space for the file info. */
-    if (!(file = calloc(sizeof(file_desc_t), 1)))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-
-    /* Fill in some file values. */
-    file->fh = -1;
-    file->iosystem = ios;
-    file->iotype = *iotype;
-    file->buffer.ioid = -1;
-    for (int i = 0; i < PIO_MAX_VARS; i++)
+    /* Run this on all tasks if async is not in use, but only on
+     * non-IO tasks if async is in use. */
+    if (!ios->async_interface || !ios->ioproc)
     {
-        file->varlist[i].record = -1;
-        file->varlist[i].ndims = -1;
-    }
-    file->mode = mode;
-
-    /* Set to true if this task should participate in IO (only true for
-     * one task with netcdf serial files. */
-    if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
-        ios->io_rank == 0)
-        file->do_io = 1;
-
-    LOG((2, "file->do_io = %d ios->async_interface = %d", file->do_io, ios->async_interface));
-
-    /* If async is in use, and this is not an IO task, bcast the
-     * parameters. */
-    if (ios->async_interface)
-    {
-        int msg = PIO_MSG_CREATE_FILE;
-        size_t len = strlen(filename);
-
-        if (!ios->ioproc)
-        {
-            /* Send the message to the message handler. */
-            if (ios->compmaster == MPI_ROOT)
-                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-
-            /* Send the parameters of the function call. */
-            if (!mpierr)
-                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            LOG((2, "len = %d filename = %s iotype = %d mode = %d", len, filename,
-                 file->iotype, file->mode));
-        }
-
-        /* Handle MPI errors. */
-        LOG((2, "handling mpi errors mpierr = %d", mpierr));
-        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            return check_mpi(file, mpierr2, __FILE__, __LINE__);
-        if (mpierr)
-            return check_mpi(file, mpierr, __FILE__, __LINE__);
+        /* Set the fill mode to NOFILL. */
+        if ((ret = PIOc_set_fill(*ncidp, NC_NOFILL, NULL)))
+            return ret;
     }
 
-    /* If this task is in the IO component, do the IO. */
-    if (ios->ioproc)
-    {
-        switch (file->iotype)
-        {
-#ifdef _NETCDF
-#ifdef _NETCDF4
-        case PIO_IOTYPE_NETCDF4P:
-            file->mode = file->mode |  NC_MPIIO | NC_NETCDF4;
-            LOG((2, "Calling nc_create_par io_comm = %d mode = %d fh = %d",
-                 ios->io_comm, file->mode, file->fh));
-            ierr = nc_create_par(filename, file->mode, ios->io_comm, ios->info, &file->fh);
-            LOG((2, "nc_create_par returned %d file->fh = %d", ierr, file->fh));
-            break;
-        case PIO_IOTYPE_NETCDF4C:
-            file->mode = file->mode | NC_NETCDF4;
-#endif
-        case PIO_IOTYPE_NETCDF:
-            if (!ios->io_rank)
-            {
-                LOG((2, "Calling nc_create mode = %d", file->mode));
-                ierr = nc_create(filename, file->mode, &file->fh);
-            }
-            break;
-#endif
-#ifdef _PNETCDF
-        case PIO_IOTYPE_PNETCDF:
-            LOG((2, "Calling ncmpi_create mode = %d", file->mode));
-            ierr = ncmpi_create(ios->io_comm, filename, file->mode, ios->info, &file->fh);
-            if (!ierr)
-                ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
-            break;
-#endif
-        }
-    }
-
-    /* Broadcast and check the return code. */
-    if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);
-
-    /* If there was an error, free the memory we allocated and handle error. */
-    if (ierr)
-    {
-        free(file);
-        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
-    }
-
-    /* Broadcast mode to all tasks. */
-    if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);
-
-    /* This flag is implied by netcdf create functions but we need
-       to know if its set. */
-    file->mode = file->mode | PIO_WRITE;
-
-    /* Assign the PIO ncid, necessary because files may be opened
-     * on mutilple iosystems, causing the underlying library to
-     * reuse ncids. Hilarious confusion ensues. */
-    file->pio_ncid = pio_next_ncid++;
-    LOG((2, "file->fh = %d file->pio_ncid = %d", file->fh, file->pio_ncid));
-
-    /* Return the ncid to the caller. */
-    *ncidp = file->pio_ncid;
-
-    /* Add the struct with this files info to the global list of
-     * open files. */
-    pio_add_to_file_list(file);
-
-    LOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
-         file->fh, file->pio_ncid));
-
-    return ierr;
+    return ret;
 }
 
 /**
- * Open a new file using pio. Input parameters are read on comp task
- * 0 and ignored elsewhere.
+ * Open a new file using pio. The default fill mode will be used (FILL
+ * for netCDF and netCDF-4 formats, NOFILL for pnetcdf.) Input
+ * parameters are read on comp task 0 and ignored elsewhere.
  *
  * @param iosysid : A defined pio system descriptor (input)
- * @param cmode : The netcdf mode for the create operation
+ * @param cmode : The netcdf mode for the create operation. 
  * @param filename : The filename to open
  * @param ncidp : A pio file descriptor (output)
  * @return 0 for success, error code otherwise.
@@ -272,7 +146,7 @@ int PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
             iotype = PIO_IOTYPE_NETCDF;
     }
 
-    return PIOc_createfile(iosysid, ncidp, &iotype, filename, cmode);
+    return PIOc_createfile_int(iosysid, ncidp, &iotype, filename, cmode);
 }
 
 /**

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -109,6 +109,9 @@ extern "C" {
     void pio_add_to_file_list(file_desc_t *file);
     void pio_push_request(file_desc_t *file, int request);
 
+    /* Create a file (internal function). */
+    int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename, int mode);
+
     /* Open a file with optional retry as netCDF-classic if first
      * iotype does not work. */
     int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -996,6 +996,178 @@ int PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
 }
 
 /**
+ * Create a new file using pio. This is an internal function that is
+ * called by both PIOc_create() and PIOc_createfile(). Input
+ * parameters are read on comp task 0 and ignored elsewhere.
+ *
+ * @param iosysid A defined pio system ID, obtained from
+ * PIOc_InitIntercomm() or PIOc_InitAsync().
+ * @param ncidp A pointer that gets the ncid of the newly created
+ * file.
+ * @param iotype A pointer to a pio output format. Must be one of
+ * PIO_IOTYPE_PNETCDF, PIO_IOTYPE_NETCDF, PIO_IOTYPE_NETCDF4C, or
+ * PIO_IOTYPE_NETCDF4P.
+ * @param filename The filename to create.
+ * @param mode The netcdf mode for the create operation.
+ * @returns 0 for success, error code otherwise.
+ * @ingroup PIO_createfile
+ */
+int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
+                        int mode)
+{
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    file_desc_t *file;     /* Pointer to file information. */
+    int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
+    int ierr;              /* Return code from function calls. */
+
+    /* Get the IO system info from the iosysid. */
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+    /* User must provide valid input for these parameters. */
+    if (!ncidp || !iotype || !filename || strlen(filename) > NC_MAX_NAME)
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+
+    /* A valid iotype must be specified. */
+    if (!iotype_is_valid(*iotype))
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+
+    LOG((1, "PIOc_createfile iosysid = %d iotype = %d filename = %s mode = %d",
+         iosysid, *iotype, filename, mode));
+
+    /* Allocate space for the file info. */
+    if (!(file = calloc(sizeof(file_desc_t), 1)))
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+
+    /* Fill in some file values. */
+    file->fh = -1;
+    file->iosystem = ios;
+    file->iotype = *iotype;
+    file->buffer.ioid = -1;
+    for (int i = 0; i < PIO_MAX_VARS; i++)
+    {
+        file->varlist[i].record = -1;
+        file->varlist[i].ndims = -1;
+    }
+    file->mode = mode;
+
+    /* Set to true if this task should participate in IO (only true for
+     * one task with netcdf serial files. */
+    if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
+        ios->io_rank == 0)
+        file->do_io = 1;
+
+    LOG((2, "file->do_io = %d ios->async_interface = %d", file->do_io, ios->async_interface));
+
+    /* If async is in use, and this is not an IO task, bcast the
+     * parameters. */
+    if (ios->async_interface)
+    {
+        int msg = PIO_MSG_CREATE_FILE;
+        size_t len = strlen(filename);
+
+        if (!ios->ioproc)
+        {
+            /* Send the message to the message handler. */
+            if (ios->compmaster == MPI_ROOT)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+
+            /* Send the parameters of the function call. */
+            if (!mpierr)
+                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            LOG((2, "len = %d filename = %s iotype = %d mode = %d", len, filename,
+                 file->iotype, file->mode));
+        }
+
+        /* Handle MPI errors. */
+        LOG((2, "handling mpi errors mpierr = %d", mpierr));
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(file, mpierr2, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
+    }
+
+    /* If this task is in the IO component, do the IO. */
+    if (ios->ioproc)
+    {
+        switch (file->iotype)
+        {
+#ifdef _NETCDF
+#ifdef _NETCDF4
+        case PIO_IOTYPE_NETCDF4P:
+            file->mode = file->mode |  NC_MPIIO | NC_NETCDF4;
+            LOG((2, "Calling nc_create_par io_comm = %d mode = %d fh = %d",
+                 ios->io_comm, file->mode, file->fh));
+            ierr = nc_create_par(filename, file->mode, ios->io_comm, ios->info, &file->fh);
+            LOG((2, "nc_create_par returned %d file->fh = %d", ierr, file->fh));
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            file->mode = file->mode | NC_NETCDF4;
+#endif
+        case PIO_IOTYPE_NETCDF:
+            if (!ios->io_rank)
+            {
+                LOG((2, "Calling nc_create mode = %d", file->mode));
+                ierr = nc_create(filename, file->mode, &file->fh);
+            }
+            break;
+#endif
+#ifdef _PNETCDF
+        case PIO_IOTYPE_PNETCDF:
+            LOG((2, "Calling ncmpi_create mode = %d", file->mode));
+            ierr = ncmpi_create(ios->io_comm, filename, file->mode, ios->info, &file->fh);
+            if (!ierr)
+                ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
+            break;
+#endif
+        }
+    }
+
+    /* Broadcast and check the return code. */
+    if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
+
+    /* If there was an error, free the memory we allocated and handle error. */
+    if (ierr)
+    {
+        free(file);
+        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+    }
+
+    /* Broadcast mode to all tasks. */
+    if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
+
+    /* This flag is implied by netcdf create functions but we need
+       to know if its set. */
+    file->mode = file->mode | PIO_WRITE;
+
+    /* Assign the PIO ncid, necessary because files may be opened
+     * on mutilple iosystems, causing the underlying library to
+     * reuse ncids. Hilarious confusion ensues. */
+    file->pio_ncid = pio_next_ncid++;
+    LOG((2, "file->fh = %d file->pio_ncid = %d", file->fh, file->pio_ncid));
+
+    /* Return the ncid to the caller. */
+    *ncidp = file->pio_ncid;
+
+    /* Add the struct with this files info to the global list of
+     * open files. */
+    pio_add_to_file_list(file);
+
+    LOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
+         file->fh, file->pio_ncid));
+
+    return ierr;
+}
+
+/**
  * Open an existing file using PIO library. This is an internal
  * function. Depending on the value of the retry parameter, a failed
  * open operation will be handled differently. If retry is non-zero,
@@ -1019,14 +1191,15 @@ int PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_openfile
  */
-int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,
-                        const char *filename, int mode, int retry)
+int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
+                        int mode, int retry)
 {
     iosystem_desc_t *ios;  /** Pointer to io system information. */
     file_desc_t *file;     /** Pointer to file information. */
-    int ierr = PIO_NOERR;  /** Return code from function calls. */
-    int mpierr = MPI_SUCCESS, mpierr2;  /** Return code from MPI function codes. */
     int imode;  /** internal mode val for netcdf4 file open */
+    int mpierr = MPI_SUCCESS, mpierr2;  /** Return code from MPI function codes. */
+    int ierr = PIO_NOERR;  /** Return code from function calls. */
+
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
@@ -1056,8 +1229,8 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,
         file->varlist[i].ndims = -1;
     }
 
-    /* Set to true if this task should participate in IO (only true for
-     * one task with netcdf serial files. */
+    /* Set to true if this task should participate in IO (only true
+     * for one task with netcdf serial files. */
     if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
         ios->io_rank == 0)
         file->do_io = 1;

--- a/tests/cunit/test_pioc_more.c
+++ b/tests/cunit/test_pioc_more.c
@@ -438,6 +438,13 @@ int create_putget_file(int iosysid, int flavor, int *dim_len, int *varid, const 
     if ((ret = PIOc_createfile(iosysid, &ncid, &flavor, filename, PIO_CLOBBER)))
         return ret;
 
+    /* Confirm that NOFILL mode is set. */
+    int old_mode;
+    if ((ret = PIOc_set_fill(ncid, NC_NOFILL, &old_mode)))
+        return ret;
+    if (old_mode != NC_NOFILL)
+        return ERR_WRONG;
+
     /* Define netCDF dimensions and variable. */
     for (int d = 0; d < NDIM; d++)
         if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
@@ -565,7 +572,7 @@ int test_fill(int iosysid, int num_flavors, int *flavor, int my_rank,
 
             /* Access to read it. */
             printf("about to try to open file %s\n", filename);
-            if ((ret = PIOc_openfile(iosysid, &ncid, &(flavor[fmt]), filename, PIO_NOWRITE)))
+            if ((ret = PIOc_openfile(iosysid, &ncid, &(flavor[fmt]), filename, PIO_WRITE)))
                 ERR(ret);
 
             /* Use the vara functions to read some data. */


### PR DESCRIPTION
Fixes #568.

Turns on NOFILL for all files created with PIOc_createfile().

Does NOT change fill setting for files created with PIOc_create().

I will merge to develop for testing.