### PR TITLE
Remove unneeded #ifdefs

### DIFF
--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -214,7 +214,6 @@ int pio_write_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid,
 
             switch (file->iotype)
             {
-#ifdef _NETCDF
 #ifdef _NETCDF4
             case PIO_IOTYPE_NETCDF4P:
 
@@ -351,7 +350,7 @@ int pio_write_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid,
                 break;
             }
             break;
-#endif /* _NETCDF */
+
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
                 for (i = 0, dsize = 1; i < ndims; i++)
@@ -1377,7 +1376,6 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
                     }
                     loffset += regionsize;
 
-#ifdef _NETCDF
                     /* Cant use switch here because MPI_DATATYPE may not be simple (openmpi). */
                     if (iodesc->basetype == MPI_DOUBLE || iodesc->basetype == MPI_REAL8)
                         ierr = nc_get_vara_double(file->fh, vid,start, count, bufptr);
@@ -1392,7 +1390,6 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
                         for (int i = 0; i < fndims; i++)
                             fprintf(stderr,"vid %d dim %d start %ld count %ld err %d\n",
                                     vid, i, start[i], count[i], ierr);
-#endif
                 }
 
                 if (rtask < ios->num_iotasks)

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -207,7 +207,6 @@ int PIOc_closefile(int ncid)
     {
         switch (file->iotype)
         {
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_close(file->fh);
@@ -218,7 +217,6 @@ int PIOc_closefile(int ncid)
             if (ios->io_rank == 0)
                 ierr = nc_close(file->fh);
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             if ((file->mode & PIO_WRITE)){
@@ -398,7 +396,6 @@ int PIOc_sync(int ncid)
         {
             switch(file->iotype)
             {
-#ifdef _NETCDF
 #ifdef _NETCDF4
             case PIO_IOTYPE_NETCDF4P:
                 ierr = nc_sync(file->fh);
@@ -409,7 +406,6 @@ int PIOc_sync(int ncid)
                 if (ios->io_rank == 0)
                     ierr = nc_sync(file->fh);
                 break;
-#endif
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
                 ierr = ncmpi_sync(file->fh);

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -95,7 +95,6 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
                     int mode)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
-    file_desc_t *file;     /* Pointer to file information. */
     int ret;               /* Return code from function calls. */
 
     /* Get the IO system info from the id. */

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -376,7 +376,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
             }
         }
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             switch(memtype)
@@ -427,7 +427,6 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
             }
         }
-#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -714,7 +713,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 #endif /* PNET_READ_AND_BCAST */
         }
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             switch(xtype)
             {
@@ -776,7 +775,6 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             default:
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
             }
-#endif /* _NETCDF */
     }
 
     if (!ios->async_interface || !ios->ioproc)
@@ -1126,7 +1124,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 free(fake_stride);
         }
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             LOG((2, "PIOc_put_vars_tc calling netcdf function file->iotype = %d",
@@ -1192,7 +1190,6 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             }
             LOG((2, "PIOc_put_vars_tc io_rank 0 done with netcdf call, ierr=%d", ierr));
         }
-#endif /* _NETCDF */
     }
 
     if (!ios->async_interface || !ios->ioproc)

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -96,7 +96,6 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
                 LOG((2, "PIOc_inq returned from ncmpi_inq unlimdimid = %d", *unlimdimidp));
         }
 #endif /* _PNETCDF */
-#ifdef _NETCDF
         if (file->iotype == PIO_IOTYPE_NETCDF && file->do_io)
         {
             LOG((2, "PIOc_inq calling classic nc_inq"));
@@ -125,7 +124,7 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
             LOG((2, "PIOc_inq calling netcdf-4 nc_inq"));
             ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);
         }
-#endif /* _NETCDF */
+
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -270,10 +269,9 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = pioc_pnetcdf_inq_type(ncid, xtype, name, sizep);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_type(file->fh, xtype, name, (size_t *)sizep);
-#endif /* _NETCDF */
         LOG((2, "PIOc_inq_type netcdf call returned %d", ierr));
     }
 
@@ -355,10 +353,9 @@ int PIOc_inq_format(int ncid, int *formatp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_format(file->fh, formatp);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_format(file->fh, formatp);
-#endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -445,13 +442,12 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
             ierr = ncmpi_inq_dim(file->fh, dimid, name, lenp);;
         }
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             LOG((2, "calling nc_inq_dim"));
             ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
         }
-#endif /* _NETCDF */
         LOG((2, "ierr = %d", ierr));
     }
 
@@ -582,10 +578,9 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_dimid(file->fh, name, idp);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_dimid(file->fh, name, idp);
-#endif /* _NETCDF */
     }
     LOG((3, "nc_inq_dimid call complete ierr = %d", ierr));
 
@@ -690,7 +685,7 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
                 ierr = ncmpi_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);
         }
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             ierr = nc_inq_varndims(file->fh, varid, &ndims);
@@ -721,7 +716,6 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
                 }
             }
         }
-#endif /* _NETCDF */
         if (ndimsp)
             LOG((2, "PIOc_inq_var ndims = %d ierr = %d", *ndimsp, ierr));
     }
@@ -910,10 +904,9 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_varid(file->fh, name, varidp);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_varid(file->fh, name, varidp);
-#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1007,10 +1000,9 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_att(file->fh, varid, name, xtypep, lenp);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);
-#endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -1128,10 +1120,9 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_attname(file->fh, varid, attnum, name);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_attname(file->fh, varid, attnum, name);
-#endif /* _NETCDF */
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
     }
 
@@ -1226,10 +1217,9 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_inq_attid(file->fh, varid, name, idp);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_attid(file->fh, varid, name, idp);
-#endif /* _NETCDF */
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
     }
 
@@ -1316,10 +1306,9 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_rename_dim(file->fh, dimid, name);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_rename_dim(file->fh, dimid, name);
-#endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -1402,10 +1391,9 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_rename_var(file->fh, varid, name);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_rename_var(file->fh, varid, name);
-#endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
@@ -1494,10 +1482,9 @@ int PIOc_rename_att(int ncid, int varid, const char *name,
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_rename_att(file->fh, varid, name, newname);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_rename_att(file->fh, varid, name, newname);
-#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1578,10 +1565,9 @@ int PIOc_del_att(int ncid, int varid, const char *name)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_del_att(file->fh, varid, name);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_del_att(file->fh, varid, name);
-#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1656,10 +1642,9 @@ int PIOc_set_fill(int ncid, int fillmode, int *old_modep)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_set_fill(file->fh, fillmode, old_modep);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_set_fill(file->fh, fillmode, old_modep);
-#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1785,10 +1770,9 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_def_dim(file->fh, name, len, idp);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_def_dim(file->fh, name, (size_t)len, idp);
-#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */
@@ -1880,7 +1864,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         if (file->iotype == PIO_IOTYPE_PNETCDF)
             ierr = ncmpi_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
 #endif /* _PNETCDF */
-#ifdef _NETCDF
+
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
 #ifdef _NETCDF4
@@ -1892,7 +1876,6 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         if (!ierr && file->iotype == PIO_IOTYPE_NETCDF4P)
             ierr = nc_var_par_access(file->fh, *varidp, NC_COLLECTIVE);
 #endif /* _NETCDF4 */
-#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -34,7 +34,6 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -47,7 +46,6 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
                 ierr = nc_put_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -105,7 +103,6 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -118,7 +115,6 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
                 ierr = nc_put_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -176,7 +172,6 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -189,7 +184,6 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
                 ierr = nc_put_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -248,7 +242,6 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -261,7 +254,6 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
                 ierr = nc_put_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -321,7 +313,6 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -334,7 +325,6 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
                 ierr = nc_put_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -394,7 +384,6 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -407,7 +396,6 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
                 ierr = nc_put_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -466,7 +454,6 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -479,7 +466,6 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
                 ierr = nc_put_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -539,7 +525,6 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -552,7 +537,6 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
                 ierr = nc_put_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -611,7 +595,6 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -624,7 +607,6 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
                 ierr = nc_put_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -685,7 +667,6 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -698,7 +679,6 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
                 ierr = nc_put_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -758,7 +738,6 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -771,7 +750,6 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
                 ierr = nc_put_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -830,7 +808,6 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -843,7 +820,6 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
                 ierr = nc_put_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -901,7 +877,6 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_var_par_access(file->fh, varid, NC_COLLECTIVE);
@@ -914,7 +889,6 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
                 ierr = nc_put_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap, op);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             vdesc = file->varlist + varid;
@@ -972,7 +946,6 @@ int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -985,7 +958,6 @@ int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
                 ierr = nc_get_varm_uchar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1043,7 +1015,6 @@ int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1056,7 +1027,6 @@ int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
                 ierr = nc_get_varm_schar(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1114,7 +1084,6 @@ int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const P
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1127,7 +1096,6 @@ int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const P
                 ierr = nc_get_varm_double(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1185,7 +1153,6 @@ int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1198,7 +1165,6 @@ int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
                 ierr = nc_get_varm_text(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1256,7 +1222,6 @@ int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1269,7 +1234,6 @@ int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
                 ierr = nc_get_varm_int(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1327,7 +1291,6 @@ int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1340,7 +1303,6 @@ int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
                 ierr = nc_get_varm_uint(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1393,7 +1355,6 @@ int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
@@ -1406,7 +1367,6 @@ int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
                 ierr = nc_get_varm(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,   buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1464,7 +1424,6 @@ int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1477,7 +1436,6 @@ int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
                 ierr = nc_get_varm_float(file->fh, varid,(size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1535,7 +1493,6 @@ int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1548,7 +1505,6 @@ int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
                 ierr = nc_get_varm_long(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1606,7 +1562,6 @@ int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1619,7 +1574,6 @@ int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
                 ierr = nc_get_varm_ushort(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1677,7 +1631,6 @@ int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1690,7 +1643,6 @@ int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
                 ierr = nc_get_varm_longlong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1748,7 +1700,6 @@ int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1761,7 +1712,6 @@ int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
                 ierr = nc_get_varm_short(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST
@@ -1819,7 +1769,6 @@ int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
 
     if (ios->ioproc){
         switch(file->iotype){
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             ierr = nc_get_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
@@ -1832,7 +1781,6 @@ int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
                 ierr = nc_get_varm_ulonglong(file->fh, varid, (size_t *) start, (size_t *) count, (ptrdiff_t *) stride, (ptrdiff_t *) imap,  buf);;
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
 #ifdef PNET_READ_AND_BCAST

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -937,7 +937,6 @@ int PIOc_iotype_available(int iotype)
 {
     switch(iotype)
     {
-#ifdef _NETCDF
 #ifdef _NETCDF4
     case PIO_IOTYPE_NETCDF4P:
     case PIO_IOTYPE_NETCDF4C:
@@ -945,7 +944,6 @@ int PIOc_iotype_available(int iotype)
 #endif
     case PIO_IOTYPE_NETCDF:
         return 1;
-#endif
 #ifdef _PNETCDF
     case PIO_IOTYPE_PNETCDF:
         return 1;

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -652,7 +652,6 @@ int PIOc_freedecomp(int iosysid, int ioid)
     iosystem_desc_t *ios;
     io_desc_t *iodesc;
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function calls. */
-    int ierr;              /* Return code. */
 
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1121,7 +1121,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     {
         switch (file->iotype)
         {
-#ifdef _NETCDF
 #ifdef _NETCDF4
         case PIO_IOTYPE_NETCDF4P:
             file->mode = file->mode |  NC_MPIIO | NC_NETCDF4;
@@ -1140,7 +1139,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
                 ierr = nc_create(filename, file->mode, &file->fh);
             }
             break;
-#endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
             LOG((2, "Calling ncmpi_create mode = %d", file->mode));
@@ -1293,7 +1291,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     {
         switch (file->iotype)
         {
-#ifdef _NETCDF
 #ifdef _NETCDF4
 
         case PIO_IOTYPE_NETCDF4P:
@@ -1325,7 +1322,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             if (ios->io_rank == 0)
                 ierr = nc_open(filename, file->mode, &file->fh);
             break;
-#endif
 
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
@@ -1351,7 +1347,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
            with just plain old basic NetCDF. */
         if (retry)
         {
-#ifdef _NETCDF
             LOG((2, "retry error code ierr = %d io_rank %d", ierr, ios->io_rank));
             if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
             {
@@ -1371,7 +1366,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
                     file->do_io = 0;
             }
             LOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d", filename, file->fh, file->iotype, file->do_io, ierr));
-#endif
         }
     }
 
@@ -1519,7 +1513,6 @@ int pioc_change_def(int ncid, int is_enddef)
                 ierr = ncmpi_redef(file->fh);
         }
 #endif /* _PNETCDF */
-#ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             if (is_enddef)
@@ -1530,7 +1523,6 @@ int pioc_change_def(int ncid, int is_enddef)
             else
                 ierr = nc_redef(file->fh);
         }
-#endif /* _NETCDF */
     }
 
     /* Broadcast and check the return code. */


### PR DESCRIPTION
Since the build will not work without at least netCDF classic, these ifdefs were not serving any purpose. The build will not work without netCDF (i.e. pnetcdf-only) without some effort.

I think it's reasonable to expect that any HPC user of PIO is already going to have at least netCDF classic on their system.

Fixes #597.

I will merge to develop for testing.