### PR TITLE
Now read netCDF decomp file and InitDecomp() with values

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -714,6 +714,10 @@ extern "C" {
     int PIOc_write_nc_decomp(const char *filename, int iosysid, int ioid, MPI_Comm comm,
                              char *title, char *history, int fortran_order);
 
+    /* Read a netCDF decomposition file. */
+    int PIOc_read_nc_decomp(const char *filename, int iosysid, int *ioid, MPI_Comm comm,
+                            char *title, char *history, int *fortran_order);
+    
     /* Initializing IO system. */
     int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
                         int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -376,7 +376,7 @@ int PIOc_write_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
     {
         /* Allocate a buffer. */
         if (!(wmb->next = bget((bufsize)sizeof(wmulti_buffer))))
-            piomemerror(*ios,sizeof(wmulti_buffer), __FILE__,__LINE__);
+            piomemerror(*ios, sizeof(wmulti_buffer), __FILE__, __LINE__);
 
         /* Set pointer to newly allocated buffer and initialize.*/
         wmb = wmb->next;

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -276,8 +276,8 @@ extern "C" {
                                  const char *history, int fortran_order);
 
     /* Read a netCDF decomp file. */
-    int pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int *global_dimlen,
-                                int *num_tasks, int *task_maplen, int *max_maplen, int *map, char *title,
+    int pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **global_dimlen,
+                                int *num_tasks, int **task_maplen, int *max_maplen, int **map, char *title,
                                 char *history, char *source, char *version, int *fortran_order);
     
 #if defined(__cplusplus)

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -1662,6 +1662,9 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
     if (PIOc_read_nc_decomp(NULL, iosysid, &ioid_in, test_comm, title_in,
                             history_in, &fortran_order_in) != PIO_EINVAL)
         return ret;
+    if (PIOc_read_nc_decomp(nc_filename, iosysid, NULL, test_comm, title_in,
+                            history_in, &fortran_order_in) != PIO_EINVAL)
+        return ret;
     
     /* Read it using the public read function. */
     if ((ret = PIOc_read_nc_decomp(nc_filename, iosysid, &ioid_in, test_comm, title_in,

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -1671,7 +1671,30 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
                                    history_in, &fortran_order_in)))
         return ret;
 
+    /* Did we get expected results? */
+    if (strcmp(title, title_in) || strcmp(history, history_in))
+        return ERR_WRONG;
+
     /* Free the PIO decomposition. */
+    if ((ret = PIOc_freedecomp(iosysid, ioid_in)))
+        ERR(ret);
+
+    /* These should also work. */
+    if ((ret = PIOc_read_nc_decomp(nc_filename, iosysid, &ioid_in, test_comm, NULL,
+                                   history_in, &fortran_order_in)))
+        return ret;
+    if ((ret = PIOc_freedecomp(iosysid, ioid_in)))
+        ERR(ret);
+
+    if ((ret = PIOc_read_nc_decomp(nc_filename, iosysid, &ioid_in, test_comm, title_in,
+                                   NULL, &fortran_order_in)))
+        return ret;
+    if ((ret = PIOc_freedecomp(iosysid, ioid_in)))
+        ERR(ret);
+
+    if ((ret = PIOc_read_nc_decomp(nc_filename, iosysid, &ioid_in, test_comm, title_in,
+                                  history_in, NULL)))
+        return ret;
     if ((ret = PIOc_freedecomp(iosysid, ioid_in)))
         ERR(ret);
 


### PR DESCRIPTION
Added function PIOc_read_nc_decomp() to read netCDF decomp file and initialized iodesc. Plus tests. Fixes #627.

Also more tests for PIOc_write_nc_decomp(). Fixes #654.

I will merge to develop for testing.