### PR TITLE
return value checking, changing parameters to pointers to struct

### DIFF
--- a/doc/source/mach_walkthrough.txt
+++ b/doc/source/mach_walkthrough.txt
@@ -426,7 +426,7 @@ build from the command line, including tests:
 
 <pre>
 cd build
-rm -rf * && CFLAGS=-g FFLAGS=-g CC=mpicc FC=mpifort cmake -DNetCDF_C_PATH=/usr/local/netcdf-4.4.1 -DNetCDF_Fortran_PATH=/usr/local/netcdf-fortran-4.4.4 -DPnetCDF_PATH=/usr/local/pnetcdf-1.7.0 -DPIO_ENABLE_LOGGING=On -DPIO_HDF5_LOGGING=On .. && make VERBOSE=1 all tests check
+rm -rf * && CFLAGS='-Wall -g' FFLAGS=-g CC=mpicc FC=mpifort cmake -DNetCDF_C_PATH=/usr/local/netcdf-4.4.1 -DNetCDF_Fortran_PATH=/usr/local/netcdf-fortran-4.4.4 -DPnetCDF_PATH=/usr/local/pnetcdf-1.7.0 -DPIO_ENABLE_LOGGING=On .. && make VERBOSE=1 all tests check
 </pre>
 
 <p>Note the optional CFLAGS=-g which allows the use of a debugger

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -608,7 +608,7 @@ int PIOc_read_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
     /* If a rearranger was specified, rearrange the data. */
     if (iodesc->rearranger > 0)
     {
-        ierr = rearrange_io2comp(*ios, iodesc, iobuf, array);
+        ierr = rearrange_io2comp(ios, iodesc, iobuf, array);
 
         /* Free the buffer. */
         if (rlen > 0)

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -124,7 +124,7 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
 
             /* Allocate memory for the variable buffer. */
             if (!(vdesc0->iobuf = bget((size_t)vsize * (size_t)rlen)))
-                piomemerror(*ios, (size_t)rlen * (size_t)vsize, __FILE__, __LINE__);
+                piomemerror(ios, (size_t)rlen * (size_t)vsize, __FILE__, __LINE__);
             LOG((3, "allocated %ld bytes for variable buffer", (size_t)rlen * (size_t)vsize));
 
             /* If data are missing for the BOX rearranger, insert fill values. */
@@ -143,7 +143,7 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
         }
 
         /* Move data from compute to IO tasks. */
-        if ((ierr = rearrange_comp2io(*ios, iodesc, array, vdesc0->iobuf, nvars)))
+        if ((ierr = rearrange_comp2io(ios, iodesc, array, vdesc0->iobuf, nvars)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
         
     }/*  this is wrong, need to think about it
@@ -383,7 +383,7 @@ int PIOc_write_darray(int ncid, int vid, int ioid, PIO_Offset arraylen, void *ar
     {
         /* Allocate a buffer. */
         if (!(wmb->next = bget((bufsize)sizeof(wmulti_buffer))))
-            piomemerror(*ios, sizeof(wmulti_buffer), __FILE__, __LINE__);
+            piomemerror(ios, sizeof(wmulti_buffer), __FILE__, __LINE__);
         LOG((3, "allocated multi-buffer"));
 
         /* Set pointer to newly allocated buffer and initialize.*/
@@ -429,7 +429,7 @@ int PIOc_write_darray(int ncid, int vid, int ioid, PIO_Offset arraylen, void *ar
              maxfree, wmb->validvars, (1 + wmb->validvars) * arraylen * tsize, totfree));
 
         /* Collect a debug report about buffer. (Shouldn't we be able to turn this off??) */
-        cn_buffer_report(*ios, true);
+        cn_buffer_report(ios, true);
 
         /* If needsflush == 2 flush to disk otherwise just flush to io node. */
         if ((ret = flush_buffer(ncid, wmb, needsflush == 2)))
@@ -440,28 +440,28 @@ int PIOc_write_darray(int ncid, int vid, int ioid, PIO_Offset arraylen, void *ar
     if (arraylen > 0)
     {
         if (!(wmb->data = bgetr(wmb->data, (1 + wmb->validvars) * arraylen * tsize)))
-            piomemerror(*ios, (1 + wmb->validvars) * arraylen * tsize, __FILE__, __LINE__);
+            piomemerror(ios, (1 + wmb->validvars) * arraylen * tsize, __FILE__, __LINE__);
         LOG((2, "got %ld bytes for data", (1 + wmb->validvars) * arraylen * tsize));
     }
 
     /* vid is an array of variable ids in the wmb list, grow the list
      * and add the new entry. */
     if (!(wmb->vid = bgetr(wmb->vid, sizeof(int) * (1 + wmb->validvars))))
-        piomemerror(*ios, (1 + wmb->validvars) * sizeof(int), __FILE__, __LINE__);
+        piomemerror(ios, (1 + wmb->validvars) * sizeof(int), __FILE__, __LINE__);
 
     /* wmb->frame is the record number, we assume that the variables
      * in the wmb list may not all have the same unlimited dimension
      * value although they usually do. */
     if (vdesc->record >= 0)
         if (!(wmb->frame = bgetr(wmb->frame, sizeof(int) * (1 + wmb->validvars))))
-            piomemerror(*ios, (1 + wmb->validvars) * sizeof(int), __FILE__, __LINE__);
+            piomemerror(ios, (1 + wmb->validvars) * sizeof(int), __FILE__, __LINE__);
 
     /* If we need a fill value, get it. */
     if (iodesc->needsfill)
     {
         /* Get memory to hold fill value. */
         if (!(wmb->fillvalue = bgetr(wmb->fillvalue, tsize * (1 + wmb->validvars))))
-            piomemerror(*ios, (1 + wmb->validvars) * tsize, __FILE__, __LINE__);
+            piomemerror(ios, (1 + wmb->validvars) * tsize, __FILE__, __LINE__);
 
         /* If the user passed a fill value, use that, otherwise use
          * the default fill value of the netCDF type. Copy the fill
@@ -582,7 +582,7 @@ int PIOc_read_darray(int ncid, int vid, int ioid, PIO_Offset arraylen,
 
             /* Allocate a buffer for one record. */
             if (!(iobuf = bget((size_t)tsize * rlen)))
-                piomemerror(*ios, rlen * (size_t)tsize, __FILE__, __LINE__);
+                piomemerror(ios, rlen * (size_t)tsize, __FILE__, __LINE__);
         }
     }
     else

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -162,12 +162,12 @@ extern "C" {
                                 const rearr_comm_fc_opt_t *exp_opt);
 
     /* Create a subset rearranger. */
-    int subset_rearrange_create(iosystem_desc_t ios, int maplen, PIO_Offset *compmap, const int *gsize,
+    int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap, const int *gsize,
                                 int ndim, io_desc_t *iodesc);
 
 
     /* Create a box rearranger. */
-    int box_rearrange_create(iosystem_desc_t ios, int maplen, const PIO_Offset *compmap, const int *gsize,
+    int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap, const int *gsize,
                              int ndim, io_desc_t *iodesc);
 
 
@@ -175,13 +175,14 @@ extern "C" {
     int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf, void *rbuf);
 
     /* Move data from compute tasks to IO tasks. */
-    int rearrange_comp2io(iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf, void *rbuf, int nvars);
+    int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf, void *rbuf, int nvars);
 
     io_desc_t *malloc_iodesc(const iosystem_desc_t *ios, int piotype, int ndims);
-    void performance_tune_rearranger(iosystem_desc_t ios, io_desc_t *iodesc);
+    
+    void performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc);
 
     int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize);
-    void compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc);
+    int compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc);
     io_region *alloc_region(int ndims);
     int pio_delete_iosystem_from_list(int piosysid);
 
@@ -211,26 +212,23 @@ extern "C" {
                              const int *mcount, int *mfrom, MPI_Datatype *mtype);
     int compare_offsets(const void *a, const void *b) ;
 
-    int subset_rearrange_create(iosystem_desc_t ios, int maplen, PIO_Offset *compmap,
-                                const int *gsize, int ndims, io_desc_t *iodesc);
-
     /* Print a trace statement, for debugging. */
     void print_trace (FILE *fp);
     
-    void cn_buffer_report(iosystem_desc_t ios, bool collective);
+    void cn_buffer_report(iosystem_desc_t *ios, bool collective);
 
     /* Initialize the compute buffer. */
-    int compute_buffer_init(iosystem_desc_t ios);
+    int compute_buffer_init(iosystem_desc_t *ios);
 
-    void free_cn_buffer_pool(iosystem_desc_t ios);
+    void free_cn_buffer_pool(iosystem_desc_t *ios);
 
     /* Flush PIO's data buffer. */
     int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk);
 
-    void compute_maxaggregate_bytes(iosystem_desc_t ios, io_desc_t *iodesc);
+    int compute_maxaggregate_bytes(iosystem_desc_t *ios, io_desc_t *iodesc);
 
     /* Announce a memory error with bget memory, and die. */
-    void piomemerror(iosystem_desc_t ios, size_t req, char *fname, int line);
+    void piomemerror(iosystem_desc_t *ios, size_t req, char *fname, int line);
 
     /* Check the return code from an MPI function call. */
     int check_mpi(file_desc_t *file, int mpierr, const char *filename, int line);

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -171,8 +171,10 @@ extern "C" {
                              int ndim, io_desc_t *iodesc);
 
 
-    int rearrange_io2comp(iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf, void *rbuf);
+    /* Move data from IO tasks to compute tasks. */
+    int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf, void *rbuf);
 
+    /* Move data from compute tasks to IO tasks. */
     int rearrange_comp2io(iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf, void *rbuf, int nvars);
 
     io_desc_t *malloc_iodesc(const iosystem_desc_t *ios, int piotype, int ndims);
@@ -199,7 +201,9 @@ extern "C" {
 
     int ceil2(int i);
     int pair(int np, int p, int k);
-    int define_iodesc_datatypes(iosystem_desc_t ios, io_desc_t *iodesc);
+
+    /* Create MPI datatypes used for comp2io and io2comp data transfers. */
+    int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc);
 
     /* Create the derived MPI datatypes used for comp2io and io2comp
      * transfers. */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -209,16 +209,24 @@ extern "C" {
 
     int subset_rearrange_create(iosystem_desc_t ios, int maplen, PIO_Offset *compmap,
                                 const int *gsize, int ndims, io_desc_t *iodesc);
+
+    /* Print a trace statement, for debugging. */
     void print_trace (FILE *fp);
+    
     void cn_buffer_report(iosystem_desc_t ios, bool collective);
 
     /* Initialize the compute buffer. */
     int compute_buffer_init(iosystem_desc_t ios);
 
     void free_cn_buffer_pool(iosystem_desc_t ios);
-    void flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk);
-    void piomemerror(iosystem_desc_t ios, size_t req, char *fname, int line);
+
+    /* Flush PIO's data buffer. */
+    int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk);
+
     void compute_maxaggregate_bytes(iosystem_desc_t ios, io_desc_t *iodesc);
+
+    /* Announce a memory error with bget memory, and die. */
+    void piomemerror(iosystem_desc_t ios, size_t req, char *fname, int line);
 
     /* Check the return code from an MPI function call. */
     int check_mpi(file_desc_t *file, int mpierr, const char *filename, int line);

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -385,13 +385,13 @@ int define_iodesc_datatypes(iosystem_desc_t ios, io_desc_t *iodesc)
                     if ((ret = create_mpi_datatypes(iodesc->basetype, iodesc->nrecvs, iodesc->llen,
                                                     iodesc->rindex, iodesc->rcount, iodesc->rfrom,
                                                     iodesc->rtype)))
-                        return ret;
+                        return pio_err(&ios, NULL, ret, __FILE__, __LINE__);
                 }
                 else
                 {
                     if ((ret = create_mpi_datatypes(iodesc->basetype, iodesc->nrecvs, iodesc->llen,
                                                     iodesc->rindex, iodesc->rcount, NULL, iodesc->rtype)))
-                        return ret;
+                        return pio_err(&ios, NULL, ret, __FILE__, __LINE__);
                 }
             }
         }
@@ -710,8 +710,8 @@ int rearrange_comp2io(iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
     MPI_Datatype *recvtypes;
     MPI_Comm mycomm;
     int mpierr; /* Return code from MPI calls. */
+    int ret;
 
-    
 #ifdef TIMING
     GPTLstart("PIO:rearrange_comp2io");
 #endif
@@ -744,7 +744,8 @@ int rearrange_comp2io(iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
 
     /* Define the MPI data types that will be used for this
      * io_desc_t. */
-    define_iodesc_datatypes(ios, iodesc);
+    if ((ret = define_iodesc_datatypes(ios, iodesc)))
+        return pio_err(&ios, NULL, ret, __FILE__, __LINE__);
 
     /* Allocate arrays needed by the pio_swapm() function. */
     if (!(sendcounts = calloc(ntasks, sizeof(int))))
@@ -903,6 +904,7 @@ int rearrange_io2comp(iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
     MPI_Datatype *recvtypes;
     int i;
     int mpierr; /* Return code from MPI calls. */
+    int ret;
 
     assert(iodesc);
 
@@ -929,7 +931,8 @@ int rearrange_io2comp(iosystem_desc_t ios, io_desc_t *iodesc, void *sbuf,
 
     /* Define the MPI data types that will be used for this
      * io_desc_t. */
-    define_iodesc_datatypes(ios, iodesc);
+    if ((ret = define_iodesc_datatypes(ios, iodesc)))
+        return pio_err(&ios, NULL, ret, __FILE__, __LINE__);
 
     /* Allocate arrays needed by the pio_swapm() function. */
     if (!(sendcounts = calloc(ntasks, sizeof(int))))

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -419,7 +419,7 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
             fprintf(stderr,"%s %s\n","Iostart and iocount arguments to PIOc_InitDecomp",
                     "are incompatable with subset rearrange method and will be ignored");
         iodesc->num_aiotasks = ios->num_iotasks;
-        if ((ierr = subset_rearrange_create(*ios, maplen, (PIO_Offset *)compmap, dims,
+        if ((ierr = subset_rearrange_create(ios, maplen, (PIO_Offset *)compmap, dims,
                                             ndims, iodesc)))
             return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     }
@@ -459,7 +459,7 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
 
         /* Compute the communications pattern for this decomposition. */
         if (iodesc->rearranger == PIO_REARR_BOX)
-            ierr = box_rearrange_create(*ios, maplen, compmap, dims, ndims, iodesc);
+            ierr = box_rearrange_create(ios, maplen, compmap, dims, ndims, iodesc);
 
         /*
           if (ios->ioproc){
@@ -477,7 +477,7 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
     *ioidp = pio_add_to_iodesc_list(iodesc);
 
     LOG((3, "About to tune rearranger..."));
-    performance_tune_rearranger(*ios, iodesc);
+    performance_tune_rearranger(ios, iodesc);
     LOG((3, "Done with rearranger tune."));
 
     return PIO_NOERR;
@@ -689,7 +689,7 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
     *iosysidp = pio_add_to_iosystem_list(ios);
 
     /* Allocate buffer space for compute nodes. */
-    if ((ret = compute_buffer_init(*ios)))
+    if ((ret = compute_buffer_init(ios)))
         return ret;
 
     LOG((2, "Init_Intracomm complete iosysid = %d", *iosysidp));
@@ -843,7 +843,7 @@ int PIOc_finalize(int iosysid)
     /* Only free the buffer pool if this is the last open iosysid. */
     if (niosysid == 1)
     {
-        free_cn_buffer_pool(*ios);
+        free_cn_buffer_pool(ios);
         LOG((2, "Freed buffer pool."));
     }
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -298,7 +298,7 @@ void print_trace(FILE *fp)
  * @param fname name of code file where error occured
  * @param line the line of code where the error occurred.
  */
-void piomemerror(iosystem_desc_t ios, size_t req, char *fname, int line)
+void piomemerror(iosystem_desc_t *ios, size_t req, char *fname, int line)
 {
     char msg[80];
     sprintf(msg, "out of memory requesting: %ld", req);


### PR DESCRIPTION
In this PR I add return code checking in several places. Remember:

`void functions + programmer laziness = ignored return codes
`
So just return int from all new functions. ;-)

Also changed some functions that were passing whole struct instead of pointer to struct. Using the struct causes the entire contents of the struct to be copied, instead of just a pointer to it. So we need to follow the C convention of always passing pointers to structs, not the structs themselves.

Fixes #679. 
Fixes #678. 
Fixes #676. 
Fixes #677.
Fixes #675.

I will merge to develop for testing.