### PR TITLE
Changes to read/write netCDF decomp files

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -64,6 +64,9 @@
 /* Name of array order (C or Fortran) attribute. */
 #define DECOMP_ORDER_ATT_NAME "array_order"
 
+/* Name of backtrace attribute. */
+#define DECOMP_BACKTRACE_ATT_NAME "backtrace"
+
 /* Name for the dim dim in decomp file. */
 #define DECOMP_DIM_DIM "dims"
 

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -714,8 +714,8 @@ extern "C" {
     int PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm);
 
     /* Write a decomposition file using netCDF. */
-    int PIOc_write_nc_decomp(int iosysid, const char *filename, int ioid, MPI_Comm comm,
-                             char *title, char *history, int fortran_order);
+    int PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
+                             MPI_Comm comm, char *title, char *history, int fortran_order);
 
     /* Read a netCDF decomposition file. */
     int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioid, MPI_Comm comm,

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -714,11 +714,11 @@ extern "C" {
     int PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm);
 
     /* Write a decomposition file using netCDF. */
-    int PIOc_write_nc_decomp(const char *filename, int iosysid, int ioid, MPI_Comm comm,
+    int PIOc_write_nc_decomp(int iosysid, const char *filename, int ioid, MPI_Comm comm,
                              char *title, char *history, int fortran_order);
 
     /* Read a netCDF decomposition file. */
-    int PIOc_read_nc_decomp(const char *filename, int iosysid, int *ioid, MPI_Comm comm,
+    int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioid, MPI_Comm comm,
                             int pio_type, char *title, char *history, int *fortran_order);
     
     /* Initializing IO system. */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -289,7 +289,7 @@ extern "C" {
     void pio_finalize_logging(void );
 
     /* Write a netCDF decomp file. */
-    int pioc_write_nc_decomp_int(int iosysid, const char *filename, int ndims, int *global_dimlen,
+    int pioc_write_nc_decomp_int(int iosysid, const char *filename, int cmode, int ndims, int *global_dimlen,
                                  int num_tasks, int *task_maplen, int *map, const char *title,
                                  const char *history, int fortran_order);
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -937,8 +937,8 @@ int PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset 
  * Write the decomposition map to a file using netCDF, everyones
  * favorite data format.
  *
- * @param file the filename to be used.
  * @param iosysid the IO system ID.
+ * @param filename the filename to be used.
  * @param ioid the ID of the IO description.
  * @param comm an MPI communicator.
  * @param title optial title attribute for the file. Must be less than
@@ -949,7 +949,7 @@ int PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset 
  * used, or to zero if C array ordering is used.
  * @returns 0 for success, error code otherwise.
  */
-int PIOc_write_nc_decomp(const char *filename, int iosysid, int ioid, MPI_Comm comm,
+int PIOc_write_nc_decomp(int iosysid, const char *filename, int ioid, MPI_Comm comm,
                          char *title, char *history, int fortran_order)
 {
     iosystem_desc_t *ios;
@@ -1034,8 +1034,8 @@ int PIOc_write_nc_decomp(const char *filename, int iosysid, int ioid, MPI_Comm c
  * Read the decomposition map from a netCDF decomp file produced by
  * PIOc_write_nc_decomp().
  *
- * @param filename the name of the decomp file.
  * @param iosysid the IO system ID.
+ * @param filename the name of the decomp file.
  * @param ioid pointer that will get the newly-assigned ID of the IO
  * description. The ioid is needed to later free the decomposition.
  * @param comm an MPI communicator.
@@ -1050,7 +1050,7 @@ int PIOc_write_nc_decomp(const char *filename, int iosysid, int ioid, MPI_Comm c
  * ordering is used, or to zero if C array ordering is used.
  * @returns 0 for success, error code otherwise.
  */
-int PIOc_read_nc_decomp(const char *filename, int iosysid, int *ioidp, MPI_Comm comm,
+int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm comm,
                         int pio_type, char *title, char *history, int *fortran_order)
 {
     iosystem_desc_t *ios; /* Pointer to the IO system info. */

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -939,6 +939,7 @@ int PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset 
  *
  * @param iosysid the IO system ID.
  * @param filename the filename to be used.
+ * @param cmode for PIOc_create(). Will be bitwise or'd with NC_WRITE.
  * @param ioid the ID of the IO description.
  * @param comm an MPI communicator.
  * @param title optial title attribute for the file. Must be less than
@@ -949,8 +950,8 @@ int PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset 
  * used, or to zero if C array ordering is used.
  * @returns 0 for success, error code otherwise.
  */
-int PIOc_write_nc_decomp(int iosysid, const char *filename, int ioid, MPI_Comm comm,
-                         char *title, char *history, int fortran_order)
+int PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
+                         MPI_Comm comm, char *title, char *history, int fortran_order)
 {
     iosystem_desc_t *ios;
     io_desc_t *iodesc;
@@ -1022,7 +1023,7 @@ int PIOc_write_nc_decomp(int iosysid, const char *filename, int ioid, MPI_Comm c
             LOG((3, "full_map[%d][%d] = %d", p, e, full_map[p][e]));
 
     /* Write the netCDF decomp file. */
-    if ((ret = pioc_write_nc_decomp_int(iosysid, filename, iodesc->ndims, iodesc->dimlen, npes,
+    if ((ret = pioc_write_nc_decomp_int(iosysid, filename, cmode, iodesc->ndims, iodesc->dimlen, npes,
                                         task_maplen, (int *)full_map, title, history, fortran_order)))
         return ret;
 
@@ -1134,6 +1135,7 @@ int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm 
  *
  * @param iosysid the IO system ID.
  * @param filename the name the decomp file will have.
+ * @param cmode for PIOc_create(). Will be bitwise or'd with NC_WRITE.
  * @param ndims number of dims in the data being described.
  * @param global_dimlen an array, of size ndims, with the size of the
  * global array in each dimension.
@@ -1152,9 +1154,9 @@ int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm 
  * ordering, 0 for C array ordering.
  * @returns 0 for success, error code otherwise.
  */
-int pioc_write_nc_decomp_int(int iosysid, const char *filename, int ndims, int *global_dimlen,
-                             int num_tasks, int *task_maplen, int *map, const char *title,
-                             const char *history, int fortran_order)
+int pioc_write_nc_decomp_int(int iosysid, const char *filename, int cmode, int ndims,
+                             int *global_dimlen, int num_tasks, int *task_maplen, int *map,
+                             const char *title, const char *history, int fortran_order)
 {
     iosystem_desc_t *ios;
     int max_maplen = 0;
@@ -1185,7 +1187,7 @@ int pioc_write_nc_decomp_int(int iosysid, const char *filename, int ndims, int *
     LOG((3, "max_maplen = %d", max_maplen));
 
     /* Create the netCDF decomp file. */
-    if ((ret = PIOc_create(iosysid, filename, NC_WRITE, &ncid)))
+    if ((ret = PIOc_create(iosysid, filename, cmode | NC_WRITE, &ncid)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with the version of this file. */

--- a/tests/cunit/test_darray_3d.c
+++ b/tests/cunit/test_darray_3d.c
@@ -214,13 +214,13 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
         sprintf(filename, "decomp_%s_iotype_%d.nc", TEST_NAME, flavor[fmt]);
 
         printf("writing decomp file %s\n", filename);
-        if ((ret = PIOc_write_nc_decomp(filename, iosysid, ioid, test_comm, NULL,
+        if ((ret = PIOc_write_nc_decomp(iosysid, filename, ioid, test_comm, NULL,
                                         NULL, 0)))
             return ret;
     
         /* Read the data. */
         printf("reading decomp file %s\n", filename);
-        if ((ret = PIOc_read_nc_decomp(filename, iosysid, &ioid2, test_comm, PIO_INT,
+        if ((ret = PIOc_read_nc_decomp(iosysid, filename, &ioid2, test_comm, PIO_INT,
                                        title_in, history_in, &fortran_order_in)))
             return ret;
     

--- a/tests/cunit/test_darray_3d.c
+++ b/tests/cunit/test_darray_3d.c
@@ -214,7 +214,7 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
         sprintf(filename, "decomp_%s_iotype_%d.nc", TEST_NAME, flavor[fmt]);
 
         printf("writing decomp file %s\n", filename);
-        if ((ret = PIOc_write_nc_decomp(iosysid, filename, ioid, test_comm, NULL,
+        if ((ret = PIOc_write_nc_decomp(iosysid, filename, 0, ioid, test_comm, NULL,
                                         NULL, 0)))
             return ret;
     

--- a/tests/cunit/test_decomps.c
+++ b/tests/cunit/test_decomps.c
@@ -273,7 +273,7 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
         sprintf(filename, "decomp_%s_iotype_%d.nc", TEST_NAME, flavor[fmt]);
 
         printf("writing decomp file %s\n", filename);
-        if ((ret = PIOc_write_nc_decomp(iosysid, filename, ioid, test_comm, NULL,
+        if ((ret = PIOc_write_nc_decomp(iosysid, filename, 0, ioid, test_comm, NULL,
                                         NULL, 0)))
             return ret;
     

--- a/tests/cunit/test_decomps.c
+++ b/tests/cunit/test_decomps.c
@@ -263,12 +263,15 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
     char title_in[PIO_MAX_NAME + 1];   /* Optional title. */
     char history_in[PIO_MAX_NAME + 1]; /* Optional history. */
     int fortran_order_in; /* Indicates fortran vs. c order. */
+    int num_decomp_file_types = 1;
     int ret;              /* Return code. */
 
-    /* Use PIO to create the decomp file in each of the four
-     * available ways. */
-#define NUM_DECOMP_FILE_TYPES 3
-    for (int decomp_file_type = 0; decomp_file_type < NUM_DECOMP_FILE_TYPES; decomp_file_type++)
+#ifdef _NETCDF4
+    /* Two extra output methods to tests if NetCDF-4 is present. */
+    num_decomp_file_types = 3;
+#endif /* _NETCDF4 */
+    
+    for (int decomp_file_type = 0; decomp_file_type < num_decomp_file_types; decomp_file_type++)
     {
         int cmode = 0;
             
@@ -278,6 +281,8 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
         if (decomp_file_type == 2)
             cmode |= NC_MPIIO;
             
+        /* Use PIO to create the decomp file in each of the four
+         * available ways. */
         for (int fmt = 0; fmt < num_flavors; fmt++) 
         {
             /* Create the filename. */

--- a/tests/cunit/test_decomps.c
+++ b/tests/cunit/test_decomps.c
@@ -267,51 +267,64 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
 
     /* Use PIO to create the decomp file in each of the four
      * available ways. */
-    for (int fmt = 0; fmt < num_flavors; fmt++) 
+#define NUM_DECOMP_FILE_TYPES 3
+    for (int decomp_file_type = 0; decomp_file_type < NUM_DECOMP_FILE_TYPES; decomp_file_type++)
     {
-        /* Create the filename. */
-        sprintf(filename, "decomp_%s_iotype_%d.nc", TEST_NAME, flavor[fmt]);
-
-        printf("writing decomp file %s\n", filename);
-        if ((ret = PIOc_write_nc_decomp(iosysid, filename, 0, ioid, test_comm, NULL,
-                                        NULL, 0)))
-            return ret;
-    
-        /* Read the data. */
-        printf("reading decomp file %s\n", filename);
-        if ((ret = PIOc_read_nc_decomp(iosysid, filename, &ioid2, test_comm, PIO_INT,
-                                       title_in, history_in, &fortran_order_in)))
-            return ret;
-    
-        /* Check the results. */
-        {
-            iosystem_desc_t *ios;
-            io_desc_t *iodesc;
+        int cmode = 0;
             
-            /* Get the IO system info. */
-            if (!(ios = pio_get_iosystem_from_id(iosysid)))
-                return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        /* Determine the create mode. */
+        if (decomp_file_type)
+            cmode |= NC_NETCDF4;
+        if (decomp_file_type == 2)
+            cmode |= NC_MPIIO;
+            
+        for (int fmt = 0; fmt < num_flavors; fmt++) 
+        {
+            /* Create the filename. */
+            sprintf(filename, "decomp_%s_iotype_%d_deomp_type_%d.nc", TEST_NAME, flavor[fmt],
+                    decomp_file_type);
 
-            /* Get the IO desc, which describes the decomposition. */
-            if (!(iodesc = pio_get_iodesc_from_id(ioid2)))
-                return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
-            if (iodesc->ioid != ioid2 || iodesc->maplen != TARGET_NTASKS || iodesc->ndims != NDIM2 ||
-                iodesc->nrecvs != 1 || iodesc->ndof != TARGET_NTASKS || iodesc->num_aiotasks != TARGET_NTASKS
-                || iodesc->rearranger != PIO_REARR_SUBSET || iodesc->maxregions != 1 ||
-                iodesc->needsfill || iodesc->basetype != MPI_INT)
-                return ERR_WRONG;
-            for (int e = 0; e < iodesc->maplen; e++)
-                if (iodesc->map[e] != my_rank * iodesc->maplen + e + 1)
+            printf("writing decomp file %s\n", filename);
+            if ((ret = PIOc_write_nc_decomp(iosysid, filename, cmode, ioid, test_comm, NULL,
+                                            NULL, 0)))
+                return ret;
+    
+            /* Read the data. */
+            printf("reading decomp file %s\n", filename);
+            if ((ret = PIOc_read_nc_decomp(iosysid, filename, &ioid2, test_comm, PIO_INT,
+                                           title_in, history_in, &fortran_order_in)))
+                return ret;
+    
+            /* Check the results. */
+            {
+                iosystem_desc_t *ios;
+                io_desc_t *iodesc;
+            
+                /* Get the IO system info. */
+                if (!(ios = pio_get_iosystem_from_id(iosysid)))
+                    return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+                /* Get the IO desc, which describes the decomposition. */
+                if (!(iodesc = pio_get_iodesc_from_id(ioid2)))
+                    return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
+                if (iodesc->ioid != ioid2 || iodesc->maplen != TARGET_NTASKS || iodesc->ndims != NDIM2 ||
+                    iodesc->nrecvs != 1 || iodesc->ndof != TARGET_NTASKS || iodesc->num_aiotasks != TARGET_NTASKS
+                    || iodesc->rearranger != PIO_REARR_SUBSET || iodesc->maxregions != 1 ||
+                    iodesc->needsfill || iodesc->basetype != MPI_INT)
                     return ERR_WRONG;
-            if (iodesc->dimlen[0] != X_DIM_LEN || iodesc->dimlen[1] != Y_DIM_LEN)
-                return ERR_WRONG;
-            printf("%d in my test iodesc->maxiobuflen = %d\n", my_rank, iodesc->maxiobuflen);
-        }
+                for (int e = 0; e < iodesc->maplen; e++)
+                    if (iodesc->map[e] != my_rank * iodesc->maplen + e + 1)
+                        return ERR_WRONG;
+                if (iodesc->dimlen[0] != X_DIM_LEN || iodesc->dimlen[1] != Y_DIM_LEN)
+                    return ERR_WRONG;
+                printf("%d in my test iodesc->maxiobuflen = %d\n", my_rank, iodesc->maxiobuflen);
+            }
         
 
-        /* Free the PIO decomposition. */
-        if ((ret = PIOc_freedecomp(iosysid, ioid2)))
-            ERR(ret);
+            /* Free the PIO decomposition. */
+            if ((ret = PIOc_freedecomp(iosysid, ioid2)))
+                ERR(ret);
+        }
     }
     return PIO_NOERR;
 }

--- a/tests/cunit/test_decomps.c
+++ b/tests/cunit/test_decomps.c
@@ -273,13 +273,13 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
         sprintf(filename, "decomp_%s_iotype_%d.nc", TEST_NAME, flavor[fmt]);
 
         printf("writing decomp file %s\n", filename);
-        if ((ret = PIOc_write_nc_decomp(filename, iosysid, ioid, test_comm, NULL,
+        if ((ret = PIOc_write_nc_decomp(iosysid, filename, ioid, test_comm, NULL,
                                         NULL, 0)))
             return ret;
     
         /* Read the data. */
         printf("reading decomp file %s\n", filename);
-        if ((ret = PIOc_read_nc_decomp(filename, iosysid, &ioid2, test_comm, PIO_INT,
+        if ((ret = PIOc_read_nc_decomp(iosysid, filename, &ioid2, test_comm, PIO_INT,
                                        title_in, history_in, &fortran_order_in)))
             return ret;
     

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -1451,34 +1451,34 @@ int test_decomp_internal(int my_test_size, int my_rank, int iosysid, int dim_len
     /* These should not work. */
     memset(too_long_name, 74, PIO_MAX_NAME * 5);
     too_long_name[PIO_MAX_NAME * 5] = 0;
-    if (pioc_write_nc_decomp_int(iosysid + TEST_VAL_42, nc_filename, NDIM1, global_dimlen,
+    if (pioc_write_nc_decomp_int(iosysid + TEST_VAL_42, nc_filename, 0, NDIM1, global_dimlen,
                                  TARGET_NTASKS, task_maplen, (int *)map, title,
                                  history, 0) != PIO_EBADID)
         return ERR_WRONG;
-    if (pioc_write_nc_decomp_int(iosysid, NULL, NDIM1, global_dimlen,
+    if (pioc_write_nc_decomp_int(iosysid, NULL, 0, NDIM1, global_dimlen,
                                  TARGET_NTASKS, task_maplen, (int *)map, title,
                                  history, 0) != PIO_EINVAL)
         return ERR_WRONG;
-    if (pioc_write_nc_decomp_int(iosysid, nc_filename, NDIM1, NULL,
+    if (pioc_write_nc_decomp_int(iosysid, nc_filename, 0, NDIM1, NULL,
                                  TARGET_NTASKS, task_maplen, (int *)map, title,
                                  history, 0) != PIO_EINVAL)
         return ERR_WRONG;
-    if (pioc_write_nc_decomp_int(iosysid, nc_filename, NDIM1, global_dimlen,
+    if (pioc_write_nc_decomp_int(iosysid, nc_filename, 0, NDIM1, global_dimlen,
                                  TARGET_NTASKS, NULL, (int *)map, title,
                                  history, 0) != PIO_EINVAL)
         return ERR_WRONG;
-    if (pioc_write_nc_decomp_int(iosysid, nc_filename, NDIM1, global_dimlen,
+    if (pioc_write_nc_decomp_int(iosysid, nc_filename, 0, NDIM1, global_dimlen,
                                  TARGET_NTASKS, task_maplen, (int *)map, too_long_name,
                                  history, 0) != PIO_EINVAL)
         return ERR_WRONG;
-    if (pioc_write_nc_decomp_int(iosysid, nc_filename, NDIM1, global_dimlen,
+    if (pioc_write_nc_decomp_int(iosysid, nc_filename, 0, NDIM1, global_dimlen,
                                  TARGET_NTASKS, task_maplen, (int *)map, title,
                                  too_long_name, 0) != PIO_EINVAL)
         return ERR_WRONG;
     
 
     /* Write the decomposition file. */
-    if ((ret = pioc_write_nc_decomp_int(iosysid, nc_filename, NDIM1, global_dimlen,
+    if ((ret = pioc_write_nc_decomp_int(iosysid, nc_filename, 0, NDIM1, global_dimlen,
                                         TARGET_NTASKS, task_maplen, (int *)map, title,
                                         history, 0)))
         return ret;
@@ -1655,15 +1655,15 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
     char *history = "Added to PIO automatic testing by Ed in February 2017.";
 
     /* These should not work. */
-    if (PIOc_write_nc_decomp(iosysid + TEST_VAL_42, nc_filename, ioid, test_comm, title, history, 0) != PIO_EBADID)
+    if (PIOc_write_nc_decomp(iosysid + TEST_VAL_42, nc_filename, 0, ioid, test_comm, title, history, 0) != PIO_EBADID)
         return ERR_WRONG;
-    if (PIOc_write_nc_decomp(iosysid, NULL, ioid, test_comm, title, history, 0) != PIO_EINVAL)
+    if (PIOc_write_nc_decomp(iosysid, NULL, 0, ioid, test_comm, title, history, 0) != PIO_EINVAL)
         return ERR_WRONG;
-    if (PIOc_write_nc_decomp(iosysid, nc_filename, ioid + TEST_VAL_42, test_comm, title, history, 0) != PIO_EBADID)
+    if (PIOc_write_nc_decomp(iosysid, nc_filename, 0, ioid + TEST_VAL_42, test_comm, title, history, 0) != PIO_EBADID)
         return ERR_WRONG;
 
     /* Write a netCDF decomp file for this iosystem. */
-    if ((ret = PIOc_write_nc_decomp(iosysid, nc_filename, ioid, test_comm, title, history, 0)))
+    if ((ret = PIOc_write_nc_decomp(iosysid, nc_filename, 0, ioid, test_comm, title, history, 0)))
         return ret;
 
     int ioid_in;
@@ -1672,18 +1672,18 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
     int fortran_order_in;
 
     /* These should not work. */
-    if (PIOc_read_nc_decomp(nc_filename, iosysid + TEST_VAL_42, &ioid_in, test_comm, PIO_INT,
+    if (PIOc_read_nc_decomp(iosysid + TEST_VAL_42, nc_filename, &ioid_in, test_comm, PIO_INT,
                             title_in, history_in, &fortran_order_in) != PIO_EBADID)
         return ret;
-    if (PIOc_read_nc_decomp(NULL, iosysid, &ioid_in, test_comm, PIO_INT, title_in,
+    if (PIOc_read_nc_decomp(iosysid, NULL, &ioid_in, test_comm, PIO_INT, title_in,
                             history_in, &fortran_order_in) != PIO_EINVAL)
         return ret;
-    if (PIOc_read_nc_decomp(nc_filename, iosysid, NULL, test_comm, PIO_INT, title_in,
+    if (PIOc_read_nc_decomp(iosysid, nc_filename, NULL, test_comm, PIO_INT, title_in,
                             history_in, &fortran_order_in) != PIO_EINVAL)
         return ret;
     
     /* Read it using the public read function. */
-    if ((ret = PIOc_read_nc_decomp(nc_filename, iosysid, &ioid_in, test_comm, PIO_INT,
+    if ((ret = PIOc_read_nc_decomp(iosysid, nc_filename, &ioid_in, test_comm, PIO_INT,
                                    title_in, history_in, &fortran_order_in)))
         return ret;
 
@@ -1696,19 +1696,19 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
         ERR(ret);
 
     /* These should also work. */
-    if ((ret = PIOc_read_nc_decomp(nc_filename, iosysid, &ioid_in, test_comm, PIO_CHAR, NULL,
+    if ((ret = PIOc_read_nc_decomp(iosysid, nc_filename, &ioid_in, test_comm, PIO_CHAR, NULL,
                                    history_in, &fortran_order_in)))
         return ret;
     if ((ret = PIOc_freedecomp(iosysid, ioid_in)))
         ERR(ret);
 
-    if ((ret = PIOc_read_nc_decomp(nc_filename, iosysid, &ioid_in, test_comm, PIO_BYTE, title_in,
+    if ((ret = PIOc_read_nc_decomp(iosysid, nc_filename, &ioid_in, test_comm, PIO_BYTE, title_in,
                                    NULL, &fortran_order_in)))
         return ret;
     if ((ret = PIOc_freedecomp(iosysid, ioid_in)))
         ERR(ret);
 
-    if ((ret = PIOc_read_nc_decomp(nc_filename, iosysid, &ioid_in, test_comm, PIO_SHORT, title_in,
+    if ((ret = PIOc_read_nc_decomp(iosysid, nc_filename, &ioid_in, test_comm, PIO_SHORT, title_in,
                                   history_in, NULL)))
         return ret;
     if ((ret = PIOc_freedecomp(iosysid, ioid_in)))
@@ -1756,7 +1756,7 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
     free(map_in);
 
     /* /\* These should also work. *\/ */
-    /* if ((ret = PIOc_write_nc_decomp(iosysid, nc_filename, ioid, test_comm, title, history, 0))) */
+    /* if ((ret = PIOc_write_nc_decomp(iosysid, nc_filename, 0, ioid, test_comm, title, history, 0))) */
     /*     return ret; */
     
     /* Free the PIO decomposition. */

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -1655,15 +1655,15 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
     char *history = "Added to PIO automatic testing by Ed in February 2017.";
 
     /* These should not work. */
-    if (PIOc_write_nc_decomp(nc_filename, iosysid + TEST_VAL_42, ioid, test_comm, title, history, 0) != PIO_EBADID)
+    if (PIOc_write_nc_decomp(iosysid + TEST_VAL_42, nc_filename, ioid, test_comm, title, history, 0) != PIO_EBADID)
         return ERR_WRONG;
-    if (PIOc_write_nc_decomp(NULL, iosysid, ioid, test_comm, title, history, 0) != PIO_EINVAL)
+    if (PIOc_write_nc_decomp(iosysid, NULL, ioid, test_comm, title, history, 0) != PIO_EINVAL)
         return ERR_WRONG;
-    if (PIOc_write_nc_decomp(nc_filename, iosysid, ioid + TEST_VAL_42, test_comm, title, history, 0) != PIO_EBADID)
+    if (PIOc_write_nc_decomp(iosysid, nc_filename, ioid + TEST_VAL_42, test_comm, title, history, 0) != PIO_EBADID)
         return ERR_WRONG;
 
     /* Write a netCDF decomp file for this iosystem. */
-    if ((ret = PIOc_write_nc_decomp(nc_filename, iosysid, ioid, test_comm, title, history, 0)))
+    if ((ret = PIOc_write_nc_decomp(iosysid, nc_filename, ioid, test_comm, title, history, 0)))
         return ret;
 
     int ioid_in;
@@ -1756,7 +1756,7 @@ int test_decomp_public(int my_test_size, int my_rank, int iosysid, int dim_len,
     free(map_in);
 
     /* /\* These should also work. *\/ */
-    /* if ((ret = PIOc_write_nc_decomp(nc_filename, iosysid, ioid, test_comm, title, history, 0))) */
+    /* if ((ret = PIOc_write_nc_decomp(iosysid, nc_filename, ioid, test_comm, title, history, 0))) */
     /*     return ret; */
     
     /* Free the PIO decomposition. */


### PR DESCRIPTION
Added cmode param to allow netCDF-4 decomp files. (Fixes #693)
Changed parameter order to match other functions. (Fixes #717)
Add backtrace as an attribute. (Fixes #436)
More tests.

I will merge to develop for testing.

