### PR TITLE
fix issue with non iotasks calling flush

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -256,7 +256,7 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
     }
 
     /* Flush data to disk. */
-    if (file->iotype == PIO_IOTYPE_PNETCDF)
+    if (ios->ioproc && file->iotype == PIO_IOTYPE_PNETCDF)
         if ((ierr = flush_output_buffer(file, flushtodisk, 0)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
 

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1521,7 +1521,7 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
 
     /* Find out the buffer usage. */
     if ((ierr = ncmpi_inq_buffer_usage(file->fh, &usage)))
-	return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, file, PIO_EBADID, __FILE__, __LINE__);
 
     /* If we are not forcing a flush, spread the usage to all IO
      * tasks. */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1521,8 +1521,7 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
 
     /* Find out the buffer usage. If I check the turn code, some tests fail. ??? */
     if ((ierr = ncmpi_inq_buffer_usage(file->fh, &usage)))
-        return ierr;
-    /*return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__);*/
+	return ierr;
 
     /* If we are not forcing a flush, spread the usage to all IO
      * tasks. */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -962,7 +962,7 @@ int pio_write_darray_multi_nc_serial(file_desc_t *file, int nvars, const int *vi
                     for (int regioncnt = 0; regioncnt < rregions; regioncnt++)
                     {
                         LOG((3, "writing data for region with regioncnt = %d", regioncnt));
-                        
+
                         /* Get the start/count arrays for this region. */
                         for (int i = 0; i < fndims; i++)
                         {
@@ -1519,9 +1519,9 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     /* Check inputs. */
     pioassert(file, "invalid input", __FILE__, __LINE__);
 
-    /* Find out the buffer usage. If I check the turn code, some tests fail. ??? */
+    /* Find out the buffer usage. */
     if ((ierr = ncmpi_inq_buffer_usage(file->fh, &usage)))
-	return ierr;
+	return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__);
 
     /* If we are not forcing a flush, spread the usage to all IO
      * tasks. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -123,7 +123,7 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
  * parameters are read on comp task 0 and ignored elsewhere.
  *
  * @param iosysid : A defined pio system descriptor (input)
- * @param cmode : The netcdf mode for the create operation. 
+ * @param cmode : The netcdf mode for the create operation.
  * @param filename : The filename to open
  * @param ncidp : A pio file descriptor (output)
  * @return 0 for success, error code otherwise.
@@ -298,7 +298,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
 
         if (!mpierr && ios->io_rank == 0)
              ierr = nc_delete(filename);
- 
+
         if (!mpierr)
             mpierr = MPI_Barrier(ios->io_comm);
     }
@@ -380,8 +380,6 @@ int PIOc_sync(int ncid)
                 brel(twmb);
             }
         }
-        if (file->iotype == PIO_IOTYPE_PNETCDF)
-            flush_output_buffer(file, true, 0);
 
         if (ios->ioproc)
         {
@@ -399,6 +397,7 @@ int PIOc_sync(int ncid)
                 break;
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
+                flush_output_buffer(file, true, 0);
                 ierr = ncmpi_sync(file->fh);
                 break;
 #endif


### PR DESCRIPTION
Non-iotasks were calling ncmpi functions and thus returning an invalid file id error.
I have merged to develop for testing
Fixes #719 