### PR TITLE
Allow user buffers larger than local ndof

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -275,10 +275,13 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
  * to.
  * @param ioid the I/O description ID as passed back by
  * PIOc_InitDecomp().
- * @param arraylen the length of the array to be written. This is the
- * length of the local component of the distrubited array. That is,
- * the length of the portion of the data that is on this task. This
- * must be equal to the size of the local array in the decomposition.
+ * @param arraylen the length of the array to be written.
+ * This should be at least the length of the local component of the 
+ * distrubited array. That is, the length of the portion of the data
+ * that is on this task. This must be at least the size of the local
+ * array in the decomposition and the initial elements in the array
+ * should contain the local component of the data, as specified in
+ * the decomposition (ioid).
  * @param array pointer to the data to be written. This is a
  * pointer to the distributed portion of the array that is on this
  * task.
@@ -332,8 +335,11 @@ int PIOc_write_darray(int ncid, int vid, int ioid, PIO_Offset arraylen, void *ar
 
     /* Check that the local size of the variable passed in matches the
      * size expected by the io descriptor. */
-    if (iodesc->ndof != arraylen)
+    if (arraylen < iodesc->ndof)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
+
+    if (iodesc->ndof != arraylen)
+        LOG((1, "User supplied array is larger than expected, arraylen != iodesc->ndof"));
 
     /* Get a pointer to the buffer space for this file. It will hold
      * data from one or more variables that fit the same

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -110,7 +110,7 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
             ERR(ERR_WRONG);
         if (PIOc_write_darray(ncid, varid, ioid + TEST_VAL_42, arraylen, test_data, &fillvalue) != PIO_EBADID)
             ERR(ERR_WRONG);
-        if (PIOc_write_darray(ncid, varid, ioid, arraylen + TEST_VAL_42, test_data, &fillvalue) != PIO_EINVAL)
+        if (PIOc_write_darray(ncid, varid, ioid, arraylen - 1, test_data, &fillvalue) != PIO_EINVAL)
             ERR(ERR_WRONG);
 
         /* Write the data. */

--- a/tests/general/pio_decomp_tests.F90.in
+++ b/tests/general/pio_decomp_tests.F90.in
@@ -90,6 +90,111 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_darray
   call PIO_freedecomp(pio_tf_iosystem_, iodesc)
 PIO_TF_AUTO_TEST_SUB_END nc_write_1d_darray
 
+! Write 1d array, although diff procs have different
+! number of elements to write locally they all use
+! the same buffer size (compdof size is different for
+! each rank but buf size is the same)
+! Odd procs write out VEC_LOCAL_SZ_ODD elements &
+! even procs write out VEC_LOCAL_SZ_EVEN elements, but
+! all procs use buf[MAX_VEC_SZ]
+! eg:
+! Elements in buffer on each proc with MAX_VEC_SZ = 2,
+! [0 1] [2 X] [3 4] [5 X] ...
+! The 'X'es in the buffer are not written out
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_const_buf_sz
+  implicit none
+  integer, parameter :: MAX_VEC_SZ = 2
+  integer, parameter :: VEC_LOCAL_SZ_ODD = MAX_VEC_SZ - 1
+  integer, parameter :: VEC_LOCAL_SZ_EVEN = MAX_VEC_SZ
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: iodesc
+  integer, dimension(:), allocatable :: compdof, compdof_rel_disps
+  integer :: compdof_rel_start
+  integer :: cdof_sz = VEC_LOCAL_SZ_ODD
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_VEC_SZ) :: wbuf, rbuf
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+  logical :: is_even = .false.
+  integer :: nodd_procs, nodd_procs_bfr, neven_procs, neven_procs_bfr
+
+  nodd_procs = pio_tf_world_sz_ / 2
+  ! Number of odd procs before this rank
+  nodd_procs_bfr = pio_tf_world_rank_ / 2
+  neven_procs = pio_tf_world_sz_ - nodd_procs
+  ! Number of even procs before this rank
+  neven_procs_bfr = pio_tf_world_rank_ - nodd_procs_bfr
+
+  ! Odd procs write out VEC_LOCAL_SZ_ODD elements &
+  ! even procs write out VEC_LOCAL_SZ_EVEN elements
+  if(mod(pio_tf_world_rank_, 2) == 0) then
+    is_even = .true.
+    cdof_sz = VEC_LOCAL_SZ_EVEN
+  end if
+  allocate(compdof(cdof_sz))
+  allocate(compdof_rel_disps(cdof_sz))
+  wbuf = 0
+  rbuf = 0
+  do i=1,cdof_sz
+    compdof_rel_disps(i) = i
+    wbuf(i) = i
+  end do
+  ! Find out where compdof starts for this rank
+  compdof_rel_start = nodd_procs_bfr * VEC_LOCAL_SZ_ODD +&
+                      neven_procs_bfr * VEC_LOCAL_SZ_EVEN
+  dims(1) = nodd_procs * VEC_LOCAL_SZ_ODD + neven_procs * VEC_LOCAL_SZ_EVEN
+  compdof = compdof_rel_start + compdof_rel_disps
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, iodesc)
+
+  deallocate(compdof)
+  deallocate(compdof_rel_disps)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variable out
+    call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    call PIO_read_darray(pio_file, pio_var, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+  call PIO_freedecomp(pio_tf_iosystem_, iodesc)
+PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_const_buf_sz
+
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_reuse_decomp
   implicit none


### PR DESCRIPTION
Allowing user buffers larger than the size expected (as specified in the
IO decomposition) by the current process.
* Fixes a C test that checked for larger user buffers to test for smaller
  user buffers
* Adds a new Fortran test that specifies larger user buffers
* Minor doc change

Fixes #577 