### PR TITLE
add darray testing for different types

### DIFF
--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -93,5 +93,8 @@ int test_all(int iosysid, int num_flavors, int *flavor, int my_rank, MPI_Comm te
 int run_test_main(int argc, char **argv, int min_ntasks, int max_ntasks,
                   int log_level, char *test_name, int *dim_len, int component_count,
                   int num_io_procs);
-int create_decomposition_2d(int ntasks, int my_rank, int iosysid, int *dim_len_2d, int *ioid);
+
+/* Create a 2D decomposition used in some tests. */
+int create_decomposition_2d(int ntasks, int my_rank, int iosysid, int *dim_len_2d, int *ioid,
+                            int pio_type);
 #endif /* _PIO_TESTS_H */

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -888,9 +888,11 @@ check_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nci
  * @param iosysid the IO system ID.
  * @param dim_len_2d an array of length 2 with the dim lengths.
  * @param ioid a pointer that gets the ID of this decomposition.
+ * @param pio_type the data type to use for the decomposition.
  * @returns 0 for success, error code otherwise.
  **/
-int create_decomposition_2d(int ntasks, int my_rank, int iosysid, int *dim_len_2d, int *ioid)
+int create_decomposition_2d(int ntasks, int my_rank, int iosysid, int *dim_len_2d,
+                            int *ioid, int pio_type)
 {
     PIO_Offset elements_per_pe;     /* Array elements per processing unit. */
     PIO_Offset *compdof;  /* The decomposition mapping. */
@@ -910,7 +912,7 @@ int create_decomposition_2d(int ntasks, int my_rank, int iosysid, int *dim_len_2
 
     /* Create the PIO decomposition for this test. */
     printf("%d Creating decomposition elements_per_pe = %lld\n", my_rank, elements_per_pe);
-    if ((ret = PIOc_InitDecomp(iosysid, PIO_INT, NDIM2, dim_len_2d, elements_per_pe,
+    if ((ret = PIOc_InitDecomp(iosysid, pio_type, NDIM2, dim_len_2d, elements_per_pe,
                                compdof, ioid, NULL, NULL, NULL)))
         ERR(ret);
 

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -221,10 +221,10 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
 int test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
                     MPI_Comm test_comm)
 {
-#define NUM_TYPES_TO_TEST 1
+#define NUM_TYPES_TO_TEST 3
     int ioid;
     char filename[NC_MAX_NAME + 1];
-    int pio_type[NUM_TYPES_TO_TEST] = {PIO_DOUBLE};
+    int pio_type[NUM_TYPES_TO_TEST] = {PIO_INT, PIO_FLOAT, PIO_DOUBLE};
     int dim_len_2d[NDIM2] = {X_DIM_LEN, Y_DIM_LEN};
     int ret; /* Return code. */
 

--- a/tests/cunit/test_decomps.c
+++ b/tests/cunit/test_decomps.c
@@ -387,7 +387,8 @@ int main(int argc, char **argv)
             return ret;
 
         /* Decompose the data over the tasks. */
-        if ((ret = create_decomposition_2d(TARGET_NTASKS, my_rank, iosysid, dim_len_2d, &ioid)))
+        if ((ret = create_decomposition_2d(TARGET_NTASKS, my_rank, iosysid, dim_len_2d, &ioid,
+                                           PIO_INT)))
             return ret;
 
         /* Test decomposition read/write. */


### PR DESCRIPTION
Looking at the code, it seems that the only types that are supported with darray are PIO_INT, PIO_FLOAT, and PIO_DOUBLE.

In this PR I change test_darray.c so that it tests all three types. Only test code changes in this PR.

Future work will include trying out other types. ;-)

Fixes #665.
Part of #205.

I will merge to develop for testing.