### PR TITLE
change malloc_iodesc to handle all types, including netCDF-4 types

### DIFF
--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -180,7 +180,8 @@ extern "C" {
     /* Move data from compute tasks to IO tasks. */
     int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf, void *rbuf, int nvars);
 
-    io_desc_t *malloc_iodesc(const iosystem_desc_t *ios, int piotype, int ndims);
+    /* Allocate and initialize storage for decomposition information. */
+    int malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims, io_desc_t **iodesc);
     
     void performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc);
 

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -386,8 +386,8 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
     }
 
     /* Allocate space for the iodesc info. */
-    if (!(iodesc = malloc_iodesc(ios, basetype, ndims)))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    if ((ierr = malloc_iodesc(ios, basetype, ndims, &iodesc)))
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 
     /* Remember the maplen. */
     iodesc->maplen = maplen;


### PR DESCRIPTION
This is one of several changes that will be necessary before all types, including netCDF-4 types (when available), can be used for darrays.

This change will not affect current users, who are limited to the three currently supported darray types, PIO_INT, PIO_FLOAT, and PIO_DOUBLE.

Fixes #473.

