### PR TITLE
changed fill value copying to be typeless

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -136,9 +136,9 @@ int PIOc_write_darray_multi(int ncid, const int *vid, int ioid, int nvars, PIO_O
             LOG((3, "vsize = %d", vsize));
 
             /* Allocate memory for the variable buffer. */
-            if (!(vdesc0->iobuf = bget(vsize * rlen)))
-                piomemerror(ios, rlen * vsize, __FILE__, __LINE__);
-            LOG((3, "allocated %ld bytes for variable buffer", rlen * vsize));
+            if (!(vdesc0->iobuf = bget((size_t)vsize * (size_t)rlen)))
+                piomemerror(ios, (size_t)rlen * (size_t)vsize, __FILE__, __LINE__);
+            LOG((3, "allocated %ld bytes for variable buffer", (size_t)rlen * (size_t)vsize));
 
             /* If data are missing for the BOX rearranger, insert fill values. */
             if (iodesc->needsfill && iodesc->rearranger == PIO_REARR_BOX)

--- a/tests/cunit/test_darray_1d.c
+++ b/tests/cunit/test_darray_1d.c
@@ -376,7 +376,7 @@ int test_darray_fill_unlim(int iosysid, int ioid, int pio_type, int num_flavors,
         if ((ret = PIOc_openfile(iosysid, &ncid, &flavor[fmt], filename, PIO_NOWRITE)))
             ERR(ret);
 
-        /* /\* Allocate space for data. *\/ */
+        /* Allocate space for data. */
         if (!(test_data_in = malloc(type_size * arraylen)))
             ERR(PIO_ENOMEM);
 
@@ -534,9 +534,9 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
 /* Run tests for darray functions. */
 int main(int argc, char **argv)
 {
-#define NUM_TYPES_TO_TEST 3
 #define NUM_REARRANGERS_TO_TEST 2
     int rearranger[NUM_REARRANGERS_TO_TEST] = {PIO_REARR_BOX, PIO_REARR_SUBSET};
+#define NUM_TYPES_TO_TEST 3
     int test_type[NUM_TYPES_TO_TEST] = {PIO_INT, PIO_FLOAT, PIO_DOUBLE};
     int my_rank;
     int ntasks;


### PR DESCRIPTION
This PR contains important code changes.

In this PR I change the code in PIOc_write_darray_multi() which copies the fill values to the buffer for both  rearrangers. This code previously only worked for types that were of length 4 and 8.

Now this code will work for all types, instead of just the big 3 (PIO_INT, PIO_FLOAT, and PIO_DOUBLE). ;-)

Fixes #543.

I will merge to develop for testing.