### PR TITLE
Removing long redundant tests

### DIFF
--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -250,15 +250,7 @@ if (PIO_USE_MPISERIAL)
     set_tests_properties(pio_rearr_opts
         PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 else ()
-    add_mpi_test(pio_rearr_opts_1p
-        EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_rearr_opts
-        NUMPROCS 1
-        TIMEOUT ${DEFAULT_TEST_TIMEOUT})
-    add_mpi_test(pio_rearr_opts_3p
-        EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_rearr_opts
-        NUMPROCS 3
-        TIMEOUT ${DEFAULT_TEST_TIMEOUT})
-    add_mpi_test(pio_rearr_opts_4p
+    add_mpi_test(pio_rearr_opts
         EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_rearr_opts
         NUMPROCS 4
         TIMEOUT ${DEFAULT_TEST_TIMEOUT})


### PR DESCRIPTION
The scenarios tested by 1 proc and 3 proc cases of this test (pio_rearr_opts) 
is also covered by another test (pio_rearr_opts2). Since this test is "heavy",
removing the 1proc and 3proc cases (and retaining the 4 proc case)
for this test.
This change speeds up the testing process without sacrificing coverage.
No code changes.