### PR TITLE
Change max requests setting in flow control code

### DIFF
--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -222,20 +222,26 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
     }
     else
     {
-        if (max_requests > 1 && max_requests < steps)
-        {
-            maxreq = max_requests;
-            maxreqh = maxreq / 2;
-        }
-        else if (max_requests >= steps)
+        if (max_requests == PIO_REARR_COMM_UNLIMITED_PEND_REQ)
         {
             maxreq = steps;
             maxreqh = steps;
         }
-        else
+        else if (max_requests > 1 && max_requests < steps)
         {
+            maxreq = max_requests;
+            maxreqh = maxreq / 2;
+        }
+        else if (max_requests == 1)
+        {
+            /* Note that steps >= 2 here */
             maxreq = 2;
             maxreqh = 1;
+        }
+        else
+        {
+            maxreq = steps;
+            maxreqh = steps;
         }
     }
 

--- a/tests/general/pio_rearr_opts2.F90.in
+++ b/tests/general/pio_rearr_opts2.F90.in
@@ -253,9 +253,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN set_rearr_opts_and_write
   integer, parameter :: NUM_ENABLE_ISEND_OPTS = 2
   logical :: enable_isend_opts(NUM_ENABLE_ISEND_OPTS) = (/.true.,.false./)
   integer :: num_enable_isend_opts_comp2io, num_enable_isend_opts_io2comp
-  integer, parameter :: NUM_MAX_PEND_REQ_OPTS = 2
+  integer, parameter :: NUM_MAX_PEND_REQ_OPTS = 3
   integer :: max_pend_req_opts(NUM_MAX_PEND_REQ_OPTS) = &
-                  (/pio_rearr_comm_unlimited_pend_req, 2/)
+                  (/pio_rearr_comm_unlimited_pend_req, 1, 2/)
   integer :: num_max_pend_req_opts_comp2io, num_max_pend_req_opts_io2comp
 
   integer ::  cur_comm_type_opt, cur_fcd_opt, cur_enable_hs_c2i, &


### PR DESCRIPTION
Change max requests setting in PIO2 to reflect the settings
in PIO1. Also handling the case where user specifies unlimited
number of requests.

Also adding a test to cover the case where user sets max requests = 1

Fixes #779 