### PR TITLE
version if init_decomp with 0-based arrays

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -701,11 +701,19 @@ extern "C" {
     int PIOc_set_log_level(int level);
 
     /* Decomposition. */
+
+    /* Init decomposition with 1-based compmap array. */
     int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int maplen,
                         const PIO_Offset *compmap, int *ioidp, const int *rearr,
                         const PIO_Offset *iostart, const PIO_Offset *iocount);
     int PIOc_InitDecomp_bc(int iosysid, int basetype, int ndims, const int *dims,
                            const long int *start, const long int *count, int *ioidp);
+
+    /* Init decomposition with 0-based compmap array. */
+    int PIOc_init_decomp(int iosysid, int basetype, int ndims, const int *dims, int maplen,
+                         const PIO_Offset *compmap, int *ioidp, const int *rearranger,
+                         const PIO_Offset *iostart, const PIO_Offset *iocount);
+    
     int PIOc_freedecomp(int iosysid, int ioid);
     int PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
                      PIO_Offset **map, MPI_Comm comm);

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -484,6 +484,47 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
 }
 
 /**
+ * Initialize the decomposition used with distributed arrays. The
+ * decomposition describes how the data will be distributed between
+ * tasks.
+ *
+ * @param iosysid the IO system ID.
+ * @param basetype the basic PIO data type used.
+ * @param ndims the number of dimensions in the variable, not
+ * including the unlimited dimension.
+ * @param dims an array of global size of each dimension.
+ * @param maplen the local length of the compmap array.
+ * @param compmap a 0 based array of offsets into the array record on
+ * file. A -1 in this array indicates a value which should not be
+ * transfered.
+ * @param ioidp pointer that will get the io description ID.
+ * @param rearranger pointer to the rearranger to be used for this
+ * decomp or NULL to use the default.
+ * @param iostart An array of start values for block cyclic
+ * decompositions. If NULL ???
+ * @param iocount An array of count values for block cyclic
+ * decompositions. If NULL ???
+ * @returns 0 on success, error code otherwise
+ * @ingroup PIO_initdecomp
+ */
+int PIOc_init_decomp(int iosysid, int basetype, int ndims, const int *dims, int maplen,
+                     const PIO_Offset *compmap, int *ioidp, const int *rearranger,
+                     const PIO_Offset *iostart, const PIO_Offset *iocount)
+{
+    PIO_Offset compmap_1_based[maplen];
+
+    LOG((1, "PIOc_init_decomp iosysid = %d basetype = %d ndims = %d maplen = %d",
+         iosysid, basetype, ndims, maplen));
+
+    /* Add 1 to all elements in compmap. */
+    for (int e = 0; e < maplen; e++)
+        compmap_1_based[e] = compmap[e] + 1;
+
+    return PIOc_InitDecomp(iosysid, basetype, ndims, dims, maplen, compmap_1_based,
+                           ioidp, rearranger, iostart, iocount);
+}
+
+/**
  * This is a simplified initdecomp which can be used if the memory
  * order of the data can be expressed in terms of start and count on
  * the file. In this case we compute the compdof.

--- a/tests/cunit/test_darray_3d.c
+++ b/tests/cunit/test_darray_3d.c
@@ -85,14 +85,14 @@ int create_decomposition_3d(int ntasks, int my_rank, int iosysid, int *ioid)
     if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
         return PIO_ENOMEM;
 
-    /* Describe the decomposition. This is a 1-based array, so add 1! */
+    /* Describe the decomposition. */
     for (int i = 0; i < elements_per_pe; i++)
-        compdof[i] = my_rank * elements_per_pe + i + 1;
+        compdof[i] = my_rank * elements_per_pe + i;
 
     /* Create the PIO decomposition for this test. */
     printf("%d Creating decomposition elements_per_pe = %lld\n", my_rank, elements_per_pe);
-    if ((ret = PIOc_InitDecomp(iosysid, PIO_INT, NDIM3, dim_len_3d, elements_per_pe,
-                               compdof, ioid, NULL, NULL, NULL)))
+    if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM3, dim_len_3d, elements_per_pe,
+                                compdof, ioid, NULL, NULL, NULL)))
         ERR(ret);
 
     printf("%d decomposition initialized.\n", my_rank);


### PR DESCRIPTION
Added a new version of init decomp, but with 0 based array.

Fixes #414.

I will merge to develop for testing.