### PR TITLE
new, less confusing PIOc_init_async() API

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -739,6 +739,12 @@ extern "C" {
     int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
                         int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
                         int *iosysidp);
+
+    /* Initializing IO system for async. */
+    int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
+                        int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
+                        int *iosysidp);
+    
     int PIOc_Init_Intercomm(int component_count, MPI_Comm peer_comm, MPI_Comm *comp_comms,
                             MPI_Comm io_comm, int *iosysidp);
     int PIOc_get_numiotasks(int iosysid, int *numiotasks);

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1741,7 +1741,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         
         /* Add proc numbers from computation component. */
         for (int p = 0; p < num_procs_per_comp[cmp]; p++)
-            proc_list_union[p + num_procs_per_comp[0]] = my_proc_list[cmp][p];
+            proc_list_union[p + num_io_procs] = my_proc_list[cmp][p];
         
         /* Create the union group. */
         if ((ret = MPI_Group_incl(world_group, nprocs_union, proc_list_union,
@@ -1832,8 +1832,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
                 LOG((3, "about to create intercomm for IO component to cmp = %d "
                      "my_iosys->io_comm = %d", cmp, my_iosys->io_comm));
                 if ((ret = MPI_Intercomm_create(my_iosys->io_comm, 0, my_iosys->union_comm,
-                                                my_proc_list[cmp][0], 0,
-                                                &my_iosys->intercomm)))
+                                                my_proc_list[cmp][0], 0, &my_iosys->intercomm)))
                     return check_mpi(NULL, ret, __FILE__, __LINE__);
             }
             else
@@ -1842,8 +1841,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
                 LOG((3, "about to create intercomm for cmp = %d my_iosys->comp_comm = %d", cmp,
                      my_iosys->comp_comm));
                 if ((ret = MPI_Intercomm_create(my_iosys->comp_comm, 0, my_iosys->union_comm,
-                                                my_proc_list[0][0], 0,
-                                                &my_iosys->intercomm)))
+                                                my_io_proc_list[0], 0, &my_iosys->intercomm)))
                     return check_mpi(NULL, ret, __FILE__, __LINE__);
             }
             LOG((3, "intercomm created for cmp = %d", cmp));

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1681,27 +1681,23 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
      * processes. */
     MPI_Group union_group[component_count];
 
-    /* For each component, starting with the IO component. */
-    for (int cmp = 0; cmp < 1; cmp++)
-    {
-        LOG((3, "processing component %d", cmp));
+    /* For the IO component. */
+    LOG((3, "processing component %d", 0));
 
-        /* Create a group for this component. */
-        if ((ret = MPI_Group_incl(world_group, num_procs_per_comp[cmp], my_proc_list[cmp],
-                                  &group[cmp])))
-            return check_mpi(NULL, ret, __FILE__, __LINE__);
-        LOG((3, "created component MPI group - group[%d] = %d", cmp, group[cmp]));
+    /* Create a group for this component. */
+    if ((ret = MPI_Group_incl(world_group, num_procs_per_comp[0], my_proc_list[0],
+                              &group[0])))
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
+    LOG((3, "created component MPI group - group[%d] = %d", 0, group[0]));
 
-        /* Is this process in this computation component (which is the
-         * IO component if cmp == 0)? */
-        int in_cmp = 0;
-        for (pidx = 0; pidx < num_procs_per_comp[cmp]; pidx++)
-            if (my_rank == my_proc_list[cmp][pidx])
-                break;
-        in_cmp = (pidx == num_procs_per_comp[cmp]) ? 0 : 1;
-        LOG((3, "pidx = %d num_procs_per_comp[%d] = %d in_cmp = %d",
-             pidx, cmp, num_procs_per_comp[cmp], in_cmp));
-    }
+    /* Is this process in the IO component? */
+    int in_cmp = 0;
+    for (pidx = 0; pidx < num_procs_per_comp[0]; pidx++)
+        if (my_rank == my_proc_list[0][pidx])
+            break;
+    in_cmp = (pidx == num_procs_per_comp[0]) ? 0 : 1;
+    LOG((3, "pidx = %d num_procs_per_comp[%d] = %d in_cmp = %d",
+         pidx, 0, num_procs_per_comp[0], in_cmp));
 
     /* For each component, starting with the IO component. */
     for (int cmp = 1; cmp < component_count + 1; cmp++)

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1690,14 +1690,6 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         return check_mpi(NULL, ret, __FILE__, __LINE__);
     LOG((3, "created component MPI group - group[%d] = %d", 0, group[0]));
 
-    /* Is this process in the IO component? */
-    int in_cmp = 0;
-    for (pidx = 0; pidx < num_io_procs; pidx++)
-        if (my_rank == my_io_proc_list[pidx])
-            break;
-    in_cmp = (pidx == num_io_procs) ? 0 : 1;
-    LOG((3, "pidx = %d num_io_procs = %d in_cmp = %d", pidx, 0, num_io_procs, in_cmp));
-
     /* For each computation component. */
     for (int cmp = 1; cmp < component_count + 1; cmp++)
     {
@@ -1755,13 +1747,13 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         if ((ret = MPI_Group_incl(world_group, nprocs_union, proc_list_union,
                                   &union_group[cmp - 1])))
             return check_mpi(NULL, ret, __FILE__, __LINE__);
-        LOG((3, "created union MPI_group - union_group[%d] = %d with %d procs", cmp, union_group[cmp-1], nprocs_union));
+        LOG((3, "created union MPI_group - union_group[%d] = %d with %d procs", cmp,
+             union_group[cmp - 1], nprocs_union));
 
         /* Remember whether this process is in the IO component. */
         my_iosys->ioproc = in_io;
 
-        /* Is this process in this computation component (which is the
-         * IO component if cmp == 0)? */
+        /* Is this process in this computation component? */
         int in_cmp = 0;
         for (pidx = 0; pidx < num_procs_per_comp[cmp]; pidx++)
             if (my_rank == my_proc_list[cmp][pidx])
@@ -1860,7 +1852,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         /* Add this id to the list of PIO iosystem ids. */
         iosysidp[cmp - 1] = pio_add_to_iosystem_list(my_iosys);
         LOG((2, "new iosys ID added to iosystem_list iosysid = %d\n", iosysidp[cmp - 1]));
-    }
+    } /* next computational component */
 
     /* Now call the function from which the IO tasks will not return
      * until the PIO_MSG_EXIT message is sent. This will handle all

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1568,7 +1568,23 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
             return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
         /* Fill the array of arrays. */
-        for (int cmp = 0; cmp < component_count + 1; cmp++)
+        for (int cmp = 0; cmp < 1; cmp++)
+        {
+            LOG((3, "calculating processors for component %d", cmp));
+
+            /* Allocate space for each array. */
+            if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
+                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+
+            int proc;
+            for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
+            {
+                my_proc_list[cmp][proc - last_proc] = proc;
+                LOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
+            }
+            last_proc = proc;
+        }
+        for (int cmp = 1; cmp < component_count + 1; cmp++)
         {
             LOG((3, "calculating processors for component %d", cmp));
 

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1576,7 +1576,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
             return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
         int proc;
-        for (proc = last_proc; proc < num_procs_per_comp[0] + last_proc; proc++)
+        for (proc = last_proc; proc < num_io_procs + last_proc; proc++)
         {
             my_proc_list[0][proc - last_proc] = proc;
             LOG((3, "my_proc_list[%d][%d] = %d", 0, proc - last_proc, proc));
@@ -1686,7 +1686,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
     LOG((3, "processing component %d", 0));
 
     /* Create a group for this component. */
-    if ((ret = MPI_Group_incl(world_group, num_io_procs, my_proc_list[0], &group[0])))
+    if ((ret = MPI_Group_incl(world_group, num_io_procs, my_io_proc_list, &group[0])))
         return check_mpi(NULL, ret, __FILE__, __LINE__);
     LOG((3, "created component MPI group - group[%d] = %d", 0, group[0]));
 
@@ -1707,7 +1707,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         my_iosys->async_interface = 1;
         my_iosys->error_handler = default_error_handler;
         my_iosys->num_comptasks = num_procs_per_comp[cmp];
-        my_iosys->num_iotasks = num_procs_per_comp[0];
+        my_iosys->num_iotasks = num_io_procs;
         my_iosys->compgroup = MPI_GROUP_NULL;
         my_iosys->iogroup = MPI_GROUP_NULL;
         
@@ -1736,8 +1736,8 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         int proc_list_union[nprocs_union];
         
         /* Add proc numbers from IO. */
-        for (int p = 0; p < num_procs_per_comp[0]; p++)
-            proc_list_union[p] = my_proc_list[0][p];
+        for (int p = 0; p < num_io_procs; p++)
+            proc_list_union[p] = my_io_proc_list[p];
         
         /* Add proc numbers from computation component. */
         for (int p = 0; p < num_procs_per_comp[cmp]; p++)

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1567,23 +1567,21 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         if (!(my_proc_list = malloc((component_count + 1) * sizeof(int *))))
             return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        /* Fill the array of arrays. */
-        for (int cmp = 0; cmp < 1; cmp++)
+        LOG((3, "calculating processors for IO component %d", 0));
+
+        /* Allocate space for IO proc array. */
+        if (!(my_proc_list[0] = malloc(num_procs_per_comp[0] * sizeof(int))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+
+        int proc;
+        for (proc = last_proc; proc < num_procs_per_comp[0] + last_proc; proc++)
         {
-            LOG((3, "calculating processors for component %d", cmp));
-
-            /* Allocate space for each array. */
-            if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
-                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-
-            int proc;
-            for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
-            {
-                my_proc_list[cmp][proc - last_proc] = proc;
-                LOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
-            }
-            last_proc = proc;
+            my_proc_list[0][proc - last_proc] = proc;
+            LOG((3, "my_proc_list[%d][%d] = %d", 0, proc - last_proc, proc));
         }
+        last_proc = proc;
+
+        /* Fill the array of arrays. */
         for (int cmp = 1; cmp < component_count + 1; cmp++)
         {
             LOG((3, "calculating processors for component %d", cmp));

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1451,6 +1451,505 @@ int PIOc_Init_Async(MPI_Comm world, int num_io_procs, int *io_proc_list,
 }
 
 /**
+ * Library initialization used when IO tasks are distinct from compute
+ * tasks.
+ *
+ * This is a collective call.  Input parameters are read on
+ * comp_rank=0 values on other tasks are ignored.  This variation of
+ * PIO_init sets up a distinct set of tasks to handle IO, these tasks
+ * do not return from this call.  Instead they go to an internal loop
+ * and wait to receive further instructions from the computational
+ * tasks.
+ *
+ * Sequence of Events to do Asynch I/O
+ * -----------------------------------
+ *
+ * Here is the sequence of events that needs to occur when an IO
+ * operation is called from the collection of compute tasks.  I'm
+ * going to use pio_put_var because write_darray has some special
+ * characteristics that make it a bit more complicated...
+ *
+ * Compute tasks call pio_put_var with an integer argument
+ *
+ * The MPI_Send sends a message from comp_rank=0 to io_rank=0 on
+ * union_comm (a comm defined as the union of io and compute tasks)
+ * msg is an integer which indicates the function being called, in
+ * this case the msg is PIO_MSG_PUT_VAR_INT
+ *
+ * The iotasks now know what additional arguments they should expect
+ * to receive from the compute tasks, in this case a file handle, a
+ * variable id, the length of the array and the array itself.
+ *
+ * The iotasks now have the information they need to complete the
+ * operation and they call the pio_put_var routine.  (In pio1 this bit
+ * of code is in pio_get_put_callbacks.F90.in)
+ *
+ * After the netcdf operation is completed (in the case of an inq or
+ * get operation) the result is communicated back to the compute
+ * tasks.
+ *
+ * @param world the communicator containing all the available tasks.
+ *
+ * @param num_io_procs the number of processes for the IO component.
+ *
+ * @param io_proc_list an array of lenth num_io_procs with the
+ * processor number for each IO processor. If NULL then the IO
+ * processes are assigned starting at processes 0.
+ *
+ * @param component_count number of computational components
+ *
+ * @param num_procs_per_comp an array of int, of length
+ * component_count, with the number of processors in each computation
+ * component.
+ *
+ * @param proc_list an array of arrays containing the processor
+ * numbers for each computation component. If NULL then the
+ * computation components are assigned processors sequentially
+ * starting with processor num_io_procs.
+ *
+ * @param user_io_comm pointer to an MPI_Comm. If not NULL, it will
+ * get an MPI duplicate of the IO communicator. (It is a full
+ * duplicate and later must be freed with MPI_Free() by the caller.)
+ *
+ * @param user_comp_comm pointer to an array of pointers to MPI_Comm;
+ * the array is of length component_count. If not NULL, it will get an
+ * MPI duplicate of each computation communicator. (These are full
+ * duplicates and each must later be freed with MPI_Free() by the
+ * caller.)
+ *
+ * @param iosysidp pointer to array of length component_count that
+ * gets the iosysid for each component.
+ *
+ * @return PIO_NOERR on success, error code otherwise.
+ * @ingroup PIO_init
+ */
+int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
+                    int component_count, int *num_procs_per_comp, int **proc_list,
+                    MPI_Comm *user_io_comm, MPI_Comm *user_comp_comm, int *iosysidp)
+{
+    int my_rank;          /* Rank of this task. */
+    int **my_proc_list;   /* Array of arrays if processor lists. */
+    int *my_io_proc_list; /* List of processors in IO component. */
+    int mpierr;           /* Return code from MPI functions. */
+    int ret;              /* Return code. */
+
+    /* Check input parameters. */
+    if (num_io_procs < 1 || component_count < 1 || !num_procs_per_comp || !iosysidp)
+        return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+
+    /* Temporarily limit to one computational component. */
+    if (component_count > 1)
+        return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+
+    /* Turn on the logging system for PIO. */
+    pio_init_logging();
+    LOG((1, "PIOc_Init_Async component_count = %d", component_count));
+
+    /* If the user did not supply a list of process numbers to use for
+     * IO, create it. */
+    if (!io_proc_list)
+    {
+        if (!(my_io_proc_list = malloc(num_io_procs * sizeof(int))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        for (int p = 0; p < num_io_procs; p++)
+            my_io_proc_list[p] = p;
+    }
+    else
+        my_io_proc_list = io_proc_list;
+
+    /* If the user did not provide a list of processes for each
+     * component, create one. */
+    if (!proc_list)
+    {
+        int last_proc = 0;
+
+        /* Allocate space for array of arrays. */
+        if (!(my_proc_list = malloc((component_count + 1) * sizeof(int *))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+
+        /* Fill the array of arrays. */
+        for (int cmp = 0; cmp < component_count + 1; cmp++)
+        {
+            LOG((3, "calculating processors for component %d", cmp));
+
+            /* Allocate space for each array. */
+            if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
+                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+
+            int proc;
+            for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
+            {
+                my_proc_list[cmp][proc - last_proc] = proc;
+                LOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
+            }
+            last_proc = proc;
+        }
+    }
+    else
+        my_proc_list = proc_list;
+
+    /* Get rank of this task. */
+    if ((ret = MPI_Comm_rank(world, &my_rank)))
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
+
+    /* Is this process in the IO component? */
+    int pidx;
+    for (pidx = 0; pidx < num_procs_per_comp[0]; pidx++)
+        if (my_rank == my_proc_list[0][pidx])
+            break;
+    int in_io = (pidx == num_procs_per_comp[0]) ? 0 : 1;
+    LOG((3, "in_io = %d", in_io));
+
+    /* Allocate struct to hold io system info for each computation component. */
+    /* Allocate struct to hold io system info for each component. */
+    iosystem_desc_t *iosys[component_count], *my_iosys;
+    for (int cmp1 = 0; cmp1 < component_count; cmp1++)
+        if (!(iosys[cmp1] = (iosystem_desc_t *)calloc(1, sizeof(iosystem_desc_t))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+
+    /* Create group for world. */
+    MPI_Group world_group;
+    if ((ret = MPI_Comm_group(world, &world_group)))
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
+    LOG((3, "world group created\n"));
+
+    /* We will create a group for the IO component. */
+    MPI_Group io_group;
+
+    /* The shared IO communicator. */
+    MPI_Comm io_comm;
+
+    /* Rank of current process in IO communicator. */
+    int io_rank = -1;
+
+    /* Set to MPI_ROOT on master process, MPI_PROC_NULL on other
+     * processes. */
+    int iomaster;
+
+    /* Create a group for the IO component. */
+    if ((ret = MPI_Group_incl(world_group, num_io_procs, my_io_proc_list, &io_group)))
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
+    LOG((3, "created IO group - io_group = %d group empty is %d", io_group, MPI_GROUP_EMPTY));
+    for (int p = 0; p < num_io_procs; p++)
+        LOG((3, "my_io_proc_list[%d] = %d", p, my_io_proc_list[p]));
+
+    /* There is one shared IO comm. Create it. */
+    if ((ret = MPI_Comm_create(world, io_group, &io_comm)))
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
+    LOG((3, "created io comm io_comm = %d", io_comm));
+
+    /* Does the user want a copy of the IO communicator? */
+    if (user_io_comm)
+    {
+        *user_io_comm = MPI_COMM_NULL;
+        if (in_io)
+            if ((mpierr = MPI_Comm_dup(io_comm, user_io_comm)))
+                return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+    }
+
+    /* For processes in the IO component, get their rank within the IO
+     * communicator. */
+    if (in_io)
+    {
+        LOG((3, "about to get io rank"));
+        if ((ret = MPI_Comm_rank(io_comm, &io_rank)))
+            return check_mpi(NULL, ret, __FILE__, __LINE__);
+        iomaster = !io_rank ? MPI_ROOT : MPI_PROC_NULL;
+        LOG((3, "intracomm created for io_comm = %d io_rank = %d IO %s",
+             io_comm, io_rank, iomaster == MPI_ROOT ? "MASTER" : "SERVANT"));
+    }
+
+    /* We will create a group for each component. */
+    MPI_Group group[component_count + 1];
+
+    /* We will also create a group for each component and the IO
+     * component processes (i.e. a union of computation and IO
+     * processes. */
+    MPI_Group union_group[component_count];
+
+    /* For each component, starting with the IO component. */
+    for (int cmp = 0; cmp < 1; cmp++)
+    {
+        LOG((3, "processing component %d", cmp));
+
+        /* Create a group for this component. */
+        if ((ret = MPI_Group_incl(world_group, num_procs_per_comp[cmp], my_proc_list[cmp],
+                                  &group[cmp])))
+            return check_mpi(NULL, ret, __FILE__, __LINE__);
+        LOG((3, "created component MPI group - group[%d] = %d", cmp, group[cmp]));
+
+        /* Is this process in this computation component (which is the
+         * IO component if cmp == 0)? */
+        int in_cmp = 0;
+        for (pidx = 0; pidx < num_procs_per_comp[cmp]; pidx++)
+            if (my_rank == my_proc_list[cmp][pidx])
+                break;
+        in_cmp = (pidx == num_procs_per_comp[cmp]) ? 0 : 1;
+        LOG((3, "pidx = %d num_procs_per_comp[%d] = %d in_cmp = %d",
+             pidx, cmp, num_procs_per_comp[cmp], in_cmp));
+
+        /* Create an intracomm for this component. Only processes in
+         * the component need to participate in the intracomm create
+         * call. */
+        /* Create the intracomm from the group. */
+        LOG((3, "creating intracomm cmp = %d from group[%d] = %d", cmp, cmp, group[cmp]));
+
+        /* We handle the IO comm differently (cmp == 0). */
+        if (!cmp)
+        {
+            /* LOG((3, "about to create io comm")); */
+            /* if ((ret = MPI_Comm_create_group(world, group[cmp], cmp, &io_comm))) */
+            /*     return check_mpi(NULL, ret, __FILE__, __LINE__); */
+            /* LOG((3, "about to get io rank"));                 */
+            /* if ((ret = MPI_Comm_rank(io_comm, &io_rank))) */
+            /*     return check_mpi(NULL, ret, __FILE__, __LINE__); */
+            /* iomaster = !io_rank ? MPI_ROOT : MPI_PROC_NULL; */
+            /* LOG((3, "intracomm created for cmp = %d io_comm = %d io_rank = %d IO %s", */
+            /*      cmp, io_comm, io_rank, iomaster == MPI_ROOT ? "MASTER" : "SERVANT")); */
+        }
+    }
+
+    /* For each component, starting with the IO component. */
+    for (int cmp = 1; cmp < component_count + 1; cmp++)
+    {
+        LOG((3, "processing component %d", cmp));
+
+        /* Don't start initing iosys until after IO component. */
+        if (cmp)
+        {
+            /* Get pointer to current iosys. */
+            my_iosys = iosys[cmp - 1];
+
+            /* Initialize some values. */
+            my_iosys->io_comm = MPI_COMM_NULL;
+            my_iosys->comp_comm = MPI_COMM_NULL;
+            my_iosys->union_comm = MPI_COMM_NULL;
+            my_iosys->intercomm = MPI_COMM_NULL;
+            my_iosys->my_comm = MPI_COMM_NULL;
+            my_iosys->async_interface = 1;
+            my_iosys->error_handler = default_error_handler;
+            my_iosys->num_comptasks = num_procs_per_comp[cmp];
+            my_iosys->num_iotasks = num_procs_per_comp[0];
+            my_iosys->compgroup = MPI_GROUP_NULL;
+            my_iosys->iogroup = MPI_GROUP_NULL;
+
+            /* The rank of the computation leader in the union comm. */
+            my_iosys->comproot = num_procs_per_comp[0];
+            LOG((3, "my_iosys->comproot = %d", my_iosys->comproot));
+
+            /* We are not providing an info object. */
+            my_iosys->info = MPI_INFO_NULL;
+        }
+
+        /* Create a group for this component. */
+        if ((ret = MPI_Group_incl(world_group, num_procs_per_comp[cmp], my_proc_list[cmp],
+                                  &group[cmp])))
+            return check_mpi(NULL, ret, __FILE__, __LINE__);
+        LOG((3, "created component MPI group - group[%d] = %d", cmp, group[cmp]));
+
+        /* For all the computation components (i.e. cmp != 0), create
+         * a union group with their processors and the processors of
+         * the (shared) IO component. */
+        if (cmp)
+        {
+            /* How many processors in the union comm? */
+            int nprocs_union = num_procs_per_comp[0] + num_procs_per_comp[cmp];
+
+            /* This will hold proc numbers from both computation and IO
+             * components. */
+            int proc_list_union[nprocs_union];
+
+            /* Add proc numbers from IO. */
+            for (int p = 0; p < num_procs_per_comp[0]; p++)
+                proc_list_union[p] = my_proc_list[0][p];
+
+            /* Add proc numbers from computation component. */
+            for (int p = 0; p < num_procs_per_comp[cmp]; p++)
+                proc_list_union[p + num_procs_per_comp[0]] = my_proc_list[cmp][p];
+
+            /* Create the union group. */
+            if ((ret = MPI_Group_incl(world_group, nprocs_union, proc_list_union,
+                                      &union_group[cmp - 1])))
+                return check_mpi(NULL, ret, __FILE__, __LINE__);
+            LOG((3, "created union MPI_group - union_group[%d] = %d with %d procs", cmp, union_group[cmp-1], nprocs_union));
+        }
+
+        /* Remember whether this process is in the IO component. */
+        if (cmp)
+            my_iosys->ioproc = in_io;
+
+        /* Is this process in this computation component (which is the
+         * IO component if cmp == 0)? */
+        int in_cmp = 0;
+        for (pidx = 0; pidx < num_procs_per_comp[cmp]; pidx++)
+            if (my_rank == my_proc_list[cmp][pidx])
+                break;
+        in_cmp = (pidx == num_procs_per_comp[cmp]) ? 0 : 1;
+        LOG((3, "pidx = %d num_procs_per_comp[%d] = %d in_cmp = %d",
+             pidx, cmp, num_procs_per_comp[cmp], in_cmp));
+
+        /* Create an intracomm for this component. Only processes in
+         * the component need to participate in the intracomm create
+         * call. */
+        /* Create the intracomm from the group. */
+        LOG((3, "creating intracomm cmp = %d from group[%d] = %d", cmp, cmp, group[cmp]));
+
+        /* We handle the IO comm differently (cmp == 0). */
+        if (!cmp)
+        {
+            /* LOG((3, "about to create io comm")); */
+            /* if ((ret = MPI_Comm_create_group(world, group[cmp], cmp, &io_comm))) */
+            /*     return check_mpi(NULL, ret, __FILE__, __LINE__); */
+            /* LOG((3, "about to get io rank"));                 */
+            /* if ((ret = MPI_Comm_rank(io_comm, &io_rank))) */
+            /*     return check_mpi(NULL, ret, __FILE__, __LINE__); */
+            /* iomaster = !io_rank ? MPI_ROOT : MPI_PROC_NULL; */
+            /* LOG((3, "intracomm created for cmp = %d io_comm = %d io_rank = %d IO %s", */
+            /*      cmp, io_comm, io_rank, iomaster == MPI_ROOT ? "MASTER" : "SERVANT")); */
+        }
+        else
+        {
+            if ((ret = MPI_Comm_create(world, group[cmp], &my_iosys->comp_comm)))
+                return check_mpi(NULL, ret, __FILE__, __LINE__);
+
+            if (in_cmp)
+            {
+                /* Does the user want a copy? */
+                if (user_comp_comm)
+                    if ((mpierr = MPI_Comm_dup(my_iosys->comp_comm, &user_comp_comm[cmp - 1])))
+                        return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+
+                /* Get the rank in this comp comm. */
+                if ((ret = MPI_Comm_rank(my_iosys->comp_comm, &my_iosys->comp_rank)))
+                    return check_mpi(NULL, ret, __FILE__, __LINE__);
+
+                /* Set comp_rank 0 to be the compmaster. It will have
+                 * a setting of MPI_ROOT, all other tasks will have a
+                 * setting of MPI_PROC_NULL. */
+                my_iosys->compmaster = my_iosys->comp_rank ? MPI_PROC_NULL : MPI_ROOT;
+
+                LOG((3, "intracomm created for cmp = %d comp_comm = %d comp_rank = %d comp %s",
+                     cmp, my_iosys->comp_comm, my_iosys->comp_rank,
+                     my_iosys->compmaster == MPI_ROOT ? "MASTER" : "SERVANT"));
+            }
+        }
+
+
+        /* If this is the IO component, make a copy of the IO comm for
+         * each computational component. */
+        if (in_io)
+            if (cmp)
+            {
+                LOG((3, "making a dup of io_comm = %d io_rank = %d", io_comm, io_rank));
+                if ((ret = MPI_Comm_dup(io_comm, &my_iosys->io_comm)))
+                    return check_mpi(NULL, ret, __FILE__, __LINE__);
+                LOG((3, "dup of io_comm = %d io_rank = %d", my_iosys->io_comm, io_rank));
+                my_iosys->iomaster = iomaster;
+                my_iosys->io_rank = io_rank;
+                my_iosys->ioroot = 0;
+                my_iosys->comp_idx = cmp - 1;
+            }
+
+        /* All the processes in this component, and the IO component,
+         * are part of the union_comm. */
+        if (cmp)
+        {
+            if (in_io || in_cmp)
+            {
+                LOG((3, "my_iosys->io_comm = %d group = %d", my_iosys->io_comm, union_group[cmp-1]));
+                /* Create a group for the union of the IO component
+                 * and one of the computation components. */
+                if ((ret = MPI_Comm_create(world, union_group[cmp - 1],
+                                           &my_iosys->union_comm)))
+                    return check_mpi(NULL, ret, __FILE__, __LINE__);
+
+                if ((ret = MPI_Comm_rank(my_iosys->union_comm, &my_iosys->union_rank)))
+                    return check_mpi(NULL, ret, __FILE__, __LINE__);
+
+                /* Set my_comm to union_comm for async. */
+                my_iosys->my_comm = my_iosys->union_comm;
+                LOG((3, "intracomm created for union cmp = %d union_rank = %d union_comm = %d",
+                     cmp, my_iosys->union_rank, my_iosys->union_comm));
+
+                if (in_io)
+                {
+                    LOG((3, "my_iosys->io_comm = %d", my_iosys->io_comm));
+                    /* Create the intercomm from IO to computation component. */
+                    LOG((3, "about to create intercomm for IO component to cmp = %d "
+                         "my_iosys->io_comm = %d", cmp, my_iosys->io_comm));
+                    if ((ret = MPI_Intercomm_create(my_iosys->io_comm, 0, my_iosys->union_comm,
+                                                    my_proc_list[cmp][0], 0,
+                                                    &my_iosys->intercomm)))
+                        return check_mpi(NULL, ret, __FILE__, __LINE__);
+                }
+                else
+                {
+                    /* Create the intercomm from computation component to IO component. */
+                    LOG((3, "about to create intercomm for cmp = %d my_iosys->comp_comm = %d", cmp,
+                         my_iosys->comp_comm));
+                    if ((ret = MPI_Intercomm_create(my_iosys->comp_comm, 0, my_iosys->union_comm,
+                                                    my_proc_list[0][0], 0,
+                                                    &my_iosys->intercomm)))
+                        return check_mpi(NULL, ret, __FILE__, __LINE__);
+                }
+                LOG((3, "intercomm created for cmp = %d", cmp));
+            }
+
+            /* Add this id to the list of PIO iosystem ids. */
+            iosysidp[cmp - 1] = pio_add_to_iosystem_list(my_iosys);
+            LOG((2, "new iosys ID added to iosystem_list iosysid = %d\n", iosysidp[cmp - 1]));
+        }
+    }
+
+    /* Now call the function from which the IO tasks will not return
+     * until the PIO_MSG_EXIT message is sent. This will handle all
+     * components. */
+    if (in_io)
+    {
+        LOG((2, "Starting message handler io_rank = %d component_count = %d",
+             io_rank, component_count));
+        if ((ret = pio_msg_handler2(io_rank, component_count, iosys, io_comm)))
+            return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
+        LOG((2, "Returned from pio_msg_handler2() ret = %d", ret));
+    }
+
+    /* Free resources if needed. */
+    LOG((2, "PIOc_Init_Async starting to free resources"));
+    if (!io_proc_list)
+        free(my_io_proc_list);
+
+    if (in_io)
+        if ((mpierr = MPI_Comm_free(&io_comm)))
+            return check_mpi(NULL, ret, __FILE__, __LINE__);
+
+    if (!proc_list)
+    {
+        for (int cmp = 0; cmp < component_count + 1; cmp++)
+            free(my_proc_list[cmp]);
+        free(my_proc_list);
+    }
+
+    /* Free MPI groups. */
+    if ((ret = MPI_Group_free(&io_group)))
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
+
+    for (int cmp = 0; cmp < component_count + 1; cmp++)
+    {
+        if ((ret = MPI_Group_free(&group[cmp])))
+            return check_mpi(NULL, ret, __FILE__, __LINE__);
+        if (cmp)
+            if ((ret = MPI_Group_free(&union_group[cmp - 1])))
+                return check_mpi(NULL, ret, __FILE__, __LINE__);
+    }
+
+    if ((ret = MPI_Group_free(&world_group)))
+        return check_mpi(NULL, ret, __FILE__, __LINE__);
+
+    LOG((2, "successfully done with PIO_Init_Async"));
+    return PIO_NOERR;
+}
+
+/**
  * Set the target blocksize for the box rearranger.
  *
  * @param newblocksize the new blocksize.

--- a/tests/cunit/test_async_4proc.c
+++ b/tests/cunit/test_async_4proc.c
@@ -34,6 +34,7 @@ int main(int argc, char **argv)
 
     /* Num procs for IO and computation. */
     int num_procs[NUM_COMBOS][COMPONENT_COUNT + 1] = {{3, 1}, {2, 2}, {1, 3}};
+    int num_procs2[NUM_COMBOS][COMPONENT_COUNT] = {{1}, {2}, {3}};
 
     /* Number of processors that will do IO. */
     int num_io_procs[NUM_COMBOS] = {3, 2, 1};
@@ -57,7 +58,7 @@ int main(int argc, char **argv)
             int comp_task = my_rank < num_io_procs[combo] ? 0 : 1;
 
             /* Initialize the IO system. */
-            if ((ret = PIOc_Init_Async(test_comm, num_io_procs[combo], NULL, COMPONENT_COUNT,
+            if ((ret = PIOc_init_async(test_comm, num_io_procs[combo], NULL, COMPONENT_COUNT,
                                        num_procs[combo], NULL, NULL, NULL, iosysid)))
                 ERR(ERR_INIT);
 

--- a/tests/cunit/test_async_4proc.c
+++ b/tests/cunit/test_async_4proc.c
@@ -33,15 +33,13 @@ int main(int argc, char **argv)
     MPI_Comm test_comm;
 
     /* Num procs for IO and computation. */
-    int num_procs[NUM_COMBOS][COMPONENT_COUNT + 1] = {{3, 1}, {2, 2}, {1, 3}};
     int num_procs2[NUM_COMBOS][COMPONENT_COUNT] = {{1}, {2}, {3}};
 
     /* Number of processors that will do IO. */
     int num_io_procs[NUM_COMBOS] = {3, 2, 1};
 
     /* Initialize test. */
-    if ((ret = pio_test_init(argc, argv, &my_rank, &ntasks, TARGET_NTASKS,
-			     &test_comm)))
+    if ((ret = pio_test_init(argc, argv, &my_rank, &ntasks, TARGET_NTASKS, &test_comm)))
         ERR(ERR_INIT);
     
     /* Test code runs on TARGET_NTASKS tasks. The left over tasks do
@@ -59,7 +57,7 @@ int main(int argc, char **argv)
 
             /* Initialize the IO system. */
             if ((ret = PIOc_init_async(test_comm, num_io_procs[combo], NULL, COMPONENT_COUNT,
-                                       num_procs[combo], NULL, NULL, NULL, iosysid)))
+                                       num_procs2[combo], NULL, NULL, NULL, iosysid)))
                 ERR(ERR_INIT);
 
             for (int c = 0; c < COMPONENT_COUNT; c++)


### PR DESCRIPTION
The API to PIOc_Init_Async() is unclear and poorly documented.

This PR introduces new function PIOc_init_async(). Yes the name is confusing bu PIOc_Init_Async() will be taken out in a future PR pretty shortly.

This is the same code, but now the API makes a more clear separation between IO and computation components.

I'm just putting this up to do the change in smaller batches, and to give people time to comment on the changed API before I change it everywhere in the library and tests. With this PR one of the async tests has been converted to the new PIOc_init_async().

Fixes #402.

I will merge to develop for testing.
