### PR TITLE
removed -ioid from PIOc_write_darray()

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -455,7 +455,8 @@ typedef struct wmulti_buffer
      * PIOc_Init_Decomp().  */
     int ioid;
 
-    /** Number of variables in this multi variable buffer. */
+    /** Number of variables or records of variables in this multi
+     * variable buffer. */
     int validvars;
 
     /** Size of this variables data on local task. All vars in the


### PR DESCRIPTION
Some important code changes in this PR, so look closely.

After recent simplifications in the code it became clear that the setting of wmb->ioid to -ioid in the case of non-record vars was never used anywhere. So I was able to simply remove it.

Fixes #713.

I will merge to develop for testing.
