### PR TITLE
change type size determination

### DIFF
--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -145,7 +145,7 @@ extern "C" {
     void pioassert(bool exp, const char *msg, const char *fname, int line);
 
     /* Compute start and count values for each io task for a decomposition. */
-    int CalcStartandCount(int basetype, int ndims, const int *gdims, int num_io_procs,
+    int CalcStartandCount(int pio_type, int ndims, const int *gdims, int num_io_procs,
                           int myiorank, PIO_Offset *start, PIO_Offset *count, int *num_aiotasks);
 
     /* Check return from MPI function and print error message. */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -12,6 +12,15 @@
 
 #include <pio.h>
 
+/* These are the sizes of types in netCDF files. Do not replace these
+ * constants with sizeof() calls for C types. They are not the
+ * same. Even on a system where sizeof(short) is 4, the size of a
+ * short in a netCDF file is 2 bytes. */
+#define NETCDF_CHAR_SIZE 1
+#define NETCDF_SHORT_SIZE 2
+#define NETCDF_INT_FLOAT_SIZE 4
+#define NETCDF_DOUBLE_INT64_SIZE 8
+
 /* It seems that some versions of openmpi fail to define
  * MPI_OFFSET. */
 #ifdef OMPI_OFFSET_DATATYPE
@@ -123,8 +132,8 @@ extern "C" {
     int check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
                       const char *fname, int line);
 
-    /* Find the MPI type that matches a PIO type. */
-    int find_mpi_type(int pio_type, MPI_Datatype *mpi_type);
+    /* Given PIO type, find MPI type and type size. */
+    int find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size);
 
     /* Check whether an IO type is valid for this build. */
     int iotype_is_valid(int iotype);
@@ -135,8 +144,9 @@ extern "C" {
     /* Assert that an expression is true. */
     void pioassert(bool exp, const char *msg, const char *fname, int line);
 
+    /* Compute start and count values for each io task for a decomposition. */
     int CalcStartandCount(int basetype, int ndims, const int *gdims, int num_io_procs,
-                          int myiorank, PIO_Offset *start, PIO_Offset *kount);
+                          int myiorank, PIO_Offset *start, PIO_Offset *count, int *num_aiotasks);
 
     /* Check return from MPI function and print error message. */
     void CheckMPIReturn(int ierr, const char *file, int line);

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -421,7 +421,7 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
         iodesc->num_aiotasks = ios->num_iotasks;
         if ((ierr = subset_rearrange_create(ios, maplen, (PIO_Offset *)compmap, dims,
                                             ndims, iodesc)))
-            return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
+            return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     }
     else
     {
@@ -444,9 +444,10 @@ int PIOc_InitDecomp(int iosysid, int basetype, int ndims, const int *dims, int m
             }
             else
             {
-                iodesc->num_aiotasks = CalcStartandCount(basetype, ndims, dims,
-                                                         ios->num_iotasks, ios->io_rank,
-                                                         iodesc->firstregion->start, iodesc->firstregion->count);
+                if ((ierr = CalcStartandCount(basetype, ndims, dims, ios->num_iotasks,
+                                             ios->io_rank, iodesc->firstregion->start,
+                                             iodesc->firstregion->count, &iodesc->num_aiotasks)))
+                    return pio_err(ios, NULL, ierr, __FILE__, __LINE__);                    
             }
             compute_maxIObuffersize(ios->io_comm, iodesc);
         }

--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -226,7 +226,7 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
  * Compute start and count values for each io task. This is used in
  * PIOc_InitDecomp().
  *
- * @param basetype the PIO data type used in this decompotion.
+ * @param pio_type the PIO data type used in this decompotion.
  * @param ndims the number of dimensions in the variable, not
  * including the unlimited dimension.
  * @param gdims an array of global size of each dimension.
@@ -237,7 +237,7 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
  * @param num_aiotasks the number of IO tasks used(?)
  * @returns 0 for success, error code otherwise.
  */
-int CalcStartandCount(int basetype, int ndims, const int *gdims, int num_io_procs,
+int CalcStartandCount(int pio_type, int ndims, const int *gdims, int num_io_procs,
                       int myiorank, PIO_Offset *start, PIO_Offset *count, int *num_aiotasks)
 {
     int minbytes; 
@@ -264,7 +264,7 @@ int CalcStartandCount(int basetype, int ndims, const int *gdims, int num_io_proc
     maxbytes = blocksize + 256;
 
     /* Determine the size of the data type. */
-    if ((ret = find_mpi_type(basetype, NULL, &basesize)))
+    if ((ret = find_mpi_type(pio_type, NULL, &basesize)))
         return ret;
 
     /* Determine the minimum block size. */

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -218,6 +218,7 @@ int test_CalcStartandCount()
     long int psize;
     long int pgdims = 1;
     int scnt;
+    int ret;
 
     for (int i = 0; i < ndims; i++)
         pgdims *= gdims[i];
@@ -226,8 +227,9 @@ int test_CalcStartandCount()
     {
         for (iorank = 0; iorank < num_io_procs; iorank++)
         {
-            numaiotasks = CalcStartandCount(PIO_DOUBLE, ndims, gdims, num_io_procs, iorank,
-                                            start, kount);
+            if ((ret = CalcStartandCount(PIO_DOUBLE, ndims, gdims, num_io_procs, iorank,
+                                         start, kount, &numaiotasks)))
+                return ret;
             if (iorank < numaiotasks)
                 printf("iorank %d start %lld %lld count %lld %lld\n", iorank, start[0],
                        start[1], kount[0], kount[1]);
@@ -395,72 +397,73 @@ int test_ceil2_pair()
 int test_find_mpi_type()
 {
     MPI_Datatype mpi_type;
+    int type_size;
     int ret;
 
     /* This should not work. */
-    if (find_mpi_type(PIO_BYTE + 42, &mpi_type) != PIO_EBADTYPE)
+    if (find_mpi_type(PIO_BYTE + 42, &mpi_type, &type_size) != PIO_EBADTYPE)
         return ERR_WRONG;
 
     /* Try every atomic type. */
-    if ((ret = find_mpi_type(PIO_BYTE, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_BYTE, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_BYTE)
+    if (mpi_type != MPI_BYTE || type_size != 1)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_CHAR, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_CHAR, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_CHAR)
+    if (mpi_type != MPI_CHAR || type_size != 1)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_SHORT, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_SHORT, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_SHORT)
+    if (mpi_type != MPI_SHORT || type_size != 2)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_INT, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_INT, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_INT)
+    if (mpi_type != MPI_INT || type_size != 4)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_FLOAT, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_FLOAT, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_FLOAT)
+    if (mpi_type != MPI_FLOAT || type_size != 4)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_DOUBLE, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_DOUBLE, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_DOUBLE)
+    if (mpi_type != MPI_DOUBLE || type_size != 8)
         return ERR_WRONG;
 
 #ifdef _NETCDF4
-    if ((ret = find_mpi_type(PIO_UBYTE, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_UBYTE, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_UNSIGNED_CHAR)
+    if (mpi_type != MPI_UNSIGNED_CHAR || type_size != 1)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_USHORT, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_USHORT, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_UNSIGNED_SHORT)
+    if (mpi_type != MPI_UNSIGNED_SHORT || type_size != 2)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_UINT, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_UINT, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_UNSIGNED)
+    if (mpi_type != MPI_UNSIGNED || type_size != 4)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_INT64, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_INT64, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_LONG_LONG)
+    if (mpi_type != MPI_LONG_LONG || type_size != 8)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_UINT64, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_UINT64, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_UNSIGNED_LONG_LONG)
+    if (mpi_type != MPI_UNSIGNED_LONG_LONG || type_size != 8)
         return ERR_WRONG;
 
-    if ((ret = find_mpi_type(PIO_STRING, &mpi_type)))
+    if ((ret = find_mpi_type(PIO_STRING, &mpi_type, &type_size)))
         return ret;
-    if (mpi_type != MPI_CHAR)
+    if (mpi_type != MPI_CHAR || type_size != 1)
         return ERR_WRONG;
 
 #endif /* _NETCDF4 */

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -435,6 +435,18 @@ int test_find_mpi_type()
     if (mpi_type != MPI_DOUBLE || type_size != 8)
         return ERR_WRONG;
 
+    /* These should also work. */
+    if ((ret = find_mpi_type(PIO_INT, &mpi_type, NULL)))
+        return ret;
+    if (mpi_type != MPI_INT)
+        return ERR_WRONG;
+    if ((ret = find_mpi_type(PIO_INT, NULL, &type_size)))
+        return ret;
+    if (type_size != 4)
+        return ERR_WRONG;
+    if ((ret = find_mpi_type(PIO_INT, NULL, NULL)))
+        return ret;
+
 #ifdef _NETCDF4
     if ((ret = find_mpi_type(PIO_UBYTE, &mpi_type, &type_size)))
         return ret;


### PR DESCRIPTION
In this PR I modify the find_mpi_type() internal function to also provide the size of the type.  

This is used in CalcStartandCount() and will be used in other places. Doing this in the find_mpi_type() function will allow us to support all types with darrays.

I also change CalcStartandCount() to return an error code, and change one of the param names to make it clear that it is a PIO type, not an MPI type.

Fixes #791.
Fixes #811.
Fixes #810.
Part of #809.
Part of #813.

I will merge to develop for testing.
