### PR TITLE
Start of testing, removed unneeded param from create_mpi_datatypes()

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -245,10 +245,7 @@ typedef struct io_desc_t
      * io tasks. */
     int nrecvs;
 
-    /** Local size of the decomposition array on the compute node. On
-        each compute task the application passes a compmap array of
-        length ndof. This array describes the arrangement of data in
-        memory on that task. */
+    /** Local size of the decomposition array on the compute node. */
     int ndof;
 
     /** All vars included in this io_desc_t have the same number of
@@ -298,10 +295,11 @@ typedef struct io_desc_t
      * in pio_swapm(). */
     int *scount;
 
-    /** Send index. */
+    /** Array of length ndof (for the BOX rearranger) with the index
+     * for computation taks (send side during writes). */
     PIO_Offset *sindex;
 
-    /** Receive index. */
+    /** Index for the IO tasks (receive side during writes). */
     PIO_Offset *rindex;
 
     /** Array of receive MPI types in pio_swapm() call. */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -221,7 +221,7 @@ extern "C" {
 
     /* Create the derived MPI datatypes used for comp2io and io2comp
      * transfers. */
-    int create_mpi_datatypes(MPI_Datatype basetype, int msgcnt, PIO_Offset dlen, const PIO_Offset *mindex,
+    int create_mpi_datatypes(MPI_Datatype basetype, int msgcnt, const PIO_Offset *mindex,
                              const int *mcount, int *mfrom, MPI_Datatype *mtype);
     int compare_offsets(const void *a, const void *b) ;
 

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -554,6 +554,31 @@ int test_misc()
     return 0;
 }
 
+/* Test the create_mpi_datatypes() function. 
+ * @returns 0 for success, error code otherwise.*/
+int test_create_mpi_datatypes()
+{
+    MPI_Datatype basetype = MPI_INT;
+    int msgcnt = 1;
+    PIO_Offset mindex[4] = {0, 0, 0, 0};
+    int mcount[4] = {1, 1, 1, 1};
+    int *mfrom = NULL;
+    MPI_Datatype mtype;
+    int mpierr;
+    int ret;
+
+    /* Create an MPI data type. */
+    if ((ret = create_mpi_datatypes(basetype, msgcnt, mindex, mcount,
+                                    mfrom, &mtype)))
+        return ret;
+
+    /* Free the type. */
+    if ((mpierr = MPI_Type_free(&mtype)))
+        return ERR_WRONG;
+    
+    return 0;
+}
+
 /* Run Tests for pio_spmd.c functions. */
 int main(int argc, char **argv)
 {
@@ -571,49 +596,53 @@ int main(int argc, char **argv)
      * nothing. */
     if (my_rank < TARGET_NTASKS)
     {
-        printf("%d running tests for functions in pioc_sc.c\n", my_rank);
-        if ((ret = run_sc_tests(test_comm)))
-            return ret;
+        /* printf("%d running tests for functions in pioc_sc.c\n", my_rank); */
+        /* if ((ret = run_sc_tests(test_comm))) */
+        /*     return ret; */
 
-        printf("%d running spmd test code\n", my_rank);
-        if ((ret = run_spmd_tests(test_comm)))
-            return ret;
+        /* printf("%d running spmd test code\n", my_rank); */
+        /* if ((ret = run_spmd_tests(test_comm))) */
+        /*     return ret; */
         
-        printf("%d running CalcStartandCount test code\n", my_rank);
-        if ((ret = test_CalcStartandCount()))
+        /* printf("%d running CalcStartandCount test code\n", my_rank); */
+        /* if ((ret = test_CalcStartandCount())) */
+        /*     return ret; */
+
+        /* printf("%d running list tests\n", my_rank); */
+        /* if ((ret = test_lists())) */
+        /*     return ret; */
+
+        /* printf("%d running rearranger opts tests 1\n", my_rank); */
+        /* if ((ret = test_rearranger_opts1())) */
+        /*     return ret; */
+
+        /* printf("%d running tests for cmp_rearr_opts()\n", my_rank); */
+        /* if ((ret = test_cmp_rearr_opts())) */
+        /*     return ret; */
+
+        /* printf("%d running rearranger opts tests 3\n", my_rank); */
+        /* if ((ret = test_rearranger_opts3())) */
+        /*     return ret; */
+
+        /* printf("%d running compare_offsets tests\n", my_rank); */
+        /* if ((ret = test_compare_offsets())) */
+        /*     return ret; */
+
+        /* printf("%d running ceil2/pair tests\n", my_rank); */
+        /* if ((ret = test_ceil2_pair())) */
+        /*     return ret; */
+
+        /* printf("%d running find_mpi_type tests\n", my_rank); */
+        /* if ((ret = test_find_mpi_type())) */
+        /*     return ret; */
+
+        printf("%d running create_mpi_datatypes tests\n", my_rank);
+        if ((ret = test_create_mpi_datatypes()))
             return ret;
 
-        printf("%d running list tests\n", my_rank);
-        if ((ret = test_lists()))
-            return ret;
-
-        printf("%d running rearranger opts tests 1\n", my_rank);
-        if ((ret = test_rearranger_opts1()))
-            return ret;
-
-        printf("%d running tests for cmp_rearr_opts()\n", my_rank);
-        if ((ret = test_cmp_rearr_opts()))
-            return ret;
-
-        printf("%d running rearranger opts tests 3\n", my_rank);
-        if ((ret = test_rearranger_opts3()))
-            return ret;
-
-        printf("%d running compare_offsets tests\n", my_rank);
-        if ((ret = test_compare_offsets()))
-            return ret;
-
-        printf("%d running ceil2/pair tests\n", my_rank);
-        if ((ret = test_ceil2_pair()))
-            return ret;
-
-        printf("%d running find_mpi_type tests\n", my_rank);
-        if ((ret = test_find_mpi_type()))
-            return ret;
-
-        printf("%d running misc tests\n", my_rank);
-        if ((ret = test_misc()))
-            return ret;
+        /* printf("%d running misc tests\n", my_rank); */
+        /* if ((ret = test_misc())) */
+        /*     return ret; */
 
     } /* endif my_rank < TARGET_NTASKS */
 

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -568,8 +568,7 @@ int test_create_mpi_datatypes()
     int ret;
 
     /* Create an MPI data type. */
-    if ((ret = create_mpi_datatypes(basetype, msgcnt, mindex, mcount,
-                                    mfrom, &mtype)))
+    if ((ret = create_mpi_datatypes(basetype, msgcnt, mindex, mcount, mfrom, &mtype)))
         return ret;
 
     /* Free the type. */

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -595,53 +595,53 @@ int main(int argc, char **argv)
      * nothing. */
     if (my_rank < TARGET_NTASKS)
     {
-        /* printf("%d running tests for functions in pioc_sc.c\n", my_rank); */
-        /* if ((ret = run_sc_tests(test_comm))) */
-        /*     return ret; */
+        printf("%d running tests for functions in pioc_sc.c\n", my_rank);
+        if ((ret = run_sc_tests(test_comm)))
+            return ret;
 
-        /* printf("%d running spmd test code\n", my_rank); */
-        /* if ((ret = run_spmd_tests(test_comm))) */
-        /*     return ret; */
+        printf("%d running spmd test code\n", my_rank);
+        if ((ret = run_spmd_tests(test_comm)))
+            return ret;
         
-        /* printf("%d running CalcStartandCount test code\n", my_rank); */
-        /* if ((ret = test_CalcStartandCount())) */
-        /*     return ret; */
+        printf("%d running CalcStartandCount test code\n", my_rank);
+        if ((ret = test_CalcStartandCount()))
+            return ret;
 
-        /* printf("%d running list tests\n", my_rank); */
-        /* if ((ret = test_lists())) */
-        /*     return ret; */
+        printf("%d running list tests\n", my_rank);
+        if ((ret = test_lists()))
+            return ret;
 
-        /* printf("%d running rearranger opts tests 1\n", my_rank); */
-        /* if ((ret = test_rearranger_opts1())) */
-        /*     return ret; */
+        printf("%d running rearranger opts tests 1\n", my_rank);
+        if ((ret = test_rearranger_opts1()))
+            return ret;
 
-        /* printf("%d running tests for cmp_rearr_opts()\n", my_rank); */
-        /* if ((ret = test_cmp_rearr_opts())) */
-        /*     return ret; */
+        printf("%d running tests for cmp_rearr_opts()\n", my_rank);
+        if ((ret = test_cmp_rearr_opts()))
+            return ret;
 
-        /* printf("%d running rearranger opts tests 3\n", my_rank); */
-        /* if ((ret = test_rearranger_opts3())) */
-        /*     return ret; */
+        printf("%d running rearranger opts tests 3\n", my_rank);
+        if ((ret = test_rearranger_opts3()))
+            return ret;
 
-        /* printf("%d running compare_offsets tests\n", my_rank); */
-        /* if ((ret = test_compare_offsets())) */
-        /*     return ret; */
+        printf("%d running compare_offsets tests\n", my_rank);
+        if ((ret = test_compare_offsets()))
+            return ret;
 
-        /* printf("%d running ceil2/pair tests\n", my_rank); */
-        /* if ((ret = test_ceil2_pair())) */
-        /*     return ret; */
+        printf("%d running ceil2/pair tests\n", my_rank);
+        if ((ret = test_ceil2_pair()))
+            return ret;
 
-        /* printf("%d running find_mpi_type tests\n", my_rank); */
-        /* if ((ret = test_find_mpi_type())) */
-        /*     return ret; */
+        printf("%d running find_mpi_type tests\n", my_rank);
+        if ((ret = test_find_mpi_type()))
+            return ret;
 
         printf("%d running create_mpi_datatypes tests\n", my_rank);
         if ((ret = test_create_mpi_datatypes()))
             return ret;
 
-        /* printf("%d running misc tests\n", my_rank); */
-        /* if ((ret = test_misc())) */
-        /*     return ret; */
+        printf("%d running misc tests\n", my_rank);
+        if ((ret = test_misc()))
+            return ret;
 
     } /* endif my_rank < TARGET_NTASKS */
 


### PR DESCRIPTION
Starting to add tests for create_mpI_datatypes() function.

Removed an unused param from the function.

Please help me turn some of the ??? into comments.

Fixes #854.
Part of #855.
Part of #205.
Part of #89.

