### PR TITLE
Fix malloc mem issue

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -152,6 +152,12 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
                 for (int i = 0; i < iodesc->maxiobuflen; i++)
                     memcpy(&((char *)vdesc0->iobuf)[vsize * (i + nv * iodesc->maxiobuflen)],
                            &((char *)fillvalue)[nv * vsize], vsize);
+    }else if(file->iotype == PIO_IOTYPE_PNETCDF){
+	/* this assures that iobuf is allocated on all iotasks thus assuring that the flush_output_buffer call
+	 above is called collectively (from all iotasks) */
+        if (!(vdesc0->iobuf = bget(1)))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        LOG((3, "allocated %lld bytes for variable buffer", (size_t)rlen * (size_t)vsize));
     }
 
     /* Move data from compute to IO tasks. */

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -216,11 +216,10 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
 	pioassert(!vdesc0->fillbuf, "buffer overwrite",__FILE__, __LINE__);
 
         /* Get a buffer. */
-	if (!vdesc0->fillbuf)
-	    if (ios->io_rank == 0)
-		vdesc0->fillbuf = bget(iodesc->maxholegridsize * vsize * nvars);
-	    else if (iodesc->holegridsize > 0)
-		vdesc0->fillbuf = bget(iodesc->holegridsize * vsize * nvars);
+	if (ios->io_rank == 0)
+	    vdesc0->fillbuf = bget(iodesc->maxholegridsize * vsize * nvars);
+	else if (iodesc->holegridsize > 0)
+	    vdesc0->fillbuf = bget(iodesc->holegridsize * vsize * nvars);
 
         /* copying the fill value into the data buffer for the box
          * rearranger. This will be overwritten with data where


### PR DESCRIPTION
Fixes #885 
Fixes #888
Flush pnetcdf output buffer before attempting to write a new record.  Allocate a token iobuf on all iotasks so that this flush is collective.   