### PR TITLE
Change case to if statement (needed for openmpi)

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -478,46 +478,74 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 
             /* Need to cast MPI_Datatype to int in switches or openmpi
              * fails. */
-            switch ((int)vtype)
-            {
-            case MPI_BYTE:
+/*             switch ((int)vtype) */
+/*             { */
+/*             case MPI_BYTE: */
+/*                 fill = &byte_fill; */
+/*                 break; */
+/*             case MPI_CHAR: */
+/*                 fill = &char_fill; */
+/*                 break; */
+/*             case MPI_SHORT: */
+/*                 fill = &short_fill; */
+/*                 break; */
+/*             case MPI_INT: */
+/*                 fill = &int_fill; */
+/*                 break; */
+/*             case MPI_FLOAT: */
+/*                 fill = &float_fill; */
+/*                 break; */
+/*             case MPI_DOUBLE: */
+/*                 fill = &double_fill; */
+/*                 break; */
+/* #ifdef _NETCDF4 */
+/*             case MPI_UNSIGNED_CHAR: */
+/*                 fill = &ubyte_fill; */
+/*                 break; */
+/*             case MPI_UNSIGNED_SHORT: */
+/*                 fill = &ushort_fill; */
+/*                 break; */
+/*             case MPI_UNSIGNED: */
+/*                 fill = &uint_fill; */
+/*                 break; */
+/*             case MPI_LONG_LONG: */
+/*                 fill = &int64_fill; */
+/*                 break; */
+/*             case MPI_UNSIGNED_LONG_LONG: */
+/*                 fill = &uint64_fill; */
+/*                 break; */
+/* #endif /\* _NETCDF4 *\/ */
+/*             default: */
+/*                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__); */
+/*             } */
+
+            if (vtype == MPI_BYTE)
                 fill = &byte_fill;
-                break;
-            case MPI_CHAR:
+            else if (vtype == MPI_CHAR)
                 fill = &char_fill;
-                break;
-            case MPI_SHORT:
+            else if (vtype == MPI_SHORT)
                 fill = &short_fill;
-                break;
-            case MPI_INT:
+            else if (vtype == MPI_INT)
                 fill = &int_fill;
-                break;
-            case MPI_FLOAT:
+            else if (vtype == MPI_FLOAT)
                 fill = &float_fill;
-                break;
-            case MPI_DOUBLE:
+            else if (vtype == MPI_DOUBLE)
                 fill = &double_fill;
-                break;
 #ifdef _NETCDF4
-            case MPI_UNSIGNED_CHAR:
+            else if (vtype == MPI_UNSIGNED_CHAR)
                 fill = &ubyte_fill;
-                break;
-            case MPI_UNSIGNED_SHORT:
+            else if (vtype == MPI_UNSIGNED_SHORT)
                 fill = &ushort_fill;
-                break;
-            case MPI_UNSIGNED:
+            else if (vtype == MPI_UNSIGNED)
                 fill = &uint_fill;
-                break;
-            case MPI_LONG_LONG:
+            else if (vtype == MPI_LONG_LONG)
                 fill = &int64_fill;
-                break;
-            case MPI_UNSIGNED_LONG_LONG:
+            else if (vtype == MPI_UNSIGNED_LONG_LONG)
                 fill = &uint64_fill;
-                break;
 #endif /* _NETCDF4 */
-            default:
+            else
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
-            }
+
             memcpy((char *)wmb->fillvalue + tsize * wmb->validvars, fill, tsize);
             LOG((3, "copied fill value"));
         }

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -475,7 +475,10 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 #endif /* _NETCDF4 */
             vtype = (MPI_Datatype)iodesc->basetype;
             LOG((3, "caller did not provide fill value vtype = %d", vtype));
-            switch (vtype)
+
+            /* Need to cast MPI_Datatype to int in switches or openmpi
+             * fails. */
+            switch ((int)vtype)
             {
             case MPI_BYTE:
                 fill = &byte_fill;

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -477,49 +477,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
             vtype = (MPI_Datatype)iodesc->basetype;
             LOG((3, "caller did not provide fill value vtype = %d", vtype));
 
-            /* Need to cast MPI_Datatype to int in switches or openmpi
-             * fails. */
-/*             switch ((int)vtype) */
-/*             { */
-/*             case MPI_BYTE: */
-/*                 fill = &byte_fill; */
-/*                 break; */
-/*             case MPI_CHAR: */
-/*                 fill = &char_fill; */
-/*                 break; */
-/*             case MPI_SHORT: */
-/*                 fill = &short_fill; */
-/*                 break; */
-/*             case MPI_INT: */
-/*                 fill = &int_fill; */
-/*                 break; */
-/*             case MPI_FLOAT: */
-/*                 fill = &float_fill; */
-/*                 break; */
-/*             case MPI_DOUBLE: */
-/*                 fill = &double_fill; */
-/*                 break; */
-/* #ifdef _NETCDF4 */
-/*             case MPI_UNSIGNED_CHAR: */
-/*                 fill = &ubyte_fill; */
-/*                 break; */
-/*             case MPI_UNSIGNED_SHORT: */
-/*                 fill = &ushort_fill; */
-/*                 break; */
-/*             case MPI_UNSIGNED: */
-/*                 fill = &uint_fill; */
-/*                 break; */
-/*             case MPI_LONG_LONG: */
-/*                 fill = &int64_fill; */
-/*                 break; */
-/*             case MPI_UNSIGNED_LONG_LONG: */
-/*                 fill = &uint64_fill; */
-/*                 break; */
-/* #endif /\* _NETCDF4 *\/ */
-/*             default: */
-/*                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__); */
-/*             } */
-
+            /* This must be done with an if statement, not a case, or
+             * openmpi will not build. */
             if (vtype == MPI_BYTE)
                 fill = &byte_fill;
             else if (vtype == MPI_CHAR)


### PR DESCRIPTION
More changes are needed for openmpi, but here is one of them. Stop treating MPI_Datatype as an int.

Part of #897.

I have merged to develop for testing.