### PR TITLE
clean up some MPI_Datatype issues in tests for openmpi builds

### DIFF
--- a/tests/cunit/test_darray_1d.c
+++ b/tests/cunit/test_darray_1d.c
@@ -719,7 +719,7 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
         {
             iosystem_desc_t *ios;
             io_desc_t *iodesc;
-            int expected_basetype;
+            MPI_Datatype expected_basetype;
 
             switch (pio_type)
             {

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -1415,11 +1415,13 @@ int test_malloc_iodesc2(int iosysid, int my_rank)
 #else
     int num_types = NUM_CLASSIC_TYPES;
 #endif /* _NETCDF4 */
-    int test_type[NUM_NETCDF_TYPES] = {PIO_BYTE, PIO_CHAR, PIO_SHORT, PIO_INT, PIO_FLOAT, PIO_DOUBLE,
-                                       PIO_UBYTE, PIO_USHORT, PIO_UINT, PIO_INT64, PIO_UINT64, PIO_STRING};
-    int mpi_type[NUM_NETCDF_TYPES] = {MPI_BYTE, MPI_CHAR, MPI_SHORT, MPI_INT, MPI_FLOAT, MPI_DOUBLE,
-                                      MPI_UNSIGNED_CHAR, MPI_UNSIGNED_SHORT, MPI_UNSIGNED, MPI_LONG_LONG,
-                                      MPI_UNSIGNED_LONG_LONG, MPI_CHAR};
+    int test_type[NUM_NETCDF_TYPES] = {PIO_BYTE, PIO_CHAR, PIO_SHORT, PIO_INT,
+                                       PIO_FLOAT, PIO_DOUBLE, PIO_UBYTE, PIO_USHORT,
+                                       PIO_UINT, PIO_INT64, PIO_UINT64, PIO_STRING};
+    MPI_Datatype mpi_type[NUM_NETCDF_TYPES] = {MPI_BYTE, MPI_CHAR, MPI_SHORT, MPI_INT,
+                                               MPI_FLOAT, MPI_DOUBLE, MPI_UNSIGNED_CHAR,
+                                               MPI_UNSIGNED_SHORT, MPI_UNSIGNED, MPI_LONG_LONG,
+                                               MPI_UNSIGNED_LONG_LONG, MPI_CHAR};
     int ioid;
     iosystem_desc_t *ios;
     io_desc_t *iodesc;


### PR DESCRIPTION
Part of #897.
Part of #898.
Part of #886.

I have merged to develop for testing.