### PR TITLE
adding rearranger parameter to init_async function

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -719,7 +719,7 @@ extern "C" {
 
     /* Init decomposition with 0-based compmap array. */
     int PIOc_init_decomp(int iosysid, int basetype, int ndims, const int *dims, int maplen,
-                         const PIO_Offset *compmap, int *ioidp, const int *rearranger,
+                         const PIO_Offset *compmap, int *ioidp, int rearranger,
                          const PIO_Offset *iostart, const PIO_Offset *iocount);
     
     int PIOc_freedecomp(int iosysid, int ioid);

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -746,7 +746,7 @@ extern "C" {
     /* Initializing IO system for async. */
     int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
                         int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
-                        int *iosysidp);
+                        int rearranger, int *iosysidp);
     
     int PIOc_Init_Intercomm(int component_count, MPI_Comm peer_comm, MPI_Comm *comp_comms,
                             MPI_Comm io_comm, int *iosysidp);

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1065,6 +1065,10 @@ int PIOc_iotype_available(int iotype)
  * duplicates and each must later be freed with MPI_Free() by the
  * caller.)
  *
+ * @param rearranger the default rearranger to use for decompositions
+ * in this IO system. Must be either PIO_REARR_BOX or
+ * PIO_REARR_SUBSET.
+ *
  * @param iosysidp pointer to array of length component_count that
  * gets the iosysid for each component.
  *
@@ -1073,7 +1077,8 @@ int PIOc_iotype_available(int iotype)
  */
 int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
                     int component_count, int *num_procs_per_comp, int **proc_list,
-                    MPI_Comm *user_io_comm, MPI_Comm *user_comp_comm, int *iosysidp)
+                    MPI_Comm *user_io_comm, MPI_Comm *user_comp_comm, int rearranger,
+                    int *iosysidp)
 {
     int my_rank;          /* Rank of this task. */
     int **my_proc_list;   /* Array of arrays of procs for comp components. */
@@ -1082,7 +1087,8 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
     int ret;              /* Return code. */
 
     /* Check input parameters. */
-    if (num_io_procs < 1 || component_count < 1 || !num_procs_per_comp || !iosysidp)
+    if (num_io_procs < 1 || component_count < 1 || !num_procs_per_comp || !iosysidp ||
+        (rearranger != PIO_REARR_BOX && rearranger != PIO_REARR_SUBSET))
         return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* Temporarily limit to one computational component. */
@@ -1237,6 +1243,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         my_iosys->num_iotasks = num_io_procs;
         my_iosys->compgroup = MPI_GROUP_NULL;
         my_iosys->iogroup = MPI_GROUP_NULL;
+        my_iosys->default_rearranger = rearranger;
 
         /* The rank of the computation leader in the union comm. */
         my_iosys->comproot = num_io_procs;

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -494,8 +494,9 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *dims, int m
  * file. A -1 in this array indicates a value which should not be
  * transfered.
  * @param ioidp pointer that will get the io description ID.
- * @param rearranger pointer to the rearranger to be used for this
- * decomp or NULL to use the default.
+ * @param rearranger the rearranger to be used for this decomp or 0 to
+ * use the default. Valid rearrangers are PIO_REARR_BOX and
+ * PIO_REARR_SUBSET.
  * @param iostart An array of start values for block cyclic
  * decompositions. If NULL ???
  * @param iocount An array of count values for block cyclic
@@ -504,20 +505,26 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *dims, int m
  * @ingroup PIO_initdecomp
  */
 int PIOc_init_decomp(int iosysid, int pio_type, int ndims, const int *dims, int maplen,
-                     const PIO_Offset *compmap, int *ioidp, const int *rearranger,
+                     const PIO_Offset *compmap, int *ioidp, int rearranger,
                      const PIO_Offset *iostart, const PIO_Offset *iocount)
 {
     PIO_Offset compmap_1_based[maplen];
+    int *rearrangerp = NULL;
 
     LOG((1, "PIOc_init_decomp iosysid = %d pio_type = %d ndims = %d maplen = %d",
          iosysid, pio_type, ndims, maplen));
+
+    /* If the user specified a non-default rearranger, use it. */
+    if (rearranger)
+        rearrangerp = &rearranger;
 
     /* Add 1 to all elements in compmap. */
     for (int e = 0; e < maplen; e++)
         compmap_1_based[e] = compmap[e] + 1;
 
+    /* Call the legacy version of the function. */
     return PIOc_InitDecomp(iosysid, pio_type, ndims, dims, maplen, compmap_1_based,
-                           ioidp, rearranger, iostart, iocount);
+                           ioidp, rearrangerp, iostart, iocount);
 }
 
 /**

--- a/tests/cunit/test_async_3proc.c
+++ b/tests/cunit/test_async_3proc.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 
             /* Initialize the IO system. */
             if ((ret = PIOc_init_async(test_comm, num_io_procs[combo], NULL, COMPONENT_COUNT,
-                                       num_procs[combo], NULL, NULL, NULL, iosysid)))
+                                       num_procs[combo], NULL, NULL, NULL, PIO_REARR_BOX, iosysid)))
                 ERR(ERR_INIT);
 
             for (int c = 0; c < COMPONENT_COUNT; c++)

--- a/tests/cunit/test_async_4proc.c
+++ b/tests/cunit/test_async_4proc.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
 
             /* Initialize the IO system. */
             if ((ret = PIOc_init_async(test_comm, num_io_procs[combo], NULL, COMPONENT_COUNT,
-                                       num_procs2[combo], NULL, NULL, NULL, iosysid)))
+                                       num_procs2[combo], NULL, NULL, NULL, PIO_REARR_BOX, iosysid)))
                 ERR(ERR_INIT);
 
             for (int c = 0; c < COMPONENT_COUNT; c++)

--- a/tests/cunit/test_async_simple.c
+++ b/tests/cunit/test_async_simple.c
@@ -60,18 +60,21 @@ int main(int argc, char **argv)
 
         /* Check for invalid values. */
         if (PIOc_init_async(test_comm, NUM_IO_PROCS, NULL, COMPONENT_COUNT,
-                            num_procs, NULL, NULL, NULL, NULL) != PIO_EINVAL)
-            ERR(ERR_WRONG);
-        if (PIOc_init_async(test_comm, NUM_IO_PROCS, NULL, -1,
-                            num_procs, NULL, NULL, NULL, iosysid) != PIO_EINVAL)
+                            num_procs, NULL, NULL, NULL, PIO_REARR_BOX, NULL) != PIO_EINVAL)
             ERR(ERR_WRONG);
         if (PIOc_init_async(test_comm, NUM_IO_PROCS, NULL, COMPONENT_COUNT,
-                            NULL, NULL, NULL, NULL, iosysid) != PIO_EINVAL)
+                            num_procs, NULL, NULL, NULL, TEST_VAL_42, iosysid) != PIO_EINVAL)
+            ERR(ERR_WRONG);
+        if (PIOc_init_async(test_comm, NUM_IO_PROCS, NULL, -1,
+                            num_procs, NULL, NULL, NULL, PIO_REARR_BOX, iosysid) != PIO_EINVAL)
+            ERR(ERR_WRONG);
+        if (PIOc_init_async(test_comm, NUM_IO_PROCS, NULL, COMPONENT_COUNT,
+                            NULL, NULL, NULL, NULL, PIO_REARR_BOX, iosysid) != PIO_EINVAL)
             ERR(ERR_WRONG);
 
         /* Initialize the IO system. */
         if ((ret = PIOc_init_async(test_comm, NUM_IO_PROCS, io_proc_list, COMPONENT_COUNT,
-                                   num_procs, (int **)proc_list, NULL, NULL, iosysid)))
+                                   num_procs, (int **)proc_list, NULL, NULL, PIO_REARR_BOX, iosysid)))
             ERR(ERR_INIT);
 
         /* All the netCDF calls are only executed on the computation

--- a/tests/cunit/test_darray_3d.c
+++ b/tests/cunit/test_darray_3d.c
@@ -92,7 +92,7 @@ int create_decomposition_3d(int ntasks, int my_rank, int iosysid, int *ioid)
     /* Create the PIO decomposition for this test. */
     printf("%d Creating decomposition elements_per_pe = %lld\n", my_rank, elements_per_pe);
     if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM3, dim_len_3d, elements_per_pe,
-                                compdof, ioid, NULL, NULL, NULL)))
+                                compdof, ioid, 0, NULL, NULL)))
         ERR(ret);
 
     printf("%d decomposition initialized.\n", my_rank);

--- a/tests/cunit/test_decomp_uneven.c
+++ b/tests/cunit/test_decomp_uneven.c
@@ -77,7 +77,7 @@ int create_decomposition_3d(int ntasks, int my_rank, int iosysid, int *dim_len,
     /* Create the PIO decomposition for this test. */
     printf("%d Creating decomposition elements_per_pe = %lld\n", my_rank, elements_per_pe);
     if ((ret = PIOc_init_decomp(iosysid, pio_type, NDIM3, dim_len, elements_per_pe,
-                                compdof, ioid, NULL, NULL, NULL)))
+                                compdof, ioid, 0, NULL, NULL)))
         ERR(ret);
 
     printf("%d decomposition initialized.\n", my_rank);

--- a/tests/cunit/test_intercomm2.c
+++ b/tests/cunit/test_intercomm2.c
@@ -328,7 +328,7 @@ int main(int argc, char **argv)
 
         /* Initialize the IO system. */
         if ((ret = PIOc_init_async(test_comm, NUM_IO_PROCS, NULL, COMPONENT_COUNT,
-                                   num_procs, NULL, NULL, NULL, iosysid)))
+                                   num_procs, NULL, NULL, NULL, PIO_REARR_BOX, iosysid)))
             ERR(ERR_AWFUL);
 
 	printf("%d: test_intercomm2 ParallelIO Library test_intercomm2 comp task returned.\n",

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -100,22 +100,23 @@ int create_decomposition(int ntasks, int my_rank, int iosysid, int dim1_len, int
     if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
         return PIO_ENOMEM;
 
-    /* Describe the decomposition. This is a 1-based array, so add 1! */
+    /* Describe the decomposition. The new init_decomp uses a 0-based
+     * array, so don't add 1! */
     for (int i = 0; i < elements_per_pe; i++)
-        compdof[i] = my_rank * elements_per_pe + i + 1;
+        compdof[i] = my_rank * elements_per_pe + i;
 
     /* These should fail. */
-    if (PIOc_InitDecomp(iosysid + TEST_VAL_42, PIO_FLOAT, NDIM1, dim_len, elements_per_pe,
-                        compdof, ioid, NULL, NULL, NULL) != PIO_EBADID)
+    if (PIOc_init_decomp(iosysid + TEST_VAL_42, PIO_FLOAT, NDIM1, dim_len, elements_per_pe,
+                         compdof, ioid, 0, NULL, NULL) != PIO_EBADID)
         ERR(ERR_WRONG);
-    if (PIOc_InitDecomp(iosysid, PIO_FLOAT, NDIM1, bad_dim_len, elements_per_pe,
-                        compdof, ioid, NULL, NULL, NULL) != PIO_EINVAL)
+    if (PIOc_init_decomp(iosysid, PIO_FLOAT, NDIM1, bad_dim_len, elements_per_pe,
+                         compdof, ioid, 0, NULL, NULL) != PIO_EINVAL)
         ERR(ERR_WRONG);
 
     /* Create the PIO decomposition for this test. */
     printf("%d Creating decomposition elements_per_pe = %lld\n", my_rank, elements_per_pe);
-    if ((ret = PIOc_InitDecomp(iosysid, PIO_FLOAT, NDIM1, dim_len, elements_per_pe,
-                               compdof, ioid, NULL, NULL, NULL)))
+    if ((ret = PIOc_init_decomp(iosysid, PIO_FLOAT, NDIM1, dim_len, elements_per_pe,
+                                compdof, ioid, 0, NULL, NULL)))
         ERR(ret);
 
     printf("%d decomposition initialized.\n", my_rank);

--- a/tests/cunit/test_shared.c
+++ b/tests/cunit/test_shared.c
@@ -102,17 +102,17 @@ int test_no_async2(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm
                                    ioproc_start, PIO_REARR_SUBSET, &iosysid)))
         return ret;
 
-    /* Describe the decomposition. This is a 1-based array, so add 1! */
+    /* Describe the decomposition. This is a 0-based array, so don't add 1! */
     elements_per_pe = x_dim_len * y_dim_len / target_ntasks;
     if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
         return PIO_ENOMEM;
     for (int i = 0; i < elements_per_pe; i++)
-        compdof[i] = my_rank * elements_per_pe + i + 1;
+        compdof[i] = my_rank * elements_per_pe + i;
 
     /* Create the PIO decomposition for this test. */
     printf("%d Creating decomposition...\n", my_rank);
-    if ((ret = PIOc_InitDecomp(iosysid, PIO_FLOAT, 2, slice_dimlen, (PIO_Offset)elements_per_pe,
-                               compdof, &ioid, NULL, NULL, NULL)))
+    if ((ret = PIOc_init_decomp(iosysid, PIO_FLOAT, 2, slice_dimlen, (PIO_Offset)elements_per_pe,
+                                compdof, &ioid, 0, NULL, NULL)))
         return ret;
     free(compdof);
 

--- a/tests/cunit/test_shared.c
+++ b/tests/cunit/test_shared.c
@@ -34,7 +34,7 @@ int test_async2(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm,
 
     /* Initialize the IO system. */
     if ((ret = PIOc_init_async(test_comm, num_io_procs, NULL, component_count,
-                               num_procs, NULL, &io_comm, comp_comm, iosysid)))
+                               num_procs, NULL, &io_comm, comp_comm, PIO_REARR_BOX, iosysid)))
         ERR(ERR_INIT);
     for (int c = 0; c < component_count; c++)
         printf("%d iosysid[%d] = %d\n", my_rank, c, iosysid[c]);


### PR DESCRIPTION
One thing that is preventing some of the decompositon tests from working in async is that async does not handle rearrangers (at all!). So when the code needs a rearranger, it can't find one.

This PR adds the rearranger parameter to the init_async call to get a default rearranger.

Fixes #908.
Fixes #907.
Part of #89.

I will merge to develop for testing.