### PR TITLE
fixing openmpi warnings

### DIFF
--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -285,7 +285,7 @@ int check_file(int ntasks, char *filename) {
 	/* Initialize MPI. */
 	if ((ret = MPI_Init(&argc, &argv)))
 	    MPIERR(ret);
-	if ((ret = MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
+	if ((ret = MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
 	    MPIERR(ret);
 
 	/* Learn my rank and the total number of processors. */

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -855,8 +855,8 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
 
                     /*  The stride here is the length of the collected array (llen) */
 
-                    if ((mpierr = MPI_Type_hvector(nvars, 1, (MPI_Aint) iodesc->llen * tsize, iodesc->rtype[i],
-                                                   recvtypes + i)))
+                    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint) iodesc->llen * tsize,
+                                                          iodesc->rtype[i], recvtypes + i)))
                         return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
                     if (recvtypes[i] == PIO_DATATYPE_NULL)
@@ -871,8 +871,8 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
                 {
                     recvcounts[iodesc->rfrom[i]] = 1;
 
-                    if ((mpierr = MPI_Type_hvector(nvars, 1, (MPI_Aint)iodesc->llen * tsize, iodesc->rtype[i],
-                                                   recvtypes + iodesc->rfrom[i])))
+                    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * tsize, iodesc->rtype[i],
+                                                          recvtypes + iodesc->rfrom[i])))
                         return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
                     if (recvtypes[iodesc->rfrom[i]] == PIO_DATATYPE_NULL)
@@ -899,8 +899,8 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
         if (scount[i] > 0 && sbuf != NULL)
         {
             sendcounts[io_comprank] = 1;
-            if ((mpierr = MPI_Type_hvector(nvars, 1, (MPI_Aint)iodesc->ndof * tsize, iodesc->stype[i],
-                                           sendtypes + io_comprank)))
+            if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->ndof * tsize,
+                                                  iodesc->stype[i], sendtypes + io_comprank)))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
             if (sendtypes[io_comprank] == PIO_DATATYPE_NULL)


### PR DESCRIPTION
There is a warning from openmpi about this (see #897); we are using a deprecated version of the MPI_Type_hvector(). Instead we should be using MPI_Type_create_hvector(), which has the exact same arguments, just a different name. From the [MPI docs](http://mpi-forum.org/docs/mpi-2.2/mpi22-report/node327.htm):

```
The following function is deprecated and is superseded by MPI_TYPE_CREATE_HVECTOR in MPI-2.0. 
The language independent definition and the C binding of the deprecated function is the same as of the 
new function, except of the function name. Only the Fortran language binding is different.

MPI_TYPE_HVECTOR( count, blocklength, stride, oldtype, newtype)

```

Similarly:

```
The following function is deprecated and is superseded by MPI_COMM_SET_ERRHANDLER in MPI-2.0. 
The language independent definition of the deprecated function is the same as of the new function, 
except of the function name. The language bindings are modified.

MPI_ERRHANDLER_SET

```

In this PR I change to the new function names.

I will merge to develop for testing.

Fixes #897.