### PR TITLE
keeping fill and type info about vars used in darrays

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -115,7 +115,20 @@ typedef struct var_desc_t
     /** Number of requests bending with pnetcdf. */
     int nreqs;
 
-    /** Buffer that contains the fill value for this variable. */
+    /* Holds the fill value of this var. */
+    void *fillvalue;
+
+    /* The PIO data type (PIO_INT, PIO_FLOAT, etc.) */
+    int pio_type;
+
+    /* The size of the data type (2 for PIO_SHORT, 4 for PIO_INT, etc.) */
+    PIO_Offset type_size;
+
+    /** Non-zero if fill mode is turned on for this var. */
+    int use_fill;
+
+    /** Buffer that contains the holegrid fill values used to fill in
+     * missing sections of data when using the subset rearranger. */
     void *fillbuf;
 
     /** Data buffer for this variable. */

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -338,7 +338,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* If we don't know the fill value for this var, get it. */
     if (!vdesc->fillvalue)
     {
-        int fill_mode;
+        int no_fill;
         LOG((3, "getting fill value"));
         
         /* Find out PIO data type of var. */
@@ -356,16 +356,11 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
         /* Get the fill value. */
-        if ((ierr = PIOc_inq_var_fill(file->pio_ncid, varid, &fill_mode, vdesc->fillvalue)))
+        if ((ierr = PIOc_inq_var_fill(file->pio_ncid, varid, &no_fill, vdesc->fillvalue)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        vdesc->use_fill = no_fill ? 0 : 1;
+        LOG((3, "vdesc->use_fill = %d", vdesc->use_fill));
     }
-
-    /* If the caller provided a fill value, make sure it's correct. */
-    /* if (fillvalue) */
-    /* { */
-    /*     if (memcmp(fillvalue, vdesc->fillvalue, vdesc->type_size)) */
-    /*         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__); */
-    /* } */
 
     /* Is this a record variable? */
     recordvar = vdesc->record >= 0 ? true : false;

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -115,8 +115,14 @@ int pio_delete_file_from_list(int ncid)
             if (current_file == cfile)
                 current_file = pfile;
 
+            /* Free any fill values that were allocated. */
+            for (int v = 0; v < PIO_MAX_VARS; v++)
+                if (cfile->varlist[v].fillvalue)
+                    free(cfile->varlist[v].fillvalue);
+
             /* Free the memory used for this file. */
             free(cfile);
+            
             return PIO_NOERR;
         }
         pfile = cfile;


### PR DESCRIPTION
Now keep track of the fill value info for each var in the varinfo array in the file struct.

The first time a darray_write is called, if this info is not present in the file varinfo array, it is obtained and stored there. This way, the metadata calls only take place once, no matter how many darray calls take place.

This fill value information will be used in the darray functions to ensure that the correct fill value was passed. Type info will be used to allow types of different sizes to share the same iodesc.

Part of #83.
Part of #690.
Part of #934.
