### PR TITLE
changed timeout times

### DIFF
--- a/tests/cunit/CMakeLists.txt
+++ b/tests/cunit/CMakeLists.txt
@@ -98,9 +98,9 @@ add_dependencies (tests test_decomps)
 
 # Test Timeout in seconds.
 if (PIO_VALGRIND_CHECK)
-  set (DEFAULT_TEST_TIMEOUT 120)
+  set (DEFAULT_TEST_TIMEOUT 240)
 else ()
-  set (DEFAULT_TEST_TIMEOUT 60)
+  set (DEFAULT_TEST_TIMEOUT 120)
 endif ()
 
 # All tests need a certain number of tasks, but they should be able to


### PR DESCRIPTION
Just increased timeout times. As I add to tests, they take longer. test_darray_multivar is now timing out on my Jenkins server.

I have merged to develop for testing.