### PR TITLE
Fixes to code to allow it to work with async; no effect on non-async cases

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -401,6 +401,11 @@ typedef struct iosystem_desc_t
     /** The number of tasks in the computation communicator. */
     int num_comptasks;
 
+    /** The number of tasks in the union communicator (will be
+     * num_comptasks for non-async, num_comptasks + num_iotasks for
+     * async). */
+    int num_uniontasks;
+
     /** Rank of this task in the union communicator. */
     int union_rank;
 
@@ -433,6 +438,10 @@ typedef struct iosystem_desc_t
      * communicator. */
     int *ioranks;
 
+    /** An array of the ranks of all computation tasks within the
+     * union communicator. */
+    int *compranks;
+
     /** Controls handling errors. */
     int error_handler;
 
@@ -445,6 +454,10 @@ typedef struct iosystem_desc_t
 
     /** True if this task is a member of the IO communicator. */
     bool ioproc;
+
+    /** True if this task is a member of a computation
+     * communicator. */
+    bool compproc;
 
     /** MPI Info object. */
     MPI_Info info;

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -551,11 +551,10 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         sr_types[i] = MPI_INT;
     }
 
-    /* Setup for the swapm call at line 550 iodesc->scount is the
-     * amount of data this compute task will transfer to/from each
-     * iotask. For the subset rearranger there is only one io task per
-     * compute task, for the box rearranger there can be more than
-     * one. This provides enough information to know the size of data
+    /* Setup for the swapm call. iodesc->scount is the amount of data
+     * this compute task will transfer to/from each iotask. For the
+     * box rearranger there can be more than one IO task per compute
+     * task. This provides enough information to know the size of data
      * on the iotask, so at line 557 we allocate arrays to hold the
      * map on the iotasks. iodesc->rcount is an array of the amount of
      * data to expect from each compute task and iodesc->rfrom is the
@@ -573,12 +572,12 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
      * swapm call. */
     if (ios->ioproc)
     {
-        /* Allocate memory to hold array of tasks that have recieved
-         * data ??? */
+        /* Allocate memory to hold array of the scounts from all
+         * computation tasks. */
         if (!(recv_buf = calloc(ios->num_comptasks, sizeof(int))))
             return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        /* Initialize arrays that keep track of receives. */
+        /* Initialize arrays that keep track of ???. */
         for (int i = 0; i < ios->num_comptasks; i++)
         {
             recv_counts[i] = 1;

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -485,14 +485,16 @@ int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
  *
  * This function:
  * <ul>
- * <li>Allocates and inits iodesc->scount, array (length
+ * <li>Allocates and inits iodesc->scount, an array (length
  * ios->num_iotasks) containing number of data elements sent to each
  * IO task from current compute task.
  * <li>Uses pio_swapm() to send iodesc->scount array from each
  * computation task to all IO tasks.
  * <li>On IO tasks, allocates and inits iodesc->rcount and
- * iodesc->rfrom arrays (length max(1, nrecvs)) which holds ???.
- * <li>Allocates and init iodesc->sindex arrays (length iodesc->ndof)
+ * iodesc->rfrom arrays (length max(1, nrecvs)) which holds the amount
+ * of data to expect from each compute task and the rank of that
+ * task. .
+ * <li>Allocates and inits iodesc->sindex arrays (length iodesc->ndof)
  * which holds indecies for computation tasks.
  * <li>On IO tasks, allocates and init iodesc->rindex (length
  * totalrecv) with indices of the data to be sent/received from this

--- a/tests/cunit/test_rearr.c
+++ b/tests/cunit/test_rearr.c
@@ -572,12 +572,18 @@ int test_compute_counts(MPI_Comm test_comm, int my_rank)
 
     ios->num_iotasks = TARGET_NTASKS;
     ios->num_comptasks = TARGET_NTASKS;
+    ios->num_uniontasks = TARGET_NTASKS;
     ios->ioproc = 1;
+    ios->compproc = 1;
     ios->union_comm = test_comm;
     if (!(ios->ioranks = malloc(TARGET_NTASKS * sizeof(int))))
         return PIO_ENOMEM;
     for (int t = 0; t < TARGET_NTASKS; t++)
         ios->ioranks[t] = t;
+    if (!(ios->compranks = calloc(ios->num_comptasks, sizeof(int))))
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    for (int i = 0; i < TARGET_NTASKS; i++)
+        ios->compranks[i] = i;
 
     /* Initialize iodesc. */
     if (!(iodesc = calloc(1, sizeof(io_desc_t))))
@@ -611,6 +617,7 @@ int test_compute_counts(MPI_Comm test_comm, int my_rank)
 
     /* Free test resources. */
     free(ios->ioranks);
+    free(ios->compranks);
     free(iodesc);
     free(ios);
 

--- a/tests/cunit/test_rearr.c
+++ b/tests/cunit/test_rearr.c
@@ -671,13 +671,19 @@ int test_box_rearrange_create(MPI_Comm test_comm, int my_rank)
 
     /* Set up the IO task info for the test. */
     ios->ioproc = 1;
+    ios->compproc = 1;
     ios->union_rank = my_rank;
     ios->num_iotasks = 4;
     ios->num_comptasks = 4;
+    ios->num_uniontasks = 4;
     if (!(ios->ioranks = calloc(ios->num_iotasks, sizeof(int))))
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     for (int i = 0; i < TARGET_NTASKS; i++)
         ios->ioranks[i] = i;
+    if (!(ios->compranks = calloc(ios->num_comptasks, sizeof(int))))
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    for (int i = 0; i < TARGET_NTASKS; i++)
+        ios->compranks[i] = i;
 
     /* This is how we allocate a region. */
     if ((ret = alloc_region2(NULL, NDIM1, &ior1)))
@@ -740,6 +746,7 @@ int test_box_rearrange_create(MPI_Comm test_comm, int my_rank)
     free(ior1->count);
     free(ior1);
     free(ios->ioranks);
+    free(ios->compranks);
     free(iodesc);
     free(ios);
 
@@ -782,13 +789,19 @@ int test_box_rearrange_create_2(MPI_Comm test_comm, int my_rank)
 
     /* Set up the IO task info for the test. */
     ios->ioproc = 1;
+    ios->compproc = 1;
     ios->union_rank = my_rank;
     ios->num_iotasks = 4;
     ios->num_comptasks = 4;
+    ios->num_uniontasks = 4;
     if (!(ios->ioranks = calloc(ios->num_iotasks, sizeof(int))))
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     for (int i = 0; i < TARGET_NTASKS; i++)
         ios->ioranks[i] = i;
+    if (!(ios->compranks = calloc(ios->num_comptasks, sizeof(int))))
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    for (int i = 0; i < TARGET_NTASKS; i++)
+        ios->compranks[i] = i;
 
     /* This is how we allocate a region. */
     if ((ret = alloc_region2(NULL, NDIM1, &ior1)))
@@ -848,6 +861,7 @@ int test_box_rearrange_create_2(MPI_Comm test_comm, int my_rank)
     free(ior1->count);
     free(ior1);
     free(ios->ioranks);
+    free(ios->compranks);
     free(iodesc);
     free(ios);
 
@@ -920,15 +934,15 @@ int test_rearrange_comp2io(MPI_Comm test_comm, int my_rank)
         return PIO_ENOMEM;
 
     ios->ioproc = 1;
+    ios->compproc = 1;
     ios->io_rank = my_rank;
     ios->union_comm = test_comm;
     ios->num_iotasks = TARGET_NTASKS;
+    ios->num_uniontasks = TARGET_NTASKS;
     iodesc->rearranger = PIO_REARR_BOX;
     iodesc->basetype = MPI_INT;
 
     /* Set up test for IO task with BOX rearranger to create one type. */
-    ios->ioproc = 1; /* this is IO proc. */
-    ios->num_iotasks = 4; /* The number of IO tasks. */
     iodesc->rtype = NULL; /* Array of MPI types will be created here. */
     iodesc->nrecvs = 1; /* Number of types created. */
     iodesc->basetype = MPI_INT;
@@ -950,14 +964,16 @@ int test_rearrange_comp2io(MPI_Comm test_comm, int my_rank)
     iodesc->ndof = 4;
 
     /* Set up the IO task info for the test. */
-    ios->ioproc = 1;
     ios->union_rank = my_rank;
-    ios->num_iotasks = 4;
     ios->num_comptasks = 4;
     if (!(ios->ioranks = calloc(ios->num_iotasks, sizeof(int))))
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     for (int i = 0; i < TARGET_NTASKS; i++)
         ios->ioranks[i] = i;
+    if (!(ios->compranks = calloc(ios->num_comptasks, sizeof(int))))
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    for (int i = 0; i < TARGET_NTASKS; i++)
+        ios->compranks[i] = i;
 
     /* This is how we allocate a region. */
     if ((ret = alloc_region2(NULL, NDIM1, &ior1)))
@@ -1004,6 +1020,7 @@ int test_rearrange_comp2io(MPI_Comm test_comm, int my_rank)
     free(ior1->count);
     free(ior1);
     free(ios->ioranks);
+    free(ios->compranks);
     free(iodesc);
     free(ios);
     free(sbuf);
@@ -1073,13 +1090,19 @@ int test_rearrange_io2comp(MPI_Comm test_comm, int my_rank)
 
     /* Set up the IO task info for the test. */
     ios->ioproc = 1;
+    ios->compproc = 1;
     ios->union_rank = my_rank;
     ios->num_iotasks = 4;
     ios->num_comptasks = 4;
+    ios->num_uniontasks = 4;
     if (!(ios->ioranks = calloc(ios->num_iotasks, sizeof(int))))
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     for (int i = 0; i < TARGET_NTASKS; i++)
         ios->ioranks[i] = i;
+    if (!(ios->compranks = calloc(ios->num_comptasks, sizeof(int))))
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    for (int i = 0; i < TARGET_NTASKS; i++)
+        ios->compranks[i] = i;
 
     /* This is how we allocate a region. */
     if ((ret = alloc_region2(NULL, NDIM1, &ior1)))
@@ -1126,6 +1149,7 @@ int test_rearrange_io2comp(MPI_Comm test_comm, int my_rank)
     free(ior1->count);
     free(ior1);
     free(ios->ioranks);
+    free(ios->compranks);
     free(iodesc);
     free(ios);
     free(sbuf);


### PR DESCRIPTION
For non-async cases, the number of computation tasks == the number of tasks in the union_comm. So ios->num_comptasks has been used in the code as the size of the union comm. This size is used for the length of 6 arrays that are passed to pio_swapm() (sendcounts, sdispls, etc.).

But with async, the union_comm has a different size.

I have added a field num_uniontasks. For non-async cases it is the same as num_comptasks.

In this PR I have changes to ensure that pio_swapm() calls on the union_comm use arrays of length ios->num_uniontasks. This fixes a problem for async, but has no effect on non-async cases.

Fixes #980.
Part of #981.
Part of #89.

I will merge to develop for testing.
