### PR TITLE
Changes to darray code -  moved some code blocks to internal functions

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -290,6 +290,9 @@ typedef struct io_desc_t
     /** The MPI type of the data. */
     MPI_Datatype basetype;
 
+    /** The size in bytes of a datum of MPI type basetype. */
+    int basetype_size;
+
     /** Length of the iobuffer on this task for a single field on the
      * IO node. The arrays from compute nodes gathered and rearranged
      * to the io-nodes (which are sometimes collocated with compute

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -200,8 +200,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         break;
     case PIO_IOTYPE_NETCDF4C:
     case PIO_IOTYPE_NETCDF:
-        if ((ierr = write_darray_multi_serial(file, nvars, varids, iodesc, iodesc->maxregions,
-                                              iodesc->firstregion, iodesc->llen, vdesc0->iobuf, frame)))
+        if ((ierr = write_darray_multi_serial(file, nvars, varids, iodesc, 0, frame)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
         break;
@@ -265,9 +264,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
             break;
         case PIO_IOTYPE_NETCDF4C:
         case PIO_IOTYPE_NETCDF:
-            if ((ierr = write_darray_multi_serial(file, nvars, varids, iodesc,
-                                                  iodesc->maxfillregions, iodesc->fillregion,
-                                                  iodesc->holegridsize, vdesc0->fillbuf, frame)))
+            if ((ierr = write_darray_multi_serial(file, nvars, varids, iodesc, 1, frame)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);
             break;
         default:

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -200,9 +200,8 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         break;
     case PIO_IOTYPE_NETCDF4C:
     case PIO_IOTYPE_NETCDF:
-        if ((ierr = pio_write_darray_multi_nc_serial(file, nvars, varids, iodesc->ndims, iodesc->basetype,
-                                                     iodesc->maxregions, iodesc->firstregion, iodesc->llen,
-                                                     iodesc->num_aiotasks, vdesc0->iobuf, frame)))
+        if ((ierr = write_darray_multi_serial(file, nvars, varids, iodesc, iodesc->maxregions,
+                                              iodesc->firstregion, iodesc->llen, vdesc0->iobuf, frame)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
         break;
@@ -266,10 +265,9 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
             break;
         case PIO_IOTYPE_NETCDF4C:
         case PIO_IOTYPE_NETCDF:
-            if ((ierr = pio_write_darray_multi_nc_serial(file, nvars, varids, iodesc->ndims, iodesc->basetype,
-                                                         iodesc->maxfillregions, iodesc->fillregion,
-                                                         iodesc->holegridsize,
-                                                         iodesc->num_aiotasks, vdesc0->fillbuf, frame)))
+            if ((ierr = write_darray_multi_serial(file, nvars, varids, iodesc,
+                                                  iodesc->maxfillregions, iodesc->fillregion,
+                                                  iodesc->holegridsize, vdesc0->fillbuf, frame)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);
             break;
         default:

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -487,11 +487,12 @@ int send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset lle
     return PIO_NOERR;
 }
 
-int recv_all_start_count(iosystem_desc_t *ios, file_desc_t *file, const int *vid, const int *frame, 
+int recv_all_start_count(file_desc_t *file, const int *vid, const int *frame, 
                          io_desc_t *iodesc, PIO_Offset llen, int maxregions, int nvars,
                          int fndims, int tsize, size_t *tmp_start, size_t *tmp_count, void *iobuf)
 {
     int dsize;             /* Size in bytes of one element of basetype. */    
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
     size_t rlen;    /* Length of IO buffer on this task. */
     int rregions;   /* Number of regions in buffer for this task. */
     size_t start[fndims], count[fndims];
@@ -501,6 +502,8 @@ int recv_all_start_count(iosystem_desc_t *ios, file_desc_t *file, const int *vid
     MPI_Status status;     /* Recv status for MPI. */    
     int mpierr;  /* Return code from MPI function codes. */
     int ierr;    /* Return code. */
+
+    ios = file->iosystem;    
 
     /* Get the size of the MPI data type. */
     if ((mpierr = MPI_Type_size(iodesc->basetype, &dsize)))
@@ -741,7 +744,7 @@ int write_darray_multi_serial(file_desc_t *file, int nvars, const int *vid, io_d
         {
             /* Task 0 will receive data from all other IO tasks. */
 
-            if ((ierr = recv_all_start_count(ios, file, vid, frame, iodesc, llen, maxregions, nvars, fndims,
+            if ((ierr = recv_all_start_count(file, vid, frame, iodesc, llen, maxregions, nvars, fndims,
                                              tsize, tmp_start, tmp_count, iobuf)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);
         }

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -296,9 +296,8 @@ extern "C" {
                                   const int *frame);
 
     /* Write aggregated arrays to file using serial I/O (netCDF-3/netCDF-4 serial) */
-    int write_darray_multi_serial(file_desc_t *file, int nvars, const int *vid, io_desc_t *iodesc,
-                                  int maxregions, io_region *firstregion, PIO_Offset llen,
-                                  void *iobuf, const int *frame);
+    int write_darray_multi_serial(file_desc_t *file, int nvars, const int *vid,
+                                  io_desc_t *iodesc, int fill, const int *frame);
 
     int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf);
     int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf);

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -296,10 +296,9 @@ extern "C" {
                                   const int *frame);
 
     /* Write aggregated arrays to file using serial I/O (netCDF-3/netCDF-4 serial) */
-    int pio_write_darray_multi_nc_serial(file_desc_t *file, int nvars, const int *vid, int iodesc_ndims,
-                                         MPI_Datatype basetype, int maxregions, io_region *firstregion,
-                                         PIO_Offset llen, int num_aiotasks, void *iobuf,
-                                         const int *frame);
+    int write_darray_multi_serial(file_desc_t *file, int nvars, const int *vid, io_desc_t *iodesc,
+                                  int maxregions, io_region *firstregion, PIO_Offset llen,
+                                  void *iobuf, const int *frame);
 
     int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf);
     int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf);

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -650,6 +650,7 @@ int malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
                   io_desc_t **iodesc)
 {
     MPI_Datatype mpi_type;
+    int mpierr;
     int ret;
 
     /* Check input. */
@@ -668,6 +669,10 @@ int malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
 
     /* Remember the MPI type. */
     (*iodesc)->basetype = mpi_type;
+
+    /* Get the size of the type. */
+    if ((mpierr = MPI_Type_size((*iodesc)->basetype, &(*iodesc)->basetype_size)))
+        return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Initialize some values in the struct. */
     (*iodesc)->maxregions = 1;

--- a/tests/cunit/CMakeLists.txt
+++ b/tests/cunit/CMakeLists.txt
@@ -69,6 +69,8 @@ if (NOT PIO_USE_MPISERIAL)
   target_link_libraries (test_darray_multi pioc)
   add_executable (test_darray_multivar EXCLUDE_FROM_ALL test_darray_multivar.c test_common.c)
   target_link_libraries (test_darray_multivar pioc)
+  add_executable (test_darray_multivar2 EXCLUDE_FROM_ALL test_darray_multivar2.c test_common.c)
+  target_link_libraries (test_darray_multivar2 pioc)
   add_executable (test_darray_1d EXCLUDE_FROM_ALL test_darray_1d.c test_common.c)
   target_link_libraries (test_darray_1d pioc)  
   add_executable (test_darray_3d EXCLUDE_FROM_ALL test_darray_3d.c test_common.c)
@@ -91,6 +93,7 @@ add_dependencies (tests test_pioc_fill)
 add_dependencies (tests test_darray)
 add_dependencies (tests test_darray_multi)
 add_dependencies (tests test_darray_multivar)
+add_dependencies (tests test_darray_multivar2)
 add_dependencies (tests test_darray_1d)
 add_dependencies (tests test_darray_3d)
 add_dependencies (tests test_decomp_uneven)
@@ -188,6 +191,10 @@ else ()
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
   add_mpi_test(test_darray_multivar
     EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_darray_multivar
+    NUMPROCS ${AT_LEAST_FOUR_TASKS}
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+  add_mpi_test(test_darray_multivar2
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_darray_multivar2
     NUMPROCS ${AT_LEAST_FOUR_TASKS}
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
   add_mpi_test(test_darray_1d

--- a/tests/cunit/test_darray_multivar2.c
+++ b/tests/cunit/test_darray_multivar2.c
@@ -1,0 +1,288 @@
+/*
+ * Tests for PIO distributed arrays.
+ *
+ * Ed Hartnett, Jim Edwards, 4/20/17
+ */
+#include <pio.h>
+#include <pio_internal.h>
+#include <pio_tests.h>
+
+/* The number of tasks this test should run on. */
+#define TARGET_NTASKS 4
+
+/* The minimum number of tasks this test should run on. */
+#define MIN_NTASKS 4
+
+/* The name of this test. */
+#define TEST_NAME "test_darray_multivar2"
+
+/* Number of processors that will do IO. */
+#define NUM_IO_PROCS 1
+
+/* Number of computational components to create. */
+#define COMPONENT_COUNT 1
+
+/* The number of dimensions in the example data. In this test, we
+ * are using three-dimensional data. */
+#define NDIM 3
+
+/* But sometimes we need arrays of the non-record dimensions. */
+#define NDIM2 2
+
+/* The length of our sample data along each dimension. */
+#define X_DIM_LEN 4
+#define Y_DIM_LEN 4
+
+/* The number of timesteps of data to write. */
+#define NUM_TIMESTEPS 2
+
+/* Number of variables in the test file. */
+#define NUM_VAR 2
+
+/* The dimension names. */
+char dim_name[NDIM][PIO_MAX_NAME + 1] = {"timestep", "x", "y"};
+
+/* The var names. */
+char var_name[NUM_VAR][PIO_MAX_NAME + 1] = {"Aubery", "Martin"};
+
+/* Length of the dimensions in the sample data. */
+int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
+
+/**
+ * Test the darray functionality. Create a netCDF file with 3
+ * dimensions and 2 variables. One of the vars uses the record
+ * dimension, the other does not. Then use darray to write to them.
+ *
+ * @param iosysid the IO system ID.
+ * @param ioid the ID of the decomposition.
+ * @param num_flavors the number of IOTYPES available in this build.
+ * @param flavor array of available iotypes.
+ * @param my_rank rank of this task.
+ * @param pio_type the type of the data.
+ * @param test_comm the communicator that is running this test.
+ * @returns 0 for success, error code otherwise.
+*/
+int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
+                         int my_rank, int pio_type, MPI_Comm test_comm)
+{
+    char filename[PIO_MAX_NAME + 1]; /* Name for the output files. */
+    int dimids[NDIM];     /* The dimension IDs. */
+    int ncid;             /* The ncid of the netCDF file. */
+    int varid[NUM_VAR];   /* The IDs of the netCDF varables. */
+    /* PIO_Offset arraylen = 4; */
+    /* int custom_fillvalue_int = -TEST_VAL_42; */
+    /* int test_data_int[arraylen]; */
+    int ret;       /* Return code. */
+
+    /* Initialize some data. */
+    /* for (int f = 0; f < arraylen; f++) */
+    /*     test_data_int[f] = my_rank * 10 + f; */
+
+    /* Use PIO to create the example file in each of the four
+     * available ways. */
+    /* for (int fmt = 0; fmt < num_flavors; fmt++) */
+    for (int fmt = 0; fmt < 1; fmt++)
+    {
+        /* Create the filename. */
+        sprintf(filename, "data_%s_iotype_%d_pio_type_%d.nc", TEST_NAME, flavor[fmt], pio_type);
+
+        /* Create the netCDF output file. */
+        printf("rank: %d Creating sample file %s with format %d type %d\n", my_rank, filename,
+               flavor[fmt], pio_type);
+        if ((ret = PIOc_createfile(iosysid, &ncid, &flavor[fmt], filename, PIO_CLOBBER)))
+            ERR(ret);
+
+        /* Define netCDF dimensions and variable. */
+        printf("%d Defining netCDF metadata...\n", my_rank);
+        for (int d = 0; d < NDIM; d++)
+            if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
+                ERR(ret);
+
+        /* Var 0 does not have a record dim, varid 1 is a record var. */
+        if ((ret = PIOc_def_var(ncid, var_name[0], pio_type, NDIM - 1, &dimids[1], &varid[0])))
+            ERR(ret);
+        if ((ret = PIOc_def_var(ncid, var_name[1], pio_type, NDIM, dimids, &varid[1])))
+            ERR(ret);
+
+        /* End define mode. */
+        if ((ret = PIOc_enddef(ncid)))
+            ERR(ret);
+
+        /* Set the value of the record dimension for varid 1. */
+        if ((ret = PIOc_setframe(ncid, varid[1], 0)))
+            ERR(ret);
+
+        /* Write the data. */
+        /* for (int v = 0; v < NUM_VAR; v++) */
+        /*     if ((ret = PIOc_write_darray(ncid, varid[v], ioid, arraylen, test_data_int, &custom_fillvalue_int))) */
+        /*         ERR(ret); */
+
+        /* Close the netCDF file. */
+        if ((ret = PIOc_closefile(ncid)))
+            ERR(ret);
+
+        /* /\* Check the file contents. *\/ */
+        /* { */
+        /*     int ncid2;            /\* The ncid of the re-opened netCDF file. *\/ */
+        /*     int test_data_int_in[arraylen]; */
+                        
+        /*     /\* Reopen the file. *\/ */
+        /*     if ((ret = PIOc_openfile(iosysid, &ncid2, &flavor[fmt], filename, PIO_NOWRITE))) */
+        /*         ERR(ret); */
+            
+        /*     for (int v = 0; v < NUM_VAR; v++) */
+        /*     { */
+        /*         /\* Read the data. *\/ */
+        /*         if ((ret = PIOc_read_darray(ncid2, varid[v], ioid, arraylen, test_data_int_in))) */
+        /*             ERR(ret); */
+                
+        /*         /\* Check the results. *\/ */
+        /*         for (int f = 0; f < arraylen; f++) */
+        /*             if (test_data_int_in[f] != test_data_int[f]) */
+        /*                 return ERR_WRONG; */
+        /*     } /\* next var *\/ */
+            
+        /*     /\* Close the netCDF file. *\/ */
+        /*     if ((ret = PIOc_closefile(ncid2))) */
+        /*         ERR(ret); */
+        /* } */
+    }
+
+    return PIO_NOERR;
+}
+
+/* Create the decomposition to divide the 3-dimensional sample data
+ * between the 4 tasks. For the purposes of decomposition we are only
+ * concerned with 2 dimensions - we ignore the unlimited dimension.
+ *
+ * @param ntasks the number of available tasks
+ * @param my_rank rank of this task.
+ * @param iosysid the IO system ID.
+ * @param dim_len_2d an array of length 2 with the dim lengths.
+ * @param ioid a pointer that gets the ID of this decomposition.
+ * @param pio_type the data type to use for the decomposition.
+ * @returns 0 for success, error code otherwise.
+ **/
+int create_decomposition_2d_2(int ntasks, int my_rank, int iosysid, int *dim_len_2d,
+                              int *ioid, int pio_type)
+{
+    PIO_Offset elements_per_pe;     /* Array elements per processing unit. */
+    PIO_Offset *compdof;  /* The decomposition mapping. */
+    int ret;
+
+    /* How many data elements per task? In this example we will end up
+     * with 4. */
+    elements_per_pe = dim_len_2d[0] * dim_len_2d[1] / ntasks;
+
+    /* Allocate space for the decomposition array. */
+    if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
+        return PIO_ENOMEM;
+
+    /* Describe the decomposition. This is a 1-based array, so add 1! */
+    for (int i = 0; i < elements_per_pe; i++)
+        compdof[i] = my_rank * elements_per_pe + i + 1;
+
+    /* Create the PIO decomposition for this test. */
+    printf("%d Creating decomposition elements_per_pe = %lld\n", my_rank, elements_per_pe);
+    if ((ret = PIOc_InitDecomp(iosysid, pio_type, NDIM2, dim_len_2d, elements_per_pe,
+                               compdof, ioid, NULL, NULL, NULL)))
+        ERR(ret);
+
+    printf("%d decomposition initialized.\n", my_rank);
+
+    /* Free the mapping. */
+    free(compdof);
+
+    return 0;
+}
+
+/**
+ * Run all the tests.
+ *
+ * @param iosysid the IO system ID.
+ * @param num_flavors number of available iotypes in the build.
+ * @param flavor pointer to array of the available iotypes.
+ * @param my_rank rank of this task.
+ * @param test_comm the communicator the test is running on.
+ * @returns 0 for success, error code otherwise.
+ */
+int test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
+                    MPI_Comm test_comm)
+{
+    int ioid;
+    int dim_len_2d[NDIM2] = {X_DIM_LEN, Y_DIM_LEN};
+    int ret; /* Return code. */
+
+    /* Decompose the data over the tasks. */
+    if ((ret = create_decomposition_2d_2(TARGET_NTASKS, my_rank, iosysid, dim_len_2d,
+                                         &ioid, PIO_INT)))
+        return ret;
+    
+    /* Run the multivar darray tests. */
+    if ((ret = test_multivar_darray(iosysid, ioid, num_flavors, flavor, my_rank, PIO_INT,
+                                    test_comm)))
+        return ret;
+    
+    /* Free the PIO decomposition. */
+    if ((ret = PIOc_freedecomp(iosysid, ioid)))
+        ERR(ret);
+
+    return PIO_NOERR;
+}
+
+/* Run tests for darray functions. */
+int main(int argc, char **argv)
+{
+    int my_rank;
+    int ntasks;
+    int num_flavors;         /* Number of PIO netCDF flavors in this build. */
+    int flavor[NUM_FLAVORS]; /* iotypes for the supported netCDF IO flavors. */
+    MPI_Comm test_comm;      /* A communicator for this test. */
+    int ret;                 /* Return code. */
+
+    /* Initialize test. */
+    if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, MIN_NTASKS, MIN_NTASKS,
+                              3, &test_comm)))
+        ERR(ERR_INIT);
+
+    if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))
+        return ret;
+
+    /* Only do something on max_ntasks tasks. */
+    if (my_rank < TARGET_NTASKS)
+    {
+        int iosysid;              /* The ID for the parallel I/O system. */
+        int ioproc_stride = 1;    /* Stride in the mpi rank between io tasks. */
+        int ioproc_start = 0;     /* Zero based rank of first processor to be used for I/O. */
+        int ret;                  /* Return code. */
+
+        /* Figure out iotypes. */
+        if ((ret = get_iotypes(&num_flavors, flavor)))
+            ERR(ret);
+        printf("Runnings tests for %d flavors\n", num_flavors);
+
+        /* Initialize the PIO IO system. This specifies how
+         * many and which processors are involved in I/O. */
+        if ((ret = PIOc_Init_Intracomm(test_comm, TARGET_NTASKS, ioproc_stride,
+                                       ioproc_start, PIO_REARR_BOX, &iosysid)))
+            return ret;
+
+        /* Run tests. */
+        printf("%d Running tests...\n", my_rank);
+        if ((ret = test_all_darray(iosysid, num_flavors, flavor, my_rank, test_comm)))
+            return ret;
+        
+        /* Finalize PIO system. */
+        if ((ret = PIOc_finalize(iosysid)))
+            return ret;
+
+    } /* endif my_rank < TARGET_NTASKS */
+
+    /* Finalize the MPI library. */
+    printf("%d %s Finalizing...\n", my_rank, TEST_NAME);
+    if ((ret = pio_test_finalize(&test_comm)))
+        return ret;
+
+    printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
+    return 0;
+}


### PR DESCRIPTION
Part of #973.

This PR does not change any existing functionality. I moved some of the code blocks in pio_write_darray_multi_nc_serial() to internal helper functions. I also changed the name of the function to write_darray_multi_serial() and cleaned up some of the parameters.

Also added a test (test_darray_multivar2.c) with the test that demonstrates the issue. (Test is commented out so CI won't fail).

This is in preparation for solving the #973 issue for serial writes.

I will merge to develop for testing.