### PR TITLE
handle record and non-record vars in darray writes

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -485,6 +485,9 @@ typedef struct wmulti_buffer
      * PIOc_Init_Decomp().  */
     int ioid;
 
+    /** Non-zero if this is a buffer for a record var. */
+    int recordvar;
+
     /** Number of arrays of data in the multibuffer. Each array had
      * data for one var or record. When multibuffer is flushed, all
      * arrays are written and num_arrays returns to zero. */

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -292,6 +292,45 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
 }
 
 /**
+ * Find the fillvalue that should be used for a variable.
+   @param file Info about file we are writing to. 
+ */
+int find_var_fillvalue(file_desc_t *file, int varid, var_desc_t *vdesc)
+{
+    iosystem_desc_t *ios;  /* Pointer to io system information. */    
+    int no_fill;
+    int ierr;
+
+    /* Check inputs. */
+    pioassert(file && file->iosystem && vdesc, "invalid input", __FILE__, __LINE__);
+    ios = file->iosystem;
+    
+    LOG((3, "find_var_fillvalue file->pio_ncid = %d varid = %d", file->pio_ncid, varid));
+    
+    /* Find out PIO data type of var. */
+    if ((ierr = PIOc_inq_vartype(file->pio_ncid, varid, &vdesc->pio_type)))
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+    
+    /* Find out length of type. */
+    if ((ierr = PIOc_inq_type(file->pio_ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+    LOG((3, "getting fill value for varid = %d pio_type = %d type_size = %d",
+         varid, vdesc->pio_type, vdesc->type_size));
+    
+    /* Allocate storage for the fill value. */
+    if (!(vdesc->fillvalue = malloc(vdesc->type_size)))
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    
+    /* Get the fill value. */
+    if ((ierr = PIOc_inq_var_fill(file->pio_ncid, varid, &no_fill, vdesc->fillvalue)))
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+    vdesc->use_fill = no_fill ? 0 : 1;
+    LOG((3, "vdesc->use_fill = %d", vdesc->use_fill));
+
+    return PIO_NOERR;
+}
+
+/**
  * Write a distributed array to the output file.
  *
  * This routine aggregates output on the compute nodes and only sends
@@ -340,7 +379,6 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     void *bufptr;          /* A data buffer. */
     MPI_Datatype vtype;    /* The MPI type of the variable. */
     wmulti_buffer *wmb;    /* The write multi buffer for one or more vars. */
-    int tsize;             /* Size of MPI type. */
     bool recordvar;        /* True if this is a record variable. */
     int needsflush = 0;    /* True if we need to flush buffer. */
     bufsize totfree;       /* Amount of free space in the buffer. */
@@ -376,44 +414,19 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 
     /* Get var description. */
     vdesc = &(file->varlist[varid]);
-    LOG((2, "vdesc record %d ndims %d nreqs %d", vdesc->record, vdesc->ndims, vdesc->nreqs));
+    LOG((2, "vdesc record %d ndims %d nreqs %d", vdesc->record, vdesc->ndims,
+         vdesc->nreqs));
 
     /* If we don't know the fill value for this var, get it. */
     if (!vdesc->fillvalue)
-    {
-        int no_fill;
-        LOG((3, "getting fill value"));
-        
-        /* Find out PIO data type of var. */
-        if ((ierr = PIOc_inq_vartype(file->pio_ncid, varid, &vdesc->pio_type)))
-            return pio_err(ios, file, ierr, __FILE__, __LINE__);
-
-        /* Find out length of type. */
-        if ((ierr = PIOc_inq_type(ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
-            return pio_err(ios, file, ierr, __FILE__, __LINE__);
-        LOG((3, "getting fill value for varid = %d pio_type = %d type_size = %d",
-             varid, vdesc->pio_type, vdesc->type_size));
-
-        /* Allocate storage for the fill value. */
-        if (!(vdesc->fillvalue = malloc(vdesc->type_size)))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-
-        /* Get the fill value. */
-        if ((ierr = PIOc_inq_var_fill(file->pio_ncid, varid, &no_fill, vdesc->fillvalue)))
-            return pio_err(ios, file, ierr, __FILE__, __LINE__);
-        vdesc->use_fill = no_fill ? 0 : 1;
-        LOG((3, "vdesc->use_fill = %d", vdesc->use_fill));
-    }
+        if ((ierr = find_var_fillvalue(file, varid, vdesc)))
+            return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__);            
 
     /* Is this a record variable? The user must set the vdesc->record
      * value by calling PIOc_setframe() before calling this
      * function. */
     recordvar = vdesc->record >= 0 ? true : false;
     LOG((3, "recordvar = %d", recordvar));
-
-    /* Get the size of the MPI type. */
-    if ((mpierr = MPI_Type_size(iodesc->basetype, &tsize)))
-        return check_mpi(file, mpierr, __FILE__, __LINE__);
 
     /* The write multi buffer wmulti_buffer is the cache on compute
        nodes that will collect and store multiple variables before
@@ -450,8 +463,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 
     /* At this point wmb should be pointing to a new or existing buffer
        so we can add the data. */
-    LOG((2, "wmb->num_arrays = %d arraylen = %d tsize = %d\n", wmb->num_arrays,
-         arraylen, tsize));
+    LOG((2, "wmb->num_arrays = %d arraylen = %d iodesc->basetype_size = %d\n", wmb->num_arrays,
+         arraylen, iodesc->basetype_size));
 
     /* Find out how much free, contiguous space is available. */
     bfreespace(&totfree, &maxfree);
@@ -459,7 +472,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* maxfree is the available memory. If that is < 10% greater than
      * the size of the current request needsflush is true. */
     if (needsflush == 0)
-        needsflush = (maxfree <= 1.1 * (1 + wmb->num_arrays) * arraylen * tsize);
+        needsflush = (maxfree <= 1.1 * (1 + wmb->num_arrays) * arraylen * iodesc->basetype_size);
 
     /* Tell all tasks on the computation communicator whether we need
      * to flush data. */
@@ -475,8 +488,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         /* Collect a debug report about buffer. */
         cn_buffer_report(ios, true);
         LOG((2, "maxfree = %ld wmb->num_arrays = %d (1 + wmb->num_arrays) *"
-             " arraylen * tsize = %ld totfree = %ld\n", maxfree, wmb->num_arrays,
-             (1 + wmb->num_arrays) * arraylen * tsize, totfree));
+             " arraylen * iodesc->basetype_size = %ld totfree = %ld\n", maxfree, wmb->num_arrays,
+             (1 + wmb->num_arrays) * arraylen * iodesc->basetype_size, totfree));
 #endif /* PIO_ENABLE_LOGGING */
 
         /* If needsflush == 2 flush to disk otherwise just flush to io node. */
@@ -487,9 +500,9 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Get memory for data. */
     if (arraylen > 0)
     {
-        if (!(wmb->data = bgetr(wmb->data, (1 + wmb->num_arrays) * arraylen * tsize)))
+        if (!(wmb->data = bgetr(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->basetype_size)))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        LOG((2, "got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * tsize));
+        LOG((2, "got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->basetype_size));
     }
 
     /* vid is an array of variable ids in the wmb list, grow the list
@@ -510,7 +523,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (iodesc->needsfill)
     {
         /* Get memory to hold fill value. */
-        if (!(wmb->fillvalue = bgetr(wmb->fillvalue, tsize * (1 + wmb->num_arrays))))
+        if (!(wmb->fillvalue = bgetr(wmb->fillvalue, iodesc->basetype_size * (1 + wmb->num_arrays))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
         /* If the user passed a fill value, use that, otherwise use
@@ -518,8 +531,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
          * value to the buffer. */
         if (fillvalue)
         {
-            memcpy((char *)wmb->fillvalue + tsize * wmb->num_arrays, fillvalue, tsize);
-            LOG((3, "copied user-provided fill value tsize = %d", tsize));
+            memcpy((char *)wmb->fillvalue + iodesc->basetype_size * wmb->num_arrays, fillvalue, iodesc->basetype_size);
+            LOG((3, "copied user-provided fill value iodesc->basetype_size = %d", iodesc->basetype_size));
         }
         else
         {
@@ -569,7 +582,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
             else
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
 
-            memcpy((char *)wmb->fillvalue + tsize * wmb->num_arrays, fill, tsize);
+            memcpy((char *)wmb->fillvalue + iodesc->basetype_size * wmb->num_arrays, fill, iodesc->basetype_size);
             LOG((3, "copied fill value"));
         }
     }
@@ -581,11 +594,11 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
          wmb->vid[wmb->num_arrays]));
 
     /* Copy the user-provided data to the buffer. */
-    bufptr = (void *)((char *)wmb->data + arraylen * tsize * wmb->num_arrays);
+    bufptr = (void *)((char *)wmb->data + arraylen * iodesc->basetype_size * wmb->num_arrays);
     if (arraylen > 0)
     {
-        memcpy(bufptr, array, arraylen * tsize);
-        LOG((3, "copied %ld bytes of user data", arraylen * tsize));
+        memcpy(bufptr, array, arraylen * iodesc->basetype_size);
+        LOG((3, "copied %ld bytes of user data", arraylen * iodesc->basetype_size));
     }
 
     /* Add the unlimited dimension value of this variable to the frame
@@ -594,8 +607,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         wmb->frame[wmb->num_arrays] = vdesc->record;
     wmb->num_arrays++;
 
-    LOG((2, "wmb->num_arrays = %d iodesc->maxbytes / tsize = %d iodesc->ndof = %d iodesc->llen = %d",
-         wmb->num_arrays, iodesc->maxbytes / tsize, iodesc->ndof, iodesc->llen));
+    LOG((2, "wmb->num_arrays = %d iodesc->maxbytes / iodesc->basetype_size = %d iodesc->ndof = %d iodesc->llen = %d",
+         wmb->num_arrays, iodesc->maxbytes / iodesc->basetype_size, iodesc->ndof, iodesc->llen));
 
     return PIO_NOERR;
 }

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -63,10 +63,10 @@ PIO_Offset PIOc_set_buffer_size_limit(PIO_Offset limit)
  * <li>For parallel iotypes (pnetcdf and netCDF-4 parallel) call
  * pio_write_darray_multi_nc().
  * <li>For serial iotypes (netcdf classic and netCDF-4 serial) call
- * pio_write_darray_multi_nc_serial().
+ * write_darray_multi_serial().
  * <li>For subset rearranger, create holegrid to write missing
  * data. Then call pio_write_darray_multi_nc() or
- * pio_write_darray_multi_nc_serial() to write the holegrid.
+ * write_darray_multi_serial() to write the holegrid.
  * <li>Special buffer flush for pnetcdf.
  * </ul>
  *

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -293,7 +293,12 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
 
 /**
  * Find the fillvalue that should be used for a variable.
-   @param file Info about file we are writing to. 
+ *
+ * @param file Info about file we are writing to. 
+ * @param varid the variable ID.
+ * @param vdesc pointer to var_desc_t info for this var.
+ * @returns 0 for success, non-zero error code for failure.
+ * @ingroup PIO_write_darray
  */
 int find_var_fillvalue(file_desc_t *file, int varid, var_desc_t *vdesc)
 {

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -308,7 +308,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
  * and flush if needed.
  * <li>Store the new user data in the mutli buffer.
  * <li>If needed (only for subset rearranger), fill in gaps in data
- * will fillvalue.
+ * with fillvalue.
  * <li>Remember the frame value (i.e. record number) of this data if
  * there is one.
  * </ul>

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -446,7 +446,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if (wmb->ioid == ioid && wmb->recordvar == recordvar)
             break;
 
-    /* If this is a new wmb entry, initialize it. */
+    /* If we did not find an existing wmb entry, create a new wmb. */
     if (wmb->ioid != ioid || wmb->recordvar != recordvar)
     {
         /* Allocate a buffer. */
@@ -466,11 +466,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         wmb->frame = NULL;
         wmb->fillvalue = NULL;
     }
-
-    /* At this point wmb should be pointing to a new or existing buffer
-       so we can add the data. */
-    LOG((2, "wmb->num_arrays = %d arraylen = %d iodesc->basetype_size = %d\n", wmb->num_arrays,
-         arraylen, iodesc->basetype_size));
+    LOG((2, "wmb->num_arrays = %d arraylen = %d iodesc->basetype_size = %d\n",
+         wmb->num_arrays, arraylen, iodesc->basetype_size));
 
     /* Find out how much free, contiguous space is available. */
     bfreespace(&totfree, &maxfree);

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -701,7 +701,7 @@ int write_darray_multi_serial(file_desc_t *file, int nvars, const int *vid,
     pioassert(file && file->iosystem && file->varlist && vid && vid[0] >= 0 &&
               vid[0] <= PIO_MAX_VARS && iodesc, "invalid input", __FILE__, __LINE__);
 
-    LOG((1, "pio_write_darray_multi_nc_serial nvars = %d iodesc->ndims = %d iodesc->basetype = %d",
+    LOG((1, "write_darray_multi_serial nvars = %d iodesc->ndims = %d iodesc->basetype = %d",
          nvars, iodesc->ndims, iodesc->basetype));
 
     /* Get the iosystem info. */

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2115,8 +2115,8 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-        LOG((2, "calling inq_var_fill file->iotype = %d file->fh = %d varid = %d no_fill = %d",
-             file->iotype, file->fh, varid, no_fill));
+        LOG((2, "calling inq_var_fill file->iotype = %d file->fh = %d varid = %d",
+             file->iotype, file->fh, varid));
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
 #ifdef _PNETCDF

--- a/tests/cunit/test_darray_multivar2.c
+++ b/tests/cunit/test_darray_multivar2.c
@@ -69,14 +69,14 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
     int dimids[NDIM];     /* The dimension IDs. */
     int ncid;             /* The ncid of the netCDF file. */
     int varid[NUM_VAR];   /* The IDs of the netCDF varables. */
-    /* PIO_Offset arraylen = 4; */
-    /* int custom_fillvalue_int = -TEST_VAL_42; */
-    /* int test_data_int[arraylen]; */
+    PIO_Offset arraylen = 4;
+    int custom_fillvalue_int = -TEST_VAL_42;
+    int test_data_int[arraylen];
     int ret;       /* Return code. */
 
     /* Initialize some data. */
-    /* for (int f = 0; f < arraylen; f++) */
-    /*     test_data_int[f] = my_rank * 10 + f; */
+    for (int f = 0; f < arraylen; f++)
+        test_data_int[f] = my_rank * 10 + f;
 
     /* Use PIO to create the example file in each of the four
      * available ways. */
@@ -113,9 +113,9 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             ERR(ret);
 
         /* Write the data. */
-        /* for (int v = 0; v < NUM_VAR; v++) */
-        /*     if ((ret = PIOc_write_darray(ncid, varid[v], ioid, arraylen, test_data_int, &custom_fillvalue_int))) */
-        /*         ERR(ret); */
+        for (int v = 0; v < NUM_VAR; v++)
+            if ((ret = PIOc_write_darray(ncid, varid[v], ioid, arraylen, test_data_int, &custom_fillvalue_int)))
+                ERR(ret);
 
         /* Close the netCDF file. */
         if ((ret = PIOc_closefile(ncid)))

--- a/tests/cunit/test_darray_multivar2.c
+++ b/tests/cunit/test_darray_multivar2.c
@@ -80,8 +80,7 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
 
     /* Use PIO to create the example file in each of the four
      * available ways. */
-    /* for (int fmt = 0; fmt < num_flavors; fmt++) */
-    for (int fmt = 0; fmt < 1; fmt++)
+    for (int fmt = 0; fmt < num_flavors; fmt++)
     {
         /* Create the filename. */
         sprintf(filename, "data_%s_iotype_%d_pio_type_%d.nc", TEST_NAME, flavor[fmt], pio_type);
@@ -121,31 +120,31 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
         if ((ret = PIOc_closefile(ncid)))
             ERR(ret);
 
-        /* /\* Check the file contents. *\/ */
-        /* { */
-        /*     int ncid2;            /\* The ncid of the re-opened netCDF file. *\/ */
-        /*     int test_data_int_in[arraylen]; */
+        /* Check the file contents. */
+        {
+            int ncid2;            /* The ncid of the re-opened netCDF file. */
+            int test_data_int_in[arraylen];
                         
-        /*     /\* Reopen the file. *\/ */
-        /*     if ((ret = PIOc_openfile(iosysid, &ncid2, &flavor[fmt], filename, PIO_NOWRITE))) */
-        /*         ERR(ret); */
+            /* Reopen the file. */
+            if ((ret = PIOc_openfile(iosysid, &ncid2, &flavor[fmt], filename, PIO_NOWRITE)))
+                ERR(ret);
             
-        /*     for (int v = 0; v < NUM_VAR; v++) */
-        /*     { */
-        /*         /\* Read the data. *\/ */
-        /*         if ((ret = PIOc_read_darray(ncid2, varid[v], ioid, arraylen, test_data_int_in))) */
-        /*             ERR(ret); */
+            for (int v = 0; v < NUM_VAR; v++)
+            {
+                /* Read the data. */
+                if ((ret = PIOc_read_darray(ncid2, varid[v], ioid, arraylen, test_data_int_in)))
+                    ERR(ret);
                 
-        /*         /\* Check the results. *\/ */
-        /*         for (int f = 0; f < arraylen; f++) */
-        /*             if (test_data_int_in[f] != test_data_int[f]) */
-        /*                 return ERR_WRONG; */
-        /*     } /\* next var *\/ */
+                /* Check the results. */
+                for (int f = 0; f < arraylen; f++)
+                    if (test_data_int_in[f] != test_data_int[f])
+                        return ERR_WRONG;
+            } /* next var */
             
-        /*     /\* Close the netCDF file. *\/ */
-        /*     if ((ret = PIOc_closefile(ncid2))) */
-        /*         ERR(ret); */
-        /* } */
+            /* Close the netCDF file. */
+            if ((ret = PIOc_closefile(ncid2)))
+                ERR(ret);
+        }
     }
 
     return PIO_NOERR;

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -2116,7 +2116,6 @@ int test_all(int iosysid, int num_flavors, int *flavor, int my_rank, MPI_Comm te
     if ((ret = test_names(iosysid, num_flavors, flavor, my_rank, test_comm, async)))
         return ret;
 
-
     /* Test netCDF-4 functions. */
     printf("%d Testing nc4 functions. async = %d\n", my_rank, async);
     if ((ret = test_nc4(iosysid, num_flavors, flavor, my_rank)))


### PR DESCRIPTION
Fixes #973.
Part of #1004.

Now mixing record and non-record variables in darray operations works again.

I added a field recordvar to the wmb. Along with the ioid, this is used to find a multi-buffer for a darray operation. As used to occur with the negative ioid, the non-record vars now have their own multi-buffer.

I will merge to develop for testing.

I will also add a ticket to further strengthen testing for this feature.

