### PR TITLE
Adding a fortran test that reuses decomp btw 3d and 4d vars

### DIFF
--- a/tests/general/pio_decomp_frame_tests.F90.in
+++ b/tests/general/pio_decomp_frame_tests.F90.in
@@ -225,3 +225,196 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_4d_col_decomp
   deallocate(rbuf)
   deallocate(wbuf)
 PIO_TF_AUTO_TEST_SUB_END nc_write_read_4d_col_decomp
+
+! Using a 3d decomp for writing out a 3d and a 4d var
+! Write with one decomp (to force rearrangement) and read with another (no
+! rearrangement)
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
+  implicit none
+  integer, parameter :: NDIMS = 4
+  integer, parameter :: NFRAMES = 3
+  type(var_desc_t)  :: pio_var3d, pio_var4d
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(NDIMS) :: start, count
+  PIO_TF_FC_DATA_TYPE, dimension(:,:,:,:), allocatable :: rbuf4d, wbuf4d, exp_val4d
+  PIO_TF_FC_DATA_TYPE, dimension(:,:,:), allocatable :: rbuf3d, wbuf3d, exp_val3d
+  integer, dimension(NDIMS-1) :: dims
+  integer, dimension(NDIMS) :: pio_dims
+  integer :: i, j, k, tmp_idx, ierr, lsz, nrows, ncols, nhgts
+  integer(kind=pio_offset_kind) :: f
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+  
+  ! Initialize the 4d var
+  allocate(wbuf4d(nrows, ncols, nhgts, NFRAMES))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          wbuf4d(i,j,k,f) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                        (start(2) - 1 + j - 1) * dims(1) + i
+          wbuf4d(i,j,k,f) = wbuf4d(i,j,k,f) + (f - 1) * (dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+  allocate(compdof(nrows * ncols * nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+        compdof(tmp_idx) = wbuf4d(i,j,k,1)
+      end do
+    end do
+  end do
+  ! Initialize the 3d var
+  allocate(wbuf3d(nrows, ncols, nhgts)) 
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        wbuf3d(i,j,k) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                      (start(2) - 1 + j - 1) * dims(1) + i
+      end do
+    end do
+  end do
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+
+  ! Set the decomposition for reading data - different from the write decomp
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+  
+  allocate(rbuf4d(nrows, ncols, nhgts, NFRAMES))
+  rbuf4d = 0
+  ! Expected val for 4d var
+  allocate(exp_val4d(nrows, ncols, nhgts, NFRAMES))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          exp_val4d(i,j,k,f) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                              (start(2) - 1 + j - 1) * dims(1) + i
+          exp_val4d(i,j,k,f) = exp_val4d(i,j,k,f)+(f - 1) * (dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+  allocate(compdof(nrows * ncols * nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+        compdof(tmp_idx) = exp_val4d(i,j,k,1)
+      end do
+    end do
+  end do
+
+  allocate(rbuf3d(nrows, ncols, nhgts))
+  rbuf3d = 0
+  ! Expected val for 3d var
+  allocate(exp_val3d(nrows, ncols, nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        exp_val3d(i,j,k) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                            (start(2) - 1 + j - 1) * dims(1) + i
+      end do
+    end do
+  end do
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, rd_iodesc)
+  deallocate(compdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_3d_var', PIO_TF_DATA_TYPE, pio_dims(1:3), pio_var3d)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a 3d var : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_4d_var', PIO_TF_DATA_TYPE, pio_dims, pio_var4d)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a 4d var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var3d, wr_iodesc, wbuf3d, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write 3d darray : " // trim(filename))
+
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var4d, f)
+      ! Write the current frame
+      call PIO_write_darray(pio_file, pio_var4d, wr_iodesc, wbuf4d(:,:,:,f), ierr)
+      PIO_TF_CHECK_ERR(ierr, "Failed to write 4d darray : " // trim(filename))
+    end do
+    call PIO_syncfile(pio_file)
+
+    rbuf4d = 0
+    rbuf3d = 0
+
+    call PIO_read_darray(pio_file, pio_var3d, rd_iodesc, rbuf3d, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read 3d darray : " // trim(filename))
+
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var4d, f)
+      call PIO_read_darray(pio_file, pio_var4d, rd_iodesc, rbuf4d(:,:,:,f), ierr)
+      PIO_TF_CHECK_ERR(ierr, "Failed to read 4d darray : " // trim(filename))
+    end do
+
+    do f=1,NFRAMES
+      PIO_TF_CHECK_VAL((rbuf4d(:,:,:,f), exp_val4d(:,:,:,f)), "Got wrong 4d val, frame=", f)
+    end do
+    PIO_TF_CHECK_VAL((rbuf3d, exp_val3d), "Got wrong 3dd val")
+
+    call PIO_closefile(pio_file)
+    
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+
+  deallocate(exp_val3d)
+  deallocate(rbuf3d)
+  deallocate(wbuf3d)
+
+  deallocate(exp_val4d)
+  deallocate(rbuf4d)
+  deallocate(wbuf4d)
+PIO_TF_AUTO_TEST_SUB_END nc_reuse_3d_decomp


### PR DESCRIPTION
The new test reuses the same 3d decomp to write out a 3d and a
4d (one frame at a time) var.

This test is related to the Issue #973 and fails before PR #1003 was
merged to master.
