### PR TITLE
Switch default from MPI_Irsends to MPI_Isends

### DIFF
--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -289,19 +289,19 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
              * a major issue anymore, or is buggy. With PIO1 we have found that
              * although the code correctly posts receives before the irsends,
              * on some systems (software stacks) the code hangs. However the
-             * code works fine with isends. The USE_MPI_ISEND_FOR_FC macro should be
+             * code works fine with isends. The USE_MPI_IRSEND_FOR_FC macro should be
              * used to choose between mpi_irsends and mpi_isends - the default
-             * is still mpi_irsend
+             * is mpi_isend
              */
             if (fc->hs && fc->isend)
             {
-#ifdef USE_MPI_ISEND_FOR_FC
-                if ((mpierr = MPI_Isend(ptr, sendcounts[p], sendtypes[p], p, tag, comm,
-                                        sndids + istep)))
-                    return check_mpi(NULL, mpierr, __FILE__, __LINE__);
-#else
+#ifdef USE_MPI_IRSEND_FOR_FC
                 if ((mpierr = MPI_Irsend(ptr, sendcounts[p], sendtypes[p], p, tag, comm,
                                          sndids + istep)))
+                    return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+#else
+                if ((mpierr = MPI_Isend(ptr, sendcounts[p], sendtypes[p], p, tag, comm,
+                                        sndids + istep)))
                     return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 #endif
             }


### PR DESCRIPTION
On some systems MPI_Irsends are buggy and can cause a hang (we
found this on titan with pio1). So switching the default from
using MPI_Irsends to MPI_Isends.

The user can use USE_MPI_IRSEND_FOR_FC (compile time flag)
to choose MPI_Irsend instead of the default.

Fixes #946