### PR TITLE
Change PIO1 default from MPI_[I]Rsends to MPI_[I]sends

### DIFF
--- a/pio/pio_spmd_utils.F90.in
+++ b/pio/pio_spmd_utils.F90.in
@@ -19,7 +19,7 @@
 ! Code added as a work around for poor rsend performance on cray systems with
 ! Gemini interconnect
 !
-#ifdef _NO_MPI_RSEND
+#ifndef _USE_MPI_RSEND
 #define MPI_RSEND MPI_SEND
 #define mpi_rsend mpi_send
 #define MPI_IRSEND MPI_ISEND


### PR DESCRIPTION
On some systems MPI_Irsends are buggy and can cause a hang (we
found this on titan with pio1). So switching the default from
using MPI_Irsends to MPI_Isends.

The user can use "_USE_MPI_RSEND" (compile time flag) to choose
MPI_[I]Rsends instead of the default

Fixes #946