### PR TITLE
Fix PIO1 NetCDF4P support

### DIFF
--- a/pio/CMakeLists.txt
+++ b/pio/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 # Netcdf is required
 #SET (NETCDF_FIND_COMPONENTS F90)
-FIND_PACKAGE(NetCDF "4.3.3" COMPONENTS Fortran)
+FIND_PACKAGE(NetCDF "4.3.3" COMPONENTS C Fortran)
 IF (${NetCDF_Fortran_FOUND})
   MESSAGE("Building PIO with netcdf support ")
   SET(pio_include_dirs_ ${pio_include_dirs_} ${NetCDF_Fortran_INCLUDE_DIR})

--- a/pio/pionfput_mod.F90.in
+++ b/pio/pionfput_mod.F90.in
@@ -125,7 +125,6 @@ contains
           ierr = nfmpi_begin_indep_data(File%fh)
 
           if(Ios%io_rank==0 .and. (ierr==NF_EINDEP .or. ierr==PIO_NOERR)) then
-             print *,__PIO_FILE__,__LINE__,index,count,trim(ival)
              ierr = nfmpi_put_vara (File%fh, varid, int(index,kind=PIO_OFFSET), &
                   int(count,kind=PIO_OFFSET), ival, int(count,kind=PIO_OFFSET), &
                   MPI_CHARACTER)


### PR DESCRIPTION
Fixes an issue with pio1 determining if netcdf4 is available and removes a debug print statement.

Porting changes from ESMCI/cime#1425 to PIO1 branch.