### PR TITLE
allow error NC_ENULLABUF from netcddf when checking buffer status

### DIFF
--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1254,7 +1254,9 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
 
     /* Find out the buffer usage. */
     if ((ierr = ncmpi_inq_buffer_usage(file->fh, &usage)))
-	return pio_err(NULL, file, PIO_EBADID, __FILE__, __LINE__);
+	/* allow the buffer to be undefined */
+	if (ierr != NC_ENULLABUF)
+	    return pio_err(NULL, file, PIO_EBADID, __FILE__, __LINE__);
 
     /* If we are not forcing a flush, spread the usage to all IO
      * tasks. */


### PR DESCRIPTION
There are cases where we call ncmpi_inq_buffer_usage before we have defined a buffer, these result in error NC_ENULLABUF from pnetcdf - ignore this error.  Tested in cesm, merged to develop.