### PR TITLE
Reset fortran test log level to 0

### DIFF
--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -129,7 +129,7 @@ CONTAINS
 
 
 
-    pio_tf_log_level_ = 3
+    pio_tf_log_level_ = 0
     pio_tf_num_aggregators_ = 0
     pio_tf_num_io_tasks_ = 0
     pio_tf_stride_ = 1


### PR DESCRIPTION
The log level for the fortran tests was inadvertently set to 3 in
45471c61f6af280bd97c3471e3d9444f8e04c507

By default the log level should be 0