### PR TITLE
Expanded testing for darray writes with async

### DIFF
--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -141,7 +141,39 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         int dimid[NDIM3];
         int varid;
         char data_filename[PIO_MAX_NAME + 1];
-        float my_data[LAT_LEN] = {my_rank * 10, my_rank * 10 + 1};
+        void *my_data;
+        float my_data_float[LAT_LEN] = {my_rank * 10, my_rank * 10 + 1};
+
+        switch (piotype)
+        {
+        case PIO_BYTE:
+            break;
+        case PIO_CHAR:
+            break;
+        case PIO_SHORT:
+            break;
+        case PIO_INT:
+            break;
+        case PIO_FLOAT:
+            my_data = my_data_float;
+            break;
+        case PIO_DOUBLE:
+            break;
+#ifdef _NETCDF4
+        case PIO_UBYTE:
+            break;
+        case PIO_USHORT:
+            break;
+        case PIO_UINT:
+            break;
+        case PIO_INT64:
+            break;
+        case PIO_UINT64:
+            break;
+#endif /* _NETCDF4 */
+        default:
+            ERR(ERR_WRONG);
+        }
 
         /* For now, only serial iotypes work. Parallel coming soon! */
         if (flavor[fmt] == PIO_IOTYPE_PNETCDF || flavor[fmt] == PIO_IOTYPE_NETCDF4P)

--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -81,7 +81,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
     sprintf(decomp_filename, "decomp_%s_rank_%d.nc", TEST_NAME, my_rank);
 
     /* Create the PIO decomposition for this test. */
-    if ((ret = PIOc_init_decomp(iosysid, PIO_FLOAT, NDIM2, &dim_len[1], elements_per_pe,
+    if ((ret = PIOc_init_decomp(iosysid, piotype, NDIM2, &dim_len[1], elements_per_pe,
                                 compdof, &ioid, PIO_REARR_BOX, NULL, NULL)))
         ERR(ret);
 
@@ -114,7 +114,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
                 ERR(ret);
 
         /* Define variable. */
-        if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM3, dimid, &varid)))
+        if ((ret = PIOc_def_var(ncid, VAR_NAME, piotype, NDIM3, dimid, &varid)))
             ERR(ret);
 
         /* End define mode. */


### PR DESCRIPTION
Only new test code in this PR, no library modifications.

With this PR, test_darray_async now runs its test for all data types. Previously only PIO_FLOAT was tested.

Fixes #1018.
Part of #89.
Part of #388.

I will merge to develop for testing.
