### PR TITLE
changed some parameters to internal darray function

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -258,9 +258,8 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     {
     case PIO_IOTYPE_NETCDF4P:
     case PIO_IOTYPE_PNETCDF:
-        if ((ierr = pio_write_darray_multi_nc(file, nvars, varids, iodesc->ndims, iodesc->mpitype,
-                                              iodesc->maxregions, iodesc->firstregion, iodesc->llen,
-                                              iodesc->num_aiotasks, vdesc0->iobuf, frame)))
+        if ((ierr = write_darray_multi_par(file, nvars, fndims, varids, iodesc,
+                                           0, frame)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
         break;
     case PIO_IOTYPE_NETCDF4C:
@@ -322,10 +321,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         {
         case PIO_IOTYPE_PNETCDF:
         case PIO_IOTYPE_NETCDF4P:
-            if ((ierr = pio_write_darray_multi_nc(file, nvars, varids,
-                                                  iodesc->ndims, iodesc->mpitype, iodesc->maxfillregions,
-                                                  iodesc->fillregion, iodesc->holegridsize,
-                                                  iodesc->num_aiotasks, vdesc0->fillbuf, frame)))
+            if ((ierr = write_darray_multi_par(file, nvars, fndims, varids, iodesc, 1, frame)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);
             break;
         case PIO_IOTYPE_NETCDF4C:

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -21,6 +21,11 @@ void *CN_bpool = NULL;
 /* Maximum buffer usage. */
 PIO_Offset maxusage = 0;
 
+/* For write_darray_multi_serial() and write_darray_multi_par() to
+ * indicate whether fill or data are being written. */
+#define DARRAY_FILL 1
+#define DARRAY_DATA 0
+
 /**
  * Set the PIO IO node data buffer size limit.
  *
@@ -259,13 +264,13 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     case PIO_IOTYPE_NETCDF4P:
     case PIO_IOTYPE_PNETCDF:
         if ((ierr = write_darray_multi_par(file, nvars, fndims, varids, iodesc,
-                                           0, frame)))
+                                           DARRAY_DATA, frame)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
         break;
     case PIO_IOTYPE_NETCDF4C:
     case PIO_IOTYPE_NETCDF:
         if ((ierr = write_darray_multi_serial(file, nvars, fndims, varids, iodesc,
-                                              0, frame)))
+                                              DARRAY_DATA, frame)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
         break;
@@ -321,12 +326,14 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         {
         case PIO_IOTYPE_PNETCDF:
         case PIO_IOTYPE_NETCDF4P:
-            if ((ierr = write_darray_multi_par(file, nvars, fndims, varids, iodesc, 1, frame)))
+            if ((ierr = write_darray_multi_par(file, nvars, fndims, varids, iodesc,
+                                               DARRAY_FILL, frame)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);
             break;
         case PIO_IOTYPE_NETCDF4C:
         case PIO_IOTYPE_NETCDF:
-            if ((ierr = write_darray_multi_serial(file, nvars, fndims, varids, iodesc, 1, frame)))
+            if ((ierr = write_darray_multi_serial(file, nvars, fndims, varids, iodesc,
+                                                  DARRAY_FILL, frame)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);
             break;
         default:

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -290,10 +290,8 @@ extern "C" {
     /* Darray support functions. */
 
     /* Write aggregated arrays to file using parallel I/O (netCDF-4 parallel/pnetcdf) */
-    int pio_write_darray_multi_nc(file_desc_t *file, int nvars, const int *vid, int iodesc_ndims,
-                                  MPI_Datatype basetype, int maxregions, io_region *firstregion,
-                                  PIO_Offset llen, int num_aiotasks, void *iobuf,
-                                  const int *frame);
+    int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vid,
+                               io_desc_t *iodesc, int fill, const int *frame);
 
     /* Write aggregated arrays to file using serial I/O (netCDF-3/netCDF-4 serial) */
     int write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *vid,


### PR DESCRIPTION
Changed internal function name and parameters of pio_write_darray_multi_nc() to match recent changes in serial version of this function.

No big functional changes, I just shortened the parameter list by passing pointer to iodesc, and fill parameter to indicate whether this is fill or data.

Also added the fndims parameter. Due to async, PIOc_* functions may not be called in these internal functions.

These changes are in support of getting async darray writes working for parallel iotypes.

Fixes #1022.
Part of #89.

I will merge to develop for testing.

