### PR TITLE
Turning on async darray tests for pnetcdf

### DIFF
--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -265,12 +265,12 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         unsigned long long my_data_uint64_norec[LAT_LEN] = {my_rank * 20, my_rank * 20 + 1};
 #endif /* _NETCDF4 */
 
-        /* For now, only serial iotypes work. Parallel coming soon! */
-        if (flavor[fmt] == PIO_IOTYPE_PNETCDF)
-            continue;
-
         /* Only netCDF-4 can handle extended types. */
         if (piotype > PIO_DOUBLE && flavor[fmt] != PIO_IOTYPE_NETCDF4C && flavor[fmt] != PIO_IOTYPE_NETCDF4P)
+            continue;
+
+        /* BYTE and CHAR don't work with pnetcdf. Don't know why yet. */
+        if (flavor[fmt] == PIO_IOTYPE_PNETCDF && (piotype == PIO_BYTE || piotype == PIO_CHAR))
             continue;
 
         /* Select the correct data to write, depending on type. */

--- a/tests/cunit/test_darray_async_many.c
+++ b/tests/cunit/test_darray_async_many.c
@@ -383,7 +383,8 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         int rec_varid[num_types];
         int norec_varid[num_types];
 
-        /* For now, only serial iotypes work. Parallel coming soon! */
+        /* For now, don't test with pnetcdf since byte and char don't
+         * work with pnetcdf. */
         if (flavor[fmt] == PIO_IOTYPE_PNETCDF)
             continue;
 

--- a/tests/cunit/test_darray_async_simple.c
+++ b/tests/cunit/test_darray_async_simple.c
@@ -99,10 +99,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         char data_filename[PIO_MAX_NAME + 1];
         float my_data = my_rank * 10;
 
-        /* For now, Pnetcdf does not work. Coming soon! */
-        if (flavor[fmt] == PIO_IOTYPE_PNETCDF)
-            continue;
-
+        /* Generate a file name. */
         sprintf(data_filename, "data_%s_iotype_%d.nc", TEST_NAME, flavor[fmt]);
 
         /* Create sample output file. */


### PR DESCRIPTION
Now all IOTYPES are working with async darray writes.

Fixes #1030.
Part of #388.
Part of #89.

I will merge to develop for testing.
