### PR TITLE
Fix the prune_decomp script to delete dup files

### DIFF
--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -53,7 +53,6 @@ sub rem_dup_decomp_files
                 $rmfile = 1;
                 foreach my $line (@file1){
                     my $nline = shift (@file2);
-                    next if($line eq $nline);
                     # Ignore stack traces when comparing files
                     # The stack traces start with a line containing
                     # "Obtained" 
@@ -63,11 +62,11 @@ sub rem_dup_decomp_files
                         if($verbose){
                             print "Files $file and $nfile are the same (ignoring stack traces)\n";
                         }
+                        last;
                     }
-                    else{
-                        # Files are different, don't remove    
-                        $rmfile = 0;
-                    }
+                    next if($line eq $nline);
+                    # Files are different, don't remove    
+                    $rmfile = 0;
                     last;
                 }
                 close(F1);

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 
 # Remove duplicate decomposition files in "dirname"

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -32,6 +32,7 @@ sub rem_dup_decomp_files
             if($verbose){
                 print "Comparing $file, size=$fsize, $nfile, size=$f2size\n";
             }
+            next if($decompfile_info[$j]->{IS_DUP});
             if($fsize == $f2size){
                 open(F1,$file);
                 my @file1 = <F1>;
@@ -59,8 +60,15 @@ sub rem_dup_decomp_files
                 }
                 close(F1);
                 close(F2);
-                unlink($nfile) if ($rmfile==1);
+                if($rmfile == 1){
+                    $decompfile_info[$j]->{IS_DUP} = 1;
+                }
             }
+        }
+    }
+    for(my $i=0; $i<=$#decompfile_info; $i++){
+        if($decompfile_info[$i]->{IS_DUP}){
+            unlink($decompfile_info[$i]->{FNAME});
         }
     }
 }

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -9,6 +9,9 @@ my $exe="";
 my $nargs = 0;
 my $verbose = 0;
 
+# Reg expression that match the pio decomposition file names
+my $PIO_DECOMP_FNAMES = "^piodecomp";
+
 # Remove duplicate decomposition files in "dirname"
 sub rem_dup_decomp_files
 {
@@ -18,12 +21,13 @@ sub rem_dup_decomp_files
     # decomposition files
     opendir(F,$dirname);
     #my @decompfiles = grep(/^piodecomp/,readdir(F));
-    my @decompfile_info_tmp = map{ {FNAME=>$_, SIZE=>-s $_, IS_DUP=>0} } grep(/^piodecomp/,readdir(F));
+    my @decompfile_info_tmp = map{ {FNAME=>$_, SIZE=>-s $_, IS_DUP=>0} } grep(/${PIO_DECOMP_FNAMES}/,readdir(F));
     closedir(F);
     my @decompfile_info = sort { $a->{SIZE} <=> $b->{SIZE} } @decompfile_info_tmp;
-    for(my $i=0; $i<=$#decompfile_info; $i++){
-      print "File : $decompfile_info[$i]->{FNAME} , size = $decompfile_info[$i]->{SIZE}\n";
-    }
+
+    #for(my $i=0; $i<=$#decompfile_info; $i++){
+    #  print "File : $decompfile_info[$i]->{FNAME} , size = $decompfile_info[$i]->{SIZE}\n";
+    #}
     
     my $rmfile=0;
     # Compare the decomposition files to find
@@ -89,7 +93,7 @@ sub decode_stack_traces
     my($dirname, $exe) = @_;
     # Decode/Translate the stack trace
     opendir(F,$dirname);
-    my @decompfiles = grep(/^piodecomp/,readdir(F));
+    my @decompfiles = grep(/${PIO_DECOMP_FNAMES}/,readdir(F));
     closedir(F);
     for(my $i=0; $i<= $#decompfiles; $i++){
         my $file = $decompfiles[$i];

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -17,17 +17,18 @@ sub rem_dup_decomp_files
     # named *piodecomp* - these are the pio 
     # decomposition files
     opendir(F,$dirname);
-    my @decompfiles = grep(/^piodecomp/,readdir(F));
+    #my @decompfiles = grep(/^piodecomp/,readdir(F));
+    my @decompfile_info = map{ {FNAME=>$_, SIZE=>-s $_, IS_DUP=>0} } grep(/^piodecomp/,readdir(F));
     closedir(F);
     my $rmfile=0;
     # Compare the decomposition files to find
     # duplicates - and delete the dups
-    for(my $i=0; $i<=$#decompfiles; $i++){
-        my $file  = $decompfiles[$i];
-        my $fsize = -s $file;
-        for(my $j=$i+1;$j<=$#decompfiles;$j++){
-            my $nfile = $decompfiles[$j];
-            my $f2size = -s $nfile;
+    for(my $i=0; $i<=$#decompfile_info; $i++){
+        my $file  = $decompfile_info[$i]->{FNAME};
+        my $fsize  = $decompfile_info[$i]->{SIZE};
+        for(my $j=$i+1;$j<=$#decompfile_info;$j++){
+            my $nfile = $decompfile_info[$j]->{FNAME};
+            my $f2size = $decompfile_info[$j]->{SIZE};
             if($verbose){
                 print "Comparing $file, size=$fsize, $nfile, size=$f2size\n";
             }

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -1,10 +1,12 @@
 #!/usr/bin/env perl
 use strict;
+use warnings;
 
 use Getopt::Long;
 
 my $rundir="";
 my $nargs = 0;
+my $verbose = 0;
 
 # Remove duplicate decomposition files in "dirname"
 sub rem_dup_decomp_files
@@ -84,11 +86,14 @@ sub decode_stack_traces
 
 sub print_usage_and_exit()
 {
-    print "\nUsage : ./prune_decomps.pl --decomp-prune-dir=<PRUNE_DECOMP_DIR> \n";
+    print "\nUsage :\n./prune_decomps.pl --decomp-prune-dir=<PRUNE_DECOMP_DIR> \n";
     print "\tOR\n";
     print "./prune_decomps.pl <PRUNE_DECOMP_DIR> \n";
     print "The above commands can be used to remove duplicate decomposition\n";
     print "files in <PRUNE_DECOMP_DIR> \n";
+    print "Available options : \n";
+    print "\t--decomp-prune-dir : Directory that contains the decomp files to be pruned\n";
+    print "\t--verbose : Verbose debug output\n";
     exit;
 }
 
@@ -96,7 +101,8 @@ sub print_usage_and_exit()
 
 # Read input args
 GetOptions(
-    "decomp-prune-dir=s"    => \$rundir
+    "decomp-prune-dir=s"    => \$rundir,
+    "verbose"               => \$verbose
 );
 
 $nargs = @ARGV;
@@ -107,8 +113,9 @@ if($rundir eq ""){
         &print_usage_and_exit();
     }
 }
-
+if($verbose){ print "Removing duplicate decomposition files from : \"", $rundir, "\"\n"; }
 &rem_dup_decomp_files($rundir);
+if($verbose){ print "Decoding stack traces for decomposition files from : \"", $rundir, "\"\n"; }
 &decode_stack_traces($rundir);
 
     

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -1,6 +1,11 @@
 #!/usr/bin/env perl
 use strict;
 
+use Getopt::Long;
+
+my $rundir="";
+my $nargs = 0;
+
 # Remove duplicate decomposition files in "dirname"
 sub rem_dup_decomp_files
 {
@@ -77,8 +82,32 @@ sub decode_stack_traces
     }
 }
 
+sub print_usage_and_exit()
+{
+    print "\nUsage : ./prune_decomps.pl --decomp-prune-dir=<PRUNE_DECOMP_DIR> \n";
+    print "\tOR\n";
+    print "./prune_decomps.pl <PRUNE_DECOMP_DIR> \n";
+    print "The above commands can be used to remove duplicate decomposition\n";
+    print "files in <PRUNE_DECOMP_DIR> \n";
+    exit;
+}
+
 # Main program
-my $rundir = shift;
+
+# Read input args
+GetOptions(
+    "decomp-prune-dir=s"    => \$rundir
+);
+
+$nargs = @ARGV;
+
+if($rundir eq ""){
+    $rundir = shift;
+    if($rundir eq ""){
+        &print_usage_and_exit();
+    }
+}
+
 &rem_dup_decomp_files($rundir);
 &decode_stack_traces($rundir);
 

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -24,19 +24,20 @@ sub rem_dup_decomp_files
     my @decompfile_info_tmp = map{ {FNAME=>$_, SIZE=>-s $_, IS_DUP=>0} } grep(/${PIO_DECOMP_FNAMES}/,readdir(F));
     closedir(F);
     my @decompfile_info = sort { $a->{SIZE} <=> $b->{SIZE} } @decompfile_info_tmp;
+    my $ndecompfile_info = @decompfile_info;
 
-    #for(my $i=0; $i<=$#decompfile_info; $i++){
+    #for(my $i=0; $i<$ndecompfile_info; $i++){
     #  print "File : $decompfile_info[$i]->{FNAME} , size = $decompfile_info[$i]->{SIZE}\n";
     #}
     
     my $rmfile=0;
     # Compare the decomposition files to find
     # duplicates - and delete the dups
-    for(my $i=0; $i<=$#decompfile_info; $i++){
+    for(my $i=0; $i<$ndecompfile_info; $i++){
         my $file  = $decompfile_info[$i]->{FNAME};
         my $fsize  = $decompfile_info[$i]->{SIZE};
         next if($decompfile_info[$i]->{IS_DUP});
-        for(my $j=$i+1;$j<=$#decompfile_info;$j++){
+        for(my $j=$i+1;$j<$ndecompfile_info;$j++){
             my $nfile = $decompfile_info[$j]->{FNAME};
             my $f2size = $decompfile_info[$j]->{SIZE};
             next if($decompfile_info[$j]->{IS_DUP});
@@ -77,7 +78,7 @@ sub rem_dup_decomp_files
             }
         }
     }
-    for(my $i=0; $i<=$#decompfile_info; $i++){
+    for(my $i=0; $i<$ndecompfile_info; $i++){
         if($decompfile_info[$i]->{IS_DUP}){
             unlink($decompfile_info[$i]->{FNAME});
         }
@@ -95,7 +96,8 @@ sub decode_stack_traces
     opendir(F,$dirname);
     my @decompfiles = grep(/${PIO_DECOMP_FNAMES}/,readdir(F));
     closedir(F);
-    for(my $i=0; $i<= $#decompfiles; $i++){
+    my $ndecompfiles = @decompfiles;
+    for(my $i=0; $i< $ndecompfiles; $i++){
         my $file = $decompfiles[$i];
         open(F1,$file);
         my @file1 = <F1>;

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -11,26 +11,26 @@ for(my $i=0; $i< $#decompfiles; $i++){
     my $file  = $decompfiles[$i];
     my $fsize = -s $file;
     for(my $j=$i+1;$j<$#decompfiles;$j++){
-	my $nfile = $decompfiles[$j];
-	my $f2size = -s $nfile;
-	if($fsize == $f2size){
-	    open(F1,$file);
-	    my @file1 = <F1>;
-	    open(F2,$nfile);
-	    my @file2 = <F2>;
-	    foreach my $line (@file1){
-		my $nline = shift (@file2);
-		if($line =~ /Obtained/){
-		    print "Files $file and $nfile are the same\n";
-		    $rmfile=1;
-		}
-		next if($line == $nline);
-		last;
-	    }
-	    close(F1);
-	    close(F2);
-	    unlink($nfile) if ($rmfile==1);
-	}
+        my $nfile = $decompfiles[$j];
+        my $f2size = -s $nfile;
+        if($fsize == $f2size){
+            open(F1,$file);
+            my @file1 = <F1>;
+            open(F2,$nfile);
+            my @file2 = <F2>;
+            foreach my $line (@file1){
+                my $nline = shift (@file2);
+                if($line =~ /Obtained/){
+                    print "Files $file and $nfile are the same\n";
+                    $rmfile=1;
+                }
+                next if($line == $nline);
+                last;
+            }
+            close(F1);
+            close(F2);
+            unlink($nfile) if ($rmfile==1);
+        }
     }
 }
 opendir(F,$rundir);
@@ -43,16 +43,14 @@ for(my $i=0; $i<= $#decompfiles; $i++){
     close(F1);
     open(F1,">$file");
     foreach(@file1){
-	if(/\[(.*)\]/){
-	    my $decode = `addr2line -e ../bld/cesm.exe $1`;
-	    print F1 "$decode\n";
-	    print  "$decode\n";
-	}else{
-	    print F1 $_;
-	}
-	    
+        if(/\[(.*)\]/){
+            my $decode = `addr2line -e ../bld/cesm.exe $1`;
+            print F1 "$decode\n";
+            print  "$decode\n";
+        }else{
+            print F1 $_;
+        }
     }
     close(F1);
-
 }
     

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -11,6 +11,7 @@ my $verbose = 0;
 
 # Reg expression that match the pio decomposition file names
 my $PIO_DECOMP_FNAMES = "^piodecomp";
+my $BEGIN_STACK_TRACE = "Obtained";
 
 # Remove duplicate decomposition files in "dirname"
 sub rem_dup_decomp_files
@@ -58,7 +59,8 @@ sub rem_dup_decomp_files
                     # "Obtained" 
                     # Also, stack trace is the last line being
                     # compared
-                    if(($line =~ /Obtained/) && ($nline =~ /Obtained/)){
+                    if(($line =~ /${BEGIN_STACK_TRACE}/)
+                          && ($nline =~ /${BEGIN_STACK_TRACE}/)){
                         if($verbose){
                             print "Files $file and $nfile are the same (ignoring stack traces)\n";
                         }

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -58,7 +58,7 @@ sub rem_dup_decomp_files
                     # "Obtained" 
                     # Also, stack trace is the last line being
                     # compared
-                    if($line =~ /Obtained/){
+                    if(($line =~ /Obtained/) && ($nline =~ /Obtained/)){
                         if($verbose){
                             print "Files $file and $nfile are the same (ignoring stack traces)\n";
                         }

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -3,10 +3,15 @@ use strict;
 
 my $rundir = shift;
 
+# Find files in current directory that are
+# named *piodecomp* - these are the pio 
+# decomposition files
 opendir(F,$rundir);
 my @decompfiles = grep(/^piodecomp/,readdir(F));
 closedir(F);
 my $rmfile=0;
+# Compare the decomposition files to find
+# duplicates - and delete the dups
 for(my $i=0; $i< $#decompfiles; $i++){
     my $file  = $decompfiles[$i];
     my $fsize = -s $file;
@@ -20,6 +25,11 @@ for(my $i=0; $i< $#decompfiles; $i++){
             my @file2 = <F2>;
             foreach my $line (@file1){
                 my $nline = shift (@file2);
+                # Ignore stack traces when comparing files
+                # The stack traces start with a line containing
+                # "Obtained" 
+                # Also, stack trace is the last line being
+                # compared
                 if($line =~ /Obtained/){
                     print "Files $file and $nfile are the same\n";
                     $rmfile=1;
@@ -33,6 +43,8 @@ for(my $i=0; $i< $#decompfiles; $i++){
         }
     }
 }
+
+# Decode/Translate the stack trace for CESM runs
 opendir(F,$rundir);
 my @decompfiles = grep(/^piodecomp/,readdir(F));
 closedir(F);
@@ -43,6 +55,9 @@ for(my $i=0; $i<= $#decompfiles; $i++){
     close(F1);
     open(F1,">$file");
     foreach(@file1){
+        # Find stack addresses in the file and use
+        # addrline to translate/decode the filenames and
+        # line numbers from it
         if(/\[(.*)\]/){
             my $decode = `addr2line -e ../bld/cesm.exe $1`;
             print F1 "$decode\n";

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -5,6 +5,7 @@ use warnings;
 use Getopt::Long;
 
 my $rundir="";
+my $exe="";
 my $nargs = 0;
 my $verbose = 0;
 
@@ -57,8 +58,11 @@ sub rem_dup_decomp_files
 # Decode the stack traces in the pio decomposition files
 sub decode_stack_traces
 {
-    my($dirname) = @_;
-    # Decode/Translate the stack trace for CESM runs
+    # dirname => Directory that contains decomp files
+    # exe => executable (including path) that generated
+    #         the decomposition files
+    my($dirname, $exe) = @_;
+    # Decode/Translate the stack trace
     opendir(F,$dirname);
     my @decompfiles = grep(/^piodecomp/,readdir(F));
     closedir(F);
@@ -73,7 +77,7 @@ sub decode_stack_traces
             # addrline to translate/decode the filenames and
             # line numbers from it
             if(/\[(.*)\]/){
-                my $decode = `addr2line -e ../bld/cesm.exe $1`;
+                my $decode = `addr2line -e $exe $1`;
                 print F1 "$decode\n";
                 print  "$decode\n";
             }else{
@@ -93,7 +97,8 @@ sub print_usage_and_exit()
     print "files in <PRUNE_DECOMP_DIR> \n";
     print "Available options : \n";
     print "\t--decomp-prune-dir : Directory that contains the decomp files to be pruned\n";
-    print "\t--verbose : Verbose debug output\n";
+    print "\t--exe      : Executable that generated the decompositions \n";
+    print "\t--verbose  : Verbose debug output\n";
     exit;
 }
 
@@ -102,6 +107,7 @@ sub print_usage_and_exit()
 # Read input args
 GetOptions(
     "decomp-prune-dir=s"    => \$rundir,
+    "exe=s"             => \$exe,
     "verbose"               => \$verbose
 );
 
@@ -115,7 +121,10 @@ if($rundir eq ""){
 }
 if($verbose){ print "Removing duplicate decomposition files from : \"", $rundir, "\"\n"; }
 &rem_dup_decomp_files($rundir);
-if($verbose){ print "Decoding stack traces for decomposition files from : \"", $rundir, "\"\n"; }
-&decode_stack_traces($rundir);
+
+if($exe ne ""){
+    if($verbose){ print "Decoding stack traces for decomposition files from : \"", $rundir, "\"\n"; }
+    &decode_stack_traces($rundir, $exe);
+}
 
     

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -1,71 +1,85 @@
 #!/usr/bin/perl
 use strict;
 
-my $rundir = shift;
-
-# Find files in current directory that are
-# named *piodecomp* - these are the pio 
-# decomposition files
-opendir(F,$rundir);
-my @decompfiles = grep(/^piodecomp/,readdir(F));
-closedir(F);
-my $rmfile=0;
-# Compare the decomposition files to find
-# duplicates - and delete the dups
-for(my $i=0; $i< $#decompfiles; $i++){
-    my $file  = $decompfiles[$i];
-    my $fsize = -s $file;
-    for(my $j=$i+1;$j<$#decompfiles;$j++){
-        my $nfile = $decompfiles[$j];
-        my $f2size = -s $nfile;
-        if($fsize == $f2size){
-            open(F1,$file);
-            my @file1 = <F1>;
-            open(F2,$nfile);
-            my @file2 = <F2>;
-            foreach my $line (@file1){
-                my $nline = shift (@file2);
-                # Ignore stack traces when comparing files
-                # The stack traces start with a line containing
-                # "Obtained" 
-                # Also, stack trace is the last line being
-                # compared
-                if($line =~ /Obtained/){
-                    print "Files $file and $nfile are the same\n";
-                    $rmfile=1;
+# Remove duplicate decomposition files in "dirname"
+sub rem_dup_decomp_files
+{
+    my($dirname) = @_;
+    # Find files in current directory that are
+    # named *piodecomp* - these are the pio 
+    # decomposition files
+    opendir(F,$dirname);
+    my @decompfiles = grep(/^piodecomp/,readdir(F));
+    closedir(F);
+    my $rmfile=0;
+    # Compare the decomposition files to find
+    # duplicates - and delete the dups
+    for(my $i=0; $i< $#decompfiles; $i++){
+        my $file  = $decompfiles[$i];
+        my $fsize = -s $file;
+        for(my $j=$i+1;$j<$#decompfiles;$j++){
+            my $nfile = $decompfiles[$j];
+            my $f2size = -s $nfile;
+            if($fsize == $f2size){
+                open(F1,$file);
+                my @file1 = <F1>;
+                open(F2,$nfile);
+                my @file2 = <F2>;
+                foreach my $line (@file1){
+                    my $nline = shift (@file2);
+                    # Ignore stack traces when comparing files
+                    # The stack traces start with a line containing
+                    # "Obtained" 
+                    # Also, stack trace is the last line being
+                    # compared
+                    if($line =~ /Obtained/){
+                        print "Files $file and $nfile are the same\n";
+                        $rmfile=1;
+                    }
+                    next if($line == $nline);
+                    last;
                 }
-                next if($line == $nline);
-                last;
+                close(F1);
+                close(F2);
+                unlink($nfile) if ($rmfile==1);
             }
-            close(F1);
-            close(F2);
-            unlink($nfile) if ($rmfile==1);
         }
     }
 }
 
-# Decode/Translate the stack trace for CESM runs
-opendir(F,$rundir);
-my @decompfiles = grep(/^piodecomp/,readdir(F));
-closedir(F);
-for(my $i=0; $i<= $#decompfiles; $i++){
-    my $file = $decompfiles[$i];
-    open(F1,$file);
-    my @file1 = <F1>;
-    close(F1);
-    open(F1,">$file");
-    foreach(@file1){
-        # Find stack addresses in the file and use
-        # addrline to translate/decode the filenames and
-        # line numbers from it
-        if(/\[(.*)\]/){
-            my $decode = `addr2line -e ../bld/cesm.exe $1`;
-            print F1 "$decode\n";
-            print  "$decode\n";
-        }else{
-            print F1 $_;
+# Decode the stack traces in the pio decomposition files
+sub decode_stack_traces
+{
+    my($dirname) = @_;
+    # Decode/Translate the stack trace for CESM runs
+    opendir(F,$dirname);
+    my @decompfiles = grep(/^piodecomp/,readdir(F));
+    closedir(F);
+    for(my $i=0; $i<= $#decompfiles; $i++){
+        my $file = $decompfiles[$i];
+        open(F1,$file);
+        my @file1 = <F1>;
+        close(F1);
+        open(F1,">$file");
+        foreach(@file1){
+            # Find stack addresses in the file and use
+            # addrline to translate/decode the filenames and
+            # line numbers from it
+            if(/\[(.*)\]/){
+                my $decode = `addr2line -e ../bld/cesm.exe $1`;
+                print F1 "$decode\n";
+                print  "$decode\n";
+            }else{
+                print F1 $_;
+            }
         }
+        close(F1);
     }
-    close(F1);
 }
+
+# Main program
+my $rundir = shift;
+&rem_dup_decomp_files($rundir);
+&decode_stack_traces($rundir);
+
     

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -18,21 +18,28 @@ sub rem_dup_decomp_files
     # decomposition files
     opendir(F,$dirname);
     #my @decompfiles = grep(/^piodecomp/,readdir(F));
-    my @decompfile_info = map{ {FNAME=>$_, SIZE=>-s $_, IS_DUP=>0} } grep(/^piodecomp/,readdir(F));
+    my @decompfile_info_tmp = map{ {FNAME=>$_, SIZE=>-s $_, IS_DUP=>0} } grep(/^piodecomp/,readdir(F));
     closedir(F);
+    my @decompfile_info = sort { $a->{SIZE} <=> $b->{SIZE} } @decompfile_info_tmp;
+    for(my $i=0; $i<=$#decompfile_info; $i++){
+      print "File : $decompfile_info[$i]->{FNAME} , size = $decompfile_info[$i]->{SIZE}\n";
+    }
+    
     my $rmfile=0;
     # Compare the decomposition files to find
     # duplicates - and delete the dups
     for(my $i=0; $i<=$#decompfile_info; $i++){
         my $file  = $decompfile_info[$i]->{FNAME};
         my $fsize  = $decompfile_info[$i]->{SIZE};
+        next if($decompfile_info[$i]->{IS_DUP});
         for(my $j=$i+1;$j<=$#decompfile_info;$j++){
             my $nfile = $decompfile_info[$j]->{FNAME};
             my $f2size = $decompfile_info[$j]->{SIZE};
+            next if($decompfile_info[$j]->{IS_DUP});
+            last if($fsize != $f2size);
             if($verbose){
                 print "Comparing $file, size=$fsize, $nfile, size=$f2size\n";
             }
-            next if($decompfile_info[$j]->{IS_DUP});
             if($fsize == $f2size){
                 open(F1,$file);
                 my @file1 = <F1>;

--- a/scripts/prune_decomps.pl
+++ b/scripts/prune_decomps.pl
@@ -22,29 +22,38 @@ sub rem_dup_decomp_files
     my $rmfile=0;
     # Compare the decomposition files to find
     # duplicates - and delete the dups
-    for(my $i=0; $i< $#decompfiles; $i++){
+    for(my $i=0; $i<=$#decompfiles; $i++){
         my $file  = $decompfiles[$i];
         my $fsize = -s $file;
-        for(my $j=$i+1;$j<$#decompfiles;$j++){
+        for(my $j=$i+1;$j<=$#decompfiles;$j++){
             my $nfile = $decompfiles[$j];
             my $f2size = -s $nfile;
+            if($verbose){
+                print "Comparing $file, size=$fsize, $nfile, size=$f2size\n";
+            }
             if($fsize == $f2size){
                 open(F1,$file);
                 my @file1 = <F1>;
                 open(F2,$nfile);
                 my @file2 = <F2>;
+                $rmfile = 1;
                 foreach my $line (@file1){
                     my $nline = shift (@file2);
+                    next if($line eq $nline);
                     # Ignore stack traces when comparing files
                     # The stack traces start with a line containing
                     # "Obtained" 
                     # Also, stack trace is the last line being
                     # compared
                     if($line =~ /Obtained/){
-                        print "Files $file and $nfile are the same\n";
-                        $rmfile=1;
+                        if($verbose){
+                            print "Files $file and $nfile are the same (ignoring stack traces)\n";
+                        }
                     }
-                    next if($line == $nline);
+                    else{
+                        # Files are different, don't remove    
+                        $rmfile = 0;
+                    }
                     last;
                 }
                 close(F1);


### PR DESCRIPTION
The prune decomp script has the following changes,

* Refactored to be more modular etc
* Has help/option message, debug messages
* New options (--exe option to specify executable, --verbose option for verbose log msgs)
* Fixed a bug that resulted in dup files not being deleted
* Some fixes that would improve performance