### PR TITLE
added instructions for author tags

### DIFF
--- a/doc/source/contributing_code.txt
+++ b/doc/source/contributing_code.txt
@@ -72,6 +72,10 @@ group.
 process.
 <li>Document in complete sentences.
 <li>Use C (not C++) comment delimiters.
+<li>Use the author tag to indicate which programmers have worked on
+each function. When adding or changing a function in a non-trivial
+way, programmers should add their name to the end of the list of
+authors for that function.
 </ul>
 
 ## Emacs ##


### PR DESCRIPTION
Fixes #1055.

If there are no objections, we can start adding author tags as we work on the code.