### PR TITLE
Check that netCDF-4 files created/opened with PIO don't misuse unlimited dims

### DIFF
--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -258,7 +258,7 @@ int PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
                 mpierr = MPI_Bcast(&nunlimdimsp_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&unlimdimidsp_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq ncid = %d nunlimdimsp_present = %d unlimdimidsp_present = %d",
+            LOG((2, "PIOc_inq_unlimdims ncid = %d nunlimdimsp_present = %d unlimdimidsp_present = %d",
                  ncid, nunlimdimsp_present, unlimdimidsp_present));
         }
 
@@ -291,6 +291,7 @@ int PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
             LOG((2, "pnetcdf"));
             int tmp_unlimdimid;            
             ierr = ncmpi_inq_unlimdim(file->fh, &tmp_unlimdimid);
+            LOG((2, "pnetcdf tmp_unlimdimid = %d", tmp_unlimdimid));
             tmp_nunlimdims = tmp_unlimdimid >= 0 ? 1 : 0;            
             if (nunlimdimsp)
                 *nunlimdimsp = tmp_nunlimdims;

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -33,6 +33,7 @@
  *
  * @return PIO_NOERR for success, error code otherwise. See
  * PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
 {
@@ -159,6 +160,7 @@ int PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
  * @param ncid the ncid of the open file.
  * @param ndimsp a pointer that will get the number of dimensions.
  * @returns 0 for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_ndims(int ncid, int *ndimsp)
 {
@@ -173,6 +175,7 @@ int PIOc_inq_ndims(int ncid, int *ndimsp)
  * @param ncid the ncid of the open file.
  * @param nvarsp a pointer that will get the number of variables.
  * @returns 0 for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_nvars(int ncid, int *nvarsp)
 {
@@ -186,6 +189,7 @@ int PIOc_inq_nvars(int ncid, int *nvarsp)
  * @param ncid the ncid of the open file.
  * @param nattsp a pointer that will get the number of attributes.
  * @returns 0 for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_natts(int ncid, int *ngattsp)
 {
@@ -200,6 +204,7 @@ int PIOc_inq_natts(int ncid, int *ngattsp)
  * @param unlimdimidp a pointer that will the ID of the unlimited
  * dimension, or -1 if there is no unlimited dimension.
  * @returns 0 for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_unlimdim(int ncid, int *unlimdimidp)
 {
@@ -218,6 +223,7 @@ int PIOc_inq_unlimdim(int ncid, int *unlimdimidp)
  * dimension IDs.
  * @returns 0 for success, error code otherwise.
  * @ingroup PIO_inq_unlimdim
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
 {
@@ -352,6 +358,7 @@ int PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
  * @param name pointer that will get the name of the type.
  * @param sizep pointer that will get the size of the type in bytes.
  * @returns 0 for success, error code otherwise.
+ * @author Ed Hartnett
  */
 int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
 {
@@ -441,6 +448,7 @@ int PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
  * @param ncid the ncid of an open file.
  * @param formatp a pointer that will get the format.
  * @returns 0 for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_format(int ncid, int *formatp)
 {
@@ -520,6 +528,7 @@ int PIOc_inq_format(int ncid, int *formatp)
  * PIOc_openfile() or PIOc_createfile().
  * @param lenp a pointer that will get the number of values
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
 {
@@ -621,6 +630,7 @@ int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
  * @param name a pointer that gets the name of the dimension. Igorned
  * if NULL.
  * @returns 0 for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_dimname(int ncid, int dimid, char *name)
 {
@@ -637,6 +647,7 @@ int PIOc_inq_dimname(int ncid, int dimid, char *name)
  * @param lenp a pointer that gets the length of the dimension. Igorned
  * if NULL.
  * @returns 0 for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_dimlen(int ncid, int dimid, PIO_Offset *lenp)
 {
@@ -656,6 +667,7 @@ int PIOc_inq_dimlen(int ncid, int dimid, PIO_Offset *lenp)
  * PIOc_openfile() or PIOc_createfile().
  * @param idp a pointer that will get the id of the variable or attribute.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_dimid(int ncid, const char *name, int *idp)
 {
@@ -747,6 +759,7 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
  * @param xtypep a pointer that will get the type of the attribute.
  * @param nattsp a pointer that will get the number of attributes
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
                  int *dimidsp, int *nattsp)
@@ -903,6 +916,7 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
  * @param varid the variable ID.
  * @param name a pointer that will get the variable name.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_varname(int ncid, int varid, char *name)
 {
@@ -918,6 +932,7 @@ int PIOc_inq_varname(int ncid, int varid, char *name)
  * @param xtypep a pointer that will get the type of the
  * attribute. Ignored if NULL.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep)
 {
@@ -933,6 +948,7 @@ int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep)
  * @param ndimsp a pointer that will get the number of
  * dimensions. Ignored if NULL.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_varndims(int ncid, int varid, int *ndimsp)
 {
@@ -948,6 +964,7 @@ int PIOc_inq_varndims(int ncid, int varid, int *ndimsp)
  * @param dimidsp a pointer that will get an array of dimids. Ignored
  * if NULL.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp)
 {
@@ -963,6 +980,7 @@ int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp)
  * @param nattsp a pointer that will get the number of attriburtes. Ignored
  * if NULL.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_varnatts(int ncid, int varid, int *nattsp)
 {
@@ -983,6 +1001,7 @@ int PIOc_inq_varnatts(int ncid, int varid, int *nattsp)
  * @param varid the variable ID.
  * @param varidp a pointer that will get the variable id
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_varid(int ncid, const char *name, int *varidp)
 {
@@ -1069,6 +1088,7 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
  * @param xtypep a pointer that will get the type of the attribute.
  * @param lenp a pointer that will get the number of values
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
                  PIO_Offset *lenp)
@@ -1163,6 +1183,7 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
  * @param lenp a pointer that gets the lenght of the attribute
  * array. Ignored if NULL.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_attlen(int ncid, int varid, const char *name, PIO_Offset *lenp)
 {
@@ -1179,6 +1200,7 @@ int PIOc_inq_attlen(int ncid, int varid, const char *name, PIO_Offset *lenp)
  * @param xtypep a pointer that gets the type of the
  * attribute. Ignored if NULL.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep)
 {
@@ -1199,6 +1221,7 @@ int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep)
  * @param varid the variable ID.
  * @param attnum the attribute ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
 {
@@ -1290,6 +1313,7 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
  * @param varid the variable ID.
  * @param idp a pointer that will get the id of the variable or attribute.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
 {
@@ -1379,6 +1403,7 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_rename_dim(int ncid, int dimid, const char *name)
 {
@@ -1464,6 +1489,7 @@ int PIOc_rename_dim(int ncid, int dimid, const char *name)
  * PIOc_openfile() or PIOc_createfile().
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_rename_var(int ncid, int varid, const char *name)
 {
@@ -1550,6 +1576,7 @@ int PIOc_rename_var(int ncid, int varid, const char *name)
  * @param varid the variable ID.
  * @return PIO_NOERR for success, error code otherwise.  See
  * PIOc_Set_File_Error_Handling
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_rename_att(int ncid, int varid, const char *name,
                     const char *newname)
@@ -1641,6 +1668,7 @@ int PIOc_rename_att(int ncid, int varid, const char *name,
  * @param varid the variable ID.
  * @param name of the attribute to delete.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_del_att(int ncid, int varid, const char *name)
 {
@@ -1723,6 +1751,7 @@ int PIOc_del_att(int ncid, int varid, const char *name)
  * @param old_modep a pointer to an int that gets the old setting.
  * @return PIO_NOERR for success, error code otherwise.
  * @ingroup PIO_set_fill
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_set_fill(int ncid, int fillmode, int *old_modep)
 {
@@ -1811,6 +1840,7 @@ int PIOc_set_fill(int ncid, int fillmode, int *old_modep)
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_enddef(int ncid)
 {
@@ -1829,6 +1859,7 @@ int PIOc_enddef(int ncid)
  * @param ncid the ncid of the open file, obtained from
  * PIOc_openfile() or PIOc_createfile().
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_redef(int ncid)
 {
@@ -1848,6 +1879,7 @@ int PIOc_redef(int ncid)
  * PIOc_openfile() or PIOc_createfile().
  * @param idp a pointer that will get the id of the variable or attribute.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
 {
@@ -1938,14 +1970,16 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
  * @param varidp a pointer that will get the variable id
  * @return PIO_NOERR for success, error code otherwise.
  * @ingroup PIO_def_var
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
                  const int *dimidsp, int *varidp)
 {
-    iosystem_desc_t *ios;  /* Pointer to io system information. */
-    file_desc_t *file;     /* Pointer to file information. */
-    int ierr;              /* Return code from function calls. */
+    iosystem_desc_t *ios;      /* Pointer to io system information. */
+    file_desc_t *file;         /* Pointer to file information. */
+    int invalid_unlim_dim = 0; /* True invalid dims are used. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
+    int ierr;                  /* Return code from function calls. */
 
     /* Get the file information. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -1958,6 +1992,22 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 
     LOG((1, "PIOc_def_var ncid = %d name = %s xtype = %d ndims = %d", ncid, name,
          xtype, ndims));
+
+    /* Run this on all tasks if async is not in use, but only on
+     * non-IO tasks if async is in use. Learn whether each dimension
+     * is unlimited. */
+    if (!ios->async || !ios->ioproc)
+    {
+        for (int d = 1; d < ndims; d++)
+        {
+            PIO_Offset dimlen;
+            
+            if ((ierr = PIOc_inq_dimlen(ncid, dimidsp[d], &dimlen)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+            if (dimlen == PIO_UNLIMITED)
+                invalid_unlim_dim++;
+        }
+    }
 
     /* If using async, and not an IO task, then send parameters. */
     if (ios->async)
@@ -1989,7 +2039,16 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
             check_mpi(file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
             return check_mpi(file, mpierr, __FILE__, __LINE__);
+
+        /* Broadcast values currently only known on computation tasks to IO tasks. */
+        if ((mpierr = MPI_Bcast(&invalid_unlim_dim, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            check_mpi(file, mpierr, __FILE__, __LINE__);
     }
+
+    /* Check that only one unlimited dim is specified, and that it is
+     * first. */
+    if (invalid_unlim_dim)
+            return PIO_EINVAL;
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
@@ -2051,6 +2110,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
  * @param fill_value pointer to the fill value to be used if fill_mode is set to NC_FILL.
  * @return PIO_NOERR for success, otherwise an error code.
  * @ingroup PIO_def_var
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_valuep)
 {
@@ -2178,6 +2238,7 @@ int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_value
  * this variable. Ignored if NULL.
  * @return PIO_NOERR for success, error code otherwise.
  * @ingroup PIO_inq_var_fill
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
 {
@@ -2348,6 +2409,7 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
  * @ingroup PIO_get_att
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
 {
@@ -2390,6 +2452,7 @@ int PIOc_get_att(int ncid, int varid, const char *name, void *ip)
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
                  PIO_Offset len, const void *op)
@@ -2410,6 +2473,7 @@ int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype,
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_double(int ncid, int varid, const char *name, double *ip)
 {
@@ -2429,6 +2493,7 @@ int PIOc_get_att_double(int ncid, int varid, const char *name, double *ip)
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_uchar(int ncid, int varid, const char *name, unsigned char *ip)
 {
@@ -2448,6 +2513,7 @@ int PIOc_get_att_uchar(int ncid, int varid, const char *name, unsigned char *ip)
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_ushort(int ncid, int varid, const char *name, unsigned short *ip)
 {
@@ -2467,6 +2533,7 @@ int PIOc_get_att_ushort(int ncid, int varid, const char *name, unsigned short *i
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
  * @ingroup PIO_get_att
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_uint(int ncid, int varid, const char *name, unsigned int *ip)
 {
@@ -2486,6 +2553,7 @@ int PIOc_get_att_uint(int ncid, int varid, const char *name, unsigned int *ip)
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_long(int ncid, int varid, const char *name, long *ip)
 {
@@ -2507,6 +2575,7 @@ int PIOc_get_att_long(int ncid, int varid, const char *name, long *ip)
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
  * @ingroup PIO_get_att
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_text(int ncid, int varid, const char *name, char *ip)
 {
@@ -2526,6 +2595,7 @@ int PIOc_get_att_text(int ncid, int varid, const char *name, char *ip)
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_schar(int ncid, int varid, const char *name, signed char *ip)
 {
@@ -2545,6 +2615,7 @@ int PIOc_get_att_schar(int ncid, int varid, const char *name, signed char *ip)
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_ulonglong(int ncid, int varid, const char *name, unsigned long long *ip)
 {
@@ -2564,6 +2635,7 @@ int PIOc_get_att_ulonglong(int ncid, int varid, const char *name, unsigned long 
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_short(int ncid, int varid, const char *name, short *ip)
 {
@@ -2583,6 +2655,7 @@ int PIOc_get_att_short(int ncid, int varid, const char *name, short *ip)
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_int(int ncid, int varid, const char *name, int *ip)
 {
@@ -2602,6 +2675,7 @@ int PIOc_get_att_int(int ncid, int varid, const char *name, int *ip)
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_longlong(int ncid, int varid, const char *name, long long *ip)
 {
@@ -2621,6 +2695,7 @@ int PIOc_get_att_longlong(int ncid, int varid, const char *name, long long *ip)
  * @param name the name of the attribute to get
  * @param ip a pointer that will get the attribute value.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_get_att_float(int ncid, int varid, const char *name, float *ip)
 {
@@ -2642,6 +2717,7 @@ int PIOc_get_att_float(int ncid, int varid, const char *name, float *ip)
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype,
                        PIO_Offset len, const signed char *op)
@@ -2664,6 +2740,7 @@ int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype,
                       PIO_Offset len, const long *op)
@@ -2686,6 +2763,7 @@ int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype,
                      PIO_Offset len, const int *op)
@@ -2708,6 +2786,7 @@ int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_uchar(int ncid, int varid, const char *name, nc_type xtype,
                        PIO_Offset len, const unsigned char *op)
@@ -2730,6 +2809,7 @@ int PIOc_put_att_uchar(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype,
                           PIO_Offset len, const long long *op)
@@ -2752,6 +2832,7 @@ int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype,
                       PIO_Offset len, const unsigned int *op)
@@ -2774,6 +2855,7 @@ int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_float(int ncid, int varid, const char *name, nc_type xtype,
                        PIO_Offset len, const float *op)
@@ -2796,6 +2878,7 @@ int PIOc_put_att_float(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype,
                            PIO_Offset len, const unsigned long long *op)
@@ -2818,6 +2901,7 @@ int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype,
                         PIO_Offset len, const unsigned short *op)
@@ -2840,6 +2924,7 @@ int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_text(int ncid, int varid, const char *name,
                       PIO_Offset len, const char *op)
@@ -2862,6 +2947,7 @@ int PIOc_put_att_text(int ncid, int varid, const char *name,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype,
                        PIO_Offset len, const short *op)
@@ -2884,6 +2970,7 @@ int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype,
  * @param len the length of the attribute array.
  * @param op a pointer with the attribute data.
  * @return PIO_NOERR for success, error code otherwise.
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_put_att_double(int ncid, int varid, const char *name, nc_type xtype,
                         PIO_Offset len, const double *op)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1875,15 +1875,17 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
  *
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_openfile
+ * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
                         int mode, int retry)
 {
-    iosystem_desc_t *ios;  /** Pointer to io system information. */
-    file_desc_t *file;     /** Pointer to file information. */
-    int imode;  /** internal mode val for netcdf4 file open */
+    iosystem_desc_t *ios;      /* Pointer to io system information. */
+    file_desc_t *file;         /* Pointer to file information. */
+    int imode;                 /* Internal mode val for netcdf4 file open. */
+    int invalid_unlim_dim = 0; /* Will be try if var has invalid use of unlim dims. */
     int mpierr = MPI_SUCCESS, mpierr2;  /** Return code from MPI function codes. */
-    int ierr = PIO_NOERR;  /** Return code from function calls. */
+    int ierr = PIO_NOERR;      /* Return code from function calls. */
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
@@ -2026,13 +2028,14 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
                 else
                     file->do_io = 0;
             }
-            LOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d", filename, file->fh, file->iotype, file->do_io, ierr));
+            LOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d",
+                 filename, file->fh, file->iotype, file->do_io, ierr));
         }
     }
 
     /* Broadcast and check the return code. */
-    LOG((2, "Bcasting error code ierr = %d ios->ioroot = %d ios->my_comm = %d", ierr, ios->ioroot,
-         ios->my_comm));
+    LOG((2, "Bcasting error code ierr = %d ios->ioroot = %d ios->my_comm = %d",
+         ierr, ios->ioroot, ios->my_comm));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     LOG((2, "Bcast error code ierr = %d", ierr));
@@ -2043,9 +2046,8 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         free(file);
         return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
     }
-    LOG((2, "error code Bcast complete ierr = %d ios->my_comm = %d", ierr, ios->my_comm));
 
-    /* Broadcast results to all tasks. Ignore NULL parameters. */
+    /* Broadcast open mode to all tasks. */
     if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
 
@@ -2062,6 +2064,71 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
 
     LOG((2, "Opened file %s file->pio_ncid = %d file->fh = %d ierr = %d",
          filename, file->pio_ncid, file->fh, ierr));
+
+    /* Run this on all tasks if async is not in use, but only on
+     * non-IO tasks if async is in use. Check that all vars have at
+     * most one unlimited dim, and that if they have one, it is the
+     * first dim. */
+    if (!ios->async || !ios->ioproc)
+    {
+        int nunlimdims;
+
+        /* How many unlimited dims? */
+        if ((ierr = PIOc_inq_unlimdims(file->pio_ncid, &nunlimdims, NULL)))
+            return check_netcdf(file, ierr, __FILE__, __LINE__);
+
+        if (nunlimdims > 1)
+        {
+            int nvars;
+            
+            /* What are the dimids of the unlimited dims? */
+            int unlimdimid[nunlimdims];
+            if ((ierr = PIOc_inq_unlimdims(*ncidp, NULL, unlimdimid)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+
+            /* How many vars? */
+            if ((ierr = PIOc_inq_nvars(*ncidp, &nvars)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+
+            /* Check each var - only first dim may be unlimited. */
+            LOG((3, "checking vars nvars = %d", nvars));
+            for (int v = 0; v < nvars; v++)
+            {
+                int ndims;
+                
+                if ((ierr = PIOc_inq_varndims(*ncidp, v, &ndims)))
+                    return check_netcdf(file, ierr, __FILE__, __LINE__);
+
+                int vdimid[ndims];
+                if ((ierr = PIOc_inq_vardimid(*ncidp, v, vdimid)))
+                    return check_netcdf(file, ierr, __FILE__, __LINE__);
+
+                for (int vd = 1; vd < ndims; vd++)
+                    for (int d = 0; d < nunlimdims; d++)
+                        if (vdimid[vd] == unlimdimid[d])
+                        {
+                            /* invalid_unlim_dim++; */
+                            break;
+                        }
+                
+            }
+        }
+    }
+
+    /* Bcast the validity of unlimited dims in this file. */
+    LOG((3, "invalid_unlim_dim = %d", invalid_unlim_dim));
+    /* if (ios->async) */
+    /*     if ((mpierr = MPI_Bcast(&invalid_unlim_dim, 1, MPI_INT, ios->comproot, ios->my_comm))) */
+    /*         return check_mpi(file, mpierr, __FILE__, __LINE__); */
+    LOG((3, "after bcast invalid_unlim_dim = %d", invalid_unlim_dim));
+
+    /* Does one or more var make invalid use of unlimited dims? */
+    if (invalid_unlim_dim)
+    {
+        LOG((1, "invalid unlimited dim detected!"));
+        /* PIOc_closefile(*ncidp); */
+        /* return check_netcdf2(ios, NULL, PIO_EINVAL, __FILE__, __LINE__); */
+    }
 
     return ierr;
 }

--- a/tests/cunit/test_pioc_unlim.c
+++ b/tests/cunit/test_pioc_unlim.c
@@ -228,9 +228,9 @@ int run_multiple_unlim_test(int iosysid, int ioid, int iotype, int my_rank,
     MPI_Barrier(test_comm);
 
     /* Try to read file. It will not work. */
-    /* if (PIOc_openfile2(iosysid, &ncid, &iotype, NETCDF4_UNLIM_FILE_NAME, */
-    /*                    0) != PIO_EINVAL) */
-    /*     ERR(ERR_WRONG); */
+    if (PIOc_openfile2(iosysid, &ncid, &iotype, NETCDF4_UNLIM_FILE_NAME,
+                       0) != PIO_EINVAL)
+        ERR(ERR_WRONG);
 
     return PIO_NOERR;
 }

--- a/tests/cunit/test_pioc_unlim.c
+++ b/tests/cunit/test_pioc_unlim.c
@@ -165,6 +165,7 @@ int run_multiple_unlim_test(int iosysid, int ioid, int iotype, int my_rank)
             ERR(ERR_WRONG);
     }
 
+    /* Check some more stuff. */
     {
         int nunlimdims;
         int unlimdimids[NUM_UNLIM_DIMS];
@@ -185,6 +186,13 @@ int run_multiple_unlim_test(int iosysid, int ioid, int iotype, int my_rank)
                 ERR(ERR_WRONG);
         }
     }
+
+    /* Now try to add a var with two unlimited dims. It will fail. */
+    int varid;
+    #define VAR_NAME2 "some_dumb_variable_name_def_var_will_fail_anyway"
+    if (PIOc_def_var(ncid, VAR_NAME2, PIO_INT, NUM_UNLIM_DIMS, unlimdimids,
+                     &varid) != PIO_EINVAL)
+        ERR(ERR_WRONG);
     
     /* Close the file. */
     if ((PIOc_closefile(ncid)))

--- a/tests/cunit/test_pioc_unlim.c
+++ b/tests/cunit/test_pioc_unlim.c
@@ -47,6 +47,10 @@ char dim_name[NDIM][PIO_MAX_NAME + 1] = {"timestep", "x", "y"};
 /* Length of the dimensions in the sample data. */
 int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
 
+#define NETCDF4_UNLIM_FILE_NAME "netcdf4_unlim_file.nc"
+#define DIM_NAME1 "dim1"
+#define DIM_NAME2 "dim2"
+
 /* Create the decomposition to divide the 3-dimensional sample data
  * between the 4 tasks.
  *
@@ -125,7 +129,8 @@ int create_test_file(int iosysid, int ioid, int iotype, int my_rank, int *ncid, 
 
 /* Tests with multiple unlimited dims. Only netcdf-4 IOTYPES support
  * multiple unlimited dims. */
-int run_multiple_unlim_test(int iosysid, int ioid, int iotype, int my_rank)
+int run_multiple_unlim_test(int iosysid, int ioid, int iotype, int my_rank,
+                            MPI_Comm test_comm)
 {
 #define UDIM1_NAME "unlimited1"
 #define UDIM2_NAME "unlimited2"
@@ -198,6 +203,35 @@ int run_multiple_unlim_test(int iosysid, int ioid, int iotype, int my_rank)
     if ((PIOc_closefile(ncid)))
         return ret;
 
+    /* Use netCDF-4 directly to create a file that PIO can not create
+     * or read. */
+    if (my_rank == 0)
+    {
+        int ncid;
+        int dimids[NUM_UNLIM_DIMS];
+        int varid;
+        
+        if ((ret = nc_create(NETCDF4_UNLIM_FILE_NAME, NC_CLOBBER|NC_NETCDF4, &ncid)))
+            ERR(ret);
+        
+        if ((ret = nc_def_dim(ncid, DIM_NAME1, NC_UNLIMITED, &dimids[0])))
+            ERR(ret);
+        if ((ret = nc_def_dim(ncid, DIM_NAME2, NC_UNLIMITED, &dimids[1])))
+            ERR(ret);
+        if ((ret = nc_def_var(ncid, VAR_NAME, PIO_INT, NUM_UNLIM_DIMS, dimids, &varid)))
+            ERR(ret);
+        if ((ret = nc_close(ncid)))
+            ERR(ret);
+    }
+
+    /* Other tasks wait for task 0 to write file using netCDF-4... */
+    MPI_Barrier(test_comm);
+
+    /* Try to read file. It will not work. */
+    /* if (PIOc_openfile2(iosysid, &ncid, &iotype, NETCDF4_UNLIM_FILE_NAME, */
+    /*                    0) != PIO_EINVAL) */
+    /*     ERR(ERR_WRONG); */
+
     return PIO_NOERR;
 }
 
@@ -251,7 +285,7 @@ int test_all(int iosysid, int num_flavors, int *flavor, int my_rank, MPI_Comm te
             /* Test file with multiple unlimited dims. Only netCDF-4
              * iotypes can run this test. */
             if (flavor[fmt] == PIO_IOTYPE_NETCDF4C || flavor[fmt] == PIO_IOTYPE_NETCDF4P)
-                if ((ret = run_multiple_unlim_test(iosysid, ioid, flavor[fmt], my_rank)))
+                if ((ret = run_multiple_unlim_test(iosysid, ioid, flavor[fmt], my_rank, test_comm)))
                     return ret;
         }
 


### PR DESCRIPTION
PIO can only tolerate one unlimited dim per variable.

NetCDF-4 files are now checked (when opened) to make sure they meet this requirement. Also def_var is changed so that invalid vars cannot be defined with PIO.

Fixes #214.

I have merged to develop for testing.