### PR TITLE
advanceframe and setframe now use new var_desc list

### DIFF
--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -388,22 +388,16 @@ int get_var_desc(int varid, var_desc_t **varlist, var_desc_t **var_desc)
     var_desc_t *my_var;
     
     /* Check inputs. */
-    pioassert(varid >= 0 && varlist && var_desc, "invalid input",
-              __FILE__, __LINE__);
     LOG((2, "get_var_desc varid = %d", varid));
 
     /* Empty varlist. */
-    LOG((3, "*varlist = %d", *varlist));
     if (!*varlist)
         return PIO_ENOTVAR;
 
     /* Find the var_desc_t for this varid. */
     for (my_var = *varlist; my_var->next; my_var = my_var->next)
-    {
-        LOG((2, "my_var->varid = %d", my_var->varid));
         if (my_var->varid == varid)
             break;
-    }
 
     /* Did we find it? */
     if (my_var->varid != varid)

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -215,6 +215,19 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
         if ((ret = PIOc_enddef(ncid)))
             ERR(ret);
 
+        /* These should not work, because this is not a record
+         * variable. */
+        if (PIOc_setframe(ncid, varid, 0) != PIO_EINVAL)
+            ERR(ERR_WRONG);
+        if (PIOc_advanceframe(ncid, varid) != PIO_EINVAL)
+            ERR(ERR_WRONG);
+
+        /* These should not work, because invalid varids are given. */
+        if (PIOc_setframe(ncid, TEST_VAL_42, 0) != PIO_ENOTVAR)
+            ERR(ERR_WRONG);
+        if (PIOc_advanceframe(ncid, TEST_VAL_42) != PIO_ENOTVAR)
+            ERR(ERR_WRONG);
+
         /* Write some data. */
         PIO_Offset arraylen = 1;
         float fillvalue = 0.0;
@@ -887,15 +900,15 @@ int test_names(int iosysid, int num_flavors, int *flavor, int my_rank,
         /* These should not work. */
         if (PIOc_setframe(ncid + TEST_VAL_42, 0, 0) != PIO_EBADID)
             return ERR_WRONG;
-        if (PIOc_setframe(ncid, -1, 0) != PIO_EINVAL)
+        if (PIOc_setframe(ncid, -1, 0) != PIO_ENOTVAR)
             return ERR_WRONG;
-        if (PIOc_setframe(ncid, NC_MAX_VARS + 1, 0) != PIO_EINVAL)
+        if (PIOc_setframe(ncid, NC_MAX_VARS + 1, 0) != PIO_ENOTVAR)
             return ERR_WRONG;
         if (PIOc_advanceframe(ncid + TEST_VAL_42, 0) != PIO_EBADID)
             return ERR_WRONG;
-        if (PIOc_advanceframe(ncid, -1) != PIO_EINVAL)
+        if (PIOc_advanceframe(ncid, -1) != PIO_ENOTVAR)
             return ERR_WRONG;
-        if (PIOc_advanceframe(ncid, NC_MAX_VARS + 1) != PIO_EINVAL)
+        if (PIOc_advanceframe(ncid, NC_MAX_VARS + 1) != PIO_ENOTVAR)
             return ERR_WRONG;
 
         /* Check the dimension names. */


### PR DESCRIPTION
In this PR I use the new var_desc_t linked list to improve error handling in PIOc_setframe() and PIOc_advanceframe().

Fixes #1083.
Part of #1052.
Part of #1051.
Part of #544.

I have merged to develop for testing.
