### PR TITLE
Final work on var_desc_t linked list, clean up if intermediate efforts

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -551,7 +551,7 @@ typedef struct file_desc_t
     int nvars;
 
     /** List of variables in this file (deprecated). */
-    struct var_desc_t varlist[PIO_MAX_VARS];
+    /* struct var_desc_t varlist[PIO_MAX_VARS]; */
 
     /** Mode used when file was opened. */
     int mode;

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -545,13 +545,10 @@ typedef struct file_desc_t
     int iotype;
 
     /** List of variables in this file. */
-    struct var_desc_t *varlist2;
+    struct var_desc_t *varlist;
 
     /** Number of variables. */
     int nvars;
-
-    /** List of variables in this file (deprecated). */
-    /* struct var_desc_t varlist[PIO_MAX_VARS]; */
 
     /** Mode used when file was opened. */
     int mode;

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -547,6 +547,9 @@ typedef struct file_desc_t
     /** List of variables in this file. */
     struct var_desc_t *varlist2;
 
+    /** Number of variables. */
+    int nvars;
+
     /** List of variables in this file (deprecated). */
     struct var_desc_t varlist[PIO_MAX_VARS];
 

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -108,7 +108,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     file_desc_t *file;     /* Pointer to file information. */
     io_desc_t *iodesc;     /* Pointer to IO description information. */
     int rlen;              /* Total data buffer size. */
-    var_desc_t *vdesc0;    /* Array of var_desc structure for each var. */
+    /* var_desc_t *vdesc0;    /\* Array of var_desc structure for each var. *\/ */
     var_desc_t *vdesc0_2;  /* First entry in array of var_desc structure for each var. */
     int fndims;            /* Number of dims in the var in the file. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function calls. */
@@ -141,7 +141,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
               "unknown rearranger", __FILE__, __LINE__);
 
     /* Get a pointer to the variable info for the first variable. */
-    vdesc0 = &file->varlist[varids[0]];
+    /* vdesc0 = &file->varlist[varids[0]]; */
     if ((ierr = get_var_desc(varids[0], &file->varlist2, &vdesc0_2)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
@@ -310,14 +310,14 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         LOG((2, "nvars = %d holegridsize = %ld iodesc->needsfill = %d\n", nvars,
              iodesc->holegridsize, iodesc->needsfill));
 
-	pioassert(!vdesc0->fillbuf, "buffer overwrite",__FILE__, __LINE__);
+	/* pioassert(!vdesc0->fillbuf, "buffer overwrite",__FILE__, __LINE__); */
 	pioassert(!vdesc0_2->fillbuf, "buffer overwrite",__FILE__, __LINE__);
 
         /* Get a buffer. */
-	if (ios->io_rank == 0)
-	    vdesc0->fillbuf = bget(iodesc->maxholegridsize * iodesc->mpitype_size * nvars);
-	else if (iodesc->holegridsize > 0)
-	    vdesc0->fillbuf = bget(iodesc->holegridsize * iodesc->mpitype_size * nvars);
+	/* if (ios->io_rank == 0) */
+	/*     vdesc0->fillbuf = bget(iodesc->maxholegridsize * iodesc->mpitype_size * nvars); */
+	/* else if (iodesc->holegridsize > 0) */
+	/*     vdesc0->fillbuf = bget(iodesc->holegridsize * iodesc->mpitype_size * nvars); */
 	if (ios->io_rank == 0)
 	    vdesc0_2->fillbuf = bget(iodesc->maxholegridsize * iodesc->mpitype_size * nvars);
 	else if (iodesc->holegridsize > 0)
@@ -326,10 +326,10 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         /* copying the fill value into the data buffer for the box
          * rearranger. This will be overwritten with data where
          * provided. */
-        for (int nv = 0; nv < nvars; nv++)
-            for (int i = 0; i < iodesc->holegridsize; i++)
-                memcpy(&((char *)vdesc0->fillbuf)[iodesc->mpitype_size * (i + nv * iodesc->holegridsize)],
-                       &((char *)fillvalue)[iodesc->mpitype_size * nv], iodesc->mpitype_size);
+        /* for (int nv = 0; nv < nvars; nv++) */
+        /*     for (int i = 0; i < iodesc->holegridsize; i++) */
+        /*         memcpy(&((char *)vdesc0->fillbuf)[iodesc->mpitype_size * (i + nv * iodesc->holegridsize)], */
+        /*                &((char *)fillvalue)[iodesc->mpitype_size * nv], iodesc->mpitype_size); */
         for (int nv = 0; nv < nvars; nv++)
             for (int i = 0; i < iodesc->holegridsize; i++)
                 memcpy(&((char *)vdesc0_2->fillbuf)[iodesc->mpitype_size * (i + nv * iodesc->holegridsize)],
@@ -358,11 +358,11 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         if (file->iotype != PIO_IOTYPE_PNETCDF)
         {
             /* Free resources. */
-            if (vdesc0->fillbuf)
-            {
-                brel(vdesc0->fillbuf);
-                vdesc0->fillbuf = NULL;
-            }
+            /* if (vdesc0->fillbuf) */
+            /* { */
+            /*     brel(vdesc0->fillbuf); */
+            /*     vdesc0->fillbuf = NULL; */
+            /* } */
             if (vdesc0_2->fillbuf)
             {
                 brel(vdesc0_2->fillbuf);
@@ -478,7 +478,6 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Info about file we are writing to. */
     io_desc_t *iodesc;     /* The IO description. */
-    var_desc_t *vdesc;     /* Info about the var being written. */
     var_desc_t *vdesc2;    /* Info about the var being written. */
     void *bufptr;          /* A data buffer. */
     MPI_Datatype vtype;    /* The MPI type of the variable. */
@@ -521,7 +520,6 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
          arraylen, iodesc->ndof));
 
     /* Get var description. */
-    vdesc = &(file->varlist[varid]);
     if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc2)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
@@ -533,7 +531,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Is this a record variable? The user must set the vdesc->record
      * value by calling PIOc_setframe() before calling this
      * function. */
-    recordvar = vdesc->record >= 0 ? 1 : 0;
+    /* recordvar = vdesc->record >= 0 ? 1 : 0; */
+    recordvar = vdesc2->rec_var;
     LOG((3, "recordvar = %d looking for multibuffer", recordvar));
 
     /* Move to end of list or the entry that matches this ioid. */
@@ -648,7 +647,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* wmb->frame is the record number, we assume that the variables
      * in the wmb list may not all have the same unlimited dimension
      * value although they usually do. */
-    if (vdesc->record >= 0)
+    if (vdesc2->rec_var)
         if (!(wmb->frame = bgetr(wmb->frame, sizeof(int) * (1 + wmb->num_arrays))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
@@ -742,7 +741,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Add the unlimited dimension value of this variable to the frame
      * array in wmb. */
     if (wmb->frame)
-        wmb->frame[wmb->num_arrays] = vdesc->record;
+        wmb->frame[wmb->num_arrays] = vdesc2->record;
     wmb->num_arrays++;
 
     LOG((2, "wmb->num_arrays = %d iodesc->maxbytes / iodesc->mpitype_size = %d "

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -214,7 +214,8 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
 
     /* if the buffer is already in use in pnetcdf we need to flush first */
     if (file->iotype == PIO_IOTYPE_PNETCDF && file->iobuf)
-	flush_output_buffer(file, 1, 0);
+        if ((ierr = flush_output_buffer(file, 1, 0)))
+            return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
     pioassert(!file->iobuf, "buffer overwrite",__FILE__, __LINE__);
 

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -108,8 +108,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     file_desc_t *file;     /* Pointer to file information. */
     io_desc_t *iodesc;     /* Pointer to IO description information. */
     int rlen;              /* Total data buffer size. */
-    /* var_desc_t *vdesc0;    /\* Array of var_desc structure for each var. *\/ */
-    var_desc_t *vdesc0_2;  /* First entry in array of var_desc structure for each var. */
+    var_desc_t *vdesc0;  /* First entry in array of var_desc structure for each var. */
     int fndims;            /* Number of dims in the var in the file. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function calls. */
     int ierr;              /* Return code. */
@@ -141,8 +140,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
               "unknown rearranger", __FILE__, __LINE__);
 
     /* Get a pointer to the variable info for the first variable. */
-    /* vdesc0 = &file->varlist[varids[0]]; */
-    if ((ierr = get_var_desc(varids[0], &file->varlist2, &vdesc0_2)))
+    if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc0)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
     /* Run these on all tasks if async is not in use, but only on
@@ -310,29 +308,20 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         LOG((2, "nvars = %d holegridsize = %ld iodesc->needsfill = %d\n", nvars,
              iodesc->holegridsize, iodesc->needsfill));
 
-	/* pioassert(!vdesc0->fillbuf, "buffer overwrite",__FILE__, __LINE__); */
-	pioassert(!vdesc0_2->fillbuf, "buffer overwrite",__FILE__, __LINE__);
+	pioassert(!vdesc0->fillbuf, "buffer overwrite",__FILE__, __LINE__);
 
         /* Get a buffer. */
-	/* if (ios->io_rank == 0) */
-	/*     vdesc0->fillbuf = bget(iodesc->maxholegridsize * iodesc->mpitype_size * nvars); */
-	/* else if (iodesc->holegridsize > 0) */
-	/*     vdesc0->fillbuf = bget(iodesc->holegridsize * iodesc->mpitype_size * nvars); */
 	if (ios->io_rank == 0)
-	    vdesc0_2->fillbuf = bget(iodesc->maxholegridsize * iodesc->mpitype_size * nvars);
+	    vdesc0->fillbuf = bget(iodesc->maxholegridsize * iodesc->mpitype_size * nvars);
 	else if (iodesc->holegridsize > 0)
-	    vdesc0_2->fillbuf = bget(iodesc->holegridsize * iodesc->mpitype_size * nvars);
+	    vdesc0->fillbuf = bget(iodesc->holegridsize * iodesc->mpitype_size * nvars);
 
         /* copying the fill value into the data buffer for the box
          * rearranger. This will be overwritten with data where
          * provided. */
-        /* for (int nv = 0; nv < nvars; nv++) */
-        /*     for (int i = 0; i < iodesc->holegridsize; i++) */
-        /*         memcpy(&((char *)vdesc0->fillbuf)[iodesc->mpitype_size * (i + nv * iodesc->holegridsize)], */
-        /*                &((char *)fillvalue)[iodesc->mpitype_size * nv], iodesc->mpitype_size); */
         for (int nv = 0; nv < nvars; nv++)
             for (int i = 0; i < iodesc->holegridsize; i++)
-                memcpy(&((char *)vdesc0_2->fillbuf)[iodesc->mpitype_size * (i + nv * iodesc->holegridsize)],
+                memcpy(&((char *)vdesc0->fillbuf)[iodesc->mpitype_size * (i + nv * iodesc->holegridsize)],
                        &((char *)fillvalue)[iodesc->mpitype_size * nv], iodesc->mpitype_size);
 
         /* Write the darray based on the iotype. */
@@ -358,15 +347,10 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         if (file->iotype != PIO_IOTYPE_PNETCDF)
         {
             /* Free resources. */
-            /* if (vdesc0->fillbuf) */
-            /* { */
-            /*     brel(vdesc0->fillbuf); */
-            /*     vdesc0->fillbuf = NULL; */
-            /* } */
-            if (vdesc0_2->fillbuf)
+            if (vdesc0->fillbuf)
             {
-                brel(vdesc0_2->fillbuf);
-                vdesc0_2->fillbuf = NULL;
+                brel(vdesc0->fillbuf);
+                vdesc0->fillbuf = NULL;
             }
         }
     }
@@ -478,7 +462,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Info about file we are writing to. */
     io_desc_t *iodesc;     /* The IO description. */
-    var_desc_t *vdesc2;    /* Info about the var being written. */
+    var_desc_t *vdesc;    /* Info about the var being written. */
     void *bufptr;          /* A data buffer. */
     MPI_Datatype vtype;    /* The MPI type of the variable. */
     wmulti_buffer *wmb;    /* The write multi buffer for one or more vars. */
@@ -520,19 +504,19 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
          arraylen, iodesc->ndof));
 
     /* Get var description. */
-    if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc2)))
+    if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
     /* If we don't know the fill value for this var, get it. */
-    if (!vdesc2->fillvalue)
-        if ((ierr = find_var_fillvalue(file, varid, vdesc2)))
+    if (!vdesc->fillvalue)
+        if ((ierr = find_var_fillvalue(file, varid, vdesc)))
             return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__);            
 
     /* Is this a record variable? The user must set the vdesc->record
      * value by calling PIOc_setframe() before calling this
      * function. */
     /* recordvar = vdesc->record >= 0 ? 1 : 0; */
-    recordvar = vdesc2->rec_var;
+    recordvar = vdesc->rec_var;
     LOG((3, "recordvar = %d looking for multibuffer", recordvar));
 
     /* Move to end of list or the entry that matches this ioid. */
@@ -647,7 +631,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* wmb->frame is the record number, we assume that the variables
      * in the wmb list may not all have the same unlimited dimension
      * value although they usually do. */
-    if (vdesc2->rec_var)
+    if (vdesc->rec_var)
         if (!(wmb->frame = bgetr(wmb->frame, sizeof(int) * (1 + wmb->num_arrays))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
@@ -741,7 +725,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Add the unlimited dimension value of this variable to the frame
      * array in wmb. */
     if (wmb->frame)
-        wmb->frame[wmb->num_arrays] = vdesc2->record;
+        wmb->frame[wmb->num_arrays] = vdesc->record;
     wmb->num_arrays++;
 
     LOG((2, "wmb->num_arrays = %d iodesc->maxbytes / iodesc->mpitype_size = %d "

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -506,12 +506,10 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     vdesc = &(file->varlist[varid]);
     if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc2)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);        
-    LOG((2, "vdesc record %d nreqs %d vdesc2->rec_var %d", vdesc->record,
-         vdesc->nreqs, vdesc2->rec_var));
 
     /* If we don't know the fill value for this var, get it. */
-    if (!vdesc->fillvalue)
-        if ((ierr = find_var_fillvalue(file, varid, vdesc)))
+    if (!vdesc2->fillvalue)
+        if ((ierr = find_var_fillvalue(file, varid, vdesc2)))
             return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__);            
 
     /* Is this a record variable? The user must set the vdesc->record

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1295,6 +1295,16 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
                 vdesc->fillbuf = NULL;
             }
         }
+        for (int v = 0; v < file->nvars; v++)
+        {
+            if ((ierr = get_var_desc(v, &file->varlist2, &vdesc)))
+                return pio_err(NULL, file, ierr, __FILE__, __LINE__);        
+            if (vdesc->fillbuf)
+            {
+                brel(vdesc->fillbuf);
+                vdesc->fillbuf = NULL;
+            }
+        }
     }
 
 #endif /* _PNETCDF */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1007,6 +1007,11 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
     if (fndims == ndims)
         vdesc->record = -1;
 
+    /* Confirm rec_var setting. */
+    pioassert((fndims == ndims && !vdesc2->rec_var) ||
+              (fndims == ndims + 1 && vdesc2->rec_var),
+              "invalid rec_var", __FILE__, __LINE__);
+
     if (ios->ioproc)
     {
         io_region *region;
@@ -1043,7 +1048,7 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
             }
             else
             {
-                if (vdesc->record >= 0 && fndims > 1)
+                if (vdesc2->rec_var && fndims > 1)
                 {
                     /* This is a record var. Find start for record dims. */
                     tmp_start[regioncnt * fndims] = vdesc->record;

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -973,6 +973,7 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;     /* Information about the variable. */
+    var_desc_t *vdesc2;    /* Information about the variable. */
     int ndims;             /* Number of dims in decomposition. */
     int fndims;            /* Number of dims for this var in file. */
     MPI_Status status;
@@ -983,6 +984,7 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
     pioassert(file && file->iosystem && iodesc && vid >= 0 && vid <= PIO_MAX_VARS,
               "invalid input", __FILE__, __LINE__);
 
+    LOG((2, "pio_read_darray_nc_serial vid = %d", vid));
 #ifdef TIMING
     /* Start timing this function. */
     GPTLstart("PIO:read_darray_nc_serial");
@@ -991,6 +993,8 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
 
     /* Get var info for this var. */
     vdesc = file->varlist + vid;
+    if ((ierr = get_var_desc(vid, &file->varlist2, &vdesc2)))
+        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Get the number of dims in our decomposition. */
     ndims = iodesc->ndims;

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -163,7 +163,6 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
                            io_desc_t *iodesc, int fill, const int *frame)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
-    var_desc_t *vdesc;     /* Pointer to var info struct. */
     var_desc_t *vdesc2;    /* Pointer to var info struct. */
     int dsize;             /* Data size (for one region). */
     int ierr = PIO_NOERR;
@@ -185,7 +184,6 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
     ios = file->iosystem;
 
     /* Point to var description scruct for first var. */
-    vdesc = file->varlist + varids[0];
     if ((ierr = get_var_desc(varids[0], &file->varlist2, &vdesc2)))
         return pio_err(NULL, file, ierr, __FILE__, __LINE__);        
 
@@ -279,8 +277,6 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
                     for (int nv = 0; nv < nvars; nv++)
                     {
                         /* Get the var info. */
-                        vdesc = file->varlist + varids[nv];
-                        LOG((3, "getting var_desc_t for varid %d", varids[nv]));
                         if ((ierr = get_var_desc(varids[nv], &file->varlist2, &vdesc2)))
                             return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
@@ -675,7 +671,6 @@ int write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const in
                               io_desc_t *iodesc, int fill, const int *frame)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
-    var_desc_t *vdesc;     /* Contains info about the variable. */
     var_desc_t *vdesc2;     /* Contains info about the variable. */
     int ierr;              /* Return code. */
 
@@ -690,7 +685,6 @@ int write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const in
     ios = file->iosystem;
 
     /* Get the var info. */
-    vdesc = file->varlist + varids[0];
     if ((ierr = get_var_desc(varids[0], &file->varlist2, &vdesc2)))
         return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
@@ -1261,13 +1255,7 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
         maxreq = 0;
         reqcnt = 0;
         rcnt = 0;
-        /* for (int i = 0; i < PIO_MAX_VARS; i++) */
-        /* { */
-        /*     vdesc = file->varlist + i; */
-        /*     reqcnt += vdesc->nreqs; */
-        /*     if (vdesc->nreqs > 0) */
-        /*         maxreq = i; */
-        /* } */
+
         for (int i = 0; i < file->nvars; i++)
         {
             if ((ierr = get_var_desc(i, &file->varlist2, &vdesc)))
@@ -1318,15 +1306,7 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
             brel(file->iobuf);
             file->iobuf = NULL;
         }
-        /* for (int i = 0; i < PIO_MAX_VARS; i++) */
-        /* { */
-        /*     vdesc = file->varlist + i; */
-        /*     if (vdesc->fillbuf) */
-        /*     { */
-        /*         brel(vdesc->fillbuf); */
-        /*         vdesc->fillbuf = NULL; */
-        /*     } */
-        /* } */
+
         for (int v = 0; v < file->nvars; v++)
         {
             if ((ierr = get_var_desc(v, &file->varlist2, &vdesc)))

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -193,7 +193,7 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
     int num_regions = fill ? iodesc->maxfillregions: iodesc->maxregions;
     io_region *region = fill ? iodesc->fillregion : iodesc->firstregion;
     PIO_Offset llen = fill ? iodesc->holegridsize : iodesc->llen;
-    void *iobuf = fill ? vdesc->fillbuf : file->iobuf;
+    void *iobuf = fill ? vdesc2->fillbuf : file->iobuf;
 
     /* If this is an IO task write the data. */
     if (ios->ioproc)
@@ -212,7 +212,7 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
         for (int regioncnt = 0; regioncnt < num_regions; regioncnt++)
         {
             /* Fill the start/count arrays. */
-            if ((ierr = find_start_count(iodesc->ndims, fndims, vdesc, region, frame, start, count)))
+            if ((ierr = find_start_count(iodesc->ndims, fndims, vdesc2, region, frame, start, count)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);            
 
             /* IO tasks will run the netCDF/pnetcdf functions to write the data. */
@@ -225,7 +225,7 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
                 {
                     /* Set the start of the record dimension. (Hasn't
                      * this already been set above ???) */
-                    if (vdesc->record >= 0 && ndims < fndims)
+                    if (vdesc2->rec_var && ndims < fndims)
                         start[0] = frame[nv];
 
                     /* If there is data for this region, get a pointer to it. */
@@ -286,7 +286,7 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
 
                         /* If this is a record var, set the start for
                          * the record dimension. */
-                        if (vdesc->record >= 0 && ndims < fndims)
+                        if (vdesc2->rec_var && ndims < fndims)
                             for (int rc = 0; rc < rrcnt; rc++)
                                 startlist[rc][0] = frame[nv];
 
@@ -389,7 +389,7 @@ int find_all_start_count(io_region *region, int maxregions, int fndims,
 
         if (region)
         {
-            if (vdesc->record >= 0)
+            if (vdesc->rec_var)
             {
                 /* This is a record based multidimensional
                  * array. Copy start/count for non-record
@@ -719,7 +719,7 @@ int write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const in
 
         /* Fill the tmp_start and tmp_count arrays, which contain the
          * start and count arrays for all regions. */
-        if ((ierr = find_all_start_count(region, num_regions, fndims, iodesc->ndims, vdesc,
+        if ((ierr = find_all_start_count(region, num_regions, fndims, iodesc->ndims, vdesc2,
                                          tmp_start, tmp_count)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
 

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -98,7 +98,7 @@ int find_start_count(int ndims, int fndims, var_desc_t *vdesc,
 
     if (region)
     {
-        if (vdesc->record >= 0)
+        if (vdesc->rec_var)
         {
             /* This is a record based multidimensional
              * array. Figure out start/count for all but the

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -98,7 +98,7 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
 
     /* Open the file. If the open fails, do not retry as serial
      * netCDF. Just return the error code. */
-    return PIOc_openfile_retry(iosysid, ncidp, &iotype, path, mode, 0);
+    return openfile_int(iosysid, ncidp, &iotype, path, mode, 0);
 }
 
 /**

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -1077,7 +1077,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
                 LOG((2, "PIOc_put_vars_tc calling pnetcdf function"));
                 /*vdesc = &file->varlist[varid];*/
-                if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                     return pio_err(ios, file, ierr, __FILE__, __LINE__);        
                 if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
                     if (!(vdesc->request = realloc(vdesc->request,

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -1076,7 +1076,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     fake_stride = (PIO_Offset *)stride;
 
                 LOG((2, "PIOc_put_vars_tc calling pnetcdf function"));
-                vdesc = &file->varlist[varid];
+                /*vdesc = &file->varlist[varid];*/
+                if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                    return pio_err(ios, file, ierr, __FILE__, __LINE__);        
                 if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
                     if (!(vdesc->request = realloc(vdesc->request,
                                                    sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -451,6 +451,8 @@ int delete_var_desc(int varid, var_desc_t **varlist)
         *varlist = v->next;
 
     /* Free memory. */
+    if (v->fillvalue)
+        free(v->fillvalue);
     free(v);
     
     return PIO_NOERR;

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -121,14 +121,9 @@ int pio_delete_file_from_list(int ncid)
             if (current_file == cfile)
                 current_file = pfile;
 
-            /* Free any fill values that were allocated. */
-            /* for (int v = 0; v < PIO_MAX_VARS; v++) */
-            /*     if (cfile->varlist[v].fillvalue) */
-            /*         free(cfile->varlist[v].fillvalue); */
-
             /* Free the varlist entries for this file. */
-            while (cfile->varlist2)
-                if ((ret = delete_var_desc(cfile->varlist2->varid, &cfile->varlist2)))
+            while (cfile->varlist)
+                if ((ret = delete_var_desc(cfile->varlist->varid, &cfile->varlist)))
                     return pio_err(NULL, cfile, ret, __FILE__, __LINE__);
 
             /* Free the memory used for this file. */

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -122,9 +122,9 @@ int pio_delete_file_from_list(int ncid)
                 current_file = pfile;
 
             /* Free any fill values that were allocated. */
-            for (int v = 0; v < PIO_MAX_VARS; v++)
-                if (cfile->varlist[v].fillvalue)
-                    free(cfile->varlist[v].fillvalue);
+            /* for (int v = 0; v < PIO_MAX_VARS; v++) */
+            /*     if (cfile->varlist[v].fillvalue) */
+            /*         free(cfile->varlist[v].fillvalue); */
 
             /* Free the varlist entries for this file. */
             while (cfile->varlist2)

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2122,6 +2122,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     /* Add to the list of var_desc_t structs for this file. */
     if ((ierr = add_to_varlist(varid, rec_var, &file->varlist2)))
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+    file->nvars++;
  
     return PIO_NOERR;
 }

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2120,7 +2120,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         *varidp = varid;
 
     /* Add to the list of var_desc_t structs for this file. */
-    if ((ierr = add_to_varlist(varid, rec_var, &file->varlist2)))
+    if ((ierr = add_to_varlist(varid, rec_var, &file->varlist)))
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     file->nvars++;
  

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -48,7 +48,7 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -118,7 +118,7 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -188,7 +188,7 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -259,7 +259,7 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -331,7 +331,7 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -403,7 +403,7 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -474,7 +474,7 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -546,7 +546,7 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -617,7 +617,7 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -690,7 +690,7 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -762,7 +762,7 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -833,7 +833,7 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
@@ -903,7 +903,7 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -48,7 +48,8 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -117,7 +118,8 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -186,7 +188,8 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -256,7 +259,8 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -327,7 +331,8 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -398,7 +403,8 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -468,7 +474,8 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -539,7 +546,8 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -609,7 +617,8 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -681,7 +690,8 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -752,7 +762,8 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -822,7 +833,8 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,
@@ -891,7 +903,8 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            vdesc = file->varlist + varid;
+            if ((ierr = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
             if (vdesc->nreqs%PIO_REQUEST_ALLOC_CHUNK == 0 ){
                 vdesc->request = realloc(vdesc->request,

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -155,7 +155,7 @@ int PIOc_advanceframe(int ncid, int varid)
     }
 
     /* Increment the record number. */
-    file->varlist[varid].record++;
+    /* file->varlist[varid].record++; */
     vdesc->record++;
     
     return PIO_NOERR;
@@ -222,7 +222,7 @@ int PIOc_setframe(int ncid, int varid, int frame)
 
     /* Set the record dimension value for this variable. This will be
      * used by the write_darray functions. */
-    file->varlist[varid].record = frame;
+    /* file->varlist[varid].record = frame; */
     vdesc->record = frame;
 
     return PIO_NOERR;

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -126,7 +126,7 @@ int PIOc_advanceframe(int ncid, int varid)
     ios = file->iosystem;
 
     /* Get info about variable. */
-    if ((ret = get_var_desc(varid, &file->varlist2, &vdesc)))
+    if ((ret = get_var_desc(varid, &file->varlist, &vdesc)))
         return pio_err(ios, file, ret, __FILE__, __LINE__);
     if (!vdesc->rec_var)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
@@ -189,7 +189,7 @@ int PIOc_setframe(int ncid, int varid, int frame)
     ios = file->iosystem;
 
     /* Get info about variable. */
-    if ((ret = get_var_desc(varid, &file->varlist2, &vdesc)))
+    if ((ret = get_var_desc(varid, &file->varlist, &vdesc)))
         return pio_err(ios, file, ret, __FILE__, __LINE__);
     LOG((2, "vdesc->rec_var = %d", vdesc->rec_var));
     if (!vdesc->rec_var)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2228,6 +2228,7 @@ int openfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
         /* Add to the list of var_desc_t structs for this file. */
         if ((ierr = add_to_varlist(v, rec_var, &file->varlist2)))
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        file->nvars++;
     }
 
     return PIO_NOERR;

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1724,17 +1724,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     file->iosystem = ios;
     file->iotype = *iotype;
     file->buffer.ioid = -1;
-    /* for (int i = 0; i < PIO_MAX_VARS; i++) */
-    /* { */
-    /*     file->varlist[i].record = -1; */
-    /*     file->varlist[i].request = NULL; */
-    /*     file->varlist[i].nreqs = 0; */
-    /*     file->varlist[i].fillvalue = NULL; */
-    /*     file->varlist[i].pio_type = 0; */
-    /*     file->varlist[i].type_size = 0; */
-    /*     file->varlist[i].use_fill = 0; */
-    /*     file->varlist[i].fillbuf = NULL; */
-    /* } */
     file->mode = mode;
 
     /* Set to true if this task should participate in IO (only true for
@@ -1963,9 +1952,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     file->iotype = *iotype;
     file->iosystem = ios;
     file->mode = mode;
-
-    /* for (int i = 0; i < PIO_MAX_VARS; i++) */
-    /*     file->varlist[i].record = -1; */
 
     /* Set to true if this task should participate in IO (only true
      * for one task with netcdf serial files. */
@@ -2226,7 +2212,7 @@ int openfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
         }
                 
         /* Add to the list of var_desc_t structs for this file. */
-        if ((ierr = add_to_varlist(v, rec_var, &file->varlist2)))
+        if ((ierr = add_to_varlist(v, rec_var, &file->varlist)))
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
         file->nvars++;
     }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1724,17 +1724,17 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     file->iosystem = ios;
     file->iotype = *iotype;
     file->buffer.ioid = -1;
-    for (int i = 0; i < PIO_MAX_VARS; i++)
-    {
-        file->varlist[i].record = -1;
-        file->varlist[i].request = NULL;
-        file->varlist[i].nreqs = 0;
-        file->varlist[i].fillvalue = NULL;
-        file->varlist[i].pio_type = 0;
-        file->varlist[i].type_size = 0;
-        file->varlist[i].use_fill = 0;
-        file->varlist[i].fillbuf = NULL;
-    }
+    /* for (int i = 0; i < PIO_MAX_VARS; i++) */
+    /* { */
+    /*     file->varlist[i].record = -1; */
+    /*     file->varlist[i].request = NULL; */
+    /*     file->varlist[i].nreqs = 0; */
+    /*     file->varlist[i].fillvalue = NULL; */
+    /*     file->varlist[i].pio_type = 0; */
+    /*     file->varlist[i].type_size = 0; */
+    /*     file->varlist[i].use_fill = 0; */
+    /*     file->varlist[i].fillbuf = NULL; */
+    /* } */
     file->mode = mode;
 
     /* Set to true if this task should participate in IO (only true for
@@ -1964,8 +1964,8 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     file->iosystem = ios;
     file->mode = mode;
 
-    for (int i = 0; i < PIO_MAX_VARS; i++)
-        file->varlist[i].record = -1;
+    /* for (int i = 0; i < PIO_MAX_VARS; i++) */
+    /*     file->varlist[i].record = -1; */
 
     /* Set to true if this task should participate in IO (only true
      * for one task with netcdf serial files. */

--- a/tests/cunit/test_pioc_unlim.c
+++ b/tests/cunit/test_pioc_unlim.c
@@ -274,9 +274,13 @@ int test_all(int iosysid, int num_flavors, int *flavor, int my_rank, MPI_Comm te
             /* Look at the internals to check that the frame commands
              * worked. */
             file_desc_t *file;            
+            var_desc_t *vdesc;     /* Contains info about the variable. */
+
             if ((ret = pio_get_file(ncid, &file)))
                 return ret;
-            if (file->varlist[varid].record != 1)
+            if ((ret = get_var_desc(varid, &file->varlist2, &vdesc)))
+                return ret;
+            if (vdesc->record != 1)
                 return ERR_WRONG;
             
             if ((PIOc_closefile(ncid)))

--- a/tests/cunit/test_pioc_unlim.c
+++ b/tests/cunit/test_pioc_unlim.c
@@ -278,7 +278,7 @@ int test_all(int iosysid, int num_flavors, int *flavor, int my_rank, MPI_Comm te
 
             if ((ret = pio_get_file(ncid, &file)))
                 return ret;
-            if ((ret = get_var_desc(varid, &file->varlist2, &vdesc)))
+            if ((ret = get_var_desc(varid, &file->varlist, &vdesc)))
                 return ret;
             if (vdesc->record != 1)
                 return ERR_WRONG;


### PR DESCRIPTION
In this PR I finish changing the var_desc_t information from an array of NC_MAX_VAR, into a linked list.

Fixes #1086.
Fixes #1085.
Fixes #1052.
Fixes #544.

These changes are needed to support proper fill value handling, as in #729, #768, #1037, and #83.

I have merged to develop for testing.

