### PR TITLE
Added test which demonstrates some problems with fill values and mixed types in iodesc

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -526,8 +526,6 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         LOG((3, "allocating multi-buffer"));
         if (!(wmb->next = bget((bufsize)sizeof(wmulti_buffer))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        /* if (!(wmb->next = calloc(1, sizeof(wmulti_buffer)))) */
-        /*     return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__); */
         LOG((3, "allocated multi-buffer"));
 
         /* Set pointer to newly allocated buffer and initialize.*/
@@ -549,17 +547,20 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Try realloc first and call flush if realloc fails. */
     if (arraylen > 0)
     {
-        realloc_data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size);
+        realloc_data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen *
+                               iodesc->mpitype_size);
         if (realloc_data)
         {
             needsflush = 0;
             wmb->data = realloc_data;
-            LOG((2, "realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
+            LOG((2, "realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen *
+                 iodesc->mpitype_size));
         }
         else /* Failed to realloc, but wmb->data is still valid for a flush. */
         {
             needsflush = 1;
-            LOG((2, "realloc failed to get %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
+            LOG((2, "realloc failed to get %ld bytes for data", (1 + wmb->num_arrays) *
+                 arraylen * iodesc->mpitype_size));
         }
     }
 #else
@@ -605,7 +606,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     {
         if (!(wmb->data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size)))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        LOG((2, "after a flush, realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
+        LOG((2, "after a flush, realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen *
+             iodesc->mpitype_size));
     }
 #else
     /* Get memory for data. */

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -464,7 +464,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Info about file we are writing to. */
     io_desc_t *iodesc;     /* The IO description. */
-    var_desc_t *vdesc;    /* Info about the var being written. */
+    var_desc_t *vdesc;     /* Info about the var being written. */
     void *bufptr;          /* A data buffer. */
     MPI_Datatype vtype;    /* The MPI type of the variable. */
     wmulti_buffer *wmb;    /* The write multi buffer for one or more vars. */
@@ -476,7 +476,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     bufsize maxfree;       /* Max amount of free space in buffer. */
 #endif
     int mpierr = MPI_SUCCESS;  /* Return code from MPI functions. */
-    int ierr = PIO_NOERR;  /* Return code. */
+    int ierr = PIO_NOERR;      /* Return code. */
 
     LOG((1, "PIOc_write_darray ncid = %d varid = %d ioid = %d arraylen = %d",
          ncid, varid, ioid, arraylen));
@@ -523,7 +523,6 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (wmb->ioid != ioid || wmb->recordvar != vdesc->rec_var)
     {
         /* Allocate a buffer. */
-        LOG((3, "allocating multi-buffer"));
         if (!(wmb->next = bget((bufsize)sizeof(wmulti_buffer))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
         LOG((3, "allocated multi-buffer"));
@@ -547,20 +546,17 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Try realloc first and call flush if realloc fails. */
     if (arraylen > 0)
     {
-        realloc_data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen *
-                               iodesc->mpitype_size);
+        realloc_data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size);
         if (realloc_data)
         {
             needsflush = 0;
             wmb->data = realloc_data;
-            LOG((2, "realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen *
-                 iodesc->mpitype_size));
+            LOG((2, "realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
         }
         else /* Failed to realloc, but wmb->data is still valid for a flush. */
         {
             needsflush = 1;
-            LOG((2, "realloc failed to get %ld bytes for data", (1 + wmb->num_arrays) *
-                 arraylen * iodesc->mpitype_size));
+            LOG((2, "realloc failed to get %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
         }
     }
 #else
@@ -606,8 +602,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     {
         if (!(wmb->data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size)))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        LOG((2, "after a flush, realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen *
-             iodesc->mpitype_size));
+        LOG((2, "after a flush, realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
     }
 #else
     /* Get memory for data. */

--- a/tests/cunit/CMakeLists.txt
+++ b/tests/cunit/CMakeLists.txt
@@ -71,6 +71,8 @@ if (NOT PIO_USE_MPISERIAL)
   target_link_libraries (test_darray_multivar pioc)
   add_executable (test_darray_multivar2 EXCLUDE_FROM_ALL test_darray_multivar2.c test_common.c)
   target_link_libraries (test_darray_multivar2 pioc)
+  add_executable (test_darray_multivar3 EXCLUDE_FROM_ALL test_darray_multivar3.c test_common.c)
+  target_link_libraries (test_darray_multivar3 pioc)
   add_executable (test_darray_1d EXCLUDE_FROM_ALL test_darray_1d.c test_common.c)
   target_link_libraries (test_darray_1d pioc)  
   add_executable (test_darray_3d EXCLUDE_FROM_ALL test_darray_3d.c test_common.c)
@@ -102,6 +104,7 @@ add_dependencies (tests test_darray)
 add_dependencies (tests test_darray_multi)
 add_dependencies (tests test_darray_multivar)
 add_dependencies (tests test_darray_multivar2)
+add_dependencies (tests test_darray_multivar3)
 add_dependencies (tests test_darray_1d)
 add_dependencies (tests test_darray_3d)
 add_dependencies (tests test_decomp_uneven)
@@ -208,6 +211,10 @@ else ()
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
   add_mpi_test(test_darray_multivar2
     EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_darray_multivar2
+    NUMPROCS ${AT_LEAST_FOUR_TASKS}
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+  add_mpi_test(test_darray_multivar3
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_darray_multivar3
     NUMPROCS ${AT_LEAST_FOUR_TASKS}
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
   add_mpi_test(test_darray_1d

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -208,6 +208,10 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                 /*     if (file_fv_float != custom_fillvalue_float) */
                 /*         return ERR_WRONG; */
                 /* } */
+
+                /* Close the netCDF file. */
+                if ((ret = PIOc_closefile(ncid2)))
+                    ERR(ret);
             }
         }
     }

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -1,0 +1,331 @@
+/*
+ * Tests for PIO distributed arrays.
+ *
+ * @author Ed Hartnett
+ */
+#include <pio.h>
+#include <pio_internal.h>
+#include <pio_tests.h>
+
+/* The number of tasks this test should run on. */
+#define TARGET_NTASKS 4
+
+/* The minimum number of tasks this test should run on. */
+#define MIN_NTASKS 4
+
+/* The name of this test. */
+#define TEST_NAME "test_darray_multivar3"
+
+/* Number of processors that will do IO. */
+#define NUM_IO_PROCS 1
+
+/* Number of computational components to create. */
+#define COMPONENT_COUNT 1
+
+/* The number of dimensions in the example data. In this test, we
+ * are using three-dimensional data. */
+#define NDIM 3
+
+/* But sometimes we need arrays of the non-record dimensions. */
+#define NDIM2 2
+
+/* The length of our sample data along each dimension. */
+#define X_DIM_LEN 4
+#define Y_DIM_LEN 4
+
+/* The number of timesteps of data to write. */
+#define NUM_TIMESTEPS 2
+
+/* Number of variables in the test file. */
+#define NUM_VAR 3
+
+/* Test with and without custom fill value. */
+#define NUM_FV_TESTS 2        
+
+/* The dimension names. */
+char dim_name[NDIM][PIO_MAX_NAME + 1] = {"timestep", "x", "y"};
+
+/* The var names. */
+char var_name[NUM_VAR][PIO_MAX_NAME + 1] = {"Kirk", "Spock", "McCoy"};
+
+/* Length of the dimensions in the sample data. */
+int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
+
+/**
+ * Test the darray functionality. Create a netCDF file with 3
+ * dimensions and 2 variables. One of the vars uses the record
+ * dimension, the other does not. Then use darray to write to them.
+ *
+ * @param iosysid the IO system ID.
+ * @param ioid the ID of the decomposition.
+ * @param num_flavors the number of IOTYPES available in this build.
+ * @param flavor array of available iotypes.
+ * @param my_rank rank of this task.
+ * @param test_comm the communicator that is running this test.
+ * @returns 0 for success, error code otherwise.
+*/
+int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
+                         int my_rank, MPI_Comm test_comm)
+{
+    char filename[PIO_MAX_NAME + 1]; /* Name for the output files. */
+    int dimids[NDIM];     /* The dimension IDs. */
+    int ncid;             /* The ncid of the netCDF file. */
+    int varid[NUM_VAR];   /* The IDs of the netCDF varables. */
+    PIO_Offset arraylen = 3;
+    int custom_fillvalue_int = -TEST_VAL_42;
+    float custom_fillvalue_float = -42.5;
+    int test_data_int[arraylen];
+    float test_data_float[arraylen];
+    int ret;       /* Return code. */
+
+    /* Initialize some data. */
+    for (int f = 0; f < arraylen; f++)
+    {
+        test_data_int[f] = my_rank * 10 + f;
+        test_data_float[f] = my_rank * 10 + f + 0.5;
+    }
+
+    /* Use PIO to create the example file in each of the four
+     * available ways. */
+    for (int fmt = 0; fmt < num_flavors; fmt++)
+    {
+        for (int use_fv = 0; use_fv < NUM_FV_TESTS; use_fv++)
+        {
+            /* Create the filename. */
+            sprintf(filename, "data_%s_iotype_%d_use_fv_%d.nc", TEST_NAME, flavor[fmt], use_fv);
+
+            /* Create the netCDF output file. */
+            printf("rank: %d Creating sample file %s with format %d\n", my_rank, filename,
+                   flavor[fmt]);
+            if ((ret = PIOc_createfile(iosysid, &ncid, &flavor[fmt], filename, PIO_CLOBBER)))
+                ERR(ret);
+
+            /* Define netCDF dimensions and variable. */
+            printf("%d Defining netCDF metadata...\n", my_rank);
+            for (int d = 0; d < NDIM; d++)
+                if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
+                    ERR(ret);
+
+            /* Var 0 does not have a record dim, varid 1 is a record var. */
+            if ((ret = PIOc_def_var(ncid, var_name[0], PIO_INT, NDIM - 1, &dimids[1], &varid[0])))
+                ERR(ret);
+            if ((ret = PIOc_def_var(ncid, var_name[1], PIO_INT, NDIM, dimids, &varid[1])))
+                ERR(ret);
+            if ((ret = PIOc_def_var(ncid, var_name[2], PIO_FLOAT, NDIM, dimids, &varid[2])))
+                ERR(ret);
+
+            /* End define mode. */
+            if ((ret = PIOc_enddef(ncid)))
+                ERR(ret);
+
+            /* Set the value of the record dimension for varid 1 and 2. */
+            if ((ret = PIOc_setframe(ncid, varid[1], 0)))
+                ERR(ret);
+            if ((ret = PIOc_setframe(ncid, varid[2], 0)))
+                ERR(ret);
+
+            int *fvp_int = NULL;
+            float *fvp_float = NULL;
+            if (use_fv)
+            {
+                fvp_int = &custom_fillvalue_int;
+                fvp_float = &custom_fillvalue_float;
+            }
+                
+            /* Write the data. */
+            if ((ret = PIOc_write_darray(ncid, varid[0], ioid, arraylen, test_data_int,
+                                         fvp_int)))
+                ERR(ret);
+            if ((ret = PIOc_write_darray(ncid, varid[1], ioid, arraylen, test_data_int,
+                                         fvp_int)))
+                ERR(ret);
+            if ((ret = PIOc_write_darray(ncid, varid[2], ioid, arraylen, test_data_float,
+                                         fvp_float)))
+                ERR(ret);
+
+            /* Close the netCDF file. */
+            if ((ret = PIOc_closefile(ncid)))
+                ERR(ret);
+
+            /* Check the file contents. */
+            {
+                int ncid2;            /* The ncid of the re-opened netCDF file. */
+                int test_data_int_in[arraylen];
+                float test_data_float_in[arraylen];
+                        
+                /* Reopen the file. */
+                if ((ret = PIOc_openfile(iosysid, &ncid2, &flavor[fmt], filename, PIO_NOWRITE)))
+                    ERR(ret);
+            
+                /* Read the var data with read_darray(). */
+                for (int v = 0; v < NUM_VAR; v++)
+                {
+                    if (v < NUM_VAR - 1)
+                    {
+                        /* Read the data. */
+                        if ((ret = PIOc_read_darray(ncid2, varid[v], ioid, arraylen, test_data_int_in)))
+                            ERR(ret);
+                
+                        /* Check the results. */
+                        for (int f = 0; f < arraylen; f++)
+                            if (test_data_int_in[f] != test_data_int[f])
+                                return ERR_WRONG;
+                    }
+                    else
+                    {
+                        /* Read the data. */
+                        if ((ret = PIOc_read_darray(ncid2, varid[v], ioid, arraylen, test_data_float_in)))
+                            ERR(ret);
+                
+                        /* Check the results. */
+                        for (int f = 0; f < arraylen; f++)
+                            if (test_data_float_in[f] != test_data_float[f])
+                                return ERR_WRONG;
+                    }
+                } /* next var */
+
+                /* Now read the fill values. */
+                PIO_Offset idx[NDIM] = {0, 0, 3};
+                int file_fv_int;
+                float file_fv_float;
+
+                /* Check an int fill value. */
+                if ((ret = PIOc_get_var1_int(ncid2, 1, idx, &file_fv_int)))
+                    return ret;
+                printf("file_fv_int = %d\n", file_fv_int);
+                if (use_fv)
+                {
+                    if (file_fv_int != custom_fillvalue_int)
+                        return ERR_WRONG;
+                }
+
+                /* Check the float fill value. */
+                if ((ret = PIOc_get_var1_float(ncid2, 2, idx, &file_fv_float)))
+                    return ret;
+                printf("file_fv_float = %g\n", file_fv_float);
+                /* if (use_fv) */
+                /* { */
+                /*     if (file_fv_float != custom_fillvalue_float) */
+                /*         return ERR_WRONG; */
+                /* } */
+            }
+        }
+    }
+
+    return PIO_NOERR;
+}
+
+/* Create the decomposition to divide the 3-dimensional sample data
+ * between the 4 tasks. For the purposes of decomposition we are only
+ * concerned with 2 dimensions - we ignore the unlimited dimension. We
+ * will leave some gaps in the decomposition, to test fill values.
+ *
+ * @param ntasks the number of available tasks
+ * @param my_rank rank of this task.
+ * @param iosysid the IO system ID.
+ * @param dim_len_2d an array of length 2 with the dim lengths.
+ * @param ioid a pointer that gets the ID of this decomposition.
+ * @param pio_type the data type to use for the decomposition.
+ * @returns 0 for success, error code otherwise.
+ **/
+int create_dcomp_gaps(int ntasks, int my_rank, int iosysid, int *dim_len_2d,
+                      int *ioid, int pio_type)
+{
+    PIO_Offset elements_per_pe;     /* Array elements per processing unit. */
+    PIO_Offset *compdof;  /* The decomposition mapping. */
+    int ret;
+
+    /* How many data elements per task? In this example we will end up
+     * with 3. */
+    elements_per_pe = (dim_len_2d[0] * dim_len_2d[1] / ntasks) - 1;
+
+    /* Allocate space for the decomposition array. */
+    if (!(compdof = malloc(elements_per_pe * sizeof(PIO_Offset))))
+        return PIO_ENOMEM;
+
+    /* Describe the decomposition. This is a 1-based array, so add 1! */
+    for (int i = 0; i < elements_per_pe; i++)
+        compdof[i] = my_rank * (elements_per_pe + 1) + i + 1;
+
+    /* Create the PIO decomposition for this test. */
+    printf("%d Creating decomposition elements_per_pe = %lld\n", my_rank, elements_per_pe);
+    if ((ret = PIOc_InitDecomp(iosysid, pio_type, NDIM2, dim_len_2d, elements_per_pe,
+                               compdof, ioid, NULL, NULL, NULL)))
+        ERR(ret);
+
+    printf("%d decomposition initialized.\n", my_rank);
+
+    /* Free the mapping. */
+    free(compdof);
+
+    return 0;
+}
+
+/* Run tests for darray functions. */
+int main(int argc, char **argv)
+{
+    int my_rank;
+    int ntasks;
+    int num_flavors;         /* Number of PIO netCDF flavors in this build. */
+    int flavor[NUM_FLAVORS]; /* iotypes for the supported netCDF IO flavors. */
+    MPI_Comm test_comm;      /* A communicator for this test. */
+    int ioid;
+    int dim_len_2d[NDIM2] = {X_DIM_LEN, Y_DIM_LEN};
+    int ret;                 /* Return code. */
+
+    /* Initialize test. */
+    if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, MIN_NTASKS, MIN_NTASKS,
+                              3, &test_comm)))
+        ERR(ERR_INIT);
+
+    if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))
+        return ret;
+
+    /* Only do something on max_ntasks tasks. */
+    if (my_rank < TARGET_NTASKS)
+    {
+        int iosysid;              /* The ID for the parallel I/O system. */
+        int ioproc_stride = 1;    /* Stride in the mpi rank between io tasks. */
+        int ioproc_start = 0;     /* Zero based rank of first processor to be used for I/O. */
+        int ret;                  /* Return code. */
+
+        /* Figure out iotypes. */
+        if ((ret = get_iotypes(&num_flavors, flavor)))
+            ERR(ret);
+        printf("Runnings tests for %d flavors\n", num_flavors);
+
+        /* Initialize the PIO IO system. This specifies how
+         * many and which processors are involved in I/O. */
+        if ((ret = PIOc_Init_Intracomm(test_comm, TARGET_NTASKS, ioproc_stride,
+                                       ioproc_start, PIO_REARR_SUBSET, &iosysid)))
+            return ret;
+
+        /* Decompose the data over the tasks. */
+        if ((ret = create_dcomp_gaps(TARGET_NTASKS, my_rank, iosysid, dim_len_2d,
+                                             &ioid, PIO_INT)))
+            return ret;
+    
+        /* Run the multivar darray tests. */
+        printf("%d Running tests...\n", my_rank);
+        if ((ret = test_multivar_darray(iosysid, ioid, num_flavors, flavor, my_rank,
+                                        test_comm)))
+            return ret;
+    
+        /* Free the PIO decomposition. */
+        if ((ret = PIOc_freedecomp(iosysid, ioid)))
+            ERR(ret);
+
+        /* Finalize PIO system. */
+        if ((ret = PIOc_finalize(iosysid)))
+            return ret;
+
+    } /* endif my_rank < TARGET_NTASKS */
+
+    /* Finalize the MPI library. */
+    printf("%d %s Finalizing...\n", my_rank, TEST_NAME);
+    if ((ret = pio_test_finalize(&test_comm)))
+        return ret;
+
+    printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
+    return 0;
+}


### PR DESCRIPTION
See #1037 for discussion.

This PR adds a test that demonstrates problem. Code in test that causes error is commented out so that CI can continue to pass.

I have merged with develop for testing. Current uses of PIO should be worried about this bug, I think. If you mix types in your iodesc, you may have problems in your output data.

Short-term fix is to disable writing in an iodesc defined for another type.

Long-term fix is to move the type information out of the decomposition, which would be type-neutral. The code needs to be modified to use the correct fill values regardless of the decomposition. But this is a fair amount of work.