### PR TITLE
darray write functions now check for correct type

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -132,6 +132,9 @@ typedef struct var_desc_t
      * missing sections of data when using the subset rearranger. */
     void *fillbuf;
 
+    /** The PIO data type. */
+    int pio_type;
+
     /** Pointer to next var in list. */
     struct var_desc_t *next;
 } var_desc_t;
@@ -535,7 +538,7 @@ typedef struct file_desc_t
     /** The ncid that will be returned to the user. */
     int pio_ncid;
 
-    /** The PIO_TYPE value that was used to open this file. */
+    /** The IOTYPE value that was used to open this file. */
     int iotype;
 
     /** List of variables in this file. */
@@ -553,6 +556,9 @@ typedef struct file_desc_t
 
     /** Data buffer for this file. */
     void *iobuf;
+
+    /** PIO data type. */
+    int pio_type;
 
     /** Pointer to the next file_desc_t in the list of open files. */
     struct file_desc_t *next;

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -139,6 +139,17 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     pioassert(iodesc->rearranger == PIO_REARR_BOX || iodesc->rearranger == PIO_REARR_SUBSET,
               "unknown rearranger", __FILE__, __LINE__);
 
+    /* Check the types of all the vars. They must match the type of
+     * the decomposition. */
+    for (int v = 0; v < nvars; v++)
+    {
+        var_desc_t *vdesc;
+        if ((ierr = get_var_desc(varids[v], &file->varlist, &vdesc)))
+            return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        if (vdesc->pio_type != iodesc->piotype)
+            return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
+    }
+
     /* Get a pointer to the variable info for the first variable. */
     if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc0)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);        

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -509,6 +509,11 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);        
 
+    /* If the type of the var doesn't match the type of the
+     * decomposition, return an error. */
+    if (iodesc->piotype != vdesc->pio_type)
+        return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);        
+
     /* If we don't know the fill value for this var, get it. */
     if (!vdesc->fillvalue)
         if ((ierr = find_var_fillvalue(file, varid, vdesc)))

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -113,7 +113,7 @@ extern "C" {
     int pio_delete_file_from_list(int ncid);
     void pio_add_to_file_list(file_desc_t *file);
     /* Add a var_desc_t to a varlist. */
-    int add_to_varlist(int varid, int rec_var, var_desc_t **varlist);
+    int add_to_varlist(int varid, int rec_var, int pio_type, var_desc_t **varlist);
 
     /* Find a var_desc_t in a varlist. */
     int get_var_desc(int varid, var_desc_t **varlist, var_desc_t **var_desc);

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -338,7 +338,7 @@ int pio_delete_iodesc_from_list(int ioid)
  * @returns 0 for success, error code otherwise.
  * @author Ed Hartnett
  */
-int add_to_varlist(int varid, int rec_var, var_desc_t **varlist)
+int add_to_varlist(int varid, int rec_var, int pio_type, var_desc_t **varlist)
 {
     var_desc_t *var_desc;
 
@@ -352,6 +352,7 @@ int add_to_varlist(int varid, int rec_var, var_desc_t **varlist)
     /* Set values. */
     var_desc->varid = varid;
     var_desc->rec_var = rec_var;
+    var_desc->pio_type = pio_type;
 
     /* Add to list. */
     if (*varlist)

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2120,7 +2120,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         *varidp = varid;
 
     /* Add to the list of var_desc_t structs for this file. */
-    if ((ierr = add_to_varlist(varid, rec_var, &file->varlist)))
+    if ((ierr = add_to_varlist(varid, rec_var, xtype, &file->varlist)))
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     file->nvars++;
  

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2137,7 +2137,7 @@ int openfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
                  int mode, int retry)
 {
     int nvars;             /* The number of vars in the file. */
-    int nunlimdims;         /* The number of unlimited dimensions. */
+    int nunlimdims;        /* The number of unlimited dimensions. */
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */
@@ -2171,10 +2171,11 @@ int openfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
     for (int v = 0; v < nvars; v++)
     {
         int rec_var = 0; /* Does var use unlimited dimension? */
-        int var_ndims;
+        int pio_type;    /* Type of this var. */
+        int var_ndims;   /* Number of dims for this var. */
 
-        /* How many dims for this var? */
-        if ((ierr = PIOc_inq_varndims(*ncidp, v, &var_ndims)))
+        /* Find type of the var and number of dims. */
+        if ((ierr = PIOc_inq_var(*ncidp, v, NULL, &pio_type, &var_ndims, NULL, NULL)))
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 
         /* What are the dimids associated with this var? */
@@ -2212,7 +2213,7 @@ int openfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
         }
                 
         /* Add to the list of var_desc_t structs for this file. */
-        if ((ierr = add_to_varlist(v, rec_var, &file->varlist)))
+        if ((ierr = add_to_varlist(v, rec_var, pio_type, &file->varlist)))
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
         file->nvars++;
     }

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -149,6 +149,14 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                                   fvp_float) != PIO_EINVAL)
                 ERR(ERR_WRONG);
 
+            /* This should also fail, because it mixes an int and a
+             * float. */
+            int frame[NUM_VAR] = {0, 0, 0};
+            if (PIOc_write_darray_multi(ncid, varid, ioid, NUM_VAR, arraylen * NUM_VAR, test_data_float,
+                                        frame, NULL, 0) != PIO_EINVAL)
+                ERR(ERR_WRONG);
+            
+
             /* Close the netCDF file. */
             if ((ret = PIOc_closefile(ncid)))
                 ERR(ret);

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -1,5 +1,7 @@
 /*
- * Tests for PIO distributed arrays.
+ * Tests for PIO distributed arrays. This test demonstrates problems
+ * with the fill value that can arrise from mixing types in a
+ * decomposition.
  *
  * @author Ed Hartnett
  */
@@ -139,9 +141,13 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             if ((ret = PIOc_write_darray(ncid, varid[1], ioid, arraylen, test_data_int,
                                          fvp_int)))
                 ERR(ret);
-            if ((ret = PIOc_write_darray(ncid, varid[2], ioid, arraylen, test_data_float,
-                                         fvp_float)))
-                ERR(ret);
+
+            /* This should not work, since the type of the var is
+             * PIO_FLOAT, and the type if the decomposition is
+             * PIO_INT. */
+            if (PIOc_write_darray(ncid, varid[2], ioid, arraylen, test_data_float,
+                                  fvp_float) != PIO_EINVAL)
+                ERR(ERR_WRONG);
 
             /* Close the netCDF file. */
             if ((ret = PIOc_closefile(ncid)))
@@ -151,7 +157,7 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             {
                 int ncid2;            /* The ncid of the re-opened netCDF file. */
                 int test_data_int_in[arraylen];
-                float test_data_float_in[arraylen];
+                /* float test_data_float_in[arraylen]; */
                         
                 /* Reopen the file. */
                 if ((ret = PIOc_openfile(iosysid, &ncid2, &flavor[fmt], filename, PIO_NOWRITE)))
@@ -169,17 +175,6 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                         /* Check the results. */
                         for (int f = 0; f < arraylen; f++)
                             if (test_data_int_in[f] != test_data_int[f])
-                                return ERR_WRONG;
-                    }
-                    else
-                    {
-                        /* Read the data. */
-                        if ((ret = PIOc_read_darray(ncid2, varid[v], ioid, arraylen, test_data_float_in)))
-                            ERR(ret);
-                
-                        /* Check the results. */
-                        for (int f = 0; f < arraylen; f++)
-                            if (test_data_float_in[f] != test_data_float[f])
                                 return ERR_WRONG;
                     }
                 } /* next var */

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -239,13 +239,13 @@ int test_varlists()
         return ERR_WRONG;
 
     /* Add a var to the list. */
-    if ((ret = add_to_varlist(0, 1, &varlist)))
+    if ((ret = add_to_varlist(0, 1, PIO_INT, &varlist)))
         return ret;
 
     /* Find that var_desc_t. */
     if ((ret = get_var_desc(0, &varlist, &var_desc)))
         return ret;
-    if (var_desc->varid != 0 || !var_desc->rec_var)
+    if (var_desc->varid != 0 || !var_desc->rec_var || var_desc->pio_type != PIO_INT)
         return ERR_WRONG;
 
     /* Try to delete a non-existing var - should fail. */
@@ -275,27 +275,27 @@ int test_varlists2()
     int ret;
 
     /* Add some vars to the list. */
-    if ((ret = add_to_varlist(0, 1, &varlist)))
+    if ((ret = add_to_varlist(0, 1, PIO_INT, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(1, 0, &varlist)))
+    if ((ret = add_to_varlist(1, 0, PIO_DOUBLE, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(2, 1, &varlist)))
+    if ((ret = add_to_varlist(2, 1, PIO_BYTE, &varlist)))
         return ret;
 
     /* Find those var_desc_t. */
     if ((ret = get_var_desc(0, &varlist, &var_desc)))
         return ret;
-    if (var_desc->varid != 0 || !var_desc->rec_var)
+    if (var_desc->varid != 0 || !var_desc->rec_var || var_desc->pio_type != PIO_INT)
         return ERR_WRONG;
 
     if ((ret = get_var_desc(1, &varlist, &var_desc)))
         return ret;
-    if (var_desc->varid != 1 || var_desc->rec_var)
+    if (var_desc->varid != 1 || var_desc->rec_var || var_desc->pio_type != PIO_DOUBLE)
         return ERR_WRONG;
 
     if ((ret = get_var_desc(2, &varlist, &var_desc)))
         return ret;
-    if (var_desc->varid != 2 || !var_desc->rec_var)
+    if (var_desc->varid != 2 || !var_desc->rec_var || var_desc->pio_type != PIO_BYTE)
         return ERR_WRONG;
 
     /* Try to delete a non-existing var - should fail. */
@@ -344,13 +344,13 @@ int test_varlists3()
     int ret;
 
     /* Add some vars to the list. */
-    if ((ret = add_to_varlist(0, 1, &varlist)))
+    if ((ret = add_to_varlist(0, 1, PIO_INT, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(1, 0, &varlist)))
+    if ((ret = add_to_varlist(1, 0, PIO_INT, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(2, 1, &varlist)))
+    if ((ret = add_to_varlist(2, 1, PIO_INT, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(3, 0, &varlist)))
+    if ((ret = add_to_varlist(3, 0, PIO_INT, &varlist)))
         return ret;
 
     /* Delete one of the vars. */


### PR DESCRIPTION
Fixes #1037.
Fixes #1034.

Now return error if user calls PIOc_write_darray() or PIOc_write_darray_multi() for vars with type that does not match decomposition type.

Someday we hope to relax this restriction. (See #934).

I have merged to develop for testing.