### PR TITLE
turned call to PIOc_write_nc_decomp() back on

### DIFF
--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -228,8 +228,8 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm, MPI_Comm
         ERR(ret);
 
     /* Write the decomp file (on appropriate tasks). */
-    /* if ((ret = PIOc_write_nc_decomp(iosysid, decomp_filename, 0, ioid, NULL, NULL, 0))) */
-    /*     return ret; */
+    if ((ret = PIOc_write_nc_decomp(iosysid, decomp_filename, 0, ioid, NULL, NULL, 0)))
+        return ret;
 
     int fortran_order;
     int ioid2;


### PR DESCRIPTION
Fixes #1106.

I have merged to develop for testing.