### PR TITLE
Added writable, removed mode flag from file_desc_t, fixed PIOc_inq_var_fill()

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -550,6 +550,9 @@ typedef struct file_desc_t
     /** Mode used when file was opened. */
     int mode;
 
+    /** True if file can be written to. */
+    int writable;
+
     /** The wmulti_buffer is used to aggregate multiple variables with
      * the same communication pattern prior to a write. */
     struct wmulti_buffer buffer;

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -547,9 +547,6 @@ typedef struct file_desc_t
     /** Number of variables. */
     int nvars;
 
-    /** Mode used when file was opened. */
-    int mode;
-
     /** True if file can be written to. */
     int writable;
 

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -127,7 +127,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
          ncid, ioid, nvars, arraylen, flushtodisk));
 
     /* Check that we can write to this file. */
-    if (!(file->mode & PIO_WRITE))
+    if (!file->writable)
         return pio_err(ios, file, PIO_EPERM, __FILE__, __LINE__);
 
     /* Get iodesc. */
@@ -496,7 +496,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     ios = file->iosystem;
 
     /* Can we write to this file? */
-    if (!(file->mode & PIO_WRITE))
+    if (!file->writable)
         return pio_err(ios, file, PIO_EPERM, __FILE__, __LINE__);
 
     /* Get decomposition information. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -210,7 +210,7 @@ int PIOc_closefile(int ncid)
     /* Sync changes before closing on all tasks if async is not in
      * use, but only on non-IO tasks if async is in use. */
     if (!ios->async || !ios->ioproc)
-        if (file->mode & PIO_WRITE)
+        if (file->writable)
             PIOc_sync(ncid);
 
     /* If async is in use and this is a comp tasks, then the compmaster
@@ -254,9 +254,8 @@ int PIOc_closefile(int ncid)
             break;
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-            if ((file->mode & PIO_WRITE)){
+            if (file->writable)
                 ierr = ncmpi_buffer_detach(file->fh);
-            }
             ierr = ncmpi_close(file->fh);
             break;
 #endif
@@ -379,7 +378,7 @@ int PIOc_sync(int ncid)
     /* Flush data buffers on computational tasks. */
     if (!ios->async || !ios->ioproc)
     {
-        if (file->mode & PIO_WRITE)
+        if (file->writable)
         {
             wmulti_buffer *wmb, *twmb;
 
@@ -428,7 +427,7 @@ int PIOc_sync(int ncid)
     }
 
     /* Call the sync function on IO tasks. */
-    if (file->mode & PIO_WRITE)
+    if (file->writable)
     {
         if (ios->ioproc)
         {

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2367,9 +2367,18 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
             /* Get the file-level fill mode. */
             if (no_fill)
             {
-                ierr = nc_set_fill(file->fh, NC_NOFILL, no_fill);
-                if (!ierr)
-                    ierr = nc_set_fill(file->fh, *no_fill, NULL);
+                if (file->writable)
+                {
+                    ierr = nc_set_fill(file->fh, NC_NOFILL, no_fill);
+                    if (!ierr)
+                        ierr = nc_set_fill(file->fh, *no_fill, NULL);
+                }
+                else
+                {
+                    /* pnetcdf and netCDF-4 return PIO_FILL for read-only
+                     * files. */
+                    *no_fill = PIO_FILL;
+                }
             }
 
             if (!ierr && fill_valuep)

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -150,7 +150,7 @@ int check_darray_file(int iosysid, int ntasks, int my_rank, char *filename)
     assert(filename);
 
     /* Open the file. */
-    if ((ret = PIOc_open(iosysid, filename, NC_NOWRITE, &ncid)))
+    if ((ret = PIOc_open(iosysid, filename, PIO_NOWRITE, &ncid)))
         ERR(ret);
 
     /* Check metadata. */
@@ -169,6 +169,13 @@ int check_darray_file(int iosysid, int ntasks, int my_rank, char *filename)
 
     /* Read data. */
     if ((ret = PIOc_read_darray(ncid, 0, ioid, arraylen, &data_in)))
+        ERR(ret);
+
+    /* Try to write, but this will fail because file was opened with
+     * NOWRITE. */
+    float fillvalue = 0.0;
+    float test_data =  my_rank * 10;
+    if (PIOc_write_darray(ncid, 0, ioid, arraylen, &test_data, &fillvalue) != PIO_EPERM)
         ERR(ret);
 
     /* Check data. */

--- a/tests/cunit/test_pioc_fill.c
+++ b/tests/cunit/test_pioc_fill.c
@@ -47,6 +47,9 @@ int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN};
 #define DIM_NAME "SonsOfTheDesert"
 #define DIM_LEN 1
 
+/* Test openfile with PIO_WRITE/PIO_NOWRITE. */
+#define NUM_OPEN_MODE_TESTS 2
+
 /* Some sample data values to write. */
 char text[] = "hi";
 char char_data = 2;
@@ -156,7 +159,7 @@ int putget_write_vara(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count
     return 0;
 }
 
-int check_fill(int ncid, int *varid, int flavor, int default_fill, int my_rank)
+int check_fill(int ncid, int *varid, int flavor, int default_fill, int nowrite, int my_rank)
 {
     int fill_mode;
     char char_fill_value_in;
@@ -176,39 +179,40 @@ int check_fill(int ncid, int *varid, int flavor, int default_fill, int my_rank)
 
     if ((ret = PIOc_inq_var_fill(ncid, varid[0], &fill_mode, &byte_fill_value_in)))
         ERR(ret);
-    printf("byte_fill_value_in = %d\n", (int)byte_fill_value_in);
-    if (fill_mode != NC_FILL || byte_fill_value_in != (default_fill ? NC_FILL_BYTE : byte_fill_value))
+    printf("nowrite = %d PIO_FILL = %d fill_mode = %d byte_fill_value_in = %d\n",
+           nowrite, PIO_FILL, fill_mode, (int)byte_fill_value_in);
+    if (fill_mode != PIO_FILL || byte_fill_value_in != (default_fill ? NC_FILL_BYTE : byte_fill_value))
         ERR(ERR_WRONG);
     fill_mode = -99;
 
     if ((ret = PIOc_inq_var_fill(ncid, varid[1], &fill_mode, &char_fill_value_in)))
         ERR(ret);
-    if (fill_mode != NC_FILL || char_fill_value_in != (default_fill ? NC_FILL_CHAR : char_fill_value))
+    if (fill_mode != PIO_FILL || char_fill_value_in != (default_fill ? NC_FILL_CHAR : char_fill_value))
         ERR(ERR_WRONG);
     fill_mode = -99;
 
     if ((ret = PIOc_inq_var_fill(ncid, varid[2], &fill_mode, &short_fill_value_in)))
         ERR(ret);
-    if (fill_mode != NC_FILL || short_fill_value_in != (default_fill ? NC_FILL_SHORT : short_fill_value))
+    if (fill_mode != PIO_FILL || short_fill_value_in != (default_fill ? NC_FILL_SHORT : short_fill_value))
         ERR(ERR_WRONG);
     fill_mode = -99;
 
     if ((ret = PIOc_inq_var_fill(ncid, varid[3], &fill_mode, &int_fill_value_in)))
         ERR(ret);
     printf("int_fill_value_in = %d\n", int_fill_value_in);
-    if (fill_mode != NC_FILL || int_fill_value_in != (default_fill ? NC_FILL_INT : int_fill_value))
+    if (fill_mode != PIO_FILL || int_fill_value_in != (default_fill ? NC_FILL_INT : int_fill_value))
         ERR(ERR_WRONG);
     fill_mode = -99;
 
     if ((ret = PIOc_inq_var_fill(ncid, varid[4], &fill_mode, &float_fill_value_in)))
         ERR(ret);
-    if (fill_mode != NC_FILL || float_fill_value_in != (default_fill ? NC_FILL_FLOAT : float_fill_value))
+    if (fill_mode != PIO_FILL || float_fill_value_in != (default_fill ? NC_FILL_FLOAT : float_fill_value))
         ERR(ERR_WRONG);
     fill_mode = -99;
 
     if ((ret = PIOc_inq_var_fill(ncid, varid[5], &fill_mode, &double_fill_value_in)))
         ERR(ret);
-    if (fill_mode != NC_FILL || double_fill_value_in != (default_fill ? NC_FILL_DOUBLE : double_fill_value))
+    if (fill_mode != PIO_FILL || double_fill_value_in != (default_fill ? NC_FILL_DOUBLE : double_fill_value))
         ERR(ERR_WRONG);
     fill_mode = -99;
 
@@ -216,31 +220,31 @@ int check_fill(int ncid, int *varid, int flavor, int default_fill, int my_rank)
     {
         if ((ret = PIOc_inq_var_fill(ncid, varid[6], &fill_mode, &ubyte_fill_value_in)))
             ERR(ret);
-        if (fill_mode != NC_FILL || ubyte_fill_value_in != (default_fill ? NC_FILL_UBYTE : ubyte_fill_value))
+        if (fill_mode != PIO_FILL || ubyte_fill_value_in != (default_fill ? NC_FILL_UBYTE : ubyte_fill_value))
             ERR(ERR_WRONG);
         fill_mode = -99;
 
         if ((ret = PIOc_inq_var_fill(ncid, varid[7], &fill_mode, &ushort_fill_value_in)))
             ERR(ret);
-        if (fill_mode != NC_FILL || ushort_fill_value_in != (default_fill ? NC_FILL_USHORT : ushort_fill_value))
+        if (fill_mode != PIO_FILL || ushort_fill_value_in != (default_fill ? NC_FILL_USHORT : ushort_fill_value))
             ERR(ERR_WRONG);
         fill_mode = -99;
 
         if ((ret = PIOc_inq_var_fill(ncid, varid[8], &fill_mode, &uint_fill_value_in)))
             ERR(ret);
-        if (fill_mode != NC_FILL || uint_fill_value_in != (default_fill ? NC_FILL_UINT : uint_fill_value))
+        if (fill_mode != PIO_FILL || uint_fill_value_in != (default_fill ? NC_FILL_UINT : uint_fill_value))
             ERR(ERR_WRONG);
         fill_mode = -99;
 
         if ((ret = PIOc_inq_var_fill(ncid, varid[9], &fill_mode, &int64_fill_value_in)))
             ERR(ret);
-        if (fill_mode != NC_FILL || int64_fill_value_in != (default_fill ? NC_FILL_INT64 : int64_fill_value))
+        if (fill_mode != PIO_FILL || int64_fill_value_in != (default_fill ? NC_FILL_INT64 : int64_fill_value))
             ERR(ERR_WRONG);
         fill_mode = -99;
 
         if ((ret = PIOc_inq_var_fill(ncid, varid[10], &fill_mode, &uint64_fill_value_in)))
             ERR(ret);
-        if (fill_mode != NC_FILL || uint64_fill_value_in != (default_fill ? NC_FILL_UINT64 : uint64_fill_value))
+        if (fill_mode != PIO_FILL || uint64_fill_value_in != (default_fill ? NC_FILL_UINT64 : uint64_fill_value))
             ERR(ERR_WRONG);
         fill_mode = -99;
     }
@@ -250,7 +254,7 @@ int check_fill(int ncid, int *varid, int flavor, int default_fill, int my_rank)
 
 /* Use the vara functions to read some data from an open test file. */
 int putget_read_vara(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
-                     int default_fill, int flavor, int my_rank)
+                     int default_fill, int flavor, int nowrite, int my_rank)
 {
     signed char byte_array_in[X_DIM_LEN/2][Y_DIM_LEN];
     char text_array_in[X_DIM_LEN/2][Y_DIM_LEN];
@@ -328,7 +332,7 @@ int putget_read_vara(int ncid, int *varid, PIO_Offset *start, PIO_Offset *count,
     }
 
     /* Check some fill value stuff. */
-    if ((ret = check_fill(ncid, varid, flavor, default_fill, my_rank)))
+    if ((ret = check_fill(ncid, varid, flavor, default_fill, nowrite, my_rank)))
         ERR(ret);
 
     return 0;
@@ -577,7 +581,7 @@ int test_fill(int iosysid, int num_flavors, int *flavor, int my_rank,
                 ERR(ret);
 
             /* Use the vara functions to read some data. */
-            if ((ret = putget_read_vara(ncid, varid, start, count, default_fill, flavor[fmt], my_rank)))
+            if ((ret = putget_read_vara(ncid, varid, start, count, default_fill, flavor[fmt], 0, my_rank)))
                 ERR(ret);
 
             /* Close the netCDF file. */
@@ -585,23 +589,28 @@ int test_fill(int iosysid, int num_flavors, int *flavor, int my_rank,
                 ERR(ret);
 
             /* Access to read it. */
-            printf("about to try to open file %s\n", filename);
-            if ((ret = PIOc_openfile(iosysid, &ncid, &(flavor[fmt]), filename, PIO_WRITE)))
-                ERR(ret);
-
-            /* Use the vara functions to read some data. */
-            if ((ret = putget_read_vara(ncid, varid, start, count, default_fill, flavor[fmt], my_rank)))
-                ERR(ret);
-
-            /* Use the vara functions to read some data which are just fill values. */
-            start[0] = 0;
-            if ((ret = putget_read_vara_fill(ncid, varid, start, count, default_fill, flavor[fmt], my_rank)))
-                ERR(ret);
-
-            /* Close the netCDF file. */
-            if ((ret = PIOc_closefile(ncid)))
-                ERR(ret);
-
+            for (int omt = 0; omt < NUM_OPEN_MODE_TESTS; omt++)
+            {
+                int omode = omt ? PIO_NOWRITE : PIO_WRITE;
+                
+                printf("about to try to open file %s\n", filename);
+                if ((ret = PIOc_openfile(iosysid, &ncid, &(flavor[fmt]), filename, omode)))
+                    ERR(ret);
+                
+                /* Use the vara functions to read some data. */
+                start[0] = 1;
+                if ((ret = putget_read_vara(ncid, varid, start, count, default_fill, flavor[fmt], omt, my_rank)))
+                    ERR(ret);
+                
+                /* Use the vara functions to read some data which are just fill values. */
+                start[0] = 0;
+                if ((ret = putget_read_vara_fill(ncid, varid, start, count, default_fill, flavor[fmt], my_rank)))
+                    ERR(ret);
+                
+                /* Close the netCDF file. */
+                if ((ret = PIOc_closefile(ncid)))
+                    ERR(ret);
+            } /* next open mode test */
         } /* next flavor */
     }
 
@@ -812,7 +821,7 @@ int main(int argc, char **argv)
     init_arrays();
 
     /* Change the 5th arg to 3 to turn on logging. */
-    if ((ret = run_test_main(argc, argv, MIN_NTASKS, TARGET_NTASKS, 0,
+    if ((ret = run_test_main(argc, argv, MIN_NTASKS, TARGET_NTASKS, 3,
                              TEST_NAME, dim_len, COMPONENT_COUNT, NUM_IO_PROCS)))
         return ret;
 


### PR DESCRIPTION
Turns out the only reason we were remembering the mode from create/open was to know if the file was writable.

I have removed mode from file_desc_t and added field writable instead.

Fixes #1119.
Fixes #1113.

I will merge to develop for testing.