### PR TITLE
fixed tests that were providing incorrect fill value for write_darray()

### DIFF
--- a/tests/cunit/test_darray_multivar.c
+++ b/tests/cunit/test_darray_multivar.c
@@ -315,7 +315,8 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             /* Write the data. */
             for (int v = 0; v < NUM_VAR; v++)
             {
-                if ((ret = PIOc_write_darray(ncid, varid[v], ioid, arraylen, test_data, fillvalue)))
+                void *fp = use_fill ? fillvalue : NULL;
+                if ((ret = PIOc_write_darray(ncid, varid[v], ioid, arraylen, test_data, fp)))
                     ERR(ret);
 
                 /* For the first test case we just write the first variable. */

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -114,6 +114,14 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             if ((ret = PIOc_def_var(ncid, var_name[2], PIO_FLOAT, NDIM, dimids, &varid[2])))
                 ERR(ret);
 
+            /* Set the custom fill values. */
+            if ((ret = PIOc_def_var_fill(ncid, varid[0], 0, &custom_fillvalue_int))) 
+                ERR(ret);
+            if ((ret = PIOc_def_var_fill(ncid, varid[1], 0, &custom_fillvalue_int))) 
+                ERR(ret);
+            if ((ret = PIOc_def_var_fill(ncid, varid[2], 0, &custom_fillvalue_float))) 
+                ERR(ret);
+
             /* End define mode. */
             if ((ret = PIOc_enddef(ncid)))
                 ERR(ret);

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -233,7 +233,7 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
 
         /* Write some data. */
         PIO_Offset arraylen = 1;
-        float fillvalue = 0.0;
+        float fillvalue = PIO_FILL_FLOAT;
         float *fillvaluep = fv ? &fillvalue : NULL;
         float test_data[arraylen];
         for (int f = 0; f < arraylen; f++)


### PR DESCRIPTION
fixed tests that were providing incorrect fill value for write_darray()

Fixes #1164.
Part of #83.

I will merge to develop for testing.