### PR TITLE
Fix problem with openfile and variable metadata

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -35,7 +35,7 @@ int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
 {
     LOG((1, "PIOc_openfile iosysid %d *iotype %d filename %s mode %d", iosysid,
          iotype ? *iotype: 0, filename, mode));
-    return openfile_int(iosysid, ncidp, iotype, filename, mode, 1);
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1);
 }
 
 /**
@@ -62,7 +62,7 @@ int PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
 {
     LOG((1, "PIOc_openfile2 iosysid %d *iotype %d filename %s mode %d", iosysid,
          iotype ? *iotype : 0, filename, mode));
-    return openfile_int(iosysid, ncidp, iotype, filename, mode, 0);
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 0);
 }
 
 /**

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -102,7 +102,7 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
 
     /* Open the file. If the open fails, do not retry as serial
      * netCDF. Just return the error code. */
-    return openfile_int(iosysid, ncidp, &iotype, path, mode, 0);
+    return PIOc_openfile_retry(iosysid, ncidp, &iotype, path, mode, 0);
 }
 
 /**

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -114,8 +114,8 @@ extern "C" {
     int pio_delete_file_from_list(int ncid);
     void pio_add_to_file_list(file_desc_t *file);
     /* Add a var_desc_t to a varlist. */
-    int add_to_varlist(int varid, int rec_var, int pio_type, int pio_type_size, MPI_Datatype mpi_type,
-                       int mpi_type_size, var_desc_t **varlist);
+    int add_to_varlist(int varid, int rec_var, int pio_type, int pio_type_size,
+                       MPI_Datatype mpi_type, int mpi_type_size, var_desc_t **varlist);
 
     /* Find a var_desc_t in a varlist. */
     int get_var_desc(int varid, var_desc_t **varlist, var_desc_t **var_desc);
@@ -128,14 +128,10 @@ extern "C" {
     /* Create a file (internal function). */
     int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename, int mode);
 
-    /* Open a file and learn about metadata. */
-    int openfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
-                     int mode, int retry);
-
     /* Open a file with optional retry as netCDF-classic if first
      * iotype does not work. */
-    int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype,
-                            const char *filename, int mode, int retry);
+    int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename, int mode,
+                            int retry);
 
     iosystem_desc_t *pio_get_iosystem_from_id(int iosysid);
     int pio_add_to_iosystem_list(iosystem_desc_t *ios);

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1973,9 +1973,11 @@ int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int *
     /* How many unlimited dims for this file? */
     if (iotype == PIO_IOTYPE_PNETCDF)
     {
+#ifdef _PNETCDF
         if ((ret = ncmpi_inq_unlimdim(ncid, &unlimdimid)))
             return pio_err(NULL, file, ret, __FILE__, __LINE__);
         nunlimdims = unlimdimid == -1 ? 0 : 1;
+#endif /* _PNETCDF */
     }
     else
     {
@@ -2011,12 +2013,14 @@ int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int *
         {
             PIO_Offset type_size;
             
+#ifdef _PNETCDF
             if ((ret = ncmpi_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
                 return pio_err(NULL, file, ret, __FILE__, __LINE__);
             (*pio_type)[v] = (int)my_type;
             if ((ret = pioc_pnetcdf_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
                 return check_netcdf(file, ret, __FILE__, __LINE__);
             (*pio_type_size)[v] = type_size;
+#endif /* _PNETCDF */            
         }
         else
         {
@@ -2044,8 +2048,10 @@ int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int *
             int var_dimids[var_ndims];
             if (iotype == PIO_IOTYPE_PNETCDF)
             {
+#ifdef _PNETCDF
                 if ((ret = ncmpi_inq_vardimid(ncid, v, var_dimids)))
                     return pio_err(NULL, file, ret, __FILE__, __LINE__);
+#endif /* _PNETCDF */                
             }
             else
             {

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1981,10 +1981,18 @@ int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int *
         nunlimdims = unlimdimid == -1 ? 0 : 1;
 #endif /* _PNETCDF */
     }
+    else if (iotype == PIO_IOTYPE_NETCDF)
+    {
+        if ((ret = nc_inq_unlimdim(ncid, &unlimdimid)))
+            return pio_err(NULL, file, ret, __FILE__, __LINE__);
+        nunlimdims = unlimdimid == -1 ? 0 : 1;
+    }
     else
     {
+#ifdef _NETCDF4
         if ((ret = nc_inq_unlimdims(ncid, &nunlimdims, NULL)))
             return pio_err(NULL, file, ret, __FILE__, __LINE__);
+#endif /* _NETCDF4 */
     }
 
     /* Learn the unlimited dimension ID(s), if there are any. */
@@ -1992,14 +2000,16 @@ int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int *
     {
         if (!(unlimdimids = malloc(nunlimdims * sizeof(int))))
             return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);        
-        if (iotype == PIO_IOTYPE_PNETCDF)
+        if (iotype == PIO_IOTYPE_PNETCDF || iotype == PIO_IOTYPE_NETCDF)
         {
             unlimdimids[0] = unlimdimid;
         }
         else
         {
+#ifdef _NETCDF4
             if ((ret = nc_inq_unlimdims(ncid, NULL, unlimdimids)))
                 return pio_err(NULL, file, ret, __FILE__, __LINE__);
+#endif /* _NETCDF4 */
         }
     }
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1947,8 +1947,10 @@ int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int *
 
     if (iotype == PIO_IOTYPE_PNETCDF)
     {
+#ifdef _PNETCDF
         if ((ret = ncmpi_inq_nvars(ncid, nvars)))
             return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
+#endif /* _PNETCDF */
     }
     else
     {

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2291,43 +2291,43 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         return check_mpi(file, mpierr, __FILE__, __LINE__);
 
     /* Broadcast some values to all tasks from io root. */
-    if (ios->async || (ios->ioproc && ios->io_rank != 0))
+    if (ios->async)
     {
         LOG((3, "open bcasting pio_next_ncid %d ios->ioroot %d", pio_next_ncid, ios->ioroot));
         if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
             return check_mpi(file, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(&nvars, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(file, mpierr, __FILE__, __LINE__);
-
-        /* Non io tasks need to allocate to store info about variables. */
-        if (nvars && !rec_var)
-        {
-            if (!(rec_var = malloc(nvars * sizeof(int))))
-                return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
-            if (!(pio_type = malloc(nvars * sizeof(int))))
-                return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
-            if (!(pio_type_size = malloc(nvars * sizeof(int))))
-                return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
-            if (!(mpi_type = malloc(nvars * sizeof(int))))
-                return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
-            if (!(mpi_type_size = malloc(nvars * sizeof(int))))
-                return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
-        }
-        if (nvars)
-        {
-            if ((mpierr = MPI_Bcast(rec_var, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-                return check_mpi(file, mpierr, __FILE__, __LINE__);
-            if ((mpierr = MPI_Bcast(pio_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-                return check_mpi(file, mpierr, __FILE__, __LINE__);
-            if ((mpierr = MPI_Bcast(pio_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-                return check_mpi(file, mpierr, __FILE__, __LINE__);
-            if ((mpierr = MPI_Bcast(mpi_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-                return check_mpi(file, mpierr, __FILE__, __LINE__);
-            if ((mpierr = MPI_Bcast(mpi_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-                return check_mpi(file, mpierr, __FILE__, __LINE__);
-        }
     }
+    
+    if ((mpierr = MPI_Bcast(&nvars, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+        return check_mpi(file, mpierr, __FILE__, __LINE__);
 
+    /* Non io tasks need to allocate to store info about variables. */
+    if (nvars && !rec_var)
+    {
+        if (!(rec_var = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
+        if (!(pio_type = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
+        if (!(pio_type_size = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
+        if (!(mpi_type = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
+        if (!(mpi_type_size = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
+    }
+    if (nvars)
+    {
+        if ((mpierr = MPI_Bcast(rec_var, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(pio_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(pio_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(mpi_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(mpi_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(file, mpierr, __FILE__, __LINE__);
+    }
 
     /* Create the ncid that the user will see. This is necessary
      * because otherwise ncids will be reused if files are opened

--- a/tests/cunit/test_iosystem3.c
+++ b/tests/cunit/test_iosystem3.c
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
                                        DIMNAME, my_rank)))
                     ERR(ret);
 
-                /* /\* Now check the first file from WORLD communicator. *\/ */
+                /* Now check the first file from WORLD communicator. */
                 int ncid;
                 if ((ret = open_and_check_file(test_comm, iosysid_world, flavor[i], &ncid, fname0,
                                                ATTNAME, DIMNAME, 1, my_rank)))

--- a/tests/cunit/test_iosystem3.c
+++ b/tests/cunit/test_iosystem3.c
@@ -272,10 +272,10 @@ int main(int argc, char **argv)
                     ERR(ret);
 
                 /* /\* Now check the first file from WORLD communicator. *\/ */
-                /* int ncid; */
-                /* if ((ret = open_and_check_file(test_comm, iosysid_world, flavor[i], &ncid, fname0, */
-                /*                                ATTNAME, DIMNAME, 1, my_rank))) */
-                /*     ERR(ret); */
+                int ncid;
+                if ((ret = open_and_check_file(test_comm, iosysid_world, flavor[i], &ncid, fname0,
+                                               ATTNAME, DIMNAME, 1, my_rank)))
+                    ERR(ret);
 
                 /* Now have the even communicators check the files. */
                 int ncid2;
@@ -308,8 +308,8 @@ int main(int argc, char **argv)
                 if (overlap_comm != MPI_COMM_NULL)
                     if ((ret = PIOc_closefile(ncid3)))
                         ERR(ret);
-                /* if ((ret = PIOc_closefile(ncid))) */
-                /*     ERR(ret); */
+                if ((ret = PIOc_closefile(ncid)))
+                    ERR(ret);
 
             } /* next iotype */
         

--- a/tests/cunit/test_iosystem3.c
+++ b/tests/cunit/test_iosystem3.c
@@ -271,11 +271,11 @@ int main(int argc, char **argv)
                                        DIMNAME, my_rank)))
                     ERR(ret);
 
-                /* Now check the first file from WORLD communicator. */
-                int ncid;
-                if ((ret = open_and_check_file(test_comm, iosysid_world, flavor[i], &ncid, fname0,
-                                               ATTNAME, DIMNAME, 1, my_rank)))
-                    ERR(ret);
+                /* /\* Now check the first file from WORLD communicator. *\/ */
+                /* int ncid; */
+                /* if ((ret = open_and_check_file(test_comm, iosysid_world, flavor[i], &ncid, fname0, */
+                /*                                ATTNAME, DIMNAME, 1, my_rank))) */
+                /*     ERR(ret); */
 
                 /* Now have the even communicators check the files. */
                 int ncid2;
@@ -308,8 +308,8 @@ int main(int argc, char **argv)
                 if (overlap_comm != MPI_COMM_NULL)
                     if ((ret = PIOc_closefile(ncid3)))
                         ERR(ret);
-                if ((ret = PIOc_closefile(ncid)))
-                    ERR(ret);
+                /* if ((ret = PIOc_closefile(ncid))) */
+                /*     ERR(ret); */
 
             } /* next iotype */
         


### PR DESCRIPTION
The necessary variable metadata was not being bcast to all the correct tasks when a file is opened. (See #1205).

In this PR I rearrange the openfile code, so that all tasks end up with the metadata. This is needed before more advanced async tests can work.

Fixes #1205.
Part of #1194.
Part of #89.