### PR TITLE
added PIO_BUFFER_SIZE to build systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ set(VERSION_MINOR   3   CACHE STRING "Project minor version number.")
 set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
+# The size of the data buffer for write/read_darray().
+set(PIO_BUFFER_SIZE 134217728)
+
 #==============================================================================
 #  USER-DEFINED OPTIONS (set with "-DOPT=VAL" from command line)
 #==============================================================================

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -25,4 +25,7 @@
 /** Size of MPI_Offset type. */
 #define SIZEOF_MPI_OFFSET @SIZEOF_MPI_OFFSET@
 
+/* buffer size for darray data. */
+#define PIO_BUFFER_SIZE @PIO_BUFFER_SIZE@
+
 #endif /* _PIO_CONFIG_ */

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,14 @@ AC_PROG_LIBTOOL
 # Always use malloc in autotools builds.
 AC_DEFINE([PIO_USE_MALLOC], [1], [use malloc for memory])
 
+AC_MSG_CHECKING([whether a PIO_BUFFER_SIZE was specified])
+AC_ARG_WITH([piobuffersize],
+              [AS_HELP_STRING([--with-piobuffersize=<integer>],
+                              [Specify buffer size for PIO.])],
+            [PIO_BUFFER_SIZE=$with_piobuffersize], [PIO_BUFFER_SIZE=134217728])
+AC_MSG_RESULT([$PIO_BUFFER_SIZE])
+AC_DEFINE_UNQUOTED([PIO_BUFFER_SIZE], [$PIO_BUFFER_SIZE], [buffer size for darray data.])
+
 # Need to allow user to set this.
 AC_DEFINE([PIO_ENABLE_LOGGING], [1], [log messages from library])
 

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -13,7 +13,7 @@
 #include <pio_internal.h>
 
 /* 10MB default limit. */
-PIO_Offset pio_buffer_size_limit = 10485760;
+PIO_Offset pio_buffer_size_limit = PIO_BUFFER_SIZE;
 
 /* Global buffer pool pointer. */
 void *CN_bpool = NULL;

--- a/tests/cunit/test_async_multi2.c
+++ b/tests/cunit/test_async_multi2.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 
     /* Initialize test. */
     if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, TARGET_NTASKS, TARGET_NTASKS,
-                              3, &test_comm)))
+                              -1, &test_comm)))
         ERR(ERR_INIT);
 
     /* Is the current process a computation task? */    

--- a/tests/cunit/test_iosystem2_simple.c
+++ b/tests/cunit/test_iosystem2_simple.c
@@ -7,7 +7,6 @@
  * @author Ed Hartnett
  */
 #include <config.h>
-#include <config.h>
 #include <pio.h>
 #include <pio_tests.h>
 
@@ -27,9 +26,6 @@
 #define STRIDE 1
 #define BASE 0
 #define REARRANGER 1
-
-/* Ten megabytes. */
-#define TEN_MEG 10485760
 
 /* Used to set PIOc_set_buffer_size_limit(). */
 #define NEW_LIMIT 200000
@@ -62,7 +58,7 @@ int main(int argc, char **argv)
 
         /* Try setting the buffer size limit. */
         oldlimit = PIOc_set_buffer_size_limit(NEW_LIMIT);
-        if (oldlimit != TEN_MEG)
+        if (oldlimit != PIO_BUFFER_SIZE)
             ERR(ERR_WRONG);
 
         /* A negative limit will silently do nothing. */
@@ -71,7 +67,7 @@ int main(int argc, char **argv)
             ERR(ERR_WRONG);
 
         /* Reset the buffer size limit. */
-        oldlimit = PIOc_set_buffer_size_limit(TEN_MEG);
+        oldlimit = PIOc_set_buffer_size_limit(PIO_BUFFER_SIZE);
         if (oldlimit != NEW_LIMIT)
             ERR(ERR_WRONG);
 

--- a/tests/cunit/test_iosystem3.c
+++ b/tests/cunit/test_iosystem3.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
 
     /* Initialize test. */
     if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, TARGET_NTASKS, TARGET_NTASKS,
-                              3, &test_comm)))
+                              -1, &test_comm)))
         ERR(ERR_INIT);
 
     /* Test code runs on TARGET_NTASKS tasks. The left over tasks do


### PR DESCRIPTION
Fixes #1203.
Fixes #1213.

Raised buffer size to 100 MB.

Added ability to override in CMake/autotools build systems.

I have merged to develop for testing.