### PR TITLE
remove usage of NC_MAX_DIMS

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -41,7 +41,8 @@
 #define PIO_MAX_VARS NC_MAX_VARS
 
 /** The maximum number of dimensions allowed in a netCDF file. */
-#define PIO_MAX_DIMS NC_MAX_DIMS
+/* versions of pnetcdf 1.9 or newer and netcdf  4.5 or newer no longer use this */
+#define PIO_MAX_DIMS min(NC_MAX_DIMS, 1024)
 
 /** Pass this to PIOc_set_iosystem_error_handling() as the iosysid in
  * order to set default error handling. */

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -190,7 +190,7 @@ int create_file_handler(iosystem_desc_t *ios)
 
     /* Call the create file function. */
     PIOc_createfile(ios->iosysid, &ncid, &iotype, filename, mode);
-    
+
     LOG((1, "create_file_handler succeeded!"));
     return PIO_NOERR;
 }
@@ -276,7 +276,7 @@ int inq_handler(iosystem_desc_t *ios)
 
     /* Call the inq function to get the values. */
     PIOc_inq(ncid, ndimsp, nvarsp, ngattsp, unlimdimidp);
-    
+
     return PIO_NOERR;
 }
 
@@ -1006,7 +1006,8 @@ int inq_var_handler(iosystem_desc_t *ios)
     char name[NC_MAX_NAME + 1], *namep = NULL;
     nc_type xtype, *xtypep = NULL;
     int *ndimsp = NULL, *dimidsp = NULL, *nattsp = NULL;
-    int ndims, dimids[NC_MAX_DIMS], natts;
+    int ndims, natts;
+    int dimids[PIO_MAX_DIMS];
     int mpierr;
 
     LOG((1, "inq_var_handler"));
@@ -1040,6 +1041,7 @@ int inq_var_handler(iosystem_desc_t *ios)
     if (ndims_present)
         ndimsp = &ndims;
     if (dimids_present)
+	assert(ndims_present);
         dimidsp = dimids;
     if (natts_present)
         nattsp = &natts;
@@ -1066,7 +1068,7 @@ int inq_var_chunking_handler(iosystem_desc_t *ios)
     int varid;
     char storage_present, chunksizes_present;
     int storage, *storagep = NULL;
-    PIO_Offset chunksizes[NC_MAX_DIMS], *chunksizesp = NULL;
+    PIO_Offset chunksizes[PIO_MAX_DIMS], *chunksizesp = NULL;
     int mpierr;
 
     assert(ios);
@@ -1492,7 +1494,7 @@ int def_var_chunking_handler(iosystem_desc_t *ios)
     int ndims;
     int storage;
     char chunksizes_present;
-    PIO_Offset chunksizes[NC_MAX_DIMS], *chunksizesp = NULL;
+    PIO_Offset chunksizes[PIO_MAX_DIMS], *chunksizesp = NULL;
     int mpierr;
 
     assert(ios);
@@ -2703,7 +2705,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
         /* If an error was returned by the handler, exit. */
         LOG((3, "pio_msg_handler2 ret %d msg %d index %d io_rank %d", ret, msg, index, io_rank));
         if (ret)
-            return pio_err(my_iosys, NULL, ret, __FILE__, __LINE__);            
+            return pio_err(my_iosys, NULL, ret, __FILE__, __LINE__);
 
         /* Listen for another msg from the component whose message we
          * just handled. */

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -186,7 +186,7 @@ module pio_types
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_NAME = nf_max_name
-   integer, public, parameter :: PIO_MAX_VAR_DIMS = nf_max_var_dims
+   integer, public, parameter :: PIO_MAX_VAR_DIMS = min(1024,nf_max_var_dims)
    integer, public, parameter :: PIO_64BIT_OFFSET = nf_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = nf_64bit_data
    integer, public, parameter :: PIO_FILL_INT = nf_fill_int;
@@ -239,7 +239,7 @@ module pio_types
 
 !>
 !! @defgroup PIO_rearr_comm_t PIO_rearr_comm_t
-!! @public 
+!! @public
 !! @brief The two choices for rearranger communication
 !! @details
 !!  - PIO_rearr_comm_p2p : Point to point
@@ -252,7 +252,7 @@ module pio_types
 
 !>
 !! @defgroup PIO_rearr_comm_dir PIO_rearr_comm_dir
-!! @public 
+!! @public
 !! @brief The four choices for rearranger communication direction
 !! @details
 !!  - PIO_rearr_comm_fc_2d_enable : COMM procs to IO procs and vice versa
@@ -271,7 +271,7 @@ module pio_types
 !! @defgroup PIO_rearr_comm_fc_options PIO_rearr_comm_fc_options
 !! @brief Type that defines the PIO rearranger options
 !! @details
-!!  - enable_hs : Enable handshake (true/false) 
+!!  - enable_hs : Enable handshake (true/false)
 !!  - enable_isend : Enable Isends (true/false)
 !!  - max_pend_req : Maximum pending requests (To indicated unlimited
 !!                    number of requests use PIO_REARR_COMM_UNLIMITED_PEND_REQ)


### PR DESCRIPTION
Remove usage of NC_MAX_DIMS which is a very large number in the pnetcdf 1.9.0 release candidate.  I have merged to develop for testing.