### PR TITLE
dont use NC_MAX values

### DIFF
--- a/ctest/runcdash-nwscla-intel.sh
+++ b/ctest/runcdash-nwscla-intel.sh
@@ -14,14 +14,14 @@ module unload netcdf
 module swap intel intel/17.0.1
 module load cmake/3.7.2
 module load netcdf-mpi/4.4.1.1
-module load pnetcdf/1.8.0
-module switch mpt mpt/2.15
+module load pnetcdf/1.8.1
+module switch mpt mpt/2.16
 echo "MODULE LIST..."
 module list
 
 export CC=mpicc
 export FC=mpif90
-
+export MPI_TYPE_DEPTH=24
 export PIO_DASHBOARD_ROOT=/glade/scratch/jedwards/dashboard
 export PIO_COMPILER_ID=Intel-`$CC --version | head -n 1 | cut -d' ' -f3`
 

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -190,7 +190,8 @@ int create_file_handler(iosystem_desc_t *ios)
 
     /* Call the create file function. */
     PIOc_createfile(ios->iosysid, &ncid, &iotype, filename, mode);
-    
+
+
     LOG((1, "create_file_handler succeeded!"));
     return PIO_NOERR;
 }
@@ -276,7 +277,7 @@ int inq_handler(iosystem_desc_t *ios)
 
     /* Call the inq function to get the values. */
     PIOc_inq(ncid, ndimsp, nvarsp, ngattsp, unlimdimidp);
-    
+
     return PIO_NOERR;
 }
 
@@ -1006,7 +1007,7 @@ int inq_var_handler(iosystem_desc_t *ios)
     char name[NC_MAX_NAME + 1], *namep = NULL;
     nc_type xtype, *xtypep = NULL;
     int *ndimsp = NULL, *dimidsp = NULL, *nattsp = NULL;
-    int ndims, dimids[NC_MAX_DIMS], natts;
+    int ndims, natts;
     int mpierr;
 
     LOG((1, "inq_var_handler"));
@@ -1040,7 +1041,8 @@ int inq_var_handler(iosystem_desc_t *ios)
     if (ndims_present)
         ndimsp = &ndims;
     if (dimids_present)
-        dimidsp = dimids;
+        if (!(dimidsp = malloc(ndims)))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     if (natts_present)
         nattsp = &natts;
 
@@ -1064,9 +1066,10 @@ int inq_var_chunking_handler(iosystem_desc_t *ios)
 {
     int ncid;
     int varid;
+    int ndims;
     char storage_present, chunksizes_present;
     int storage, *storagep = NULL;
-    PIO_Offset chunksizes[NC_MAX_DIMS], *chunksizesp = NULL;
+    PIO_Offset *chunksizesp = NULL;
     int mpierr;
 
     assert(ios);
@@ -1080,6 +1083,8 @@ int inq_var_chunking_handler(iosystem_desc_t *ios)
         return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&storage_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
+    if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, 0, ios->intercomm)))
+        return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&chunksizes_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
     LOG((2,"inq_var_handler ncid = %d varid = %d storage_present = %d chunksizes_present = %d",
@@ -1089,7 +1094,8 @@ int inq_var_chunking_handler(iosystem_desc_t *ios)
     if (storage_present)
         storagep = &storage;
     if (chunksizes_present)
-        chunksizesp = chunksizes;
+        if (!(chunksizesp = malloc(ndims)))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Call the inq function to get the values. */
     PIOc_inq_var_chunking(ncid, varid, storagep, chunksizesp);
@@ -1492,7 +1498,7 @@ int def_var_chunking_handler(iosystem_desc_t *ios)
     int ndims;
     int storage;
     char chunksizes_present;
-    PIO_Offset chunksizes[NC_MAX_DIMS], *chunksizesp = NULL;
+    PIO_Offset *chunksizesp = NULL;
     int mpierr;
 
     assert(ios);
@@ -1510,15 +1516,14 @@ int def_var_chunking_handler(iosystem_desc_t *ios)
         return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&chunksizes_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
-    if (chunksizes_present)
-        if ((mpierr = MPI_Bcast(chunksizes, ndims, MPI_OFFSET, 0, ios->intercomm)))
+    if (chunksizes_present){
+        if (!(chunksizesp = malloc(ndims)))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(chunksizesp, ndims, MPI_OFFSET, 0, ios->intercomm)))
             return check_mpi2(ios, NULL, mpierr, __FILE__, __LINE__);
+    }
     LOG((1, "def_var_chunking_handler got parameters ncid = %d varid = %d storage = %d "
          "ndims = %d chunksizes_present = %d", ncid, varid, storage, ndims, chunksizes_present));
-
-    /* Set the non-NULL pointers. */
-    if (chunksizes_present)
-        chunksizesp = chunksizes;
 
     /* Call the function. */
     PIOc_def_var_chunking(ncid, varid, storage, chunksizesp);
@@ -2703,7 +2708,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
         /* If an error was returned by the handler, exit. */
         LOG((3, "pio_msg_handler2 ret %d msg %d index %d io_rank %d", ret, msg, index, io_rank));
         if (ret)
-            return pio_err(my_iosys, NULL, ret, __FILE__, __LINE__);            
+            return pio_err(my_iosys, NULL, ret, __FILE__, __LINE__);
 
         /* Listen for another msg from the component whose message we
          * just handled. */

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -401,6 +401,8 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
             if (!mpierr)
                 mpierr = MPI_Bcast(&storage_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
+                mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
                 mpierr = MPI_Bcast(&chunksizes_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             LOG((2, "PIOc_inq_var_chunking ncid = %d varid = %d storage_present = %d chunksizes_present = %d",
                  ncid, varid, storage_present, chunksizes_present));

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -186,7 +186,7 @@ module pio_types
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_NAME = nf_max_name
-   integer, public, parameter :: PIO_MAX_VAR_DIMS = nf_max_var_dims
+   integer, public, parameter :: PIO_MAX_VAR_DIMS = min(6,nf_max_var_dims)
    integer, public, parameter :: PIO_64BIT_OFFSET = nf_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = nf_64bit_data
    integer, public, parameter :: PIO_FILL_INT = nf_fill_int;
@@ -209,7 +209,7 @@ module pio_types
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_NAME = nf_max_name
-   integer, public, parameter :: PIO_MAX_VAR_DIMS = nf_max_var_dims
+   integer, public, parameter :: PIO_MAX_VAR_DIMS = min(6,nf_max_var_dims)
    integer, public, parameter :: PIO_64BIT_OFFSET = nf_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = 0
    integer, public, parameter :: PIO_FILL_INT = nf_fill_int;
@@ -239,7 +239,7 @@ module pio_types
 
 !>
 !! @defgroup PIO_rearr_comm_t PIO_rearr_comm_t
-!! @public 
+!! @public
 !! @brief The two choices for rearranger communication
 !! @details
 !!  - PIO_rearr_comm_p2p : Point to point
@@ -252,7 +252,7 @@ module pio_types
 
 !>
 !! @defgroup PIO_rearr_comm_dir PIO_rearr_comm_dir
-!! @public 
+!! @public
 !! @brief The four choices for rearranger communication direction
 !! @details
 !!  - PIO_rearr_comm_fc_2d_enable : COMM procs to IO procs and vice versa
@@ -271,7 +271,7 @@ module pio_types
 !! @defgroup PIO_rearr_comm_fc_options PIO_rearr_comm_fc_options
 !! @brief Type that defines the PIO rearranger options
 !! @details
-!!  - enable_hs : Enable handshake (true/false) 
+!!  - enable_hs : Enable handshake (true/false)
 !!  - enable_isend : Enable Isends (true/false)
 !!  - max_pend_req : Maximum pending requests (To indicated unlimited
 !!                    number of requests use PIO_REARR_COMM_UNLIMITED_PEND_REQ)


### PR DESCRIPTION
pnetcdf 1.9.0 sets NC_MAX_VARS and NC_MAX_DIMS to MAX_INT to indicate they should no longer be used.  