### PR TITLE
Adding Cray Fortran specific flags.

### DIFF
--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -55,6 +55,8 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
   set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -mismatch_all" )
   #    target_compile_options (piof
   #        PRIVATE -mismatch_all)
+elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+  set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ef")
 endif()
 
 # Look for c_sizeof capability


### PR DESCRIPTION
The Cray Fortran compiler by default write module files in
all uppercase. The "-ef" flag tells it to write them as
lowercase. This means the install phase can file the module
files to install.

This fixes #1249.