### PR TITLE
fixed compiler warnings

### DIFF
--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -163,7 +163,6 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;    /* Pointer to var info struct. */
-    int dsize;             /* Data size (for one region). */
     int ierr = PIO_NOERR;
 
     /* Check inputs. */
@@ -195,13 +194,10 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
     /* If this is an IO task write the data. */
     if (ios->ioproc)
     {
-        int rrcnt = 0; /* Number of subarray requests (pnetcdf only). */
         void *bufptr;
         size_t start[fndims];
         size_t count[fndims];
         int ndims = iodesc->ndims;
-        PIO_Offset *startlist[num_regions]; /* Array of start arrays for ncmpi_iput_varn(). */
-        PIO_Offset *countlist[num_regions]; /* Array of count  arrays for ncmpi_iput_varn(). */
 
         LOG((3, "num_regions = %d", num_regions));
 
@@ -241,6 +237,12 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
 #endif
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
+            {
+                int dsize;             /* Data size (for one region). */
+                int rrcnt = 0; /* Number of subarray requests (pnetcdf only). */
+                PIO_Offset *startlist[num_regions]; /* Array of start arrays for ncmpi_iput_varn(). */
+                PIO_Offset *countlist[num_regions]; /* Array of count  arrays for ncmpi_iput_varn(). */
+
                 /* Get the total number of data elements we are
                  * writing for this region. */
                 dsize = 1;
@@ -320,6 +322,7 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
                     }
                 }
                 break;
+            }
 #endif
             default:
                 return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
@@ -794,11 +797,7 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobu
         io_region *region;
         size_t start[fndims];
         size_t count[fndims];
-        size_t tmp_bufsize = 1;
         void *bufptr;
-        int rrlen = 0;
-        PIO_Offset *startlist[iodesc->maxregions];
-        PIO_Offset *countlist[iodesc->maxregions];
 
         /* buffer is incremented by byte and loffset is in terms of
            the iodessc->mpitype so we need to multiply by the size of
@@ -814,7 +813,6 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobu
         /* For each regions, read the data. */
         for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
         {
-            tmp_bufsize = 1;
             if (region == NULL || iodesc->llen == 0)
             {
                 /* No data for this region. */
@@ -914,7 +912,11 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobu
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
             {
-                tmp_bufsize = 1;
+                int rrlen = 0;
+                PIO_Offset *startlist[iodesc->maxregions];
+                PIO_Offset *countlist[iodesc->maxregions];
+                size_t tmp_bufsize = 1;
+                
                 for (int j = 0; j < fndims; j++)
                     tmp_bufsize *= count[j];
 
@@ -1277,12 +1279,12 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
  */
 int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
 {
-    int mpierr;  /* Return code from MPI functions. */
     int ierr = PIO_NOERR;
 
 #ifdef _PNETCDF
     var_desc_t *vdesc;
     PIO_Offset usage = 0;
+    int mpierr;  /* Return code from MPI functions. */
 
     /* Check inputs. */
     pioassert(file, "invalid input", __FILE__, __LINE__);

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -895,8 +895,6 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     char start_present = start ? true : false;    /* Is start non-NULL? */
     char count_present = count ? true : false;    /* Is count non-NULL? */
     char stride_present = stride ? true : false;  /* Is stride non-NULL? */
-    var_desc_t *vdesc;
-    int *request;
     nc_type vartype;   /* The type of the var we are reading from. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr;          /* Return code from function calls. */
@@ -1068,6 +1066,8 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             {
                 /* This is not a scalar var. */
                 PIO_Offset *fake_stride;
+                var_desc_t *vdesc;
+                int *request;
 
                 if (!stride_present)
                 {

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -2028,7 +2028,6 @@ int initdecomp_dof_handler(iosystem_desc_t *ios)
     char iocount_present;
     PIO_Offset *iocountp = NULL;
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
-    int ret; /* Return code. */
 
     LOG((1, "initdecomp_dof_handler called"));
     assert(ios);
@@ -2090,10 +2089,10 @@ int initdecomp_dof_handler(iosystem_desc_t *ios)
         iocountp = iocount;
 
     /* Call the function. */
-    ret = PIOc_InitDecomp(iosysid, pio_type, ndims, dims, maplen, compmap, &ioid, rearrangerp,
-                          iostartp, iocountp);
+    PIOc_InitDecomp(iosysid, pio_type, ndims, dims, maplen, compmap, &ioid, rearrangerp,
+                    iostartp, iocountp);
 
-    LOG((1, "PIOc_InitDecomp returned %d", ret));
+    LOG((1, "PIOc_InitDecomp returned"));
     return PIO_NOERR;
 }
 
@@ -2428,7 +2427,6 @@ int freedecomp_handler(iosystem_desc_t *ios)
     int iosysid;
     int ioid;
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
-    int ret; /* Return code. */
 
     LOG((1, "freedecomp_handler called"));
     assert(ios);
@@ -2442,9 +2440,9 @@ int freedecomp_handler(iosystem_desc_t *ios)
     LOG((2, "freedecomp_handler iosysid = %d ioid = %d", iosysid, ioid));
 
     /* Call the function. */
-    ret = PIOc_freedecomp(iosysid, ioid);
+    PIOc_freedecomp(iosysid, ioid);
 
-    LOG((1, "PIOc_freedecomp returned %d", ret));
+    LOG((1, "PIOc_freedecomp returned"));
     return PIO_NOERR;
 }
 

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -14,9 +14,10 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
-
+#endif /* _PNETCDF */
     ierr = PIO_NOERR;
 
     /* Get file info. */
@@ -88,8 +89,10 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -158,8 +161,10 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -227,8 +232,10 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -299,8 +306,10 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -371,8 +380,10 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -442,8 +453,10 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -514,8 +527,10 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -585,8 +600,10 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -657,8 +674,10 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -730,8 +749,10 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -801,8 +822,10 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 
@@ -873,8 +896,10 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
     int ierr;
     iosystem_desc_t *ios;
     file_desc_t *file;
+#ifdef _PNETCDF
     var_desc_t *vdesc;
     int *request;
+#endif /* _PNETCDF */
 
     ierr = PIO_NOERR;
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2023,9 +2023,9 @@ int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int *
          * learn about type. */
         if (iotype == PIO_IOTYPE_PNETCDF)
         {
+#ifdef _PNETCDF
             PIO_Offset type_size;
             
-#ifdef _PNETCDF
             if ((ret = ncmpi_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
                 return pio_err(NULL, file, ret, __FILE__, __LINE__);
             (*pio_type)[v] = (int)my_type;


### PR DESCRIPTION
Fixes #1260.

I have merged to develop for testing.
  
Mostly moving pnetcdf-only vars into the pnetcdf blocks of code that use them.