### PR TITLE
Fixes to PIO for newer netCDF library versions

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -529,8 +529,10 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if ((ierr = find_var_fillvalue(file, varid, vdesc)))
             return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__);
 
-    /* Check that if the user passed a fill value, it is correct. */
-    if (fillvalue)
+    /* Check that if the user passed a fill value, it is correct. If
+     * use_fill is false, then find_var_fillvalue will not end up
+     * getting a fill value. */
+    if (fillvalue && vdesc->use_fill)
         if (memcmp(fillvalue, vdesc->fillvalue, vdesc->pio_type_size))
             return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -1121,7 +1121,7 @@ int inq_var_fill_handler(iosystem_desc_t *ios)
     char fill_mode_present, fill_value_present;
     PIO_Offset type_size;
     int fill_mode, *fill_modep = NULL;
-    PIO_Offset *fill_value, *fill_valuep = NULL;
+    void *fill_value, *fill_valuep = NULL;
     int mpierr;
 
     assert(ios);
@@ -1154,12 +1154,21 @@ int inq_var_fill_handler(iosystem_desc_t *ios)
         fill_valuep = fill_value;
 
     /* Call the inq function to get the values. */
+    LOG((3, "inq_var_fill_handlder about to call inq_var_fill"));
     PIOc_inq_var_fill(ncid, varid, fill_modep, fill_valuep);
+    if (fill_modep)
+        LOG((3, "after inq_var_fill fill_modep %d", *fill_modep));
 
     /* Free fill value storage if we allocated some. */
     if (fill_value_present)
+    {
+        LOG((3, "about to free fill_value"));
         free(fill_value);
+        LOG((3, "freed fill_value"));
+    }
 
+    if (fill_modep)
+        LOG((3, "done with inq_var_fill_handler", *fill_modep));
     return PIO_NOERR;
 }
 

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2208,8 +2208,8 @@ int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_value
             return check_netcdf(file, ierr, __FILE__, __LINE__);
         if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &type_size)))
             return check_netcdf(file, ierr, __FILE__, __LINE__);
+        LOG((2, "PIOc_def_var_fill type_size = %d", type_size));
     }
-    LOG((2, "PIOc_def_var_fill type_size = %d", type_size));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -2264,7 +2264,11 @@ int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_value
         {
             LOG((2, "defining fill value attribute for netCDF classic file"));
             if (file->do_io)
-                ierr = nc_put_att(file->fh, varid, _FillValue, xtype, 1, fill_valuep);
+            {
+                ierr = nc_set_fill(file->fh, NC_FILL, NULL);
+                if (!ierr)
+                    ierr = nc_put_att(file->fh, varid, _FillValue, xtype, 1, fill_valuep);
+            }
         }
         else
         {

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -220,7 +220,6 @@ int PIOc_setframe(int ncid, int varid, int frame)
 
     /* Set the record dimension value for this variable. This will be
      * used by the write_darray functions. */
-    /* file->varlist[varid].record = frame; */
     vdesc->record = frame;
 
     return PIO_NOERR;

--- a/tests/cunit/test_darray_1d.c
+++ b/tests/cunit/test_darray_1d.c
@@ -579,11 +579,9 @@ int test_darray_fill_unlim(int iosysid, int ioid, int pio_type, int num_flavors,
         if (!(test_data_in = malloc(type_size * arraylen)))
             ERR(PIO_ENOMEM);
 
-        /* Set the record number for the unlimited dimension. */
-        if ((ret = PIOc_setframe(ncid, varid, 0)))
-            ERR(ret);
-
-        /* Read the data. */
+        /* Read the data. We don't have to set the record number for
+         * the unlimited dimension. If we don't set it, PIO will
+         * assume a value of 0. */
         if ((ret = PIOc_read_darray(ncid, varid, ioid, arraylen, test_data_in)))
             ERR(ret);
 

--- a/tests/cunit/test_darray_2sync.c
+++ b/tests/cunit/test_darray_2sync.c
@@ -189,6 +189,10 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
             if ((ret = PIOc_def_var(ncid, VAR_NAME, test_type[t], NDIM1, &dimid, &varid)))
                 ERR(ret);
 
+            /* Turn on fill mode for this var. */
+            if ((ret = PIOc_def_var_fill(ncid, varid, 0, default_fillvalue)))
+                ERR(ret);
+
             /* End define mode. */
             if ((ret = PIOc_enddef(ncid)))
                 ERR(ret);


### PR DESCRIPTION
Some fixes to adjust fill value behavior to match netCDF library changes.

C tests now all pass with newer netCDF versions. One fortran test continues to fail with netcdf versions after 4.4.1.1.

Fixes #1259.
Part of #1248.

I have merged to develop for testing.