### PR TITLE
Add pnetcdf vard2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,15 @@ option (PIO_TEST_BIG_ENDIAN  "Enable test to see if machine is big endian"  ON)
 option (PIO_USE_MPIIO        "Enable support for MPI-IO auto detect"        ON)
 option (PIO_USE_MPISERIAL    "Enable mpi-serial support (instead of MPI)"   OFF)
 option (PIO_USE_MALLOC       "Use native malloc (instead of bget package)"  OFF)
+option (PIO_USE_PNETCDF_VARD       "Use pnetcdf put_vard "  OFF)
 option (WITH_PNETCDF         "Require the use of PnetCDF"                   ON)
+
+# Set a variable that appears in the config.h.in file.
+if(PIO_USE_PNETCDF_VARD)
+  set(USE_VARD 1)
+else()
+  set(USE_VARD 0)
+endif()
 
 # Set a variable that appears in the config.h.in file.
 if(PIO_USE_MALLOC)

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -1,4 +1,4 @@
-/** @file 
+/** @file
  *
  * This is the template for the config.h file, which is created at
  * build-time by cmake.
@@ -27,5 +27,7 @@
 
 /* buffer size for darray data. */
 #define PIO_BUFFER_SIZE @PIO_BUFFER_SIZE@
+
+#define USE_VARD @USE_VARD@
 
 #endif /* _PIO_CONFIG_ */

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -28,7 +28,7 @@
 #define NDIM3 3
 
 /* The number of timesteps of data. */
-#define NUM_TIMESTEPS 1
+#define NUM_TIMESTEPS 2
 
 /* The length of our sample data in X dimension.*/
 #define DIM_LEN_X 4

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -28,7 +28,7 @@
 #define NDIM3 3
 
 /* The number of timesteps of data. */
-#define NUM_TIMESTEPS 2
+#define NUM_TIMESTEPS 1
 
 /* The length of our sample data in X dimension.*/
 #define DIM_LEN_X 4
@@ -125,8 +125,8 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
     for (int d = 0; d < NDIM3; d++)
     {
         char my_dim_name[NC_MAX_NAME];
-        PIO_Offset dimlen; 
-        
+        PIO_Offset dimlen;
+
         if ((ret = PIOc_inq_dim(ncid, d, my_dim_name, &dimlen)))
             return ret;
         if (dimlen != (d ? dim_len[d] : NUM_TIMESTEPS) || strcmp(my_dim_name, dim_name[d]))
@@ -148,7 +148,7 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
     for (int t = 0; t < NUM_TIMESTEPS; t++)
     {
         int varid = 0; /* There's only one var in sample file. */
-        
+
         /* This is the data we expect for this timestep. */
         for (int i = 0; i < elements_per_pe; i++)
             buffer[i] = 100 * t + START_DATA_VAL + my_rank;
@@ -208,7 +208,7 @@ data:
 	int ioproc_stride = 1;	    /* Stride in the mpi rank between io tasks. */
 	int ioproc_start = 0; 	    /* Rank of first task to be used for I/O. */
         PIO_Offset elements_per_pe; /* Array elements per processing unit. */
-	int iosysid;  /* The ID for the parallel I/O system. */	
+	int iosysid;  /* The ID for the parallel I/O system. */
 	int ncid;     /* The ncid of the netCDF file. */
 	int dimid[NDIM3];    /* The dimension ID. */
 	int varid;    /* The ID of the netCDF varable. */
@@ -245,7 +245,7 @@ data:
         /* Turn on logging. */
         if ((ret = PIOc_set_log_level(LOG_LEVEL)))
             return ret;
-        
+
 	/* Initialize the PIO IO system. This specifies how many and
 	 * which processors are involved in I/O. */
 	if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, 1, ioproc_stride,
@@ -310,7 +310,7 @@ data:
                 /* Create some data for this timestep. */
                 for (int i = 0; i < elements_per_pe; i++)
                     buffer[i] = 100 * t + START_DATA_VAL + my_rank;
-                
+
                 /* Write data to the file. */
                 printf("rank: %d Writing sample data...\n", my_rank);
                 if ((ret = PIOc_setframe(ncid, varid, t)))

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -119,7 +119,7 @@ typedef struct var_desc_t
     /** ID of each outstanding pnetcdf request for this variable. */
     int *request;
 
-    /** Number of requests bending with pnetcdf. */
+    /** Number of requests pending with pnetcdf. */
     int nreqs;
 
     /* Holds the fill value of this var. */
@@ -278,7 +278,7 @@ typedef struct io_desc_t
      * dimensions. */
     int ndims;
 
-    /** An array of size ndims with the length of each dimension. */
+    /** An array of size ndims with the global length of each dimension. */
     int *dimlen;
 
     /** The actual number of IO tasks participating. */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -353,20 +353,24 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
 				    gdims[0] = gdim0;
 				    sa_ndims = fndims;
 				    dim_offset = 0;
+				    for (int i=1; i < fndims; i++)
+					gdims[i] = iodesc->dimlen[i-1];
 				}
 				else
 				{
 				    sa_ndims = ndims;
 				    dim_offset = 1;
+				    for (int i=0; i < ndims; i++)
+					gdims[i] = iodesc->dimlen[i];
 				}
 			    }
 			    else
 			    {
 				sa_ndims = fndims;
 				dim_offset = 0;
+				for (int i=0; i < fndims; i++)
+				    gdims[i] = iodesc->dimlen[i];
 			    }
-			    for (int i=dim_offset; i<fndims; i++)
-				gdims[i] = iodesc->dimlen[i-dim_offset];
 
 			    for (int i=dim_offset; i< fndims; i++)
 			    {
@@ -379,7 +383,7 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
 				    sastart[0] = frame[nv];
 
 				for (int i=0; i< sa_ndims; i++)
-				    LOG((3, "vard: sastart[%d]=%d sacount[%d]=%d", i,sastart[i], i,sacount[i]));
+				    LOG((3, "vard: sastart[%d]=%d sacount[%d]=%d gdims[%d]=%d %ld %ld", i,sastart[i], i,sacount[i], i, gdims[i], start[i], count[i]));
 				if((mpierr = MPI_Type_create_subarray(sa_ndims, gdims,
 								      sacount, sastart,MPI_ORDER_C
 								      ,iodesc->mpitype, subarray + rc)))
@@ -1459,7 +1463,7 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
 
     /* If we are not forcing a flush, spread the usage to all IO
      * tasks. */
-    if (!force && file->iosystem->io_comm != MPI_COMM_NULL)
+    if (!force && file->iosystem->ioproc)
     {
         usage += addsize;
         if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &usage, 1,  MPI_OFFSET,  MPI_MAX,

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -450,7 +450,6 @@ int PIOc_sync(int ncid)
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
                 flush_output_buffer(file, true, 0);
-/*                ierr = ncmpi_sync(file->fh); */
                 break;
 #endif
             default:

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -450,7 +450,7 @@ int PIOc_sync(int ncid)
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
                 flush_output_buffer(file, true, 0);
-                ierr = ncmpi_sync(file->fh);
+/*                ierr = ncmpi_sync(file->fh); */
                 break;
 #endif
             default:

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -425,7 +425,7 @@ int check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
     LOG((2, "check_netcdf2 chose error handler = %d", eh));
 
     /* Decide what to do based on the error handler. */
-    if (eh == PIO_INTERNAL_ERROR)
+    if (eh == PIO_INTERNAL_ERROR && status != PIO_NOERR)
     {
         char errmsg[PIO_MAX_NAME + 1];  /* Error message. */
         PIOc_strerror(status, errmsg);

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -341,7 +341,7 @@ int main(int argc, char **argv)
 
     /* Initialize test. */
     if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, MIN_NTASKS,
-                              MIN_NTASKS, 3, &test_comm)))
+                              MIN_NTASKS, -1, &test_comm)))
         ERR(ERR_INIT);
 
     if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -341,7 +341,7 @@ int main(int argc, char **argv)
 
     /* Initialize test. */
     if ((ret = pio_test_init2(argc, argv, &my_rank, &ntasks, MIN_NTASKS,
-                              MIN_NTASKS, -1, &test_comm)))
+                              MIN_NTASKS, 3, &test_comm)))
         ERR(ERR_INIT);
 
     if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))

--- a/tests/cunit/test_darray_frame.c
+++ b/tests/cunit/test_darray_frame.c
@@ -37,7 +37,7 @@
 #define LON_LEN_SHORT 2
 
 /* The number of timesteps of data to write. */
-#define NUM_TIMESTEPS 2
+#define NUM_TIMESTEPS 3
 
 /* The names of variable in the netCDF output files. */
 #define VAR_NAME "prc"
@@ -120,7 +120,7 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
             ERR(ret);
 
         /* Write records of data. */
-        for (int r = 0; r < TIME_LEN_SHORT; r++)
+        for (int r = 0; r < NUM_TIMESTEPS; r++)
         {
             int test_data_int[elements_per_pe];
 

--- a/tests/cunit/test_darray_frame.c
+++ b/tests/cunit/test_darray_frame.c
@@ -32,7 +32,7 @@
 /* #define LON_LEN 192 */
 
 /* Here's a shorter version for a simpler test. */
-#define TIME_LEN_SHORT 3
+#define TIME_LEN_SHORT 1
 #define LAT_LEN_SHORT 2
 #define LON_LEN_SHORT 2
 
@@ -112,6 +112,7 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
                 ERR(ret);
 
         /* Define a variable. */
+        printf("rank: %d Define a variable\n", my_rank);
         if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_INT, NDIM3, dimids, &varid)))
             ERR(ret);
 
@@ -137,6 +138,7 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
                 ERR(ret);
         }
 
+	printf("rank: %d close file\n", my_rank);
         /* Close the netCDF file. */
         if ((ret = PIOc_closefile(ncid)))
             ERR(ret);
@@ -144,6 +146,7 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
         {
             int test_data_int_in[elements_per_pe];
 
+	    printf("rank: %d reopen sample file %s\n", my_rank, filename);
             /* Reopen the file. */
             if ((ret = PIOc_openfile(iosysid, &ncid2, &iotype[fmt], filename, PIO_NOWRITE)))
                 ERR(ret);
@@ -155,6 +158,7 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
                 if ((ret = PIOc_setframe(ncid2, varid, r)))
                     ERR(ret);
 
+		printf("rank: %d read darray record %d\n", my_rank, r);
                 /* Read the data. */
                 if ((ret = PIOc_read_darray(ncid2, varid, ioid, elements_per_pe, test_data_int_in)))
                     ERR(ret);

--- a/tests/cunit/test_darray_frame.c
+++ b/tests/cunit/test_darray_frame.c
@@ -32,7 +32,7 @@
 /* #define LON_LEN 192 */
 
 /* Here's a shorter version for a simpler test. */
-#define TIME_LEN_SHORT 1
+#define TIME_LEN_SHORT 3
 #define LAT_LEN_SHORT 2
 #define LON_LEN_SHORT 2
 
@@ -112,7 +112,6 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
                 ERR(ret);
 
         /* Define a variable. */
-        printf("rank: %d Define a variable\n", my_rank);
         if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_INT, NDIM3, dimids, &varid)))
             ERR(ret);
 
@@ -138,7 +137,6 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
                 ERR(ret);
         }
 
-	printf("rank: %d close file\n", my_rank);
         /* Close the netCDF file. */
         if ((ret = PIOc_closefile(ncid)))
             ERR(ret);
@@ -146,7 +144,6 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
         {
             int test_data_int_in[elements_per_pe];
 
-	    printf("rank: %d reopen sample file %s\n", my_rank, filename);
             /* Reopen the file. */
             if ((ret = PIOc_openfile(iosysid, &ncid2, &iotype[fmt], filename, PIO_NOWRITE)))
                 ERR(ret);
@@ -158,7 +155,6 @@ int test_frame_simple(int iosysid, int num_iotypes, int *iotype, int my_rank,
                 if ((ret = PIOc_setframe(ncid2, varid, r)))
                     ERR(ret);
 
-		printf("rank: %d read darray record %d\n", my_rank, r);
                 /* Read the data. */
                 if ((ret = PIOc_read_darray(ncid2, varid, ioid, elements_per_pe, test_data_int_in)))
                     ERR(ret);

--- a/tests/unit/basic_tests.F90
+++ b/tests/unit/basic_tests.F90
@@ -6,7 +6,7 @@
 
 module basic_tests
 
-  use pio 
+  use pio
   use global_vars
 
   Implicit None
@@ -53,7 +53,7 @@ module basic_tests
         err_msg = "Could not create " // trim(filename)
         call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
       end if
-      
+
       call mpi_barrier(mpi_comm_world,ret_val)
       ! netcdf files need to end define mode before closing
       if (is_netcdf(iotype)) then
@@ -215,6 +215,16 @@ module basic_tests
           call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
         end if
 
+        ret_val = PIO_put_att(pio_file, pio_var, '_FillValue', -1)
+        if (ret_val .ne. PIO_NOERR) then
+          ! Error in PIO_def_var
+          err_msg = "Could not define _FillValue attribute"
+          call PIO_closefile(pio_file)
+          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+        end if
+
+
+
         ! Leave define mode
         ret_val = PIO_enddef(pio_file)
         if (ret_val .ne. PIO_NOERR) then
@@ -290,11 +300,11 @@ module basic_tests
            call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
         end if
         ret_val = PIO_set_log_level(0)
-        
+
         ! Close file
         call PIO_closefile(pio_file)
       end if
-        
+
       call mpi_barrier(MPI_COMM_WORLD,ret_val)
 
       ! Try to open standard binary file as netcdf (if iotype = netcdf)
@@ -304,6 +314,7 @@ module basic_tests
 
         ret_val = PIO_openfile(pio_iosystem, pio_file, iotype, &
                                "not_netcdf.ieee", PIO_nowrite)
+
         if (ret_val.eq.PIO_NOERR) then
           ! Error in PIO_openfile
           err_msg = "Opened a non-netcdf file as netcdf"

--- a/tests/unit/driver.F90
+++ b/tests/unit/driver.F90
@@ -15,7 +15,7 @@ Program pio_unit_test_driver
 
   ! local variables
   character(len=str_len) :: err_msg
-  integer :: fail_cnt, test_cnt, ios, test_id, ierr, test_val 
+  integer :: fail_cnt, test_cnt, ios, test_id, ierr, test_val
   logical :: ltest_netcdf, ltest_pnetcdf
   logical :: ltest_netcdf4p, ltest_netcdf4c
   namelist/piotest_nml/  ltest_netcdf,     &
@@ -26,7 +26,7 @@ Program pio_unit_test_driver
   integer ret_val
   character(len=pio_max_name) :: errmsg
   character(len=pio_max_name) :: expected
-  
+
   ! Set up MPI
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, my_rank, ierr)
@@ -63,7 +63,7 @@ Program pio_unit_test_driver
 
      ! Ignore namelist values if PIO not built with correct options
      ! (i.e. don't test pnetcdf if not built with pnetcdf)
-     ret_val = PIO_set_log_level(2)
+
 #ifndef _NETCDF
      if (ltest_netcdf) then
         write(*,"(A,1x,A)") "WARNING: can not test netcdf files because PIO", &
@@ -132,7 +132,7 @@ Program pio_unit_test_driver
      print *, err_msg
      call parse(err_msg, fail_cnt)
   end if
-     
+
   do test_id=1,ntest
      if (ltest(test_id)) then
         ! Make sure i is a valid test number
@@ -154,7 +154,7 @@ Program pio_unit_test_driver
                 write(*,"(A,I0)") "Error, not configured for test #", test_id
            call MPI_Abort(MPI_COMM_WORLD, 0, ierr)
         end select
-        
+
         ! test_create()
         if (master_task) write(*,"(3x,A,1x)") "testing PIO_createfile..."
         call test_create(test_id, err_msg)
@@ -209,7 +209,7 @@ Program pio_unit_test_driver
   call MPI_Finalize(ierr)
   if(fail_cnt>0) then
      stop 1
-  else	 
+  else
      stop 0
   endif
 Contains


### PR DESCRIPTION
pnetcdf has added a vard api which uses an MPI_DATATYPE as an input to describe the data.  This is implemented in cmake with PIO_USE_PNETCDF_VARD.   I've tested both with and without this feature and all tests pass on cheyenne with netcdf-mpi/4.4.1.1 and pnetcdf r3683