### PR TITLE
Support NetCDF libs without NetCDF4 support

### DIFF
--- a/pio/pionfput_mod.F90.in
+++ b/pio/pionfput_mod.F90.in
@@ -696,9 +696,11 @@ contains
 #endif
 #endif
 #ifdef _NETCDF
+#ifdef _NETCDF4
        case(pio_iotype_netcdf4p)
           ierr=nf90_var_par_access(File%fh, varid, NF90_COLLECTIVE)
           ierr = nf90_put_var(File%fh, varid, ival, start=int(pstart), count=int(pcount))
+#endif
        case(pio_iotype_netcdf, pio_iotype_netcdf4c)
           ! Only io proc 0 will do writing
           if (Ios%io_rank == 0) then


### PR DESCRIPTION
Making sure that NetCDF4-specific code is not built when 
using NetCDF libraries without support for NetCDF4.
 
Without the fix PIO1 build fails with NetCDF libs without
 NetCDF4 support.