### PR TITLE
Bugfix to the MPI_HAS_MPIIO check.

### DIFF
--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -161,7 +161,7 @@ if (MPIF_H_PATH)
   check_macro (MPI_HAS_MPIIO
     NAME TryMPIIO.f90
     HINTS ${CMAKE_MODULE_PATH}
-    DEFINITIONS -I{MPIF_H_PATH}
+    DEFINITIONS -I${MPIF_H_PATH}
     COMMENT "whether MPIIO is supported")
   if (${MPI_HAS_MPIIO})
     message (STATUS "MPIIO verified and enabled.")


### PR DESCRIPTION
The passing of the defines for the MPI include path lacked
a dollar sign so it was not being expanded as a variable.
Therefore the actual include when compiling was `-IMPIF_H_PATH`.

This fixes #1307 