### PR TITLE
add a check to make sure dof is monotonic

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -751,6 +751,7 @@ enum PIO_ERROR_HANDLERS
 /** Define error codes for PIO. */
 #define PIO_FIRST_ERROR_CODE (-500)
 #define PIO_EBADIOTYPE  (-500)
+#define PIO_EBADDOF     (-501)
 
 /** ??? */
 #define PIO_REQ_NULL (NC_REQ_NULL-1)

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -495,8 +495,14 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, in
     /* Remember the map. */
     if (!(iodesc->map = malloc(sizeof(PIO_Offset) * maplen)))
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    PIO_Offset maxval = 0;
     for (int m = 0; m < maplen; m++)
     {
+	if (compmap[m] > maxval)
+	    maxval = compmap[m];
+	else if(compmap[m] > 0 && compmap[m] <= maxval)
+	    return pio_err(ios, NULL, PIO_EBADDOF, __FILE__, __LINE__);
+
         iodesc->map[m] = compmap[m];
         LOG((4, "compmap[%d] = %d", m, compmap[m]));
     }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -76,6 +76,9 @@ int PIOc_strerror(int pioerr, char *errmsg)
         case PIO_EBADIOTYPE:
             strcpy(errmsg, "Bad IO type");
             break;
+	case PIO_EBADDOF:
+	    strcpy(errmsg, "DOF must be monotonically increasing (except for 0's)");
+	    break;
         default:
             strcpy(errmsg, "Unknown Error: Unrecognized error code");
         }


### PR DESCRIPTION
The pio dof must be monotonic (with the exception of 0 (-1) values) for the rearranger algorithm to work correctly.  This will throw an error if that is not the case.   Ultimately we may want to sort the dof and the corresponding io fields instead of throwing an error.  I have a prototype of this idea in branch
trytosort of my fork of the repo.