### PR TITLE
Trytosort

### DIFF
--- a/ctest/CTestEnvironment-nwscla.cmake
+++ b/ctest/CTestEnvironment-nwscla.cmake
@@ -10,7 +10,7 @@
 # set with existing environment variables: NETCDF, PNETCDF, HDF5, etc.
 
 # Define the extra CMake configure options
-set (CTEST_CONFIGURE_OPTIONS "-DCMAKE_VERBOSE_MAKEFILE=TRUE -DPIO_ENABLE_ASYNC=TRUE")
+set (CTEST_CONFIGURE_OPTIONS "-DCMAKE_VERBOSE_MAKEFILE=TRUE ")
 
 # If MPISERIAL environment variable is set, then enable MPISERIAL
 if (DEFINED ENV{MPISERIAL})

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -267,6 +267,12 @@ typedef struct io_desc_t
      * 1-based mappings to the global array for that task. */
     PIO_Offset *map;
 
+    /** If the map passed in is not monotonically increasing
+     *	then map is sorted and remap is an array of original
+     * indices of map. */
+
+    int *remap;
+
     /** Number of tasks involved in the communication between comp and
      * io tasks. */
     int nrecvs;
@@ -293,6 +299,9 @@ typedef struct io_desc_t
     /** Does this decomp leave holes in the field (true) or write
      * everywhere (false) */
     bool needsfill;
+
+    /** If the map is not monotonically increasing we will need to sort it. */
+    bool needssort;
 
     /** The maximum number of bytes of this iodesc before flushing. */
     int maxbytes;

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -269,7 +269,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     {
 	if (!(tmparray = malloc(arraylen*nvars*iodesc->piotype_size)))
 	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	pio_sorted_copy(array, tmparray, iodesc, nvars);
+	pio_sorted_copy(array, tmparray, iodesc, nvars, 0);
     }
     else
     {
@@ -890,6 +890,8 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
     {
 	if (!(tmparray = malloc(iodesc->piotype_size*iodesc->maplen)))
 	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	for(int m=0; m<iodesc->maplen;m++)
+	    ((int *) array)[m] = -1;
     }
     else
 	tmparray = array;
@@ -900,7 +902,7 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
 
     if (iodesc->needssort)
     {
-	pio_sorted_copy(tmparray, array, iodesc, 1);
+	pio_sorted_copy(tmparray, array, iodesc, 1, 1);
 	free(tmparray);
     }
 

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1948,9 +1948,7 @@ int pio_sorted_copy(const void *array, void *sortedarray, io_desc_t *iodesc, int
 		{
 		    ((int *)sortedarray)[m] = ((int *)array)[iodesc->remap[m]+maplen*v];
 		}
-/*		for (int m=0; m < maplen; m++)
-		    printf("0:%d: array=%d sorted=%d\n",m,((int *)array)[m], ((int *)sortedarray)[m]);
-*/	    }
+	    }
 	    break;
 	case PIO_FLOAT:
 	    for (int v=0; v < nvars; v++)
@@ -2067,14 +2065,6 @@ int pio_sorted_copy(const void *array, void *sortedarray, io_desc_t *iodesc, int
 		{
 		    ((int *)sortedarray)[iodesc->remap[m]] = ((int *)array)[m+maplen*v];
 		}
-		int flag=0;
-		for (int m=0; m < maplen; m++)
-		    if(((int *)sortedarray)[m] < 0)
-			flag =1;
-		if(flag==1)
-		    for (int m=0; m < maplen; m++)
-			printf("%d %d %d %d\n",m, iodesc->remap[m], ((int *)sortedarray)[iodesc->remap[m]], ((int *)array)[m]);
-
 	    }
 	    break;
 	case PIO_FLOAT:

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1905,3 +1905,126 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
 
     return PIO_NOERR;
 }
+
+void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int nvars)
+{
+    void *tmparray;
+    if (!(tmparray = malloc(iodesc->piotype_size * arraylen)))
+	return NULL;
+
+    int maplen = arraylen / nvars;
+    switch (iodesc->piotype)
+    {
+    case PIO_BYTE:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((signed char *)tmparray)[iodesc->remap[m]] = ((signed char *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_CHAR:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((char *)tmparray)[iodesc->remap[m]] = ((char *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_SHORT:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((short *)tmparray)[iodesc->remap[m]] = ((short *)array)[m+maplen*v];
+	    }
+	}
+
+	break;
+    case PIO_INT:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((int *)tmparray)[iodesc->remap[m]] = ((int *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_FLOAT:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((float *)tmparray)[iodesc->remap[m]] = ((float *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_DOUBLE:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((double *)tmparray)[iodesc->remap[m]] = ((double *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_UBYTE:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((unsigned char *)tmparray)[iodesc->remap[m]] = ((unsigned char *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_USHORT:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((unsigned short *)tmparray)[iodesc->remap[m]] = ((unsigned short *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_UINT:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((unsigned int *)tmparray)[iodesc->remap[m]] = ((unsigned int *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_INT64:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((long long *)tmparray)[iodesc->remap[m]] = ((long long *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_UINT64:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((unsigned long long *)tmparray)[iodesc->remap[m]] = ((unsigned long long *)array)[m+maplen*v];
+	    }
+	}
+	break;
+    case PIO_STRING:
+	for (int v=0; v < nvars; v++)
+	{
+	    for (int m=0; m < maplen; m++)
+	    {
+		((char **)tmparray)[iodesc->remap[m]] = ((char **)array)[m+maplen*v];
+	    }
+	}
+	break;
+    default:
+	return NULL;
+    }
+}

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -397,8 +397,8 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
 #if USE_VARD_WRITE
     if (!ios->async || !ios->ioproc)
     {
-      if ((ierr = get_gdim0(file, iodesc, varids[0], fndims, &gdim0)))
-        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	if ((ierr = get_gdim0(file, iodesc, varids[0], fndims, &gdim0)))
+	    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     }
 #endif
@@ -618,7 +618,7 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
                             if(filetype != MPI_DATATYPE_NULL)
                             {
                                 if((mpierr = MPI_Type_free(&filetype)))
-                                return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+				    return check_mpi(NULL, mpierr, __FILE__, __LINE__);
                             }
                             vard_llen = 0; /* reset request size to 0 */
                             numReqs = 0;
@@ -1291,23 +1291,23 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobu
                 if (regioncnt == iodesc->maxregions - 1)
                 {
 #if USE_VARD_READ
-		  MPI_Datatype filetype;
-		  PIO_Offset unlimdimoffset;
-		  int mpierr;
-		  if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
+		    MPI_Datatype filetype;
+		    PIO_Offset unlimdimoffset;
+		    int mpierr;
+		    if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
 		    {
-		      if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
-			return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+			if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
+			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 		    }
-		  else
-		    unlimdimoffset = gdim0;
+		    else
+			unlimdimoffset = gdim0;
 
-		  ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
-					      rrlen, ndims, fndims,
-					      vdesc->record, startlist, countlist, &filetype);
-		  ierr = ncmpi_get_vard_all(file->fh, vid, filetype, iobuf, iodesc->llen, iodesc->mpitype);
-		  if(filetype != MPI_DATATYPE_NULL && (mpierr = MPI_Type_free(&filetype)))
-		    return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+		    ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
+						rrlen, ndims, fndims,
+						vdesc->record, startlist, countlist, &filetype);
+		    ierr = ncmpi_get_vard_all(file->fh, vid, filetype, iobuf, iodesc->llen, iodesc->mpitype);
+		    if(filetype != MPI_DATATYPE_NULL && (mpierr = MPI_Type_free(&filetype)))
+			return check_mpi(NULL, mpierr, __FILE__, __LINE__);
 
 #else
                     /* Read a list of subarrays. */
@@ -1906,122 +1906,252 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
     return PIO_NOERR;
 }
 
-int pio_sorted_copy(const void *array, void *sortedarray, io_desc_t *iodesc, int nvars)
+int pio_sorted_copy(const void *array, void *sortedarray, io_desc_t *iodesc, int nvars,int direction)
 {
     int maplen = iodesc->maplen;
-    switch (iodesc->piotype)
-    {
-    case PIO_BYTE:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
-	    {
-		((signed char *)sortedarray)[iodesc->remap[m]] = ((signed char *)array)[m+maplen*v];
-	    }
-	}
-	break;
-    case PIO_CHAR:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
-	    {
-		((char *)sortedarray)[iodesc->remap[m]] = ((char *)array)[m+maplen*v];
-	    }
-	}
-	break;
-    case PIO_SHORT:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
-	    {
-		((short *)sortedarray)[iodesc->remap[m]] = ((short *)array)[m+maplen*v];
-	    }
-	}
 
-	break;
-    case PIO_INT:
-	for (int v=0; v < nvars; v++)
+    if (direction == 0){
+	switch (iodesc->piotype)
 	{
-	    for (int m=0; m < maplen; m++)
+	case PIO_BYTE:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((int *)sortedarray)[iodesc->remap[m]] = ((int *)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((signed char *)sortedarray)[m] = ((signed char *)array)[iodesc->remap[m]+maplen*v];
+		}
 	    }
+	    break;
+	case PIO_CHAR:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((char *)sortedarray)[m] = ((char *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_SHORT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((short *)sortedarray)[m] = ((short *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+
+	    break;
+	case PIO_INT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((int *)sortedarray)[m] = ((int *)array)[iodesc->remap[m]+maplen*v];
+		}
+/*		for (int m=0; m < maplen; m++)
+		    printf("0:%d: array=%d sorted=%d\n",m,((int *)array)[m], ((int *)sortedarray)[m]);
+*/	    }
+	    break;
+	case PIO_FLOAT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((float *)sortedarray)[m] = ((float *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_DOUBLE:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((double *)sortedarray)[m] = ((double *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UBYTE:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned char *)sortedarray)[m] = ((unsigned char *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_USHORT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned short *)sortedarray)[m] = ((unsigned short *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UINT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned int *)sortedarray)[m] = ((unsigned int *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_INT64:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((long long *)sortedarray)[m] = ((long long *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UINT64:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned long long *)sortedarray)[m] = ((unsigned long long *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_STRING:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((char **)sortedarray)[m] = ((char **)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	default:
+	    return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
 	}
-	break;
-    case PIO_FLOAT:
-	for (int v=0; v < nvars; v++)
+    }
+    else
+    {
+	switch (iodesc->piotype)
 	{
-	    for (int m=0; m < maplen; m++)
+	case PIO_BYTE:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((float *)sortedarray)[iodesc->remap[m]] = ((float *)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((signed char *)sortedarray)[iodesc->remap[m]] = ((signed char *)array)[m+maplen*v];
+		}
 	    }
-	}
-	break;
-    case PIO_DOUBLE:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
+	    break;
+	case PIO_CHAR:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((double *)sortedarray)[iodesc->remap[m]] = ((double *)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((char *)sortedarray)[iodesc->remap[m]] = ((char *)array)[m+maplen*v];
+		}
 	    }
-	}
-	break;
-    case PIO_UBYTE:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
+	    break;
+	case PIO_SHORT:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((unsigned char *)sortedarray)[iodesc->remap[m]] = ((unsigned char *)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((short *)sortedarray)[iodesc->remap[m]] = ((short *)array)[m+maplen*v];
+		}
 	    }
-	}
-	break;
-    case PIO_USHORT:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
+
+	    break;
+	case PIO_INT:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((unsigned short *)sortedarray)[iodesc->remap[m]] = ((unsigned short *)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((int *)sortedarray)[iodesc->remap[m]] = ((int *)array)[m+maplen*v];
+		}
+		int flag=0;
+		for (int m=0; m < maplen; m++)
+		    if(((int *)sortedarray)[m] < 0)
+			flag =1;
+		if(flag==1)
+		    for (int m=0; m < maplen; m++)
+			printf("%d %d %d %d\n",m, iodesc->remap[m], ((int *)sortedarray)[iodesc->remap[m]], ((int *)array)[m]);
+
 	    }
-	}
-	break;
-    case PIO_UINT:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
+	    break;
+	case PIO_FLOAT:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((unsigned int *)sortedarray)[iodesc->remap[m]] = ((unsigned int *)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((float *)sortedarray)[iodesc->remap[m]] = ((float *)array)[m+maplen*v];
+		}
 	    }
-	}
-	break;
-    case PIO_INT64:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
+	    break;
+	case PIO_DOUBLE:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((long long *)sortedarray)[iodesc->remap[m]] = ((long long *)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((double *)sortedarray)[iodesc->remap[m]] = ((double *)array)[m+maplen*v];
+		}
 	    }
-	}
-	break;
-    case PIO_UINT64:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
+	    break;
+	case PIO_UBYTE:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((unsigned long long *)sortedarray)[iodesc->remap[m]] = ((unsigned long long *)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned char *)sortedarray)[iodesc->remap[m]] = ((unsigned char *)array)[m+maplen*v];
+		}
 	    }
-	}
-	break;
-    case PIO_STRING:
-	for (int v=0; v < nvars; v++)
-	{
-	    for (int m=0; m < maplen; m++)
+	    break;
+	case PIO_USHORT:
+	    for (int v=0; v < nvars; v++)
 	    {
-		((char **)sortedarray)[iodesc->remap[m]] = ((char **)array)[m+maplen*v];
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned short *)sortedarray)[iodesc->remap[m]] = ((unsigned short *)array)[m+maplen*v];
+		}
 	    }
+	    break;
+	case PIO_UINT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned int *)sortedarray)[iodesc->remap[m]] = ((unsigned int *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_INT64:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((long long *)sortedarray)[iodesc->remap[m]] = ((long long *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UINT64:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned long long *)sortedarray)[iodesc->remap[m]] = ((unsigned long long *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_STRING:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((char **)sortedarray)[iodesc->remap[m]] = ((char **)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	default:
+	    return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
 	}
-	break;
-    default:
-	return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
     }
     return PIO_NOERR;
 }

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1906,13 +1906,9 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
     return PIO_NOERR;
 }
 
-void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int nvars)
+int pio_sorted_copy(const void *array, void *sortedarray, io_desc_t *iodesc, int nvars)
 {
-    void *tmparray;
-    if (!(tmparray = malloc(iodesc->piotype_size * arraylen)))
-	return NULL;
-
-    int maplen = arraylen / nvars;
+    int maplen = iodesc->maplen;
     switch (iodesc->piotype)
     {
     case PIO_BYTE:
@@ -1920,7 +1916,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((signed char *)tmparray)[iodesc->remap[m]] = ((signed char *)array)[m+maplen*v];
+		((signed char *)sortedarray)[iodesc->remap[m]] = ((signed char *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -1929,7 +1925,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((char *)tmparray)[iodesc->remap[m]] = ((char *)array)[m+maplen*v];
+		((char *)sortedarray)[iodesc->remap[m]] = ((char *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -1938,7 +1934,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((short *)tmparray)[iodesc->remap[m]] = ((short *)array)[m+maplen*v];
+		((short *)sortedarray)[iodesc->remap[m]] = ((short *)array)[m+maplen*v];
 	    }
 	}
 
@@ -1948,7 +1944,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((int *)tmparray)[iodesc->remap[m]] = ((int *)array)[m+maplen*v];
+		((int *)sortedarray)[iodesc->remap[m]] = ((int *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -1957,7 +1953,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((float *)tmparray)[iodesc->remap[m]] = ((float *)array)[m+maplen*v];
+		((float *)sortedarray)[iodesc->remap[m]] = ((float *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -1966,7 +1962,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((double *)tmparray)[iodesc->remap[m]] = ((double *)array)[m+maplen*v];
+		((double *)sortedarray)[iodesc->remap[m]] = ((double *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -1975,7 +1971,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((unsigned char *)tmparray)[iodesc->remap[m]] = ((unsigned char *)array)[m+maplen*v];
+		((unsigned char *)sortedarray)[iodesc->remap[m]] = ((unsigned char *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -1984,7 +1980,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((unsigned short *)tmparray)[iodesc->remap[m]] = ((unsigned short *)array)[m+maplen*v];
+		((unsigned short *)sortedarray)[iodesc->remap[m]] = ((unsigned short *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -1993,7 +1989,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((unsigned int *)tmparray)[iodesc->remap[m]] = ((unsigned int *)array)[m+maplen*v];
+		((unsigned int *)sortedarray)[iodesc->remap[m]] = ((unsigned int *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -2002,7 +1998,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((long long *)tmparray)[iodesc->remap[m]] = ((long long *)array)[m+maplen*v];
+		((long long *)sortedarray)[iodesc->remap[m]] = ((long long *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -2011,7 +2007,7 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((unsigned long long *)tmparray)[iodesc->remap[m]] = ((unsigned long long *)array)[m+maplen*v];
+		((unsigned long long *)sortedarray)[iodesc->remap[m]] = ((unsigned long long *)array)[m+maplen*v];
 	    }
 	}
 	break;
@@ -2020,11 +2016,12 @@ void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int n
 	{
 	    for (int m=0; m < maplen; m++)
 	    {
-		((char **)tmparray)[iodesc->remap[m]] = ((char **)array)[m+maplen*v];
+		((char **)sortedarray)[iodesc->remap[m]] = ((char **)array)[m+maplen*v];
 	    }
 	}
 	break;
     default:
-	return NULL;
+	return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
     }
+    return PIO_NOERR;
 }

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -361,7 +361,7 @@ extern "C" {
     int determine_procs(int num_io_procs, int component_count, int *num_procs_per_comp,
                         int **proc_list, int **my_proc_list);
 
-    void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int nvars);
+    int pio_sorted_copy(const void *array, void *tmparray, io_desc_t *iodesc, int nvars);
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -361,7 +361,7 @@ extern "C" {
     int determine_procs(int num_io_procs, int component_count, int *num_procs_per_comp,
                         int **proc_list, int **my_proc_list);
 
-    int pio_sorted_copy(const void *array, void *tmparray, io_desc_t *iodesc, int nvars);
+    int pio_sorted_copy(const void *array, void *tmparray, io_desc_t *iodesc, int nvars, int direction);
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -145,7 +145,7 @@ extern "C" {
     int pio_get_file(int ncid, file_desc_t **filep);
     int pio_delete_file_from_list(int ncid);
     void pio_add_to_file_list(file_desc_t *file);
-    
+
     /* List operations for var_desc_t list. */
     int add_to_varlist(int varid, int rec_var, int pio_type, int pio_type_size,
                        MPI_Datatype mpi_type, int mpi_type_size, var_desc_t **varlist);
@@ -312,7 +312,7 @@ extern "C" {
 
     int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf);
     int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf);
-    int find_var_fillvalue(file_desc_t *file, int varid, var_desc_t *vdesc);    
+    int find_var_fillvalue(file_desc_t *file, int varid, var_desc_t *vdesc);
 
     /* Read atts with type conversion. */
     int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip);
@@ -361,6 +361,7 @@ extern "C" {
     int determine_procs(int num_io_procs, int component_count, int *num_procs_per_comp,
                         int **proc_list, int **my_proc_list);
 
+    void *pio_sorted_copy(io_desc_t *iodesc, void *array, PIO_Offset arraylen, int nvars);
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -986,6 +986,7 @@ int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     int niotasks;
     int mpierr; /* Return code from MPI calls. */
     int ret;
+    void *tmparray;
 
     /* Check inputs. */
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -113,7 +113,7 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
 #if PIO_ENABLE_LOGGING
     {
         for (int p = 0; p < ntasks; p++)
-            LOG((3, "sendcounts[%d] = %d sdispls[%d] = %d sendtypes[%d] = %d recvcounts[%d] = %d "
+            LOG((4, "sendcounts[%d] = %d sdispls[%d] = %d sendtypes[%d] = %d recvcounts[%d] = %d "
                  "rdispls[%d] = %d recvtypes[%d] = %d", p, sendcounts[p], p, sdispls[p], p,
                  sendtypes[p], p, recvcounts[p], p, rdispls[p], p, recvtypes[p]));
     }

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -370,7 +370,7 @@ void pio_map_sort(const PIO_Offset *map, int *remap, int maplen)
 	switched = false;
 	for(int i=1; i<maplen; i++)
 	{
-	    if (map[remap[i-1]] < map[remap[i]])
+	    if (map[remap[i-1]] > map[remap[i]])
 	    {
 		int remaptemp = remap[i];
 		remap[i] = remap[i-1];
@@ -531,9 +531,7 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, in
 	    iodesc->remap[m] = m;
 	pio_map_sort(compmap, iodesc->remap, maplen);
 	for (int m=0; m < maplen; m++)
-	{
 	    iodesc->map[iodesc->remap[m]] = compmap[m];
-	}
     }
     else
     {

--- a/src/flib/piodarray.F90.in
+++ b/src/flib/piodarray.F90.in
@@ -368,7 +368,6 @@ contains
     integer(C_SIZE_T) :: tlen
 
     tlen = size(array)
-
     call read_darray_internal_{TYPE} (File%fh, vardesc%varid, iodesc%ioid, tlen, array, iostat)
 
   end subroutine read_darray_{DIMS}d_{TYPE}
@@ -399,4 +398,3 @@ contains
   end subroutine read_darray_internal_{TYPE}
 
 end module piodarray
-

--- a/tests/general/pio_decomp_tests_1d.F90.in
+++ b/tests/general/pio_decomp_tests_1d.F90.in
@@ -122,7 +122,7 @@ END SUBROUTINE
 
 ! Test block cyclic interface
 ! Write with one decomp and read with another
-! Test all combs 
+! Test all combs
 ! - no rearrage read + no rearrange write
 ! - rearrage read + no rearrange write
 ! - no rearrage read + rearrange write
@@ -185,7 +185,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc
       filename = "test_pio_decomp_simple_tests.testfile"
       do i=1,num_iotypes
         PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
-        ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+        ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
         PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
 
         ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
@@ -210,7 +210,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc
         PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
 
         call PIO_closefile(pio_file)
-        
+
         call PIO_deletefile(pio_tf_iosystem_, filename);
       end do
 
@@ -266,7 +266,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes
   filename = "test_pio_decomp_simple_tests.testfile"
   do i=1,num_iotypes
     PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
-    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
     PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
 
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
@@ -290,7 +290,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes
     PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
 
     call PIO_closefile(pio_file)
-    
+
     call PIO_deletefile(pio_tf_iosystem_, filename);
   end do
 
@@ -304,3 +304,96 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes
   deallocate(rbuf)
   deallocate(wbuf)
 PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_bc_with_holes
+
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_random
+  use mpi, only : MPI_INT, MPI_SCATTER
+  implicit none
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc
+  integer, dimension(:), allocatable :: compdof, gcompdof
+  integer, dimension(1) :: count
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf, wbuf
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, j, ierr, lsz
+  integer :: tmp
+  real :: u
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  ! Set the decomposition for writing data - random order same local size
+  count(1) = 4
+  dims(1) = count(1)*pio_tf_world_sz_
+  if(pio_tf_world_rank_ == 0) then
+     allocate(gcompdof(dims(1)))
+     gcompdof = 0
+     do i=1,dims(1)
+        gcompdof(i) = i
+     enddo
+     do i=dims(1),1,-1
+        call random_number(u)
+        j = CEILING(real(i)*u)
+        tmp = gcompdof(j)
+        gcompdof(j) = gcompdof(i)
+        gcompdof(i) = tmp
+     enddo
+  endif
+  allocate(compdof(count(1)))
+  call mpi_scatter(gcompdof, count(1), MPI_INT, compdof, 4, MPI_INT, 0, pio_tf_comm_, ierr)
+  if(allocated(gcompdof)) deallocate(gcompdof)
+  allocate(rbuf(count(1)))
+  allocate(wbuf(count(1)))
+  do i=1,count(1)
+    wbuf(i) = compdof(i)
+  end do
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variable out
+    call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    call PIO_read_darray(pio_file, pio_var, wr_iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+  deallocate(rbuf)
+  deallocate(wbuf)
+PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_bc_random

--- a/tests/performance/pioperformance.F90
+++ b/tests/performance/pioperformance.F90
@@ -1,4 +1,4 @@
-#define VARINT 1 
+#define VARINT 1
 !#define VARREAL 1
 !#define VARDOUBLE 1
 
@@ -8,11 +8,11 @@ program pioperformance
 #endif
   use perf_mod, only : t_initf, t_finalizef
   use pio, only : pio_iotype_netcdf, pio_iotype_pnetcdf, pio_iotype_netcdf4p, &
-       pio_iotype_netcdf4c, pio_rearr_subset, pio_rearr_box
+       pio_iotype_netcdf4c, pio_rearr_subset, pio_rearr_box, pio_set_log_level
   implicit none
 #ifdef NO_MPIMOD
 #include <mpif.h>
-#endif  
+#endif
   integer, parameter :: max_io_task_array_size=64, max_decomp_files=64
 
 
@@ -102,8 +102,8 @@ program pioperformance
   if(rearrangers(1)==0) then
     rearrangers(1)=1
     rearrangers(2)=2
-  endif  
-
+  endif
+!  i = pio_set_log_level(2)
   do i=1,max_decomp_files
      if(len_trim(decompfile(i))==0) exit
      if(mype == 0) print *, ' Testing decomp: ',trim(decompfile(i))
@@ -112,7 +112,7 @@ program pioperformance
            do nv=1,max_nvars
               if(nvars(nv)>0) then
                  call pioperformancetest(decompfile(i), piotypes(1:niotypes), mype, npe, &
-                      rearrangers, niotasks, nframes, nvars(nv), varsize(vs),unlimdimindof) 
+                      rearrangers, niotasks, nframes, nvars(nv), varsize(vs),unlimdimindof)
               endif
            enddo
         endif
@@ -133,7 +133,7 @@ contains
     integer, intent(in) :: piotypes(:)
     integer, intent(in) :: rearrangers(:)
     integer, intent(inout) :: niotasks(:)
-    integer, intent(in) :: nframes 
+    integer, intent(in) :: nframes
     integer, intent(in) :: nvars
     integer, intent(in) :: varsize
     logical, intent(in) :: unlimdimindof
@@ -206,7 +206,7 @@ contains
 !       if(gmaplen /= product(gdims)) then
 !          print *,__FILE__,__LINE__,gmaplen,gdims
 !       endif
-    
+
        allocate(ifld(maplen,nvars))
        allocate(ifld_in(maplen,nvars,nframes))
 
@@ -255,9 +255,9 @@ contains
                 stride = max(1,npe/ntasks)
 
                 call pio_init(mype, comm, ntasks, 0, stride, PIO_REARR_SUBSET, iosystem)
-                   
+
                 write(fname, '(a,i1,a,i4.4,a,i1,a)') 'pioperf.',rearr,'-',ntasks,'-',iotype,'.nc'
-		
+
                 ierr =  PIO_CreateFile(iosystem, File, iotype, trim(fname), mode)
 
                 call WriteMetadata(File, gdims, vari, varr, vard, unlimdimindof)
@@ -297,7 +297,7 @@ contains
                    endif
                    if(mype==0) print *,__FILE__,__LINE__,'Frame: ',recnum
 
-                   do nv=1,nvars   
+                   do nv=1,nvars
                       if(mype==0) print *,__FILE__,__LINE__,'var: ',nv
 #ifdef VARINT
                       call PIO_setframe(File, vari(nv), recnum)
@@ -313,7 +313,7 @@ contains
 #endif
                    enddo
                    if(unlimdimindof) then
-#ifdef VARREAL                
+#ifdef VARREAL
                       call PIO_freedecomp(File, iodesc_r4)
 #endif
 #ifdef VARDOUBLE
@@ -321,7 +321,7 @@ contains
 #endif
 #ifdef VARINT
                       call PIO_freedecomp(File, iodesc_i4)
-#endif                
+#endif
                    endif
                 enddo
                 call pio_closefile(File)
@@ -344,7 +344,7 @@ contains
 #ifdef VARDOUBLE
                    nvarmult = nvarmult+2
 #endif
-                   write(*,'(a15,a9,i10,i10,i10,f20.10)') &	
+                   write(*,'(a15,a9,i10,i10,i10,f20.10)') &
                    'RESULT: write ',rearr_name(rearr), piotypes(k), ntasks, nvars, &
                                      nvarmult*nvars*nframes*gmaplen*4.0/(1048576.0*wall(2))
 #ifdef BGQTRY
@@ -383,8 +383,8 @@ contains
 
                 call MPI_Barrier(comm,ierr)
                 call t_stampf(wall(1), usr(1), sys(1))
-                
-                do frame=1,nframes                   
+
+                do frame=1,nframes
                    do nv=1,nvars
 #ifdef VARINT
                       call PIO_setframe(File, vari(nv), frame)
@@ -400,7 +400,7 @@ contains
 #endif
                    enddo
                 enddo
-                
+
                 call pio_closefile(File)
                 call MPI_Barrier(comm,ierr)
                 call t_stampf(wall(2), usr(2), sys(2))
@@ -413,7 +413,7 @@ contains
                          if(compmap(j)>0) then
 #ifdef VARINT
 #ifdef DEBUG
-                             write(*,'(a11,i2,a9,i11,a9,i11,a9,i2)') & 
+                             write(*,'(a11,i2,a9,i11,a9,i11,a9,i2)') &
 			        ' Int    PE=',mype,'ifld=',ifld(j,nv),' ifld_in=',ifld_in(j,nv,frame),' compmap=',compmap(j)
 #endif
                             if(ifld(j,nv) /= ifld_in(j,nv,frame)) then
@@ -421,7 +421,7 @@ contains
                                !   print *,__LINE__,'Int: ',mype,j,nv,ifld(j,nv),ifld_in(j,nv,frame),compmap(j)
                                !endif
                                write(*,*) '***ERROR:Mismatch!***'
-                               write(*,'(a11,i2,a9,i11,a9,i11,a9,i2)') & 
+                               write(*,'(a11,i2,a9,i11,a9,i11,a9,i2)') &
 			         ' Int    PE=',mype,'ifld=',ifld(j,nv),' ifld_in=',ifld_in(j,nv,frame),' compmap=',compmap(j)
 
                                errorcnt = errorcnt+1
@@ -432,7 +432,7 @@ contains
                             write(*,'(a11,i2,a9,f11.2,a9,f11.2,a9,i2)') &
 			        ' Real   PE=',mype,'rfld=',rfld(j,nv),' rfld_in=',rfld_in(j,nv,frame),' compmap=',compmap(j)
 #endif
-                            
+
                             if(rfld(j,nv) /= rfld_in(j,nv,frame) ) then
                                !if(errorcnt < 10) then
                                !   print *,__LINE__,'Real:', mype,j,nv,rfld(j,nv),rfld_in(j,nv,frame),compmap(j)
@@ -441,7 +441,7 @@ contains
                                write(*,'(a11,i2,a9,f11.2,a9,f11.2,a9,i2)') &
 			         ' Real   PE=',mype,'rfld=',rfld(j,nv),' rfld_in=',rfld_in(j,nv,frame),' compmap=',compmap(j)
 
-                               errorcnt = errorcnt+1                           
+                               errorcnt = errorcnt+1
                             endif
 #endif
 #ifdef VARDOUBLE
@@ -466,7 +466,7 @@ contains
                 enddo
                 j = errorcnt
                 call MPI_Reduce(j, errorcnt, 1, MPI_INTEGER, MPI_SUM, 0, comm, ierr)
-                
+
                 if(mype==0) then
                    if(errorcnt > 0) then
                       print *,'ERROR: INPUT/OUTPUT data mismatch ',errorcnt
@@ -484,11 +484,11 @@ contains
                    write(*,'(a15,a9,i10,i10,i10,f20.10)') &
                         'RESULT: read ',rearr_name(rearr), piotypes(k), ntasks, nvars, &
 			           nvarmult*nvars*nframes*gmaplen*4.0/(1048576.0*wall(2))
-#ifdef BGQTRY 
+#ifdef BGQTRY
   call print_memusage()
 #endif
                 end if
-#ifdef VARREAL                
+#ifdef VARREAL
                 call PIO_freedecomp(iosystem, iodesc_r4)
 #endif
 #ifdef VARDOUBLE
@@ -496,7 +496,7 @@ contains
 #endif
 #ifdef VARINT
                 call PIO_freedecomp(iosystem, iodesc_i4)
-#endif                
+#endif
                 call pio_finalize(iosystem, ierr)
              enddo
           enddo
@@ -533,7 +533,7 @@ contains
     allocate(compmap(varsize))
     if(doftype .eq. 'ROUNDROBIN') then
        do i=1,varsize
-          compmap(i) = (i-1)*npe+mype+1 
+          compmap(i) = (i-1)*npe+mype+1
        enddo
     else if(doftype .eq. 'BLOCK') then
        do i=1,varsize
@@ -570,7 +570,7 @@ contains
 
    do i=1,ndims
 
-      write(dimname,'(a,i6.6)') 'dim',i  
+      write(dimname,'(a,i6.6)') 'dim',i
       iostat = PIO_def_dim(File, trim(dimname), int(gdims(i),pio_offset_kind), dimid(i))
    enddo
    iostat = PIO_def_dim(File, 'time', PIO_UNLIMITED, dimid(ndims+1))
@@ -611,15 +611,15 @@ contains
     implicit none
 #ifdef NO_MPIMOD
 #include <mpif.h>
-#endif  
+#endif
     integer, intent(in) :: errcode
     integer, intent(in) :: line
     character(len=MPI_MAX_ERROR_STRING) :: errorstring
-    
+
     integer :: errorlen
-    
+
     integer :: ierr
-    
+
     if (errcode .ne. MPI_SUCCESS) then
        call MPI_Error_String(errcode,errorstring,errorlen,ierr)
        write(*,*) errorstring(1:errorlen)


### PR DESCRIPTION
If the supplied compmap is not monotonically increasing sort it before copying to iodesc and use the sorted map for rearranging.  If sort is required it will be done on each field prior to calling rearrange routines.   I've merged this to develop for testing.  @edhartnett @jayeshkrishna I would really appreciate your feedback if/when you have time to consider this.
Thanks