### PR TITLE
Fix null stride problem in netCDF-4.6.2

### DIFF
--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -896,6 +896,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     char count_present = count ? true : false;    /* Is count non-NULL? */
     char stride_present = stride ? true : false;  /* Is stride non-NULL? */
     nc_type vartype;   /* The type of the var we are reading from. */
+    PIO_Offset *fake_stride;
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr;          /* Return code from function calls. */
 
@@ -1065,7 +1066,6 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             else
             {
                 /* This is not a scalar var. */
-                PIO_Offset *fake_stride;
                 var_desc_t *vdesc;
                 int *request;
 


### PR DESCRIPTION
Due to a mistake I made netCDF 4.6.2 segfaults when presented with a NULL stride parameter. Whoops! Sorry about that. (It is fixed in netCDF for future releases, but 4.6.2 is out there.)

In this PR I use the same fake_stride solution formerly used for pnetcdf only. Now it is used for pnetcdf and netcdf.

This has been merged to develop for testing.

Fixes #1320.
Fixes #1326.