### PR TITLE
removed mpi_scatter from only clause of use statement, which causes gfortran/mpich to error

### DIFF
--- a/tests/general/pio_decomp_tests_1d.F90.in
+++ b/tests/general/pio_decomp_tests_1d.F90.in
@@ -316,7 +316,7 @@ PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_bc_with_holes
 
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_random
-  use mpi, only : MPI_INT, MPI_SCATTER
+  use mpi, only : MPI_INT
   implicit none
   type(var_desc_t)  :: pio_var1, pio_var2
   type(file_desc_t) :: pio_file


### PR DESCRIPTION
Fixes #1328.

I will merge to develop for testing.