### PR TITLE
remove restrictions to data conversion

### DIFF
--- a/cmake/mpiexec.nwscla
+++ b/cmake/mpiexec.nwscla
@@ -8,9 +8,4 @@
 
 NP=$1
 shift
-if [[ "$LMOD_FAMILY_MPI" == "openmpi" ]]
-then
-  mpirun -np $NP $@
-else
-  mpiexec_mpt -n $NP $@
-fi
+mpirun -np $NP $@

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -760,6 +760,8 @@ enum PIO_ERROR_HANDLERS
 /** Define error codes for PIO. */
 #define PIO_FIRST_ERROR_CODE (-500)
 #define PIO_EBADIOTYPE  (-500)
+/** variable dimensions do not match in a multivar call */
+#define PIO_EVARDIMMISMATCH (-501)
 
 /** ??? */
 #define PIO_REQ_NULL (NC_REQ_NULL-1)

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -145,8 +145,8 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         var_desc_t *vdesc;
         if ((ierr = get_var_desc(varids[v], &file->varlist, &vdesc)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
-        if (vdesc->pio_type != iodesc->piotype)
-            return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
+//        if (vdesc->pio_type != iodesc->piotype)
+//            return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
     }
 
     /* Get a pointer to the variable info for the first variable. */
@@ -247,7 +247,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
 
         /* If fill values are desired, and we're using the BOX
          * rearranger, insert fill values. */
-        if (iodesc->needsfill && iodesc->rearranger == PIO_REARR_BOX)
+        if (iodesc->needsfill && iodesc->rearranger == PIO_REARR_BOX && fillvalue)
         {
             LOG((3, "inerting fill values iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
             for (int nv = 0; nv < nvars; nv++)
@@ -339,10 +339,11 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         /* copying the fill value into the data buffer for the box
          * rearranger. This will be overwritten with data where
          * provided. */
-        for (int nv = 0; nv < nvars; nv++)
-            for (int i = 0; i < iodesc->holegridsize; i++)
-                memcpy(&((char *)vdesc0->fillbuf)[iodesc->mpitype_size * (i + nv * iodesc->holegridsize)],
-                       &((char *)fillvalue)[iodesc->mpitype_size * nv], iodesc->mpitype_size);
+	if(fillvalue)
+	    for (int nv = 0; nv < nvars; nv++)
+		for (int i = 0; i < iodesc->holegridsize; i++)
+		    memcpy(&((char *)vdesc0->fillbuf)[iodesc->mpitype_size * (i + nv * iodesc->holegridsize)],
+			   &((char *)fillvalue)[iodesc->mpitype_size * nv], iodesc->mpitype_size);
 
         /* Write the darray based on the iotype. */
         switch (file->iotype)
@@ -647,10 +648,10 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 
     /* If the type of the var doesn't match the type of the
      * decomposition, return an error. */
-    if (iodesc->piotype != vdesc->pio_type)
-        return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
-    pioassert(iodesc->mpitype_size == vdesc->mpi_type_size, "wrong mpi info",
-              __FILE__, __LINE__);
+//    if (iodesc->piotype != vdesc->pio_type)
+//        return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
+//    pioassert(iodesc->mpitype_size == vdesc->mpi_type_size, "wrong mpi info",
+//              __FILE__, __LINE__);
 
     /* If we don't know the fill value for this var, get it. */
     if (!vdesc->fillvalue)
@@ -689,13 +690,13 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         wmb->frame = NULL;
         wmb->fillvalue = NULL;
     }
-    LOG((2, "wmb->num_arrays = %d arraylen = %d vdesc->mpi_type_size = %d\n",
-         wmb->num_arrays, arraylen, vdesc->mpi_type_size));
+    LOG((2, "wmb->num_arrays = %d arraylen = %d iodesc->mpitype_size = %d\n",
+         wmb->num_arrays, arraylen, iodesc->mpitype_size));
 #if PIO_USE_MALLOC
     /* Try realloc first and call flush if realloc fails. */
     if (arraylen > 0)
     {
-        size_t data_size = (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size;
+        size_t data_size = (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size;
 
         if ((realloc_data = realloc(wmb->data, data_size)))
         {
@@ -716,12 +717,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* maxfree is the available memory. If that is < 10% greater than
      * the size of the current request needsflush is true. */
     if (needsflush == 0)
-        needsflush = (maxfree <= 1.1 * (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size);
+        needsflush = (maxfree <= 1.1 * (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size);
 #endif
     /* the limit of data_size < INT_MAX is due to a bug in ROMIO which limits
        the size of contiguous data to INT_MAX, a fix has been proposed in
        https://github.com/pmodels/mpich/pull/2888 */
-    io_data_size = (1 + wmb->num_arrays) * iodesc->maxiobuflen * vdesc->mpi_type_size;
+    io_data_size = (1 + wmb->num_arrays) * iodesc->maxiobuflen * iodesc->mpitype_size;
     if(io_data_size > INT_MAX)
 	needsflush = 2;
 
@@ -740,8 +741,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         /* Collect a debug report about buffer. */
         cn_buffer_report(ios, true);
         LOG((2, "maxfree = %ld wmb->num_arrays = %d (1 + wmb->num_arrays) *"
-             " arraylen * vdesc->mpi_type_size = %ld totfree = %ld\n", maxfree, wmb->num_arrays,
-             (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size, totfree));
+             " arraylen * iodesc->mpitype_size = %ld totfree = %ld\n", maxfree, wmb->num_arrays,
+             (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size, totfree));
 #endif /* PIO_ENABLE_LOGGING */
 #endif /* !PIO_USE_MALLOC */
 
@@ -756,17 +757,17 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     /* Try realloc again if there is a flush. */
     if (arraylen > 0 && needsflush > 0)
     {
-        if (!(wmb->data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size)))
+        if (!(wmb->data = realloc(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size)))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        LOG((2, "after a flush, realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size));
+        LOG((2, "after a flush, realloc got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
     }
 #else
     /* Get memory for data. */
     if (arraylen > 0)
     {
-        if (!(wmb->data = bgetr(wmb->data, (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size)))
+        if (!(wmb->data = bgetr(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size)))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        LOG((2, "got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size));
+        LOG((2, "got %ld bytes for data", (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
     }
 #endif
 
@@ -788,11 +789,11 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (iodesc->needsfill)
     {
         /* Get memory to hold fill value. */
-        if (!(wmb->fillvalue = bgetr(wmb->fillvalue, vdesc->mpi_type_size * (1 + wmb->num_arrays))))
+        if (!(wmb->fillvalue = bgetr(wmb->fillvalue, iodesc->mpitype_size * (1 + wmb->num_arrays))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
-        memcpy((char *)wmb->fillvalue + vdesc->mpi_type_size * wmb->num_arrays,
-               vdesc->fillvalue, vdesc->mpi_type_size);
+        memcpy((char *)wmb->fillvalue + iodesc->mpitype_size * wmb->num_arrays,
+               vdesc->fillvalue, iodesc->mpitype_size);
     }
 
     /* Tell the buffer about the data it is getting. */
@@ -802,11 +803,11 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
          wmb->vid[wmb->num_arrays]));
 
     /* Copy the user-provided data to the buffer. */
-    bufptr = (void *)((char *)wmb->data + arraylen * vdesc->mpi_type_size * wmb->num_arrays);
+    bufptr = (void *)((char *)wmb->data + arraylen * iodesc->mpitype_size * wmb->num_arrays);
     if (arraylen > 0)
     {
-        memcpy(bufptr, array, arraylen * vdesc->mpi_type_size);
-        LOG((3, "copied %ld bytes of user data", arraylen * vdesc->mpi_type_size));
+        memcpy(bufptr, array, arraylen * iodesc->mpitype_size);
+        LOG((3, "copied %ld bytes of user data", arraylen * iodesc->mpitype_size));
     }
 
     /* Add the unlimited dimension value of this variable to the frame
@@ -815,9 +816,9 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         wmb->frame[wmb->num_arrays] = vdesc->record;
     wmb->num_arrays++;
 
-    LOG((2, "wmb->num_arrays = %d iodesc->maxbytes / vdesc->mpi_type_size = %d "
+    LOG((2, "wmb->num_arrays = %d iodesc->maxbytes / iodesc->mpitype_size = %d "
          "iodesc->ndof = %d iodesc->llen = %d", wmb->num_arrays,
-         iodesc->maxbytes / vdesc->mpi_type_size, iodesc->ndof, iodesc->llen));
+         iodesc->maxbytes / iodesc->mpitype_size, iodesc->ndof, iodesc->llen));
 
     return PIO_NOERR;
 }

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -110,7 +110,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     io_desc_t *iodesc;     /* Pointer to IO description information. */
     int rlen;              /* Total data buffer size. */
     var_desc_t *vdesc0;    /* First entry in array of var_desc structure for each var. */
-    int fndims;            /* Number of dims in the var in the file. */
+    int fndims, fndims2;            /* Number of dims in the var in the file. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function calls. */
     int ierr;              /* Return code. */
     void *tmparray;
@@ -162,6 +162,13 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         if ((ierr = PIOc_inq_varndims(file->pio_ncid, varids[0], &fndims)))
             return check_netcdf(file, ierr, __FILE__, __LINE__);
         LOG((3, "called PIOc_inq_varndims varids[0] = %d fndims = %d", varids[0], fndims));
+	for (int v=1; v < nvars; v++){
+	    if ((ierr = PIOc_inq_varndims(file->pio_ncid, varids[v], &fndims2)))
+		return check_netcdf(file, ierr, __FILE__, __LINE__);
+	    if(fndims != fndims2)
+		return pio_err(ios, file, PIO_EVARDIMMISMATCH, __FILE__, __LINE__);
+	}
+
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1213,7 +1213,7 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobu
                 }
             }
 
-#ifdef LOGGING
+#ifdef PIO_ENABLE_LOGGING
             for (int i = 1; i < ndims; i++)
                 LOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
 #endif /* LOGGING */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -638,7 +638,9 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
                         /* Write, in non-blocking fashion, a list of subarrays. */
                         LOG((3, "about to call ncmpi_iput_varn() varids[%d] = %d rrcnt = %d, llen = %d",
                              nv, varids[nv], rrcnt, llen));
-                        ierr = ncmpi_iput_varn(file->fh, varids[nv], rrcnt, startlist, countlist,
+			for (int i=0; i< rrcnt; i++)
+			    LOG((3, "i %d start %ld count %ld start %ld count %ld\n",i,startlist[i][0], countlist[i][0],startlist[i][1], countlist[i][1]));
+			ierr = ncmpi_iput_varn(file->fh, varids[nv], rrcnt, startlist, countlist,
                                                bufptr, llen, iodesc->mpitype, &vdesc->request[vdesc->nreqs]);
 
                         /* keeps wait calls in sync */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -362,6 +362,9 @@ extern "C" {
                         int **proc_list, int **my_proc_list);
 
     int pio_sorted_copy(const void *array, void *tmparray, io_desc_t *iodesc, int nvars, int direction);
+
+    int PIOc_inq_att_eh(int ncid, int varid, const char *name, int eh,
+			nc_type *xtypep, PIO_Offset *lenp);
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -76,6 +76,9 @@ int PIOc_strerror(int pioerr, char *errmsg)
         case PIO_EBADIOTYPE:
             strcpy(errmsg, "Bad IO type");
             break;
+	case PIO_EVARDIMMISMATCH:
+	    strcpy(errmsg, "Variable dim mismatch in multivar call");
+	    break;
         default:
             strcpy(errmsg, "Unknown Error: Unrecognized error code");
         }

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -202,10 +202,9 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
                         ERR(ERR_WRONG);
 
 		    /* This should work - library type conversion */
-		    if (other_type && (ret = PIOc_write_darray(ncid, varid2, ioid, arraylen, test_data, ofillvalue))){
-			printf("other_type %d ret %d fillvalue %x\n",other_type, ret, fillvalue);
+		    if (other_type && (ret = PIOc_write_darray(ncid, varid2, ioid, arraylen, test_data, ofillvalue)))
                         ERR(ret);
-		    }
+
                     /* Write the data. */
                     if ((ret = PIOc_write_darray(ncid, varid, ioid, arraylen, test_data, fillvalue)))
                         ERR(ret);

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -79,7 +79,7 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
     int varid2;     /* The ID of a netCDF varable of different type. */
     int wrong_varid = TEST_VAL_42;  /* A wrong ID. */
     int ret;       /* Return code. */
-    int mpi_type;
+    MPI_Datatype mpi_type;
     int type_size; /* size of a variable of type pio_type */
     int other_type; /* another variable of the same size but different type */
     PIO_Offset arraylen = 4;
@@ -231,9 +231,11 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
                     if (PIOc_write_darray_multi(ncid, &varid_big, ioid, 1, arraylen, test_data, &frame,
                                                 fillvalue, flushtodisk) != PIO_ENOTVAR)
                         ERR(ERR_WRONG);
+//		    pio_setloglevel(3);
                     if (PIOc_write_darray_multi(ncid, &wrong_varid, ioid, 1, arraylen, test_data, &frame,
                                                 fillvalue, flushtodisk) != PIO_ENOTVAR)
                         ERR(ERR_WRONG);
+//		    pio_setloglevel(0);
 
 		    /* This should work - library type conversion */
 		    if (other_type && (ret = PIOc_write_darray_multi(ncid, &varid2, ioid, 1, arraylen, test_data, &frame,

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -178,8 +178,8 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
                         ERR(ERR_WRONG);
                     if (PIOc_write_darray(ncid, TEST_VAL_42, ioid, arraylen, test_data, fillvalue) != PIO_ENOTVAR)
                         ERR(ERR_WRONG);
-                    if (PIOc_write_darray(ncid, varid2, ioid, arraylen, test_data, fillvalue) != PIO_EINVAL)
-                        ERR(ERR_WRONG);
+//                    if (PIOc_write_darray(ncid, varid2, ioid, arraylen, test_data, fillvalue) != PIO_EINVAL)
+//                        ERR(ERR_WRONG);
 
                     /* Write the data. */
                     if ((ret = PIOc_write_darray(ncid, varid, ioid, arraylen, test_data, fillvalue)))

--- a/tests/cunit/test_darray_multi.c
+++ b/tests/cunit/test_darray_multi.c
@@ -283,9 +283,9 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
                 wrong_varid[0] = varid[0];
                 wrong_varid[1] = varid[1];
                 wrong_varid[0] = other_varid;
-                if (PIOc_write_darray_multi(ncid, wrong_varid, ioid, NVAR, arraylen, test_data, frame,
-                                            fillvalue, flushtodisk) != PIO_EINVAL)
-                    ERR(ERR_WRONG);
+//                if (PIOc_write_darray_multi(ncid, wrong_varid, ioid, NVAR, arraylen, test_data, frame,
+//                                            fillvalue, flushtodisk) != PIO_EINVAL)
+//                    ERR(ERR_WRONG);
 
                 /* Write the data with the _multi function. */
                 if ((ret = PIOc_write_darray_multi(ncid, varid, ioid, NVAR, arraylen, test_data, frame,

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -115,11 +115,11 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                 ERR(ret);
 
             /* Set the custom fill values. */
-            if ((ret = PIOc_def_var_fill(ncid, varid[0], 0, &custom_fillvalue_int))) 
+            if ((ret = PIOc_def_var_fill(ncid, varid[0], 0, &custom_fillvalue_int)))
                 ERR(ret);
-            if ((ret = PIOc_def_var_fill(ncid, varid[1], 0, &custom_fillvalue_int))) 
+            if ((ret = PIOc_def_var_fill(ncid, varid[1], 0, &custom_fillvalue_int)))
                 ERR(ret);
-            if ((ret = PIOc_def_var_fill(ncid, varid[2], 0, &custom_fillvalue_float))) 
+            if ((ret = PIOc_def_var_fill(ncid, varid[2], 0, &custom_fillvalue_float)))
                 ERR(ret);
 
             /* End define mode. */
@@ -149,18 +149,18 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                 ERR(ret);
 
             /* This should not work, since the type of the var is
-             * PIO_FLOAT, and the type if the decomposition is
+             * PIO_FLOAT, and the type of the decomposition is
              * PIO_INT. */
-            if (PIOc_write_darray(ncid, varid[2], ioid, arraylen, test_data_float,
-                                  fvp_float) != PIO_EINVAL)
-                ERR(ERR_WRONG);
+//            if (PIOc_write_darray(ncid, varid[2], ioid, arraylen, test_data_float,
+//                                  fvp_float) != PIO_EINVAL)
+//                ERR(ERR_WRONG);
 
             /* This should also fail, because it mixes an int and a
              * float. */
-            int frame[NUM_VAR] = {0, 0, 0};
-            if (PIOc_write_darray_multi(ncid, varid, ioid, NUM_VAR, arraylen * NUM_VAR, test_data_float,
-                                        frame, NULL, 0) != PIO_EINVAL)
-                ERR(ERR_WRONG);
+//            int frame[NUM_VAR] = {0, 0, 0};
+//            if (PIOc_write_darray_multi(ncid, varid, ioid, NUM_VAR, arraylen * NUM_VAR, test_data_float,
+//                                        frame, NULL, 0) != PIO_EINVAL)
+//                ERR(ERR_WRONG);
 
 
             /* Close the netCDF file. */

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -148,19 +148,12 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                                          fvp_int)))
                 ERR(ret);
 
-            /* This should not work, since the type of the var is
-             * PIO_FLOAT, and the type of the decomposition is
-             * PIO_INT. */
-//            if (PIOc_write_darray(ncid, varid[2], ioid, arraylen, test_data_float,
-//                                  fvp_float) != PIO_EINVAL)
-//                ERR(ERR_WRONG);
-
-            /* This should also fail, because it mixes an int and a
-             * float. */
-//            int frame[NUM_VAR] = {0, 0, 0};
-//            if (PIOc_write_darray_multi(ncid, varid, ioid, NUM_VAR, arraylen * NUM_VAR, test_data_float,
-//                                        frame, NULL, 0) != PIO_EINVAL)
-//                ERR(ERR_WRONG);
+            /* This should work since an int and a
+             * float are the same size. */
+	    int frame[NUM_VAR] = {0, 0, 0};
+            if (PIOc_write_darray_multi(ncid, varid, ioid, NUM_VAR, arraylen * NUM_VAR, test_data_float,
+                                        frame, NULL, 0) != PIO_EINVAL)
+                ERR(ret);
 
 
             /* Close the netCDF file. */

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -106,7 +106,7 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                 if ((ret = PIOc_def_dim(ncid, dim_name[d], (PIO_Offset)dim_len[d], &dimids[d])))
                     ERR(ret);
 
-            /* Var 0 does not have a record dim, varid 1 is a record var. */
+            /* Var 0 does not have a record dim, varid 1 and 2 are record vars. */
             if ((ret = PIOc_def_var(ncid, var_name[0], PIO_INT, NDIM - 1, &dimids[1], &varid[0])))
                 ERR(ret);
             if ((ret = PIOc_def_var(ncid, var_name[1], PIO_INT, NDIM, dimids, &varid[1])))
@@ -148,13 +148,16 @@ int test_multivar_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                                          fvp_int)))
                 ERR(ret);
 
-            /* This should work since an int and a
-             * float are the same size. */
+            /* This should not work since we cannot mix record and not record vars */
 	    int frame[NUM_VAR] = {0, 0, 0};
-            if (PIOc_write_darray_multi(ncid, varid, ioid, NUM_VAR, arraylen * NUM_VAR, test_data_float,
-                                        frame, NULL, 0) != PIO_EINVAL)
-                ERR(ret);
 
+            if (PIOc_write_darray_multi(ncid, varid, ioid, NUM_VAR, arraylen * NUM_VAR, test_data_float,
+                                        frame, NULL, 0) != PIO_EVARDIMMISMATCH)
+                ERR(ERR_WRONG);
+	    /* This should work since int and float are the same size and both are record vars */
+            if ((ret = PIOc_write_darray_multi(ncid, varid+1, ioid, NUM_VAR-1, arraylen * (NUM_VAR-1), test_data_float,
+					       frame, NULL, 0)))
+                ERR(ret);
 
             /* Close the netCDF file. */
             if ((ret = PIOc_closefile(ncid)))


### PR DESCRIPTION
This removes the restrictions to data conversion at the netcdf/pnetcdf library level.   All tests pass but only because I removed a few expected failures.  I plan to add back some tests before merging to develop.  
Fixes #1334 