### PR TITLE
optimize the linked list with a pointer to the list end

### DIFF
--- a/pio/pio_types.F90
+++ b/pio/pio_types.F90
@@ -192,6 +192,7 @@ module pio_types
     type, public :: File_desc_t
        type(iosystem_desc_t), pointer :: iosystem => null()
        type(io_data_list), pointer :: data_list_top  => null()  ! used for non-blocking pnetcdf calls
+       type(io_data_list), pointer :: data_list_end  => null()  ! used for non-blocking pnetcdf calls
        integer :: buffsize=0
        integer(i4) :: fh
        integer(kind=PIO_OFFSET) :: offset             ! offset into file

--- a/pio/piodarray.F90.in
+++ b/pio/piodarray.F90.in
@@ -1242,8 +1242,9 @@ contains
     if(.not. associated(File%data_list_top)) then
        allocate(file%data_list_top)
        ptr => file%data_list_top
+       file%data_list_end => file%data_list_top
     else
-       ptr => file%data_list_top
+       ptr => file%data_list_end
        do while(associated(ptr%next))
           ptr => ptr%next
        end do
@@ -1257,6 +1258,7 @@ contains
     this_buffsize = size(iobuf)*c_sizeof(iobuf(1))
     file%buffsize=file%buffsize+this_buffsize
     total_buffsize = total_buffsize+this_buffsize
+    file%data_list_end => ptr
 #ifdef TIMING
     call t_startf("PIO:allred_add_data_to_buf")
 #endif
@@ -1324,6 +1326,7 @@ contains
           deallocate(prevptr)
        end do
        nullify(file%data_list_top)
+       nullify(file%data_list_end)
 
        total_buffsize=total_buffsize-file%buffsize
 
@@ -1546,4 +1549,3 @@ subroutine read_vdc2_real(File, Vardesc, iodesc, array, iostat)
 
 
 end module piodarray
-


### PR DESCRIPTION
Add a pointer to the end of the linked list to avoid traversing the list each time add_data_to_buffer_{TYPE}  is called.  