### PR TITLE
Msg overwrite fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option (PIO_INTERNAL_DOC     "Enable PIO developer documentation"           OFF)
 option (PIO_TEST_BIG_ENDIAN  "Enable test to see if machine is big endian"  ON)
 option (PIO_USE_MPIIO        "Enable support for MPI-IO auto detect"        ON)
 option (PIO_USE_MPISERIAL    "Enable mpi-serial support (instead of MPI)"   OFF)
-option (PIO_USE_MALLOC       "Use native malloc (instead of bget package)"  OFF)
+option (PIO_USE_MALLOC       "Use native malloc (instead of bget package)"  ON)
 option (PIO_USE_PNETCDF_VARD       "Use pnetcdf put_vard "  OFF)
 option (WITH_PNETCDF         "Require the use of PnetCDF"                   ON)
 

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -373,6 +373,7 @@ extern "C" {
  * async is being used. */
 enum PIO_MSG
 {
+    PIO_MSG_NULL,
     PIO_MSG_OPEN_FILE,
     PIO_MSG_CREATE_FILE,
     PIO_MSG_INQ_ATT,

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -2521,7 +2521,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
         {
             my_iosys = iosys[cmp];
             LOG((1, "about to call MPI_Irecv union_comm = %d", my_iosys->union_comm));
-            if ((mpierr = MPI_Irecv(messages+cmp, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG,
+            if ((mpierr = MPI_Irecv(&(messages[cmp]), 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG,
                                     my_iosys->union_comm, &req[cmp])))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
             LOG((1, "MPI_Irecv req[%d] = %d", cmp, req[cmp]));
@@ -2732,7 +2732,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
             my_iosys = iosys[index];
             LOG((3, "pio_msg_handler2 about to Irecv index = %d comproot = %d union_comm = %d",
                  index, my_iosys->comproot, my_iosys->union_comm));
-            if ((mpierr = MPI_Irecv(messages+index, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
+            if ((mpierr = MPI_Irecv(&(messages[index]), 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
                                     &req[index])))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
             LOG((3, "pio_msg_handler2 called MPI_Irecv req[%d] = %d", index, req[index]));

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -2501,7 +2501,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
                      MPI_Comm io_comm)
 {
     iosystem_desc_t *my_iosys;
-    int msg = 0;
+    int msg = PIO_MSG_NULL, messages[component_count];
     MPI_Request req[component_count];
     MPI_Status status;
     int index;
@@ -2521,7 +2521,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
         {
             my_iosys = iosys[cmp];
             LOG((1, "about to call MPI_Irecv union_comm = %d", my_iosys->union_comm));
-            if ((mpierr = MPI_Irecv(&msg, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG,
+            if ((mpierr = MPI_Irecv(messages+cmp, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG,
                                     my_iosys->union_comm, &req[cmp])))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
             LOG((1, "MPI_Irecv req[%d] = %d", cmp, req[cmp]));
@@ -2545,6 +2545,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
             if ((mpierr = MPI_Waitany(component_count, req, &index, &status)))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
             LOG((3, "Waitany returned index = %d req[%d] = %d", index, index, req[index]));
+	    msg = messages[index];
             for (int c = 0; c < component_count; c++)
                 LOG((3, "req[%d] = %d", c, req[c]));
         }
@@ -2731,7 +2732,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
             my_iosys = iosys[index];
             LOG((3, "pio_msg_handler2 about to Irecv index = %d comproot = %d union_comm = %d",
                  index, my_iosys->comproot, my_iosys->union_comm));
-            if ((mpierr = MPI_Irecv(&msg, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
+            if ((mpierr = MPI_Irecv(messages+index, 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
                                     &req[index])))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
             LOG((3, "pio_msg_handler2 called MPI_Irecv req[%d] = %d", index, req[index]));
@@ -2739,7 +2740,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
 
         LOG((3, "pio_msg_handler2 done msg = %d open_components = %d",
              msg, open_components));
-
+	msg = PIO_MSG_NULL;
         /* If there are no more open components, exit. */
         if (finalize)
         {


### PR DESCRIPTION
The issue was that all components were writing to the same memory location on the io root and so the value of msg could be overwritten at any point in the pio_msg_handler2.   The solution is to provide a unique location for each component to send messages to.   

All tests now pass with gnu/openmpi - test 30 test_darray_async_many is still timing out with
intel/mpt.   