### PR TITLE
bug fix: allocate my_proc_list after checking component_count

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1333,7 +1333,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
                     int *iosysidp)
 {
     int my_rank;          /* Rank of this task. */
-    int *my_proc_list[component_count];   /* Array of arrays of procs for comp components. */
+    int **my_proc_list;   /* Array of arrays of procs for comp components. */
     int my_io_proc_list[num_io_procs]; /* List of processors in IO component. */
     int mpierr;           /* Return code from MPI functions. */
     int ret;              /* Return code. */
@@ -1342,6 +1342,8 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
     if (num_io_procs < 1 || component_count < 1 || !num_procs_per_comp || !iosysidp ||
         (rearranger != PIO_REARR_BOX))
         return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+
+    my_proc_list = (int**) malloc(component_count * sizeof(int*));
 
     /* Turn on the logging system for PIO. */
     pio_init_logging();
@@ -1640,6 +1642,8 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
     /* Free the arrays of processor numbers. */
     for (int cmp = 0; cmp < component_count; cmp++)
         free(my_proc_list[cmp]);
+
+    free(my_proc_list);
 
     /* Free MPI groups. */
     if ((ret = MPI_Group_free(&io_group)))


### PR DESCRIPTION
Test program tests/cunit/test_async_simple.c, line 70 calls PIOc_init_async with argument component_count set to -1.
https://github.com/NCAR/ParallelIO/blob/bd08dcc9ce4f30b2c03f5d705496a1630a4a92d8/tests/cunit/test_async_simple.c#L70-L71

This negative value can cause an error for variable my_proc_list.
https://github.com/NCAR/ParallelIO/blob/bd08dcc9ce4f30b2c03f5d705496a1630a4a92d8/src/clib/pioc.c#L1336