### PR TITLE
Make async mode writes really async

### DIFF
--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -1254,13 +1254,16 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         /* Free malloced resources. */
         if (ndims && !stride_present)
            free(fake_stride);
+
+        if (ierr)
+            return check_netcdf(file, ierr, __FILE__, __LINE__);
     }
 
     /* Broadcast and check the return code. */
-    if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-    if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+    /* if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm))) */
+    /*     return check_mpi(NULL, file, mpierr, __FILE__, __LINE__); */
+    /* if (ierr) */
+    /*     return check_netcdf(file, ierr, __FILE__, __LINE__); */
     LOG((2, "PIOc_put_vars_tc bcast netcdf return code %d complete", ierr));
 
     return PIO_NOERR;

--- a/tests/cunit/test_async_perf.c
+++ b/tests/cunit/test_async_perf.c
@@ -36,9 +36,9 @@
 #define LON_LEN 3
 
 /* The length of our sample data along each dimension. */
-#define X_DIM_LEN 4
-#define Y_DIM_LEN 4
-#define Z_DIM_LEN 4
+#define X_DIM_LEN 1024
+#define Y_DIM_LEN 1024
+#define Z_DIM_LEN 256
 
 /* The number of timesteps of data to write. */
 #define NUM_TIMESTEPS 3

--- a/tests/cunit/test_perf2.c
+++ b/tests/cunit/test_perf2.c
@@ -30,9 +30,9 @@
 #define NDIM3 3
 
 /* The length of our sample data along each dimension. */
-#define X_DIM_LEN 128
-#define Y_DIM_LEN 128
-#define Z_DIM_LEN 16
+#define X_DIM_LEN 1024
+#define Y_DIM_LEN 1024
+#define Z_DIM_LEN 256
 
 /* The number of timesteps of data to write. */
 #define NUM_TIMESTEPS 10
@@ -429,6 +429,6 @@ int main(int argc, char **argv)
     if ((ret = pio_test_finalize(&test_comm)))
         return ret;
 
-    printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
+    /* printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME); */
     return 0;
 }

--- a/tests/cunit/test_perf2.c
+++ b/tests/cunit/test_perf2.c
@@ -32,7 +32,7 @@
 /* The length of our sample data along each dimension. */
 #define X_DIM_LEN 1024
 #define Y_DIM_LEN 1024
-#define Z_DIM_LEN 256
+#define Z_DIM_LEN 128
 
 /* The number of timesteps of data to write. */
 #define NUM_TIMESTEPS 10


### PR DESCRIPTION
Fixes #1427.

No longer make compute processors wait for return code from data writes, allowing them to continue processing while writes are happening.