### PR TITLE
turning on docs build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: trusty
+dist: xenial
 sudo: false
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran
+    - pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran doxygen
 
 before_install:
   - test -n $CC && unset CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev gfortran doxygen graphviz
+    - pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev gfortran doxygen graphviz 
 
 before_install:
   - test -n $CC && unset CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran doxygen
+    - pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran doxygen netcdf-fortran
 
 before_install:
   - test -n $CC && unset CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran doxygen netcdf-fortran
+    - pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev gfortran doxygen
 
 before_install:
   - test -n $CC && unset CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ script:
   - export FFLAGS='-fsanitize=address -fno-omit-frame-pointer'
   - export FCFLAGS='-fsanitize=address -fno-omit-frame-pointer'
   - export DISTCHECK_CONFIGURE_FLAGS='--enable-fortran'
-  - ./configure --enable-fortran
+  - ./configure --enable-fortran --enable-docs
+  - make -j
   - make -j distcheck
   - rm -rf build
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ env:
   
 script:
   - set -e
+  - doxygen -v
   - autoreconf -i
   - export CFLAGS='-std=c99  -fsanitize=address -fno-omit-frame-pointer'
   - export FFLAGS='-fsanitize=address -fno-omit-frame-pointer'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev gfortran doxygen
+    - pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev gfortran doxygen graphviz
 
 before_install:
   - test -n $CC && unset CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ env:
     - LDFLAGS='-L/usr/lib'
   
 script:
+  - set -e
   - autoreconf -i
   - export CFLAGS='-std=c99  -fsanitize=address -fno-omit-frame-pointer'
   - export FFLAGS='-fsanitize=address -fno-omit-frame-pointer'

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -9,6 +9,8 @@ DoxygenLayout.xml doxygen.sty
 check: all
 all:
 	doxygen Doxyfile
+	ls -l doxywarn.log
+	cat doxywarn.log
 	[ ! -s doxywarn.log ]
 
 CLEANFILES = *.log


### PR DESCRIPTION
Turning on documentation build in travis. Build will fail for undocumented functions or warnings in documentation. Such warnings must be corrected before travis will pass the PR.