### PR TITLE
added PIOc_free_iosystem()

### DIFF
--- a/examples/c/darray_async.c
+++ b/examples/c/darray_async.c
@@ -374,7 +374,7 @@ int main(int argc, char* argv[])
 
         /* Finalize the IO system. Only call this from the computation tasks. */
         printf("%d %s Freeing PIO resources\n", my_rank, TEST_NAME);
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             ERR(ret);
     } /* endif comp_task */
 

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -365,7 +365,7 @@ int main(int argc, char* argv[])
 
     /* Finalize the IO system. */
     printf("rank: %d Freeing PIO resources...\n", my_rank);
-    if ((ret = PIOc_finalize(iosysid)))
+    if ((ret = PIOc_free_iosystem(iosysid)))
         ERR(ret);
 
     /* Finalize the MPI library. */

--- a/examples/c/examplePio.c
+++ b/examples/c/examplePio.c
@@ -442,7 +442,7 @@ struct examplePioClass* epc_closeFile( struct examplePioClass* this )
 
     This function frees the memory used in this example. It calls the
     ParallelIO library function PIOc_freedecomp() to free
-    decomposition resources. Then calles PIOc_finalize() and
+    decomposition resources. Then calles PIOc_free_iosystem() and
     MPI_finalize() to free library resources.
     
     @param [in] this  Pointer to self.
@@ -457,7 +457,7 @@ struct examplePioClass* epc_cleanUp( struct examplePioClass* this )
     free(this->compdof);
     
     PIOc_freedecomp(this->pioIoSystem, this->iodescNCells);
-    PIOc_finalize(this->pioIoSystem);
+    PIOc_free_iosystem(this->pioIoSystem);
     MPI_Finalize();
     
     return this;

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -840,7 +840,8 @@ extern "C" {
     int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
                             int *iosysidp);
 
-    /* Shut down an iosystem and free all associated resources. */
+    /** Shut down an iosystem and free all associated resources. Use
+     * PIOc_free_iosystem() instead. */
     int PIOc_finalize(int iosysid);
 
     /* Shut down an iosystem and free all associated resources. */

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -840,8 +840,11 @@ extern "C" {
     int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
                             int *iosysidp);
 
-    /* Shut down iosystem and free all associated resources. */
+    /* Shut down an iosystem and free all associated resources. */
     int PIOc_finalize(int iosysid);
+
+    /* Shut down an iosystem and free all associated resources. */
+    int PIOc_free_iosystem(int iosysid);
 
     /* Set error handling for entire io system. */
     int PIOc_Set_IOSystem_Error_Handling(int iosysid, int method);

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -373,6 +373,24 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
 }
 
 /**
+ * Clean up internal data structures, and free MPI resources,
+ * associated with an IOSystem. This is the old name for
+ * PIOc_free_iosystem(). This function is maintained for backward
+ * compatibility. Use PIOc_free_iosystem() for new code.
+ *
+ * @param iosysid: the io system ID provided by PIOc_Init_Intracomm()
+ * or PIOc_init_async().
+ * @returns 0 for success or non-zero for error.
+ * @ingroup PIO_finalize_c
+ * @author Jim Edwards, Ed Hartnett
+ */
+int
+PIOc_finalize(int iosysid)
+{
+    return PIOc_free_iosystem(iosysid);
+}
+
+/**
  * Provides the functionality of MPI_Gatherv with flow control
  * options. This function is not currently used, but we hope it will
  * be useful in future optimizations.

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1138,7 +1138,7 @@ PIOc_set_hint(int iosysid, const char *hint, const char *hintval)
  * or PIOc_init_async().
  * @returns 0 for success or non-zero for error.
  * @ingroup PIO_finalize_c
- * @author Ed Hartnett
+ * @author Jim Edwards, Ed Hartnett
  */
 int
 PIOc_free_iosystem(int iosysid)
@@ -1241,24 +1241,6 @@ PIOc_free_iosystem(int iosysid)
 
     LOG((2, "PIOc_finalize completed successfully"));
     return PIO_NOERR;
-}
-
-/**
- * Clean up internal data structures, and free MPI resources,
- * associated with an IOSystem. This is the old name for
- * PIOc_free_iosystem(). This function is maintained for backward
- * compatibility. Use PIOc_free_iosystem() for new code.
- *
- * @param iosysid: the io system ID provided by PIOc_Init_Intracomm()
- * or PIOc_init_async().
- * @returns 0 for success or non-zero for error.
- * @ingroup PIO_finalize_c
- * @author Jim Edwards, Ed Hartnett
- */
-int
-PIOc_finalize(int iosysid)
-{
-    return PIOc_free_iosystem(iosysid);
 }
 
 /**

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1143,22 +1143,6 @@ PIOc_set_hint(int iosysid, const char *hint, const char *hintval)
 int
 PIOc_free_iosystem(int iosysid)
 {
-    return PIOc_finalize(iosysid);
-}
-
-/**
- * Clean up internal data structures, and free MPI resources,
- * associated with an IOSystem.
- *
- * @param iosysid: the io system ID provided by PIOc_Init_Intracomm()
- * or PIOc_init_async().
- * @returns 0 for success or non-zero for error.
- * @ingroup PIO_finalize_c
- * @author Jim Edwards, Ed Hartnett
- */
-int
-PIOc_finalize(int iosysid)
-{
     iosystem_desc_t *ios;
     int niosysid;          /* The number of currently open IO systems. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
@@ -1257,6 +1241,24 @@ PIOc_finalize(int iosysid)
 
     LOG((2, "PIOc_finalize completed successfully"));
     return PIO_NOERR;
+}
+
+/**
+ * Clean up internal data structures, and free MPI resources,
+ * associated with an IOSystem. This is the old name for
+ * PIOc_free_iosystem(). This function is maintained for backward
+ * compatibility. Use PIOc_free_iosystem() for new code.
+ *
+ * @param iosysid: the io system ID provided by PIOc_Init_Intracomm()
+ * or PIOc_init_async().
+ * @returns 0 for success or non-zero for error.
+ * @ingroup PIO_finalize_c
+ * @author Jim Edwards, Ed Hartnett
+ */
+int
+PIOc_finalize(int iosysid)
+{
+    return PIOc_free_iosystem(iosysid);
 }
 
 /**

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1131,10 +1131,27 @@ PIOc_set_hint(int iosysid, const char *hint, const char *hintval)
 }
 
 /**
- * Clean up internal data structures, free MPI resources, and exit the
- * pio library.
+ * Clean up internal data structures, and free MPI resources,
+ * associated with an IOSystem.
  *
- * @param iosysid: the io system ID provided by PIOc_Init_Intracomm().
+ * @param iosysid: the io system ID provided by PIOc_Init_Intracomm()
+ * or PIOc_init_async().
+ * @returns 0 for success or non-zero for error.
+ * @ingroup PIO_finalize_c
+ * @author Ed Hartnett
+ */
+int
+PIOc_free_iosystem(int iosysid)
+{
+    return PIOc_finalize(iosysid);
+}
+
+/**
+ * Clean up internal data structures, and free MPI resources,
+ * associated with an IOSystem.
+ *
+ * @param iosysid: the io system ID provided by PIOc_Init_Intracomm()
+ * or PIOc_init_async().
  * @returns 0 for success or non-zero for error.
  * @ingroup PIO_finalize_c
  * @author Jim Edwards, Ed Hartnett

--- a/tests/cunit/test_async_3proc.c
+++ b/tests/cunit/test_async_3proc.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
                 /* Finalize the IO system. Only call this from the computation tasks. */
                 for (int c = 0; c < COMPONENT_COUNT; c++)
                 {
-                    if ((ret = PIOc_finalize(iosysid[c])))
+                    if ((ret = PIOc_free_iosystem(iosysid[c])))
                         ERR(ret);
                 }
             } /* endif comp_task */

--- a/tests/cunit/test_async_4proc.c
+++ b/tests/cunit/test_async_4proc.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 
                 /* Finalize the IO system. Only call this from the computation tasks. */
                 for (int c = 0; c < COMPONENT_COUNT; c++)
-                    if ((ret = PIOc_finalize(iosysid[c])))
+                    if ((ret = PIOc_free_iosystem(iosysid[c])))
                         ERR(ret);
             } /* endif comp_task */
 

--- a/tests/cunit/test_async_manyproc.c
+++ b/tests/cunit/test_async_manyproc.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
 
             /* Finalize the IO system. Only call this from the computation tasks. */
             for (int c = 0; c < COMPONENT_COUNT; c++)
-                if ((ret = PIOc_finalize(iosysid[c])))
+                if ((ret = PIOc_free_iosystem(iosysid[c])))
                     ERR(ret);
         } /* endif comp_task */
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_async_mpi.c
+++ b/tests/cunit/test_async_mpi.c
@@ -1,4 +1,4 @@
-/*
+ /*
  * This program tests some MPI functionality that is used in PIO. This
  * runs on three processors, and does the same MPI commands that are
  * done when async mode is used, with 1 IO task, and two computation

--- a/tests/cunit/test_async_multi2.c
+++ b/tests/cunit/test_async_multi2.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 
             /* Finalize the IO system. Only call this from the computation tasks. */
             for (int c = 0; c < COMPONENT_COUNT; c++)
-                if ((ret = PIOc_finalize(iosysid[c])))
+                if ((ret = PIOc_free_iosystem(iosysid[c])))
                     ERR(ret);
         } /* endif comp_task */
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_async_multicomp.c
+++ b/tests/cunit/test_async_multicomp.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 
             /* Finalize the IO system. Only call this from the computation tasks. */
             for (int c = 0; c < COMPONENT_COUNT; c++)
-                if ((ret = PIOc_finalize(iosysid[c])))
+                if ((ret = PIOc_free_iosystem(iosysid[c])))
                     ERR(ret);
         } /* endif comp_task */
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_async_perf.c
+++ b/tests/cunit/test_async_perf.c
@@ -269,7 +269,7 @@ int main(int argc, char **argv)
                     return ret;
 
                 /* Finalize PIO system. */
-                if ((ret = PIOc_finalize(iosysid)))
+                if ((ret = PIOc_free_iosystem(iosysid)))
                     return ret;
 
                 /* Free the computation conomponent communicator. */

--- a/tests/cunit/test_async_simple.c
+++ b/tests/cunit/test_async_simple.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
 
             /* Finalize the IO system. Only call this from the computation tasks. */
             for (int c = 0; c < COMPONENT_COUNT; c++)
-                if ((ret = PIOc_finalize(iosysid[c])))
+                if ((ret = PIOc_free_iosystem(iosysid[c])))
                     ERR(ret);
         } /* endif comp_task */
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -1,4 +1,4 @@
-/*
+ /*
  * Common test code for PIO C tests.
  *
  * Ed Hartnett

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
         } /* next rearranger */
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_darray_1d.c
+++ b/tests/cunit/test_darray_1d.c
@@ -865,7 +865,7 @@ int main(int argc, char **argv)
             }
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
         } /* next rearranger */
 

--- a/tests/cunit/test_darray_2sync.c
+++ b/tests/cunit/test_darray_2sync.c
@@ -512,7 +512,7 @@ int run_async_tests(MPI_Comm test_comm, int my_rank, int num_iotypes, int *iotyp
             ERR(ret);
 
         /* Finalize PIO system. */
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             return ret;
 
         /* Free the computation conomponent communicator. */
@@ -548,7 +548,7 @@ int run_noasync_tests(MPI_Comm test_comm, int my_rank, int num_iotypes, int *iot
         ERR(ret);
 
     /* Finalize PIO system. */
-    if ((ret = PIOc_finalize(iosysid)))
+    if ((ret = PIOc_free_iosystem(iosysid)))
         return ret;
 
     return PIO_NOERR;

--- a/tests/cunit/test_darray_3d.c
+++ b/tests/cunit/test_darray_3d.c
@@ -401,7 +401,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
 
         } /* next rearranger */

--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -542,7 +542,7 @@ int main(int argc, char **argv)
                     return ret;
 
                 /* Finalize PIO system. */
-                if ((ret = PIOc_free_iosystem(iosysid)))
+                if ((ret = PIOc_free_iosystem (iosysid)))
                     return ret;
 
                 /* Free the computation conomponent communicator. */

--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -542,7 +542,7 @@ int main(int argc, char **argv)
                     return ret;
 
                 /* Finalize PIO system. */
-                if ((ret = PIOc_finalize(iosysid)))
+                if ((ret = PIOc_free_iosystem(iosysid)))
                     return ret;
 
                 /* Free the computation conomponent communicator. */

--- a/tests/cunit/test_darray_async_many.c
+++ b/tests/cunit/test_darray_async_many.c
@@ -642,7 +642,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
 
             /* Free the computation conomponent communicator. */

--- a/tests/cunit/test_darray_async_simple.c
+++ b/tests/cunit/test_darray_async_simple.c
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
 
             /* Free the computation conomponent communicator. */

--- a/tests/cunit/test_darray_fill.c
+++ b/tests/cunit/test_darray_fill.c
@@ -362,7 +362,7 @@ int main(int argc, char **argv)
             } /* next fill value test case */
 
             /* Finalize PIO iosysid. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
         } /* next rearranger */
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_darray_frame.c
+++ b/tests/cunit/test_darray_frame.c
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
         } /* next rearranger */
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_darray_multi.c
+++ b/tests/cunit/test_darray_multi.c
@@ -464,7 +464,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
         } /* next rearranger */
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_darray_multivar.c
+++ b/tests/cunit/test_darray_multivar.c
@@ -587,7 +587,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
         }
 

--- a/tests/cunit/test_darray_multivar2.c
+++ b/tests/cunit/test_darray_multivar2.c
@@ -275,7 +275,7 @@ int main(int argc, char **argv)
             return ret;
 
         /* Finalize PIO system. */
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             return ret;
 
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_darray_multivar3.c
+++ b/tests/cunit/test_darray_multivar3.c
@@ -323,7 +323,7 @@ int main(int argc, char **argv)
             ERR(ret);
 
         /* Finalize PIO system. */
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             return ret;
 
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_decomp_frame.c
+++ b/tests/cunit/test_decomp_frame.c
@@ -364,7 +364,7 @@ int main(int argc, char **argv)
         } /* next rearranger */
 
         /* Finalize PIO system. */
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             return ret;
 
     } /* endif my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_decomp_uneven.c
+++ b/tests/cunit/test_decomp_uneven.c
@@ -354,7 +354,7 @@ int main(int argc, char **argv)
             }
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
 
         } /* next rearranger */

--- a/tests/cunit/test_decomps.c
+++ b/tests/cunit/test_decomps.c
@@ -420,7 +420,7 @@ int main(int argc, char **argv)
                     ERR(ret);
 
                 /* Finalize PIO systems. */
-                if ((ret = PIOc_finalize(iosysid)))
+                if ((ret = PIOc_free_iosystem(iosysid)))
                     ERR(ret);
             } /* next io test */
         } /* next rearranger */

--- a/tests/cunit/test_intercomm2.c
+++ b/tests/cunit/test_intercomm2.c
@@ -521,7 +521,7 @@ int main(int argc, char **argv)
             } /* next netcdf flavor */
 
             /* Finalize the IO system. Only call this from the computation tasks. */
-            if ((ret = PIOc_finalize(iosysid[my_comp_idx])))
+            if ((ret = PIOc_free_iosystem(iosysid[my_comp_idx])))
                 ERR(ret);
         }
     } /* my_rank < TARGET_NTASKS */

--- a/tests/cunit/test_iosystem2.c
+++ b/tests/cunit/test_iosystem2.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
             ERR(ret);
 
         /* This should fail. */
-        if (PIOc_finalize(iosysid + TEST_VAL_42) != PIO_EBADID)
+        if (PIOc_free_iosystem(iosysid + TEST_VAL_42) != PIO_EBADID)
             ERR(ERR_WRONG);
 
         /* Initialize another PIO system. */
@@ -201,11 +201,11 @@ int main(int argc, char **argv)
             MPIERR(ret);
 
         /* Finalize PIO system. */
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             ERR(ret);
 
         /* Finalize PIO system. */
-        if ((ret = PIOc_finalize(iosysid_world)))
+        if ((ret = PIOc_free_iosystem(iosysid_world)))
             ERR(ret);
     } /* my_rank < TARGET_NTASKS */
 

--- a/tests/cunit/test_iosystem2_simple.c
+++ b/tests/cunit/test_iosystem2_simple.c
@@ -221,12 +221,12 @@ int main(int argc, char **argv)
             MPIERR(ret);
 
         /* Finalize PIO odd/even intracomm. */
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             ERR(ret);
 
 
         /* Finalize PIO world intracomm. */
-        if ((ret = PIOc_finalize(iosysid_world)))
+        if ((ret = PIOc_free_iosystem(iosysid_world)))
             ERR(ret);
     }/* my_rank < TARGET_NTASKS */
 

--- a/tests/cunit/test_iosystem2_simple2.c
+++ b/tests/cunit/test_iosystem2_simple2.c
@@ -120,11 +120,11 @@ int main(int argc, char **argv)
             MPIERR(ret);
 
         /* Finalize PIO odd/even intracomm. */
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             ERR(ret);
 
         /* Finalize PIO world intracomm. */
-        if ((ret = PIOc_finalize(iosysid_world)))
+        if ((ret = PIOc_free_iosystem(iosysid_world)))
             ERR(ret);
     }  /* my_rank < TARGET_NTASKS */
 

--- a/tests/cunit/test_iosystem3.c
+++ b/tests/cunit/test_iosystem3.c
@@ -317,14 +317,14 @@ int main(int argc, char **argv)
         
             /* Finalize PIO systems. */
             if (even_comm != MPI_COMM_NULL)
-                if ((ret = PIOc_finalize(even_iosysid)))
+                if ((ret = PIOc_free_iosystem(even_iosysid)))
                     ERR(ret);
             if (overlap_comm != MPI_COMM_NULL)
             {
-                if ((ret = PIOc_finalize(overlap_iosysid)))
+                if ((ret = PIOc_free_iosystem(overlap_iosysid)))
                     ERR(ret);
             }
-            if ((ret = PIOc_finalize(iosysid_world)))
+            if ((ret = PIOc_free_iosystem(iosysid_world)))
                 ERR(ret);
 
             /* Free MPI resources used by test. */

--- a/tests/cunit/test_iosystem3_simple.c
+++ b/tests/cunit/test_iosystem3_simple.c
@@ -85,10 +85,10 @@ int main(int argc, char **argv)
 
         /* Finalize PIO system. */
         if (overlap_comm != MPI_COMM_NULL)
-            if ((ret = PIOc_finalize(overlap_iosysid)))
+            if ((ret = PIOc_free_iosystem(overlap_iosysid)))
                 ERR(ret);
 
-        if ((ret = PIOc_finalize(iosysid_world)))
+        if ((ret = PIOc_free_iosystem(iosysid_world)))
             ERR(ret);
 
         /* Free MPI resources used by test. */

--- a/tests/cunit/test_iosystem3_simple2.c
+++ b/tests/cunit/test_iosystem3_simple2.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
         } /* next iotype */
 
         /* Finalize PIO systems. */
-        if ((ret = PIOc_finalize(iosysid_world)))
+        if ((ret = PIOc_free_iosystem(iosysid_world)))
             ERR(ret);
     } /* my_rank < TARGET_NTASKS */
 

--- a/tests/cunit/test_perf2.c
+++ b/tests/cunit/test_perf2.c
@@ -416,7 +416,7 @@ int main(int argc, char **argv)
                 return ret;
 
             /* Finalize PIO system. */
-            if ((ret = PIOc_finalize(iosysid)))
+            if ((ret = PIOc_free_iosystem(iosysid)))
                 return ret;
 
         } /* next rearranger */

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -1,4 +1,4 @@
-/*
+ /*
  * Tests for PIO Functions.
  *
  * @author Ed Hartnett

--- a/tests/cunit/test_pioc_fill.c
+++ b/tests/cunit/test_pioc_fill.c
@@ -1,4 +1,4 @@
-/*
+ /*
  * More tests for PIO data reading and writing routines.
  *
  * Ed Hartnett

--- a/tests/cunit/test_pioc_putget.c
+++ b/tests/cunit/test_pioc_putget.c
@@ -1,4 +1,4 @@
-/*
+ /*
  * Tests for PIO data reading and writing routines.
  *
  * @author Ed Hartnett

--- a/tests/cunit/test_pioc_unlim.c
+++ b/tests/cunit/test_pioc_unlim.c
@@ -1,4 +1,4 @@
-/*
+ /*
  * Tests for PIO Functions. In this test we use a simple 3D variable,
  * with an unlimited dimension. The data will have two timesteps, and
  * 4x4 elements each timestep.

--- a/tests/cunit/test_rearr.c
+++ b/tests/cunit/test_rearr.c
@@ -1578,7 +1578,7 @@ int main(int argc, char **argv)
                     return ret;
 
                 /* Finalize PIO system. */
-                if ((ret = PIOc_finalize(iosysid)))
+                if ((ret = PIOc_free_iosystem(iosysid)))
                     return ret;
             } /* next numio */
         } /* next rearranger */

--- a/tests/cunit/test_shared.c
+++ b/tests/cunit/test_shared.c
@@ -48,7 +48,7 @@ int test_async2(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm,
                 return ret;
 
             /* Finalize the IO system. Only call this from the computation tasks. */
-            if ((ret = PIOc_finalize(iosysid[c])))
+            if ((ret = PIOc_free_iosystem(iosysid[c])))
                 ERR(ret);
             if ((mpierr = MPI_Comm_free(&comp_comm[c])))
                 MPIERR(mpierr);
@@ -118,7 +118,7 @@ int test_no_async2(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm
         return ret;
 
     /* Finalize PIO system. */
-    if ((ret = PIOc_finalize(iosysid)))
+    if ((ret = PIOc_free_iosystem(iosysid)))
         return ret;
 
     return PIO_NOERR;

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -780,7 +780,7 @@ int main(int argc, char **argv)
             return ret;
 
         /* Finalize PIO system. */
-        if ((ret = PIOc_finalize(iosysid)))
+        if ((ret = PIOc_free_iosystem(iosysid)))
             return ret;
 
     } /* endif my_rank < TARGET_NTASKS */


### PR DESCRIPTION
Fixes #1463.

Added new function PIOc_free_iosystem() as a duplicate for PIOc_finalize().

Documentation changes as well, plus changes to tests and example to use PIOc_free_iosystem().