### PR TITLE
Basic MPE logging capability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,22 +52,6 @@ if test "x$enable_logging" = xyes; then
    AC_DEFINE([PIO_ENABLE_LOGGING], 1, [If true, turn on logging.])
 fi
 
-# Does the user want to use MPE library?
-AC_MSG_CHECKING([whether use of MPE library is enabled])
-AC_ARG_ENABLE([mpe],
-              [AS_HELP_STRING([--enable-mpe],
-                              [enable use of MPE library for timing and diagnostic info (may negatively impact performance).])])
-test "x$enable_mpe" = xyes || enable_mpe=no
-AC_MSG_RESULT([$enable_mpe])
-if test "x$enable_mpe" = xyes; then
-   AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [-lpthread -lm])
-   AC_CHECK_HEADERS([mpe.h], [HAVE_MPE=yes], [HAVE_MPE=no])
-   if test "x$HAVE_LIBMPE" = xno -o "x$HAVE_MPE" = xno; then
-      AC_MSG_ERROR([MPE not found but --enable-mpe used.])
-   fi
-   AC_DEFINE([USE_MPE], 1, [If true, use MPE timing library.])
-fi
-
 # Does the user want to enable timing?
 AC_MSG_CHECKING([whether GPTL timing library is used])
 AC_ARG_ENABLE([timing],
@@ -103,6 +87,25 @@ AC_ARG_ENABLE([fortran],
 test "x$enable_fortran" = xyes || enable_fortran=no
 AC_MSG_RESULT([$enable_fortran])
 AM_CONDITIONAL(BUILD_FORTRAN, [test "x$enable_fortran" = xyes])
+
+# Does the user want to use MPE library?
+AC_MSG_CHECKING([whether use of MPE library is enabled])
+AC_ARG_ENABLE([mpe],
+              [AS_HELP_STRING([--enable-mpe],
+                              [enable use of MPE library for timing and diagnostic info (may negatively impact performance).])])
+test "x$enable_mpe" = xyes || enable_mpe=no
+AC_MSG_RESULT([$enable_mpe])
+if test "x$enable_mpe" = xyes; then
+   AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [-lpthread -lm])
+   AC_CHECK_HEADERS([mpe.h], [HAVE_MPE=yes], [HAVE_MPE=no])
+   if test "x$HAVE_LIBMPE" = xno -o "x$HAVE_MPE" = xno; then
+      AC_MSG_ERROR([MPE not found but --enable-mpe used.])
+   fi
+   if test $enable_fortran = yes; then
+      AC_MSG_ERROR([MPE not implemented in Fortran tests and examples.])
+   fi
+   AC_DEFINE([USE_MPE], 1, [If true, use MPE timing library.])
+fi
 
 # Does the user want to disable pnetcdf?
 AC_MSG_CHECKING([whether pnetcdf is to be used])

--- a/configure.ac
+++ b/configure.ac
@@ -96,9 +96,12 @@ AC_ARG_ENABLE([mpe],
 test "x$enable_mpe" = xyes || enable_mpe=no
 AC_MSG_RESULT([$enable_mpe])
 if test "x$enable_mpe" = xyes; then
+
+   AC_SEARCH_LIBS([pthread_setspecific], [pthread], [HAVE_PTHREAD=yes], [HAVE_PTHREAD=no], [])
    AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [-lpthread -lm])
+   AC_SEARCH_LIBS([MPE_Init_mpi_core], [lmpe], [HAVE_LIBLMPE=yes], [HAVE_LIBLMPE=no], [-lmpe -lpthread -lm])
    AC_CHECK_HEADERS([mpe.h], [HAVE_MPE=yes], [HAVE_MPE=no])
-   if test "x$HAVE_LIBMPE" = xno -o "x$HAVE_MPE" = xno; then
+   if test "x$HAVE_LIBMPE" = xno -o "x$HAVE_MPE" = xno -o "x$HAVE_LIBLMPE" = xno; then
       AC_MSG_ERROR([MPE not found but --enable-mpe used.])
    fi
    if test $enable_fortran = yes; then
@@ -106,6 +109,7 @@ if test "x$enable_mpe" = xyes; then
    fi
    LD=ld # MPE needs this.
    AC_DEFINE([USE_MPE], 1, [If true, use MPE timing library.])
+
 fi
 
 # Does the user want to disable pnetcdf?

--- a/configure.ac
+++ b/configure.ac
@@ -99,15 +99,15 @@ AC_MSG_RESULT([$enable_mpe])
 if test "x$enable_mpe" = xyes; then
 
    AC_SEARCH_LIBS([pthread_setspecific], [pthread], [], [], [])
-   AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [])
-   AC_SEARCH_LIBS([MPE_Init_mpi_core], [lmpe], [HAVE_LIBLMPE=yes], [HAVE_LIBLMPE=no], [])
+   dnl AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [])
+   dnl AC_SEARCH_LIBS([MPE_Init_mpi_core], [lmpe], [HAVE_LIBLMPE=yes], [HAVE_LIBLMPE=no], [])
    AC_CHECK_HEADERS([mpe.h], [HAVE_MPE=yes], [HAVE_MPE=no])
-   if test "x$HAVE_LIBMPE" != xyes; then
-      AC_MSG_ERROR([-lmpe not found but --enable-mpe used.])
-   fi
-   if test "x$HAVE_LIBLMPE" != xyes; then
-      AC_MSG_ERROR([-llmpe not found but --enable-mpe used.])
-   fi
+   dnl if test "x$HAVE_LIBMPE" != xyes; then
+   dnl    AC_MSG_ERROR([-lmpe not found but --enable-mpe used.])
+   dnl fi
+   dnl if test "x$HAVE_LIBLMPE" != xyes; then
+   dnl    AC_MSG_ERROR([-llmpe not found but --enable-mpe used.])
+   dnl fi
    if test $enable_fortran = yes; then
       AC_MSG_ERROR([MPE not implemented in Fortran tests and examples. Build without --enable-fortran])
    fi

--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,7 @@ if test "x$enable_mpe" = xyes; then
    if test $enable_fortran = yes; then
       AC_MSG_ERROR([MPE not implemented in Fortran tests and examples.])
    fi
+   LD=ld # MPE needs this.
    AC_DEFINE([USE_MPE], 1, [If true, use MPE timing library.])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ AC_SUBST([VERSION_PATCH], [4])
 AC_CONFIG_MACRO_DIR([m4])
 
 # Libtool initialisation.
+LD=ld # Required for MPE to work.
 LT_INIT
 
 # Find and learn about the C compiler.
@@ -97,17 +98,19 @@ test "x$enable_mpe" = xyes || enable_mpe=no
 AC_MSG_RESULT([$enable_mpe])
 if test "x$enable_mpe" = xyes; then
 
-   AC_SEARCH_LIBS([pthread_setspecific], [pthread], [HAVE_PTHREAD=yes], [HAVE_PTHREAD=no], [])
-   AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [-lpthread -lm])
-   AC_SEARCH_LIBS([MPE_Init_mpi_core], [lmpe], [HAVE_LIBLMPE=yes], [HAVE_LIBLMPE=no], [-lmpe -lpthread -lm])
+   AC_SEARCH_LIBS([pthread_setspecific], [pthread], [], [], [])
+   AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [])
+   AC_SEARCH_LIBS([MPE_Init_mpi_core], [lmpe], [HAVE_LIBLMPE=yes], [HAVE_LIBLMPE=no], [])
    AC_CHECK_HEADERS([mpe.h], [HAVE_MPE=yes], [HAVE_MPE=no])
-   if test "x$HAVE_LIBMPE" = xno -o "x$HAVE_MPE" = xno -o "x$HAVE_LIBLMPE" = xno; then
-      AC_MSG_ERROR([MPE not found but --enable-mpe used.])
+   if test "x$HAVE_LIBMPE" != xyes; then
+      AC_MSG_ERROR([-lmpe not found but --enable-mpe used.])
+   fi
+   if test "x$HAVE_LIBLMPE" != xyes; then
+      AC_MSG_ERROR([-llmpe not found but --enable-mpe used.])
    fi
    if test $enable_fortran = yes; then
-      AC_MSG_ERROR([MPE not implemented in Fortran tests and examples.])
+      AC_MSG_ERROR([MPE not implemented in Fortran tests and examples. Build without --enable-fortran])
    fi
-   LD=ld # MPE needs this.
    AC_DEFINE([USE_MPE], 1, [If true, use MPE timing library.])
 
 fi

--- a/examples/c/Makefile.am
+++ b/examples/c/Makefile.am
@@ -19,4 +19,4 @@ endif # RUN_TESTS
 EXTRA_DIST = run_tests.sh
 
 # Clean up files produced during testing.
-CLEANFILES = *.nc *.log
+CLEANFILES = *.nc *.log *.clog2 *.slog2

--- a/examples/c/Makefile.am
+++ b/examples/c/Makefile.am
@@ -4,7 +4,7 @@
 # Ed Hartnett 5/7/18
 
 # Link to our assembled library.
-AM_LDFLAGS = ${top_builddir}/src/clib/libpio.la
+LDADD = ${top_builddir}/src/clib/libpio.la
 AM_CPPFLAGS = -I$(top_srcdir)/src/clib
 
 # Build the tests for make check.

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -377,11 +377,6 @@ int main(int argc, char* argv[])
     if ((ret = PIOc_free_iosystem(iosysid)))
         ERR(ret);
 
-#ifdef USE_MPE
-    if ((ret = MPE_Finish_log(TEST_NAME)))
-        MPIERR(ret);
-#endif /* USE_MPE */
-
     /* Finalize the MPI library. */
     MPI_Finalize();
 

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -21,6 +21,9 @@
 #include <gptl.h>
 #endif
 
+/* The name of this program. */
+#define TEST_NAME "darray_no_async"
+
 /* The number of possible output netCDF output flavors available to
  * the ParallelIO library. */
 #define NUM_NETCDF_FLAVORS 4
@@ -250,6 +253,12 @@ int main(int argc, char* argv[])
     if ((ret = MPI_Comm_size(MPI_COMM_WORLD, &ntasks)))
         MPIERR(ret);
 
+#ifdef USE_MPE
+    /* If MPE logging is being used, then initialize it. */
+    if ((ret = MPE_Init_log()))
+        return ret;
+#endif /* USE_MPE */
+
     /* Check that a valid number of processors was specified. */
     if (ntasks != TARGET_NTASKS)
         fprintf(stderr, "Number of processors must be 16!\n");
@@ -367,6 +376,11 @@ int main(int argc, char* argv[])
     printf("rank: %d Freeing PIO resources...\n", my_rank);
     if ((ret = PIOc_free_iosystem(iosysid)))
         ERR(ret);
+
+#ifdef USE_MPE
+    if ((ret = MPE_Finish_log(TEST_NAME)))
+        MPIERR(ret);
+#endif /* USE_MPE */
 
     /* Finalize the MPI library. */
     MPI_Finalize();

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -122,7 +122,7 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
     /* Open the file. */
     if ((ret = PIOc_openfile_retry(iosysid, &ncid, &iotype, filename, 0, 0)))
         return ret;
-    printf("opened file %s ncid = %d\n", filename, ncid);
+    /* printf("opened file %s ncid = %d\n", filename, ncid); */
 
     /* Check the metadata. */
     if ((ret = PIOc_inq(ncid, &ndims, &nvars, &ngatts, &unlimdimid)))
@@ -262,8 +262,8 @@ int main(int argc, char* argv[])
     /* Check that a valid number of processors was specified. */
     if (ntasks != TARGET_NTASKS)
         fprintf(stderr, "Number of processors must be 16!\n");
-    printf("%d: ParallelIO Library darray_no_async example running on %d processors.\n",
-           my_rank, ntasks);
+    /* printf("%d: ParallelIO Library darray_no_async example running on %d processors.\n", */
+    /*        my_rank, ntasks); */
 
     /* Turn on logging. */
     if ((ret = PIOc_set_log_level(LOG_LEVEL)))
@@ -290,8 +290,8 @@ int main(int argc, char* argv[])
     /* Create the PIO decomposition for this example. Since this
      * is a variable with an unlimited dimension, we want to
      * create a 2-D composition which represents one record. */
-    printf("rank: %d Creating decomposition, elements_per_pe %lld...\n", my_rank,
-           elements_per_pe);
+    /* printf("rank: %d Creating decomposition, elements_per_pe %lld...\n", my_rank, */
+    /*        elements_per_pe); */
     if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM3 - 1, &dim_len[1], elements_per_pe,
                                 compdof, &ioid, PIO_REARR_SUBSET, NULL, NULL)))
         ERR(ret);
@@ -319,13 +319,13 @@ int main(int argc, char* argv[])
         sprintf(filename, "darray_no_async_iotype_%d.nc", format[fmt]);
 
         /* Create the netCDF output file. */
-        printf("rank: %d Creating sample file %s with format %d...\n",
-               my_rank, filename, format[fmt]);
+        /* printf("rank: %d Creating sample file %s with format %d...\n", */
+        /*        my_rank, filename, format[fmt]); */
         if ((ret = PIOc_createfile(iosysid, &ncid, &(format[fmt]), filename, PIO_CLOBBER)))
             ERR(ret);
 
         /* Define netCDF dimension and variable. */
-        printf("rank: %d Defining netCDF metadata...\n", my_rank);
+        /* printf("rank: %d Defining netCDF metadata...\n", my_rank); */
         for (int d = 0; d < NDIM3; d++)
             if ((ret = PIOc_def_dim(ncid, dim_name[d], dim_len[d], &dimid[d])))
                 ERR(ret);
@@ -345,7 +345,7 @@ int main(int argc, char* argv[])
                 buffer[i] = 100 * t + START_DATA_VAL + my_rank;
 
             /* Write data to the file. */
-            printf("rank: %d Writing sample data...\n", my_rank);
+            /* printf("rank: %d Writing sample data...\n", my_rank); */
             if ((ret = PIOc_setframe(ncid, varid, t)))
                 ERR(ret);
             if ((ret = PIOc_write_darray(ncid, varid, ioid, elements_per_pe, buffer, NULL)))
@@ -357,7 +357,7 @@ int main(int argc, char* argv[])
             ERR(ret);
 
         /* Close the netCDF file. */
-        printf("rank: %d Closing the sample data file...\n", my_rank);
+        /* printf("rank: %d Closing the sample data file...\n", my_rank); */
         if ((ret = PIOc_closefile(ncid)))
             ERR(ret);
 
@@ -368,12 +368,12 @@ int main(int argc, char* argv[])
     }
 
     /* Free the PIO decomposition. */
-    printf("rank: %d Freeing PIO decomposition...\n", my_rank);
+    /* printf("rank: %d Freeing PIO decomposition...\n", my_rank); */
     if ((ret = PIOc_freedecomp(iosysid, ioid)))
         ERR(ret);
 
     /* Finalize the IO system. */
-    printf("rank: %d Freeing PIO resources...\n", my_rank);
+    /* printf("rank: %d Freeing PIO resources...\n", my_rank); */
     if ((ret = PIOc_free_iosystem(iosysid)))
         ERR(ret);
 
@@ -391,6 +391,7 @@ int main(int argc, char* argv[])
         return ret;
 #endif
 
-    printf("rank: %d SUCCESS!\n", my_rank);
+    if (!my_rank)
+        printf("rank: %d SUCCESS!\n", my_rank);
     return 0;
 }

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -20,6 +20,12 @@
 #ifdef TIMING
 #include <gptl.h>
 #endif
+#ifdef USE_MPE
+#include <mpe.h>
+#endif /* USE_MPE */
+
+/* The name of this program. */
+#define TEST_NAME "example1"
 
 /** The number of possible output netCDF output flavors available to
  * the ParallelIO library. */
@@ -303,7 +309,13 @@ int check_file(int ntasks, char *filename) {
 	    printf("%d: ParallelIO Library example1 running on %d processors.\n",
 		   my_rank, ntasks);
 
-	/* keep things simple - 1 iotask per MPI process */    
+#ifdef USE_MPE
+        /* If MPE logging is being used, then initialize it. */
+        if ((ret = MPE_Init_log()))
+            return ret;
+#endif /* USE_MPE */
+
+        /* keep things simple - 1 iotask per MPI process */
 	niotasks = ntasks;
 
         /* Turn on logging if available. */
@@ -415,6 +427,11 @@ int check_file(int ntasks, char *filename) {
 		    ERR(ret);
             }
 
+#ifdef USE_MPE
+        if ((ret = MPE_Finish_log(TEST_NAME)))
+            MPIERR(ret);
+#endif /* USE_MPE */
+
 	/* Finalize the MPI library. */
 	MPI_Finalize();
 
@@ -424,7 +441,7 @@ int check_file(int ntasks, char *filename) {
 	    return ret;
 #endif    
 
-	if (verbose)
+        if (verbose)
 	    printf("rank: %d SUCCESS!\n", my_rank);
 	return 0;
     }

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -24,7 +24,7 @@
 #include <mpe.h>
 #endif /* USE_MPE */
 
-/* The name of this program. */
+/** The name of this program. */
 #define TEST_NAME "example1"
 
 /** The number of possible output netCDF output flavors available to

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -427,11 +427,6 @@ int check_file(int ntasks, char *filename) {
 		    ERR(ret);
             }
 
-#ifdef USE_MPE
-        if ((ret = MPE_Finish_log(TEST_NAME)))
-            MPIERR(ret);
-#endif /* USE_MPE */
-
 	/* Finalize the MPI library. */
 	MPI_Finalize();
 

--- a/examples/c/examplePio.c
+++ b/examples/c/examplePio.c
@@ -186,14 +186,14 @@ struct examplePioClass* epc_init( struct examplePioClass* this )
 	this->errorHandler(this, "Number of processors must be 1, 2, 4, 8, or 16!",
 			   ERR_CODE);
 
-#ifdef USE_MPE
-    /* If MPE logging is being used, then initialize it. */
-    {
-        int ret;
-        if ((ret = MPE_Init_log()))
-            return NULL;
-    }
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*     /\* If MPE logging is being used, then initialize it. *\/ */
+/*     { */
+/*         int ret; */
+/*         if ((ret = MPE_Init_log())) */
+/*             return NULL; */
+/*     } */
+/* #endif /\* USE_MPE *\/ */
 
     /*
     ** set up PIO for rest of example
@@ -612,10 +612,10 @@ int main(int argc, char* argv[])
     pioExInst->readVar(pioExInst);
     pioExInst->closeFile(pioExInst);
 
-#ifdef USE_MPE
-    if ((ret = MPE_Finish_log("examplePio")))
-        return ret;
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*     if ((ret = MPE_Finish_log("examplePio"))) */
+/*         return ret; */
+/* #endif /\* USE_MPE *\/ */
 
     pioExInst->cleanUp(pioExInst);
     

--- a/examples/c/examplePio.c
+++ b/examples/c/examplePio.c
@@ -24,7 +24,7 @@
 #include <mpe.h>
 #endif /* USE_MPE */
 
-/* The name of this program. */
+/** The name of this program. */
 #define TEST_NAME "examplePio"
 
 /** The length of our 1-d data array. */

--- a/examples/c/examplePio.c
+++ b/examples/c/examplePio.c
@@ -473,13 +473,6 @@ struct examplePioClass* epc_cleanUp( struct examplePioClass* this )
     
     PIOc_freedecomp(this->pioIoSystem, this->iodescNCells);
     PIOc_free_iosystem(this->pioIoSystem);
-#ifdef USE_MPE
-    {
-        int ret;
-        if ((ret = MPE_Finish_log(TEST_NAME)))
-            return NULL;
-    }
-#endif /* USE_MPE */
 
     MPI_Finalize();
     

--- a/examples/c/examplePio.c
+++ b/examples/c/examplePio.c
@@ -611,6 +611,12 @@ int main(int argc, char* argv[])
     pioExInst->writeVar(pioExInst);
     pioExInst->readVar(pioExInst);
     pioExInst->closeFile(pioExInst);
+
+#ifdef USE_MPE
+    if ((ret = MPE_Finish_log("examplePio")))
+        return ret;
+#endif /* USE_MPE */
+
     pioExInst->cleanUp(pioExInst);
     
 #ifdef TIMING    

--- a/examples/c/examplePio.c
+++ b/examples/c/examplePio.c
@@ -20,6 +20,12 @@
 #ifdef TIMING
 #include <gptl.h>
 #endif
+#ifdef USE_MPE
+#include <mpe.h>
+#endif /* USE_MPE */
+
+/* The name of this program. */
+#define TEST_NAME "examplePio"
 
 /** The length of our 1-d data array. */
 static const int LEN = 16;
@@ -179,7 +185,16 @@ struct examplePioClass* epc_init( struct examplePioClass* this )
 	  this->ntasks == 8 || this->ntasks == 16))
 	this->errorHandler(this, "Number of processors must be 1, 2, 4, 8, or 16!",
 			   ERR_CODE);
-    
+
+#ifdef USE_MPE
+    /* If MPE logging is being used, then initialize it. */
+    {
+        int ret;
+        if ((ret = MPE_Init_log()))
+            return NULL;
+    }
+#endif /* USE_MPE */
+
     /*
     ** set up PIO for rest of example
     */
@@ -458,6 +473,14 @@ struct examplePioClass* epc_cleanUp( struct examplePioClass* this )
     
     PIOc_freedecomp(this->pioIoSystem, this->iodescNCells);
     PIOc_free_iosystem(this->pioIoSystem);
+#ifdef USE_MPE
+    {
+        int ret;
+        if ((ret = MPE_Finish_log(TEST_NAME)))
+            return NULL;
+    }
+#endif /* USE_MPE */
+
     MPI_Finalize();
     
     return this;
@@ -587,7 +610,7 @@ int main(int argc, char* argv[])
     if ((ret = GPTLinitialize ()))
       return ret;
 #endif    
-    
+
     pioExInst->init(pioExInst);
     pioExInst->createDecomp(pioExInst);
     pioExInst->createFile(pioExInst);

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -134,6 +134,10 @@ PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     int ierr;              /* Return code. */
     void *tmparray;
 
+/* #ifdef USE_MPE */
+/*     pio_start_mpe_log(DARRAY_WRITE); */
+/* #endif /\* USE_MPE *\/ */
+
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
@@ -411,6 +415,10 @@ PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         if ((ierr = flush_output_buffer(file, flushtodisk, 0)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
+/* #ifdef USE_MPE */
+/*     pio_stop_mpe_log(DARRAY_WRITE, __func__); */
+/* #endif /\* USE_MPE *\/ */
+
     return PIO_NOERR;
 }
 
@@ -649,9 +657,7 @@ PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *arra
     LOG((1, "PIOc_write_darray ncid = %d varid = %d ioid = %d arraylen = %d",
          ncid, varid, ioid, arraylen));
 #ifdef USE_MPE
-    if ((ierr = MPE_Log_event(event_num[START][DARRAY_WRITE], 0,
-                             "PIOc_write_darray")))
-        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+    pio_start_mpe_log(DARRAY_WRITE);
 #endif /* USE_MPE */
 
     /* Get the file info. */
@@ -852,9 +858,7 @@ PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *arra
     wmb->num_arrays++;
 
 #ifdef USE_MPE
-    if ((ierr = MPE_Log_event(event_num[END][DARRAY_WRITE], 0,
-                             "PIOc_write_darray")))
-        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+    pio_stop_mpe_log(DARRAY_WRITE, __func__);
 #endif /* USE_MPE */
 
     LOG((2, "wmb->num_arrays = %d iodesc->maxbytes / iodesc->mpitype_size = %d "
@@ -896,9 +900,7 @@ PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
     void *tmparray;        /* unsorted copy of array buf if required */
 
 #ifdef USE_MPE
-    if ((ierr = MPE_Log_event(event_num[START][DARRAY_READ], 0,
-                             "PIOc_read_darray")))
-        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+    pio_start_mpe_log(DARRAY_READ);
 #endif /* USE_MPE */
 
     /* Get the file info. */
@@ -965,9 +967,7 @@ PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
         brel(iobuf);
 
 #ifdef USE_MPE
-    if ((ierr = MPE_Log_event(event_num[END][DARRAY_READ], 0,
-                             "PIOc_read_darray")))
-        return pio_err(ios, file, PIO_EIO, __FILE__, __LINE__);
+    pio_stop_mpe_log(DARRAY_READ, __func__);
 #endif /* USE_MPE */
 
     return PIO_NOERR;

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -895,6 +895,12 @@ PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
     int ierr;              /* Return code. */
     void *tmparray;        /* unsorted copy of array buf if required */
 
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[START][DARRAY_READ], 0,
+                             "PIOc_read_darray")))
+        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
+
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
@@ -957,6 +963,12 @@ PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
     /* Free the buffer. */
     if (rlen > 0)
         brel(iobuf);
+
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[END][DARRAY_READ], 0,
+                             "PIOc_read_darray")))
+        return pio_err(ios, file, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
 
     return PIO_NOERR;
 }

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -38,6 +38,11 @@ PIO_Offset maxusage = 0;
  * indicate that data are being written. */
 #define DARRAY_DATA 0
 
+#ifdef USE_MPE
+/* The event numbers for MPE logging. */
+extern int event_num[2][NUM_EVENTS];
+#endif /* USE_MPE */
+
 /**
  * Set the PIO IO node data buffer size limit.
  *
@@ -643,6 +648,11 @@ PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *arra
 
     LOG((1, "PIOc_write_darray ncid = %d varid = %d ioid = %d arraylen = %d",
          ncid, varid, ioid, arraylen));
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[START][DARRAY_WRITE], 0,
+                             "PIOc_write_darray")))
+        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -840,6 +850,12 @@ PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *arra
     if (wmb->frame)
         wmb->frame[wmb->num_arrays] = vdesc->record;
     wmb->num_arrays++;
+
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[END][DARRAY_WRITE], 0,
+                             "PIOc_write_darray")))
+        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
 
     LOG((2, "wmb->num_arrays = %d iodesc->maxbytes / iodesc->mpitype_size = %d "
          "iodesc->ndof = %d iodesc->llen = %d", wmb->num_arrays,

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -28,6 +28,11 @@
    netCDF-4/HDF5 (starts at 65xxx). */
 int pio_next_ncid = 16;
 
+#ifdef USE_MPE
+/* The event numbers for MPE logging. */
+extern int event_num[2][NUM_EVENTS];
+#endif /* USE_MPE */
+
 /**
  * Open an existing file using PIO library.
  *
@@ -221,6 +226,12 @@ int PIOc_closefile(int ncid)
     int ierr = PIO_NOERR;  /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[START][CLOSE], 0,
+                              "PIOc_closefile")))
+        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
+
     LOG((1, "PIOc_closefile ncid = %d", ncid));
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -293,6 +304,12 @@ int PIOc_closefile(int ncid)
     /* Delete file from our list of open files. */
     if ((ierr = pio_delete_file_from_list(ncid)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);
+
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[END][CLOSE], 0,
+                              "PIOc_closefile")))
+        return pio_err(ios, NULL, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
 
     return ierr;
 }

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -304,7 +304,7 @@ int PIOc_closefile(int ncid)
         return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
 #ifdef USE_MPE
-    pio_stop_mpe_log(INIT, __func__);
+    pio_stop_mpe_log(CLOSE, __func__);
 #endif /* USE_MPE */
 
     return ierr;

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -227,9 +227,7 @@ int PIOc_closefile(int ncid)
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
 #ifdef USE_MPE
-    if ((ierr = MPE_Log_event(event_num[START][CLOSE], 0,
-                              "PIOc_closefile")))
-        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+    pio_start_mpe_log(CLOSE);
 #endif /* USE_MPE */
 
     LOG((1, "PIOc_closefile ncid = %d", ncid));
@@ -306,9 +304,7 @@ int PIOc_closefile(int ncid)
         return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
 #ifdef USE_MPE
-    if ((ierr = MPE_Log_event(event_num[END][CLOSE], 0,
-                              "PIOc_closefile")))
-        return pio_err(ios, NULL, PIO_EIO, __FILE__, __LINE__);
+    pio_stop_mpe_log(INIT, __func__);
 #endif /* USE_MPE */
 
     return ierr;

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -19,6 +19,9 @@
 #include <gptl.h>
 #endif
 #include <assert.h>
+#ifdef USE_MPE
+#include <mpe.h>
+#endif /* USE_MPE */
 
 /* These are the sizes of types in netCDF files. Do not replace these
  * constants with sizeof() calls for C types. They are not the
@@ -84,6 +87,23 @@ void pio_log(int severity, const char *fmt, ...);
  * a data type when creating attributes or varaibles, it is only used
  * internally. */
 #define PIO_LONG_INTERNAL 13
+
+#ifdef USE_MPE
+/* These are for the event numbers array used to log various events in
+ * the program with the MPE library, which produces output for the
+ * Jumpshot program. */
+#define NUM_EVENTS 7
+#define START 0
+#define END 1
+#define INIT 0
+#define DECOMP 1
+#define CREATE 2
+#define DARRAY_WRITE 3
+#define CLOSE 4
+#define CALCULATE 5
+#define INGEST 6
+#define ERR_LOGGING 99
+#endif /* USE_MPE */
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -92,9 +92,13 @@ void pio_log(int severity, const char *fmt, ...);
 /* These are for the event numbers array used to log various events in
  * the program with the MPE library, which produces output for the
  * Jumpshot program. */
-#define NUM_EVENTS 7
+
+/* Each event has start and end. */
 #define START 0
 #define END 1
+
+/* These are the events. */
+#define NUM_EVENTS 7
 #define INIT 0
 #define DECOMP 1
 #define CREATE 2
@@ -102,7 +106,6 @@ void pio_log(int severity, const char *fmt, ...);
 #define CLOSE 4
 #define CALCULATE 5
 #define INGEST 6
-#define ERR_LOGGING 99
 #endif /* USE_MPE */
 
 #if defined(__cplusplus)

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -368,9 +368,11 @@ extern "C" {
     int pio_init_logging(void);
     void pio_finalize_logging(void );
 
+#ifdef USE_MPE
     /* Logging with the MPE library, use --enable-mpe at configure. */
     void pio_start_mpe_log(int state);
     void pio_stop_mpe_log(int state, const char *msg);
+#endif /* USE_MPE */
 
     /* Write a netCDF decomp file. */
     int pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, int ndims,

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -104,8 +104,8 @@ void pio_log(int severity, const char *fmt, ...);
 #define CREATE 2
 #define OPEN 3
 #define DARRAY_WRITE 4
-#define DARRAY_READ 5
-#define CLOSE 6
+#define DARRAY_READ 6
+#define CLOSE 5
 #endif /* USE_MPE */
 
 #if defined(__cplusplus)

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -102,10 +102,10 @@ void pio_log(int severity, const char *fmt, ...);
 #define INIT 0
 #define DECOMP 1
 #define CREATE 2
-#define DARRAY_WRITE 3
-#define CLOSE 4
-#define CALCULATE 5
-#define INGEST 6
+#define OPEN 3
+#define DARRAY_WRITE 4
+#define DARRAY_READ 5
+#define CLOSE 6
 #endif /* USE_MPE */
 
 #if defined(__cplusplus)

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -364,9 +364,13 @@ extern "C" {
     /* Handle end and re-defs. */
     int pioc_change_def(int ncid, int is_enddef);
 
-    /* Initialize and finalize logging. */
+    /* Initialize and finalize logging, use --enable-logging at configure. */
     int pio_init_logging(void);
     void pio_finalize_logging(void );
+
+    /* Logging with the MPE library, use --enable-mpe at configure. */
+    void pio_start_mpe_log(int state);
+    void pio_stop_mpe_log(int state, const char *msg);
 
     /* Write a netCDF decomp file. */
     int pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, int ndims,

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -1,4 +1,5 @@
-/** @file
+/**
+ * @file
  *
  * PIO async message handling. This file contains the code which
  * runs on the IO nodes when async is in use. This code waits for
@@ -21,6 +22,11 @@
 extern int my_rank;
 extern int pio_log_level;
 #endif /* PIO_ENABLE_LOGGING */
+
+#ifdef USE_MPE
+/* The event numbers for MPE logging. */
+extern int event_num[2][NUM_EVENTS];
+#endif /* USE_MPE */
 
 /**
  * This function is run on the IO tasks to handle nc_inq_type*()

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -190,10 +190,10 @@ init_mpe(int my_rank)
     event_num[END][OPEN] = MPE_Log_get_event_number();
     event_num[START][DARRAY_WRITE] = MPE_Log_get_event_number();
     event_num[END][DARRAY_WRITE] = MPE_Log_get_event_number();
-    event_num[START][DARRAY_READ] = MPE_Log_get_event_number();
-    event_num[END][DARRAY_READ] = MPE_Log_get_event_number();
     event_num[START][CLOSE] = MPE_Log_get_event_number();
     event_num[END][CLOSE] = MPE_Log_get_event_number();
+    event_num[START][DARRAY_READ] = MPE_Log_get_event_number();
+    event_num[END][DARRAY_READ] = MPE_Log_get_event_number();
 
     /* Available colors: "white", "black", "red", "yellow", "green",
        "cyan", "blue", "magenta", "aquamarine", "forestgreen",
@@ -213,10 +213,11 @@ init_mpe(int my_rank)
                                 event_num[END][DARRAY_WRITE], "PIO darray write",
                                 "pink", "%s");
         MPE_Describe_info_state(event_num[START][DARRAY_READ],
-                                event_num[END][DARRAY_WRITE], "PIO darray read",
+                                event_num[END][DARRAY_READ], "PIO darray read",
                                 "magenta", "%s");
-        MPE_Describe_info_state(event_num[START][CLOSE], event_num[END][CLOSE],
-                                "PIO close file", "purple", "%s");
+        MPE_Describe_info_state(event_num[START][CLOSE],
+                                event_num[END][CLOSE], "PIO close",
+                                "white", "%s");
     }
     return 0;
 }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2338,6 +2338,12 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
     int mpierr = MPI_SUCCESS, mpierr2;  /** Return code from MPI function codes. */
     int ierr = PIO_NOERR;      /* Return code from function calls. */
 
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[START][OPEN], 0,
+                              "PIOc_openfile_retry")))
+        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
+
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
@@ -2595,6 +2601,10 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
             free(mpi_type_size);
     }
 
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[END][OPEN], 0, "PIOc_openfile_retry")))
+        return pio_err(ios, file, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
     LOG((2, "Opened file %s file->pio_ncid = %d file->fh = %d ierr = %d",
          filename, file->pio_ncid, file->fh, ierr));
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -163,6 +163,56 @@ PIOc_set_log_level(int level)
     return PIO_NOERR;
 }
 
+#ifdef USE_MPE
+
+/* This array holds even numbers for MPE. */
+int event_num[2][NUM_EVENTS];
+
+/** This will set up the MPE logging event numbers. The calling program
+ * must call MPE_Init_log() before this function is called.
+ *
+ * @param my_rank rank of processor in MPI_COMM_WORLD.
+ * @author Ed Hartnett
+*/
+int
+init_mpe(int my_rank)
+{
+    int ret;
+
+    /* Get a bunch of event numbers. */
+    event_num[START][INIT] = MPE_Log_get_event_number();
+    event_num[END][INIT] = MPE_Log_get_event_number();
+    event_num[START][DECOMP] = MPE_Log_get_event_number();
+    event_num[END][DECOMP] = MPE_Log_get_event_number();
+    event_num[START][INGEST] = MPE_Log_get_event_number();
+    event_num[END][INGEST] = MPE_Log_get_event_number();
+    event_num[START][CLOSE] = MPE_Log_get_event_number();
+    event_num[END][CLOSE] = MPE_Log_get_event_number();
+    event_num[START][CALCULATE] = MPE_Log_get_event_number();
+    event_num[END][CALCULATE] = MPE_Log_get_event_number();
+    event_num[START][CREATE] = MPE_Log_get_event_number();
+    event_num[END][CREATE] = MPE_Log_get_event_number();
+    event_num[START][DARRAY_WRITE] = MPE_Log_get_event_number();
+    event_num[END][DARRAY_WRITE] = MPE_Log_get_event_number();
+
+    /* You should track at least initialization and partitioning, data
+     * ingest, update computation, all communications, any memory
+     * copies (if you do that), any output rendering, and any global
+     * communications. */
+    if (!my_rank)
+    {
+        MPE_Describe_state(event_num[START][INIT], event_num[END][INIT], "init", "red");
+        MPE_Describe_state(event_num[START][INGEST], event_num[END][INGEST], "ingest", "yellow");
+        MPE_Describe_state(event_num[START][DECOMP], event_num[END][DECOMP], "decomposition", "green");
+        MPE_Describe_state(event_num[START][CALCULATE], event_num[END][CALCULATE], "calculate", "orange");
+        MPE_Describe_state(event_num[START][CREATE], event_num[END][CREATE], "create", "purple");
+        MPE_Describe_state(event_num[START][CLOSE], event_num[END][CLOSE], "close file", "blue");
+        MPE_Describe_state(event_num[START][DARRAY_WRITE], event_num[END][DARRAY_WRITE], "darray write", "pink");
+    }
+    return 0;
+}
+#endif /* USE_MPE */
+
 /**
  * Initialize logging.  Open log file, if not opened yet, or increment
  * ref count if already open.

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -168,8 +168,10 @@ PIOc_set_log_level(int level)
 /* This array holds even numbers for MPE. */
 int event_num[2][NUM_EVENTS];
 
-/** This will set up the MPE logging event numbers. The calling program
- * must call MPE_Init_log() before this function is called.
+/** This will set up the MPE logging event numbers. The calling
+ * program must call MPE_Init_log() before this function is
+ * called. MPE must be installed, get it from
+ * https://www.mcs.anl.gov/research/projects/perfvis/software/MPE/.
  *
  * @param my_rank rank of processor in MPI_COMM_WORLD.
  * @author Ed Hartnett
@@ -193,29 +195,28 @@ init_mpe(int my_rank)
     event_num[START][CLOSE] = MPE_Log_get_event_number();
     event_num[END][CLOSE] = MPE_Log_get_event_number();
 
-    /* You should track at least initialization and partitioning, data
-     * ingest, update computation, all communications, any memory
-     * copies (if you do that), any output rendering, and any global
-     * communications. */
+    /* Available colors: "white", "black", "red", "yellow", "green",
+       "cyan", "blue", "magenta", "aquamarine", "forestgreen",
+       "orange", "marroon", "brown", "pink", "coral", "gray" */
     if (!my_rank)
     {
         MPE_Describe_info_state(event_num[START][INIT], event_num[END][INIT],
-                                "PIO init", "red", "%s");
+                                "PIO init", "green", "%s");
         MPE_Describe_info_state(event_num[START][DECOMP],
                                 event_num[END][DECOMP], "PIO decomposition",
-                                "green", "%s");
+                                "cyan", "%s");
         MPE_Describe_info_state(event_num[START][CREATE], event_num[END][CREATE],
-                                "PIO create file", "purple", "%s");
+                                "PIO create file", "red", "%s");
         MPE_Describe_info_state(event_num[START][OPEN], event_num[END][OPEN],
                                 "PIO open file", "orange", "%s");
         MPE_Describe_info_state(event_num[START][DARRAY_WRITE],
                                 event_num[END][DARRAY_WRITE], "PIO darray write",
                                 "pink", "%s");
         MPE_Describe_info_state(event_num[START][DARRAY_READ],
-                           event_num[END][DARRAY_WRITE], "PIO darray read",
-                           "brown", "%s");
+                                event_num[END][DARRAY_WRITE], "PIO darray read",
+                                "magenta", "%s");
         MPE_Describe_info_state(event_num[START][CLOSE], event_num[END][CLOSE],
-                                "PIO close file", "blue", "%s");
+                                "PIO close file", "purple", "%s");
     }
     return 0;
 }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -182,16 +182,16 @@ init_mpe(int my_rank)
     event_num[END][INIT] = MPE_Log_get_event_number();
     event_num[START][DECOMP] = MPE_Log_get_event_number();
     event_num[END][DECOMP] = MPE_Log_get_event_number();
-    event_num[START][INGEST] = MPE_Log_get_event_number();
-    event_num[END][INGEST] = MPE_Log_get_event_number();
-    event_num[START][CLOSE] = MPE_Log_get_event_number();
-    event_num[END][CLOSE] = MPE_Log_get_event_number();
-    event_num[START][CALCULATE] = MPE_Log_get_event_number();
-    event_num[END][CALCULATE] = MPE_Log_get_event_number();
     event_num[START][CREATE] = MPE_Log_get_event_number();
     event_num[END][CREATE] = MPE_Log_get_event_number();
+    event_num[START][OPEN] = MPE_Log_get_event_number();
+    event_num[END][OPEN] = MPE_Log_get_event_number();
     event_num[START][DARRAY_WRITE] = MPE_Log_get_event_number();
     event_num[END][DARRAY_WRITE] = MPE_Log_get_event_number();
+    event_num[START][DARRAY_READ] = MPE_Log_get_event_number();
+    event_num[END][DARRAY_READ] = MPE_Log_get_event_number();
+    event_num[START][CLOSE] = MPE_Log_get_event_number();
+    event_num[END][CLOSE] = MPE_Log_get_event_number();
 
     /* You should track at least initialization and partitioning, data
      * ingest, update computation, all communications, any memory
@@ -200,12 +200,12 @@ init_mpe(int my_rank)
     if (!my_rank)
     {
         MPE_Describe_state(event_num[START][INIT], event_num[END][INIT], "init", "red");
-        MPE_Describe_state(event_num[START][INGEST], event_num[END][INGEST], "ingest", "yellow");
         MPE_Describe_state(event_num[START][DECOMP], event_num[END][DECOMP], "decomposition", "green");
-        MPE_Describe_state(event_num[START][CALCULATE], event_num[END][CALCULATE], "calculate", "orange");
-        MPE_Describe_state(event_num[START][CREATE], event_num[END][CREATE], "create", "purple");
-        MPE_Describe_state(event_num[START][CLOSE], event_num[END][CLOSE], "close file", "blue");
+        MPE_Describe_state(event_num[START][CREATE], event_num[END][CREATE], "create file", "purple");
+        MPE_Describe_state(event_num[START][OPEN], event_num[END][OPEN], "open file", "orange");
         MPE_Describe_state(event_num[START][DARRAY_WRITE], event_num[END][DARRAY_WRITE], "darray write", "pink");
+        MPE_Describe_state(event_num[START][DARRAY_READ], event_num[END][DARRAY_WRITE], "darray read", "brown");
+        MPE_Describe_state(event_num[START][CLOSE], event_num[END][CLOSE], "close file", "blue");
     }
     return 0;
 }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1888,6 +1888,12 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr;              /* Return code from function calls. */
 
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[START][CREATE], 0,
+                              "PIOc_createfile_int")))
+        return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
+
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
@@ -2029,6 +2035,11 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
      * open files. */
     pio_add_to_file_list(file);
 
+#ifdef USE_MPE
+    if ((ierr = MPE_Log_event(event_num[END][CREATE], 0,
+                              "PIOc_createfile_int")))
+        return pio_err(NULL, file, PIO_EIO, __FILE__, __LINE__);
+#endif /* USE_MPE */
     LOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
          file->fh, file->pio_ncid));
 

--- a/tests/cunit/Makefile.am
+++ b/tests/cunit/Makefile.am
@@ -70,4 +70,4 @@ test_darray_vard_SOURCES = test_darray_vard.c test_common.c pio_tests.h
 EXTRA_DIST = run_tests.sh
 
 # Clean up files produced during testing.
-CLEANFILES = *.nc *.log decomp*.txt
+CLEANFILES = *.nc *.log decomp*.txt *.clog2 *.slog2

--- a/tests/cunit/Makefile.am
+++ b/tests/cunit/Makefile.am
@@ -4,7 +4,7 @@
 # Ed Hartnett 8/17/17
 
 # Link to our assembled library.
-AM_LDFLAGS = ${top_builddir}/src/clib/libpio.la
+#AM_LDFLAGS = ${top_builddir}/src/clib/libpio.la
 AM_CPPFLAGS = -I$(top_srcdir)/src/clib
 LDADD = ${top_builddir}/src/clib/libpio.la
 

--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -16,6 +16,10 @@
 #include <gptl.h>
 #endif
 
+#ifdef USE_MPE
+#include <mpe.h>
+#endif /* USE_MPE */
+
 /** The number of possible output netCDF output flavors available to
  * the ParallelIO library. */
 #define NUM_FLAVORS 4
@@ -127,6 +131,7 @@ int check_nc_sample_4(int iosysid, int iotype, int my_rank, int my_comp_idx,
 int get_iotypes(int *num_flavors, int *flavors);
 int get_iotype_name(int iotype, char *name);
 int pio_test_finalize(MPI_Comm *test_comm);
+int pio_test_finalize2(MPI_Comm *test_comm, const char *test_name);
 int test_async2(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm,
                 int component_count, int num_io_procs, int target_ntasks, char *test_name);
 int test_no_async2(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm, int target_ntasks,

--- a/tests/cunit/test_async_multicomp.c
+++ b/tests/cunit/test_async_multicomp.c
@@ -83,7 +83,6 @@ int main(int argc, char **argv)
         {
             for (int i = 0; i < num_iotypes; i++)
             {
-                char filename[NC_MAX_NAME + 1]; /* Test filename. */
                 int my_comp_idx = my_rank - 1; /* Index in iosysid array. */
                 int dim_len_2d[NDIM2] = {DIM_LEN2, DIM_LEN3};
                 int ioid = 0;
@@ -92,9 +91,11 @@ int main(int argc, char **argv)
                                                    &ioid, PIO_SHORT)))
                     ERR(ret);
 
+#ifndef USE_MPE /* For some reason MPE logging breaks this test! */
                 /* Test with and without darrays. */
                 for (int use_darray = 0; use_darray < 2; use_darray++)
                 {
+                    char filename[NC_MAX_NAME + 1]; /* Test filename. */
 
                     /* Create sample file. */
                     if ((ret = create_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
@@ -106,6 +107,7 @@ int main(int argc, char **argv)
                                                  filename, 0, 0, ioid)))
                         ERR(ret);
                 } /* next use_darray */
+#endif /* USE_MPE */
 
                 /* Free the decomposition. */
                 if ((ret = PIOc_freedecomp(iosysid[my_comp_idx], ioid)))

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -251,11 +251,37 @@ int pio_test_init2(int argc, char **argv, int *my_rank, int *ntasks,
     if ((ret = PIOc_set_log_level(log_level)))
         return ret;
 
+#ifdef USE_MPE
+    /* If MPE logging is being used, then initialize it. */
+    if ((ret = MPE_Init_log()))
+        return ret;
+#endif /* USE_MPE */
+
     /* Change error handling so we can test inval parameters. */
     if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))
         return ret;
 
     return PIO_NOERR;
+}
+
+/* Finalize a PIO C test. This version of the finalize function takes
+ * a test name, which is used if MPE logging is in use.
+ *
+ * @param test_comm pointer to the test communicator.
+ * @param test_name name of the test
+ * @returns 0 for success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int pio_test_finalize2(MPI_Comm *test_comm, const char *test_name)
+{
+    int ret;
+
+#ifdef USE_MPE
+    if ((ret = MPE_Finish_log(test_name)))
+        MPIERR(ret);
+#endif /* USE_MPE */
+
+    return pio_test_finalize(test_comm);
 }
 
 /* Finalize a PIO C test.

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -274,9 +274,8 @@ int pio_test_init2(int argc, char **argv, int *my_rank, int *ntasks,
  */
 int pio_test_finalize2(MPI_Comm *test_comm, const char *test_name)
 {
-    int ret;
-
 #ifdef USE_MPE
+    int ret;
     if ((ret = MPE_Finish_log(test_name)))
         MPIERR(ret);
 #endif /* USE_MPE */

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -423,6 +423,8 @@ int main(int argc, char **argv)
     /* Finalize the MPI library. */
     if ((ret = pio_test_finalize(&test_comm)))
         return ret;
+    /* if ((ret = pio_test_finalize2(&test_comm, TEST_NAME))) */
+    /*     return ret; */
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
     return 0;

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -421,10 +421,10 @@ int main(int argc, char **argv)
     } /* endif my_rank < TARGET_NTASKS */
 
     /* Finalize the MPI library. */
-    if ((ret = pio_test_finalize(&test_comm)))
-        return ret;
-    /* if ((ret = pio_test_finalize2(&test_comm, TEST_NAME))) */
+    /* if ((ret = pio_test_finalize(&test_comm))) */
     /*     return ret; */
+    if ((ret = pio_test_finalize2(&test_comm, TEST_NAME)))
+        return ret;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
     return 0;

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -421,10 +421,10 @@ int main(int argc, char **argv)
     } /* endif my_rank < TARGET_NTASKS */
 
     /* Finalize the MPI library. */
-    /* if ((ret = pio_test_finalize(&test_comm))) */
-    /*     return ret; */
-    if ((ret = pio_test_finalize2(&test_comm, TEST_NAME)))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ret;
+    /* if ((ret = pio_test_finalize2(&test_comm, TEST_NAME))) */
+    /*     return ret; */
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
     return 0;

--- a/tests/cunit/test_darray_async_simple.c
+++ b/tests/cunit/test_darray_async_simple.c
@@ -208,7 +208,7 @@ int main(int argc, char **argv)
     } /* endif my_rank < TARGET_NTASKS */
 
     /* Finalize the MPI library. */
-    if ((ret = pio_test_finalize(&test_comm)))
+    if ((ret = pio_test_finalize2(&test_comm, TEST_NAME)))
         return ret;
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/cunit/test_darray_async_simple.c
+++ b/tests/cunit/test_darray_async_simple.c
@@ -208,8 +208,10 @@ int main(int argc, char **argv)
     } /* endif my_rank < TARGET_NTASKS */
 
     /* Finalize the MPI library. */
-    if ((ret = pio_test_finalize2(&test_comm, TEST_NAME)))
+    if ((ret = pio_test_finalize(&test_comm)))
         return ret;
+    /* if ((ret = pio_test_finalize2(&test_comm, TEST_NAME))) */
+    /*     return ret; */
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
 

--- a/tests/cunit/test_perf2.c
+++ b/tests/cunit/test_perf2.c
@@ -9,9 +9,9 @@
 #include <pio_internal.h>
 #include <pio_tests.h>
 #include <sys/time.h>
-#ifdef USE_MPE
-#include <mpe.h>
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/* #include <mpe.h> */
+/* #endif /\* USE_MPE *\/ */
 
 /* The number of tasks this test should run on. */
 #define TARGET_NTASKS 16
@@ -65,63 +65,63 @@ int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN, Z_DIM_LEN};
 /* Run test for each of the rearrangers. */
 #define NUM_REARRANGERS_TO_TEST 2
 
-#ifdef USE_MPE
-/* These are for the event numbers array used to log various events in
- * the program with the MPE library, which produces output for the
- * Jumpshot program. */
-#define NUM_EVENTS 7
-#define START 0
-#define END 1
-#define INIT 0
-#define DECOMP 1
-#define CREATE 2
-#define DARRAY_WRITE 3
-#define CLOSE 4
-#define CALCULATE 5
-#define INGEST 6
+/* #ifdef USE_MPE */
+/* /\* These are for the event numbers array used to log various events in */
+/*  * the program with the MPE library, which produces output for the */
+/*  * Jumpshot program. *\/ */
+/* #define NUM_EVENTS 7 */
+/* #define START 0 */
+/* #define END 1 */
+/* #define INIT 0 */
+/* #define DECOMP 1 */
+/* #define CREATE 2 */
+/* #define DARRAY_WRITE 3 */
+/* #define CLOSE 4 */
+/* #define CALCULATE 5 */
+/* #define INGEST 6 */
 
-#define ERR_LOGGING 99
+/* #define ERR_LOGGING 99 */
 
-/* This array holds even numbers for MPE. */
-int event_num[2][NUM_EVENTS];
+/* /\* This array holds even numbers for MPE. *\/ */
+/* int event_num[2][NUM_EVENTS]; */
 
-/* This will set up the MPE logging event numbers. */
-int
-init_logging(int my_rank, int event_num[][NUM_EVENTS])
-{
-   /* Get a bunch of event numbers. */
-   event_num[START][INIT] = MPE_Log_get_event_number();
-   event_num[END][INIT] = MPE_Log_get_event_number();
-   event_num[START][DECOMP] = MPE_Log_get_event_number();
-   event_num[END][DECOMP] = MPE_Log_get_event_number();
-   event_num[START][INGEST] = MPE_Log_get_event_number();
-   event_num[END][INGEST] = MPE_Log_get_event_number();
-   event_num[START][CLOSE] = MPE_Log_get_event_number();
-   event_num[END][CLOSE] = MPE_Log_get_event_number();
-   event_num[START][CALCULATE] = MPE_Log_get_event_number();
-   event_num[END][CALCULATE] = MPE_Log_get_event_number();
-   event_num[START][CREATE] = MPE_Log_get_event_number();
-   event_num[END][CREATE] = MPE_Log_get_event_number();
-   event_num[START][DARRAY_WRITE] = MPE_Log_get_event_number();
-   event_num[END][DARRAY_WRITE] = MPE_Log_get_event_number();
+/* /\* This will set up the MPE logging event numbers. *\/ */
+/* int */
+/* init_logging(int my_rank, int event_num[][NUM_EVENTS]) */
+/* { */
+/*    /\* Get a bunch of event numbers. *\/ */
+/*    event_num[START][INIT] = MPE_Log_get_event_number(); */
+/*    event_num[END][INIT] = MPE_Log_get_event_number(); */
+/*    event_num[START][DECOMP] = MPE_Log_get_event_number(); */
+/*    event_num[END][DECOMP] = MPE_Log_get_event_number(); */
+/*    event_num[START][INGEST] = MPE_Log_get_event_number(); */
+/*    event_num[END][INGEST] = MPE_Log_get_event_number(); */
+/*    event_num[START][CLOSE] = MPE_Log_get_event_number(); */
+/*    event_num[END][CLOSE] = MPE_Log_get_event_number(); */
+/*    event_num[START][CALCULATE] = MPE_Log_get_event_number(); */
+/*    event_num[END][CALCULATE] = MPE_Log_get_event_number(); */
+/*    event_num[START][CREATE] = MPE_Log_get_event_number(); */
+/*    event_num[END][CREATE] = MPE_Log_get_event_number(); */
+/*    event_num[START][DARRAY_WRITE] = MPE_Log_get_event_number(); */
+/*    event_num[END][DARRAY_WRITE] = MPE_Log_get_event_number(); */
 
-   /* You should track at least initialization and partitioning, data
-    * ingest, update computation, all communications, any memory
-    * copies (if you do that), any output rendering, and any global
-    * communications. */
-   if (!my_rank)
-   {
-      MPE_Describe_state(event_num[START][INIT], event_num[END][INIT], "init", "yellow");
-      MPE_Describe_state(event_num[START][INGEST], event_num[END][INGEST], "ingest", "red");
-      MPE_Describe_state(event_num[START][DECOMP], event_num[END][DECOMP], "decomposition", "green");
-      MPE_Describe_state(event_num[START][CALCULATE], event_num[END][CALCULATE], "calculate", "orange");
-      MPE_Describe_state(event_num[START][CREATE], event_num[END][CREATE], "create", "purple");
-      MPE_Describe_state(event_num[START][CLOSE], event_num[END][CLOSE], "close file", "blue");
-      MPE_Describe_state(event_num[START][DARRAY_WRITE], event_num[END][DARRAY_WRITE], "darray write", "pink");
-   }
-   return 0;
-}
-#endif /* USE_MPE */
+/*    /\* You should track at least initialization and partitioning, data */
+/*     * ingest, update computation, all communications, any memory */
+/*     * copies (if you do that), any output rendering, and any global */
+/*     * communications. *\/ */
+/*    if (!my_rank) */
+/*    { */
+/*       MPE_Describe_state(event_num[START][INIT], event_num[END][INIT], "init", "yellow"); */
+/*       MPE_Describe_state(event_num[START][INGEST], event_num[END][INGEST], "ingest", "red"); */
+/*       MPE_Describe_state(event_num[START][DECOMP], event_num[END][DECOMP], "decomposition", "green"); */
+/*       MPE_Describe_state(event_num[START][CALCULATE], event_num[END][CALCULATE], "calculate", "orange"); */
+/*       MPE_Describe_state(event_num[START][CREATE], event_num[END][CREATE], "create", "purple"); */
+/*       MPE_Describe_state(event_num[START][CLOSE], event_num[END][CLOSE], "close file", "blue"); */
+/*       MPE_Describe_state(event_num[START][DARRAY_WRITE], event_num[END][DARRAY_WRITE], "darray write", "pink"); */
+/*    } */
+/*    return 0; */
+/* } */
+/* #endif /\* USE_MPE *\/ */
 
 /* Create the decomposition to divide the 4-dimensional sample data
  * between the 4 tasks. For the purposes of decomposition we are only
@@ -204,7 +204,8 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
 
     /* Use PIO to create the example file in each of the four
      * available ways. */
-    for (int fmt = 0; fmt < num_flavors; fmt++)
+    /* for (int fmt = 0; fmt < num_flavors; fmt++) */
+    for (int fmt = 0; fmt < 1; fmt++)
     {
         struct timeval starttime, endtime;
         long long startt, endt;
@@ -213,10 +214,10 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
         float delta_in_sec;
         float mb_per_sec;
 
-#ifdef USE_MPE
-        if ((ret = MPE_Log_event(event_num[START][CREATE], 0, "start init")))
-            return ERR_MPI;
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*         if ((ret = MPE_Log_event(event_num[START][CREATE], 0, "start init"))) */
+/*             return ERR_MPI; */
+/* #endif /\* USE_MPE *\/ */
 
         /* Create the filename. Use the same filename for all, so we
          * don't waste disk space. */
@@ -245,24 +246,25 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
         if ((ret = PIOc_enddef(ncid)))
             ERR(ret);
 
-#ifdef USE_MPE
-        if ((ret = MPE_Log_event(event_num[END][CREATE], 0, "end init")))
-            MPIERR(ret);
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*         if ((ret = MPE_Log_event(event_num[END][CREATE], 0, "end init"))) */
+/*             MPIERR(ret); */
+/* #endif /\* USE_MPE *\/ */
 
         /* Start the clock. */
         gettimeofday(&starttime, NULL);
 
-        for (int t = 0; t < NUM_TIMESTEPS; t++)
+        /* for (int t = 0; t < NUM_TIMESTEPS; t++) */
+        for (int t = 0; t < 1; t++)
         {
             /* Initialize some data. */
             for (int f = 0; f < arraylen; f++)
                 test_data[f] = (my_rank * 10 + f) + t * 1000;
 
-#ifdef USE_MPE
-            if ((ret = MPE_Log_event(event_num[START][DARRAY_WRITE], 0, "start init")))
-                return ERR_MPI;
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*             if ((ret = MPE_Log_event(event_num[START][DARRAY_WRITE], 0, "start init"))) */
+/*                 return ERR_MPI; */
+/* #endif /\* USE_MPE *\/ */
 
             /* Set the value of the record dimension. */
             if ((ret = PIOc_setframe(ncid, varid, t)))
@@ -272,27 +274,27 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             if ((ret = PIOc_write_darray(ncid, varid, ioid, arraylen, test_data, fillvalue)))
                 ERR(ret);
 
-#ifdef USE_MPE
-            if ((ret = MPE_Log_event(event_num[END][DARRAY_WRITE], 0, "end init")))
-                MPIERR(ret);
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*             if ((ret = MPE_Log_event(event_num[END][DARRAY_WRITE], 0, "end init"))) */
+/*                 MPIERR(ret); */
+/* #endif /\* USE_MPE *\/ */
 
             num_megabytes += (X_DIM_LEN * Y_DIM_LEN * Z_DIM_LEN * sizeof(int))/(1024*1024);
         }
 
-#ifdef USE_MPE
-        if ((ret = MPE_Log_event(event_num[START][CLOSE], 0, "start init")))
-            return ERR_MPI;
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*         if ((ret = MPE_Log_event(event_num[START][CLOSE], 0, "start init"))) */
+/*             return ERR_MPI; */
+/* #endif /\* USE_MPE *\/ */
 
         /* Close the netCDF file. */
         if ((ret = PIOc_closefile(ncid)))
             ERR(ret);
 
-#ifdef USE_MPE
-        if ((ret = MPE_Log_event(event_num[END][CLOSE], 0, "end init")))
-            MPIERR(ret);
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*         if ((ret = MPE_Log_event(event_num[END][CLOSE], 0, "end init"))) */
+/*             MPIERR(ret); */
+/* #endif /\* USE_MPE *\/ */
 
 
         /* Stop the clock. */
@@ -428,27 +430,28 @@ test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
     if ((ret = MPI_Comm_size(test_comm, &my_test_size)))
         MPIERR(ret);
 
-#ifdef USE_MPE
-    if ((ret = MPE_Log_event(event_num[START][DECOMP], 0, "start init")))
-        return ERR_MPI;
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*     if ((ret = MPE_Log_event(event_num[START][DECOMP], 0, "start init"))) */
+/*         return ERR_MPI; */
+/* #endif /\* USE_MPE *\/ */
 
     /* Decompose the data over the tasks. */
     if ((ret = create_decomposition_3d(ntasks, my_rank, iosysid, &ioid)))
         return ret;
 
-    /* Test decomposition read/write. */
-    if ((ret = test_decomp_read_write(iosysid, ioid, num_flavors, flavor, my_rank,
-                                      ntasks, rearranger, test_comm)))
-        return ret;
+    /* /\* Test decomposition read/write. *\/ */
+    /* if ((ret = test_decomp_read_write(iosysid, ioid, num_flavors, flavor, my_rank, */
+    /*                                   ntasks, rearranger, test_comm))) */
+    /*     return ret; */
 
-#ifdef USE_MPE
-    if ((ret = MPE_Log_event(event_num[END][DECOMP], 0, "end init")))
-        MPIERR(ret);
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*     if ((ret = MPE_Log_event(event_num[END][DECOMP], 0, "end init"))) */
+/*         MPIERR(ret); */
+/* #endif /\* USE_MPE *\/ */
 
     /* Test with/without providing a fill value to PIOc_write_darray(). */
-    for (int provide_fill = 0; provide_fill < NUM_TEST_CASES_FILLVALUE; provide_fill++)
+    /* for (int provide_fill = 0; provide_fill < NUM_TEST_CASES_FILLVALUE; provide_fill++) */
+    for (int provide_fill = 0; provide_fill < 1; provide_fill++)
     {
         /* Run a simple darray test. */
         if ((ret = test_darray(iosysid, ioid, num_flavors, flavor, my_rank,
@@ -456,19 +459,19 @@ test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
             return ret;
     }
 
-#ifdef USE_MPE
-    if ((ret = MPE_Log_event(event_num[START][DECOMP], 0, "start init")))
-        return ERR_MPI;
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*     if ((ret = MPE_Log_event(event_num[START][DECOMP], 0, "start init"))) */
+/*         return ERR_MPI; */
+/* #endif /\* USE_MPE *\/ */
 
     /* Free the PIO decomposition. */
     if ((ret = PIOc_freedecomp(iosysid, ioid)))
         ERR(ret);
 
-#ifdef USE_MPE
-    if ((ret = MPE_Log_event(event_num[END][DECOMP], 0, "end init")))
-        MPIERR(ret);
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*     if ((ret = MPE_Log_event(event_num[END][DECOMP], 0, "end init"))) */
+/*         MPIERR(ret); */
+/* #endif /\* USE_MPE *\/ */
 
     return PIO_NOERR;
 }
@@ -496,13 +499,12 @@ main(int argc, char **argv)
                               0, -1, &test_comm)))
         ERR(ERR_INIT);
 
-#ifdef USE_MPE
-
-   if ((ret = MPE_Init_log()))
-       return ret;
-   if (init_logging(my_rank, event_num))
-       return ERR_LOGGING;
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*    if ((ret = MPE_Init_log())) */
+/*        return ret; */
+/*    if (init_logging(my_rank, event_num)) */
+/*        return ERR_LOGGING; */
+/* #endif /\* USE_MPE *\/ */
 
 
     if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))
@@ -532,10 +534,10 @@ main(int argc, char **argv)
         /* for (r = 0; r < NUM_REARRANGERS_TO_TEST; r++) */
         for (r = 0; r < 1; r++)
         {
-#ifdef USE_MPE
-            if ((ret = MPE_Log_event(event_num[START][INIT], 0, "start init")))
-                return ERR_MPI;
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*             if ((ret = MPE_Log_event(event_num[START][INIT], 0, "start init"))) */
+/*                 return ERR_MPI; */
+/* #endif /\* USE_MPE *\/ */
 
             /* Initialize the PIO IO system. This specifies how
              * many and which processors are involved in I/O. */
@@ -543,10 +545,10 @@ main(int argc, char **argv)
                                            ioproc_start, rearranger[r], &iosysid)))
                 return ret;
 
-#ifdef USE_MPE
-            if ((ret = MPE_Log_event(event_num[END][INIT], 0, "end init")))
-                MPIERR(ret);
-#endif /* USE_MPE */
+/* #ifdef USE_MPE */
+/*             if ((ret = MPE_Log_event(event_num[END][INIT], 0, "end init"))) */
+/*                 MPIERR(ret); */
+/* #endif /\* USE_MPE *\/ */
 
             /* Run tests. */
             if ((ret = test_all_darray(iosysid, num_flavors, flavor, my_rank,
@@ -560,17 +562,17 @@ main(int argc, char **argv)
     } /* next num io procs */
 
 
-#ifdef USE_MPE
-   {
-       /* This causes problems on my MPICH2 library on Linux, but seems to be
-	* required for frost. */
-       char file_name[128];
-       sprintf(file_name, "chart_%d", 1);
-       if ((ret = MPE_Finish_log(file_name)))
-	   MPIERR(ret);
-   }
+/* #ifdef USE_MPE */
+/*    { */
+/*        /\* This causes problems on my MPICH2 library on Linux, but seems to be */
+/* 	* required for frost. *\/ */
+/*        char file_name[128]; */
+/*        sprintf(file_name, "chart_%d", 1); */
+/*        if ((ret = MPE_Finish_log(file_name))) */
+/* 	   MPIERR(ret); */
+/*    } */
 
-#endif /* USE_MPE */
+/* #endif /\* USE_MPE *\/ */
 
 
     if (!my_rank)

--- a/tests/cunit/test_perf2.c
+++ b/tests/cunit/test_perf2.c
@@ -33,12 +33,12 @@
 #define NDIM3 3
 
 /* The length of our sample data along each dimension. */
-#define X_DIM_LEN 128
-#define Y_DIM_LEN 128
-#define Z_DIM_LEN 32
-/* #define X_DIM_LEN 1024 */
-/* #define Y_DIM_LEN 1024 */
-/* #define Z_DIM_LEN 128 */
+/* #define X_DIM_LEN 128 */
+/* #define Y_DIM_LEN 128 */
+/* #define Z_DIM_LEN 32 */
+#define X_DIM_LEN 1024
+#define Y_DIM_LEN 1024
+#define Z_DIM_LEN 128
 
 /* The number of timesteps of data to write. */
 #define NUM_TIMESTEPS 10
@@ -254,8 +254,7 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
         /* Start the clock. */
         gettimeofday(&starttime, NULL);
 
-        /* for (int t = 0; t < NUM_TIMESTEPS; t++) */
-        for (int t = 0; t < 1; t++)
+        for (int t = 0; t < NUM_TIMESTEPS; t++)
         {
             /* Initialize some data. */
             for (int f = 0; f < arraylen; f++)

--- a/tests/cunit/test_perf2.c
+++ b/tests/cunit/test_perf2.c
@@ -30,12 +30,12 @@
 #define NDIM3 3
 
 /* The length of our sample data along each dimension. */
-#define X_DIM_LEN 128
-#define Y_DIM_LEN 128
-#define Z_DIM_LEN 32
-/* #define X_DIM_LEN 1024 */
-/* #define Y_DIM_LEN 1024 */
-/* #define Z_DIM_LEN 128 */
+/* #define X_DIM_LEN 128 */
+/* #define Y_DIM_LEN 128 */
+/* #define Z_DIM_LEN 32 */
+#define X_DIM_LEN 1024
+#define Y_DIM_LEN 1024
+#define Z_DIM_LEN 128
 
 /* The number of timesteps of data to write. */
 #define NUM_TIMESTEPS 10
@@ -230,8 +230,7 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
 
     /* Use PIO to create the example file in each of the four
      * available ways. */
-    /* for (int fmt = 0; fmt < num_flavors; fmt++) */
-    for (int fmt = 0; fmt < 1; fmt++)
+    for (int fmt = 0; fmt < num_flavors; fmt++)
     {
         char filename[PIO_MAX_NAME + 1]; /* Name for the output files. */
         struct timeval starttime, endtime;
@@ -367,8 +366,7 @@ test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor,
                        MPI_Comm test_comm)
 {
 
-    /* for (int fmt = 0; fmt < num_flavors; fmt++) */
-    for (int fmt = 0; fmt < 1; fmt++)
+    for (int fmt = 0; fmt < num_flavors; fmt++)
     {
 	int ioid2;             /* ID for decomposition we will create from file. */
 	char filename[PIO_MAX_NAME + 1]; /* Name for the output files. */
@@ -488,19 +486,17 @@ test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
             return ret;
     }
 
-/* #ifdef USE_MPE */
-/*     if ((ret = MPE_Log_event(event_num[START][DECOMP], 0, "start init"))) */
-/*         return ERR_MPI; */
-/* #endif /\* USE_MPE *\/ */
+#ifdef USE_MPE
+    test_start_mpe_log(TEST_DECOMP);
+#endif /* USE_MPE */
 
     /* Free the PIO decomposition. */
     if ((ret = PIOc_freedecomp(iosysid, ioid)))
         ERR(ret);
 
-/* #ifdef USE_MPE */
-/*     if ((ret = MPE_Log_event(event_num[END][DECOMP], 0, "end init"))) */
-/*         MPIERR(ret); */
-/* #endif /\* USE_MPE *\/ */
+#ifdef USE_MPE
+    test_stop_mpe_log(TEST_DECOMP, TEST_NAME);
+#endif /* USE_MPE */
 
     return PIO_NOERR;
 }


### PR DESCRIPTION
Part of #1488.

After this PR, when PIO and the whole I/O stack are built with gcc -llmpe -lmpe -lmpi -lpthread (instead of mpicc), then MPE logging is automatically turned on for every PIO program.

I will put some output in the issue for illustration.

Of course this only works if MPE is installed and --enable-mpe is used at configure.