### PR TITLE
Clean up of error handling macros

### DIFF
--- a/src/clib/Makefile.am
+++ b/src/clib/Makefile.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES = libpio.la
 # for information regarding incrementing `-version-info`.
 libpio_la_LDFLAGS = -version-info 2:0:1
 
-# The header file.
+# The library header file will be installed in include dir.
 include_HEADERS = pio.h
 
 # The library soure files.
@@ -17,6 +17,6 @@ libpio_la_SOURCES = bget.c pioc_sc.c pio_darray.c pio_file.c		\
 pio_getput_int.c pio_msg.c pio_nc.c pio_rearrange.c pioc.c		\
 pioc_support.c pio_darray_int.c pio_get_nc.c pio_lists.c pio_nc4.c	\
 pio_put_nc.c pio_spmd.c pio_get_vard.c pio_put_vard.c pio_internal.h	\
-bget.h uthash.h
+bget.h uthash.h pio_error.h
 
 EXTRA_DIST = CMakeLists.txt

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -1,0 +1,31 @@
+/**
+ * @file
+ * Macros to handle errors in tests or libray code.
+ * @author Ed Hartnett
+ * @date 2019
+ *
+ * @see https://github.com/NCAR/ParallelIO
+ */
+
+#ifndef __PIO_ERROR__
+#define __PIO_ERROR__
+
+#include <config.h>
+#include <pio.h>
+
+/** Handle non-MPI errors by finalizing the MPI library and goto
+ * exit. Finalize and goto exit. */
+#define BAIL(e) do {                                                    \
+        fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
+        goto exit;                                                      \
+    } while (0)
+
+/** Handle non-MPI errors by finalizing the MPI library and exiting
+ * with an exit code. Finalize and return. */
+#define ERR(e) do {                                                     \
+        fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
+        MPI_Finalize();                                                 \
+        return e;                                                       \
+    } while (0)
+
+#endif /* __PIO_ERROR__ */

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -13,23 +13,29 @@
 #include <config.h>
 #include <pio.h>
 
-/** Handle non-MPI errors by finalizing the MPI library and goto
- * exit. Finalize and goto exit. */
+/**
+ * Handle non-MPI errors by printing error message and goto exit.
+ */
 #define BAIL(e) do {                                                    \
         fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
         goto exit;                                                      \
     } while (0)
 
-/** Handle non-MPI errors by finalizing the MPI library and exiting
- * with an exit code. Finalize and return. */
+/**
+ * Handle non-MPI errors by finalizing the MPI library and exiting
+ * with an exit code.
+ */
 #define ERR(e) do {                                                     \
         fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
         MPI_Finalize();                                                 \
         return e;                                                       \
     } while (0)
 
-/** Handle MPI errors. This should only be used with MPI library
- * function calls. Finalize and return. */
+/**
+ * Handle MPI errors. This should only be used with MPI library
+ * function calls. Print error message, finalize MPI and return error
+ * code.
+*/
 #define MPIERR(e) do {                                                  \
         MPI_Error_string(e, err_buffer, &resultlen);                    \
         fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
@@ -37,8 +43,10 @@
         return ERR_AWFUL;                                               \
     } while (0)
 
-/** Handle MPI errors. This should only be used with MPI library
- * function calls. Finalize and goto exit. */
+/**
+ * Handle MPI errors. This should only be used with MPI library
+ * function calls. Print error message, finalize MPI and goto exit.
+ */
 #define MPIBAIL(e) do {                                                 \
         MPI_Error_string(e, err_buffer, &resultlen);                    \
         fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
@@ -46,13 +54,17 @@
         goto exit;                                                      \
     } while (0)
 
-/** Global err buffer for MPI. When there is an MPI error, this buffer
+/**
+ * Global err buffer for MPI. When there is an MPI error, this buffer
  * is used to store the error message that is associated with the MPI
- * error. */
+ * error.
+ */
 char err_buffer[MPI_MAX_ERROR_STRING];
 
-/** This is the length of the most recent MPI error message, stored
- * int the global error string. */
+/**
+ * This is the length of the most recent MPI error message, stored
+ * int the global error string.
+ */
 int resultlen;
 
 #endif /* __PIO_ERROR__ */

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -14,12 +14,27 @@
 #include <pio.h>
 
 /**
- * Handle non-MPI errors by printing error message and goto exit.
+ * Handle non-MPI errors by printing error message and goto exit. This
+ * is used in test code.
  */
 #define BAIL(e) do {                                                    \
         fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
         goto exit;                                                      \
     } while (0)
+
+/**
+ * Handle non-MPI errors by calling pio_err(), setting return code,
+ * and goto exit. This is used in library code.
+ */
+#define EXIT(ios, e) do {                                               \
+        ret = pio_err(NULL, NULL, e, __FILE__, __LINE__);        \
+        goto exit;                                                      \
+    } while (0)
+
+/**
+ * Same as the EXIT macro, but uses NULL for iosystem.
+ */
+#define EXIT1(e) EXIT(NULL, e)
 
 /**
  * Handle non-MPI errors by finalizing the MPI library and exiting
@@ -35,7 +50,7 @@
  * Handle MPI errors. This should only be used with MPI library
  * function calls. Print error message, finalize MPI and return error
  * code.
-*/
+ */
 #define MPIERR(e) do {                                                  \
         MPI_Error_string(e, err_buffer, &resultlen);                    \
         fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -28,4 +28,31 @@
         return e;                                                       \
     } while (0)
 
+/** Handle MPI errors. This should only be used with MPI library
+ * function calls. Finalize and return. */
+#define MPIERR(e) do {                                                  \
+        MPI_Error_string(e, err_buffer, &resultlen);                    \
+        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
+        MPI_Finalize();                                                 \
+        return ERR_AWFUL;                                               \
+    } while (0)
+
+/** Handle MPI errors. This should only be used with MPI library
+ * function calls. Finalize and goto exit. */
+#define MPIBAIL(e) do {                                                 \
+        MPI_Error_string(e, err_buffer, &resultlen);                    \
+        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
+        ret = NC_EIO;                                                   \
+        goto exit;                                                      \
+    } while (0)
+
+/** Global err buffer for MPI. When there is an MPI error, this buffer
+ * is used to store the error message that is associated with the MPI
+ * error. */
+char err_buffer[MPI_MAX_ERROR_STRING];
+
+/** This is the length of the most recent MPI error message, stored
+ * int the global error string. */
+int resultlen;
+
 #endif /* __PIO_ERROR__ */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -12,6 +12,7 @@
 
 #include <config.h>
 #include <pio.h>
+#include <pio_error.h>
 #include <bget.h>
 #include <limits.h>
 #include <math.h>

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -355,7 +355,7 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
             int *displace;
 
             if (!(displace = malloc(sizeof(int) * len)))
-                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+                EXIT1(PIO_ENOMEM);
 
             LOG((3, "blocksize = %d i = %d mcount[%d] = %d len = %d", blocksize, i, i,
                  mcount[i], len));
@@ -412,12 +412,14 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
         }
     }
 
+    LOG((3, "done with create_mpi_datatypes()"));
+
+exit:
     /* Free resources. */
     if (lindex)
         free(lindex);
 
-    LOG((3, "done with create_mpi_datatypes()"));
-    return PIO_NOERR;
+    return ret;
 }
 
 /**

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -28,8 +28,9 @@
  * corresponding to this index.
  * @author Jim Edwards
  */
-inline void idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
-                            PIO_Offset *dim_list)
+inline void
+idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
+                PIO_Offset *dim_list)
 {
     /* Check inputs. */
     pioassert(ndims >= 0 && gdimlen && idx >= -1 && dim_list, "invalid input",
@@ -74,9 +75,10 @@ inline void idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
  * @param count array of size dim + 1 that gets the new counts.
  * @author Jim Edwards
  */
-void expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
-                   int region_size, int region_stride, const int *max_size,
-                   PIO_Offset *count)
+void
+expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
+              int region_size, int region_stride, const int *max_size,
+              PIO_Offset *count)
 {
     /* Flag used to signal that we can no longer expand the region
        along dimension dim. */
@@ -151,8 +153,9 @@ void expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *ma
  * @returns length of the region found.
  * @author Jim Edwards
  */
-PIO_Offset find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
-                       PIO_Offset *start, PIO_Offset *count)
+PIO_Offset
+find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
+            PIO_Offset *start, PIO_Offset *count)
 {
     PIO_Offset regionlen = 1;
 
@@ -198,7 +201,8 @@ PIO_Offset find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offs
  * @returns the local array index.
  * @author Jim Edwards
  */
-inline PIO_Offset coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO_Offset *count)
+inline PIO_Offset
+coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO_Offset *count)
 {
     PIO_Offset lindex = 0;
     PIO_Offset stride = 1;
@@ -225,7 +229,8 @@ inline PIO_Offset coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO
  * @returns 0 for success, error code otherwise.
  * @author Jim Edwards
  */
-int compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
+int
+compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
 {
     PIO_Offset totiosize = 0;
     int mpierr; /* Return code from MPI calls. */
@@ -275,23 +280,27 @@ int compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
-                         const PIO_Offset *mindex, const int *mcount, int *mfrom,
-                         MPI_Datatype *mtype)
+int
+create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
+                     const PIO_Offset *mindex, const int *mcount, int *mfrom,
+                     MPI_Datatype *mtype)
 {
     int blocksize;
     int numinds = 0;
     PIO_Offset *lindex = NULL;
     int mpierr; /* Return code from MPI functions. */
+    int ret = PIO_NOERR;
 
     /* Check inputs. */
     pioassert(msgcnt > 0 && mcount, "invalid input", __FILE__, __LINE__);
 
     PIO_Offset bsizeT[msgcnt];
 
-    LOG((1, "create_mpi_datatypes mpitype = %d msgcnt = %d", mpitype, msgcnt));
-    LOG((2, "MPI_BYTE = %d MPI_CHAR = %d MPI_SHORT = %d MPI_INT = %d MPI_FLOAT = %d MPI_DOUBLE = %d",
-         MPI_BYTE, MPI_CHAR, MPI_SHORT, MPI_INT, MPI_FLOAT, MPI_DOUBLE));
+    LOG((1, "create_mpi_datatypes mpitype = %d msgcnt = %d", mpitype,
+         msgcnt));
+    LOG((2, "MPI_BYTE = %d MPI_CHAR = %d MPI_SHORT = %d MPI_INT = %d "
+         "MPI_FLOAT = %d MPI_DOUBLE = %d", MPI_BYTE, MPI_CHAR, MPI_SHORT,
+         MPI_INT, MPI_FLOAT, MPI_DOUBLE));
 
     /* How many indicies in the array? */
     for (int j = 0; j < msgcnt; j++)
@@ -432,7 +441,8 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
+int
+define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
 {
     int ret; /* Return value. */
 
@@ -539,8 +549,9 @@ int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
-                   const int *dest_ioproc, const PIO_Offset *dest_ioindex)
+int
+compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
+               const int *dest_ioproc, const PIO_Offset *dest_ioindex)
 {
     int *recv_buf = NULL;
     int nrecvs = 0;
@@ -801,8 +812,9 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
-                      void *rbuf, int nvars)
+int
+rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
+                  void *rbuf, int nvars)
 {
     int ntasks;       /* Number of tasks in communicator. */
     int niotasks;     /* Number of IO tasks. */
@@ -987,8 +999,9 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
-                      void *rbuf)
+int
+rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
+                  void *rbuf)
 {
     MPI_Comm mycomm;
     int ntasks;
@@ -1118,8 +1131,9 @@ int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
-                   const PIO_Offset *compmap)
+int
+determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
+               const PIO_Offset *compmap)
 {
     PIO_Offset totalllen = 0;
     PIO_Offset totalgridsize = 1;
@@ -1199,8 +1213,9 @@ int determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap,
-                         const int *gdimlen, int ndims, io_desc_t *iodesc)
+int
+box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap,
+                     const int *gdimlen, int ndims, io_desc_t *iodesc)
 {
     int ret;
 
@@ -1493,7 +1508,6 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
     return PIO_NOERR;
 }
 
-
 /**
  * The box_rearrange_create algorithm optimized for the case where many
  * iotasks have iomaplen == 0 (holes)
@@ -1510,10 +1524,11 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
-                                    const PIO_Offset *compmap,
-                                    const int *gdimlen, int ndims,
-                                    io_desc_t *iodesc)
+int
+box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
+                                const PIO_Offset *compmap,
+                                const int *gdimlen, int ndims,
+                                io_desc_t *iodesc)
 {
     int ret;
 
@@ -1794,7 +1809,8 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
  * @returns 0 if offsets are the same or either pointer is NULL.
  * @author Jim Edwards
  */
-int compare_offsets(const void *a, const void *b)
+int
+compare_offsets(const void *a, const void *b)
 {
     mapsort *x = (mapsort *)a;
     mapsort *y = (mapsort *)b;
@@ -1822,8 +1838,9 @@ int compare_offsets(const void *a, const void *b)
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
-                int *maxregions, io_region *firstregion)
+int
+get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
+            int *maxregions, io_region *firstregion)
 {
     int nmaplen = 0;
     int regionlen;
@@ -1909,7 +1926,8 @@ int get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
+int
+default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
 {
     int color;
     int key;
@@ -1990,8 +2008,9 @@ int default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
-                            const int *gdimlen, int ndims, io_desc_t *iodesc)
+int
+subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
+                        const int *gdimlen, int ndims, io_desc_t *iodesc)
 {
     int i, j;
     PIO_Offset *iomap = NULL;
@@ -2402,7 +2421,8 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-void performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
+void
+performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
 {
 #ifdef TIMING
 #ifdef PERFTUNE

--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -7,7 +7,7 @@
 
 #ifndef _PIO_TESTS_H
 #define _PIO_TESTS_H
-
+#include <pio_error.h>
 #include <unistd.h> /* Include this for the sleep function. */
 #include <assert.h>
 
@@ -96,21 +96,6 @@ void test_stop_mpe_log(int state, const char *msg);
         MPI_Error_string(e, err_buffer, &resultlen);                    \
         fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
         ret = NC_EIO;                                                   \
-        goto exit;                                                      \
-    } while (0)
-
-/** Handle non-MPI errors by finalizing the MPI library and exiting
- * with an exit code. Finalize and return. */
-#define ERR(e) do {                                                     \
-        fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
-        MPI_Finalize();                                                 \
-        return e;                                                       \
-    } while (0)
-
-/** Handle non-MPI errors by finalizing the MPI library and goto
- * exit. Finalize and goto exit. */
-#define BAIL(e) do {                                                    \
-        fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
         goto exit;                                                      \
     } while (0)
 

--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -81,33 +81,6 @@ void test_stop_mpe_log(int state, const char *msg);
 #define NUM_PIO_TYPES_TO_TEST 6
 #endif /* _NETCDF4 */
 
-/** Handle MPI errors. This should only be used with MPI library
- * function calls. Finalize and return. */
-#define MPIERR(e) do {                                                  \
-        MPI_Error_string(e, err_buffer, &resultlen);                    \
-        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
-        MPI_Finalize();                                                 \
-        return ERR_AWFUL;                                               \
-    } while (0)
-
-/** Handle MPI errors. This should only be used with MPI library
- * function calls. Finalize and goto exit. */
-#define MPIBAIL(e) do {                                                 \
-        MPI_Error_string(e, err_buffer, &resultlen);                    \
-        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
-        ret = NC_EIO;                                                   \
-        goto exit;                                                      \
-    } while (0)
-
-/** Global err buffer for MPI. When there is an MPI error, this buffer
- * is used to store the error message that is associated with the MPI
- * error. */
-char err_buffer[MPI_MAX_ERROR_STRING];
-
-/** This is the length of the most recent MPI error message, stored
- * int the global error string. */
-int resultlen;
-
 /* Function prototypes. */
 int pio_test_init2(int argc, char **argv, int *my_rank, int *ntasks, int min_ntasks,
                    int max_ntasks, int log_level, MPI_Comm *test_comm);

--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -92,11 +92,10 @@ void test_stop_mpe_log(int state, const char *msg);
 
 /** Handle MPI errors. This should only be used with MPI library
  * function calls. Finalize and goto exit. */
-#define MPIBAIL(e) do {                                                  \
+#define MPIBAIL(e) do {                                                 \
         MPI_Error_string(e, err_buffer, &resultlen);                    \
         fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
-        MPI_Finalize();                                                 \
-        ret = NC_EIO;                                                  \
+        ret = NC_EIO;                                                   \
         goto exit;                                                      \
     } while (0)
 
@@ -110,9 +109,8 @@ void test_stop_mpe_log(int state, const char *msg);
 
 /** Handle non-MPI errors by finalizing the MPI library and goto
  * exit. Finalize and goto exit. */
-#define BAIL(e) do {                                                     \
+#define BAIL(e) do {                                                    \
         fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
-        MPI_Finalize();                                                 \
         goto exit;                                                      \
     } while (0)
 


### PR DESCRIPTION
Part of #1500.

I am trying to move some stack allocations to heap. This means we need slightly more sophisticated error handling in some functions, in order to clean up our memory before leaving the function on error.

The method is the same as is used in the netcdf-c library. An exit label is added and all allocations freed after that. Instead of returning an error code, the code calls macro EXIT() with the error code. This calls pio_err() and then goes to exit to free memory and return the error code.

Note some important parts of this idiom:
* The var "ret" is used for return codes.
* ret must be initialized to PIO_NOERR.
* All pointers that will receive memory allocations must be initialized to NULL.

