### PR TITLE
fix some fortran warnings

### DIFF
--- a/src/flib/Makefile.am
+++ b/src/flib/Makefile.am
@@ -32,7 +32,7 @@ libpio_types_la_SOURCES = pio_types.F90
 libpio_support_la_SOURCES = pio_support.F90
 libpio_nf_la_SOURCES = pio_nf.F90
 libpiodarray_la_SOURCES = piodarray.F90
-libpionfatt_la_SOURCES = pionfatt_mod.F90
+libpionfatt_la_SOURCES = p1ionfatt_mod.f901
 libpionfget_la_SOURCES = pionfget_mod.F90
 libpionfput_la_SOURCES = pionfput_mod.F90
 libpiolib_mod_la_SOURCES = piolib_mod.F90
@@ -55,7 +55,7 @@ pio_types.mod: pio_types.$(OBJEXT)
 pio_support.mod: pio_support.$(OBJEXT)
 pio_nf.mod: pio_nf.$(OBJEXT)
 piodarray.mod: piodarray.F90 piodarray.$(OBJEXT)
-pionfatt_mod.mod: pionfatt_mod.F90 pionfatt_mod.$(OBJEXT)
+pionfatt_mod.mod: pionfatt_mod.f90 pionfatt_mod.$(OBJEXT)
 pionfget_mod.mod: pionfget_mod.F90 pionfget_mod.$(OBJEXT)
 pionfput_mod.mod: pionfput_mod.F90 pionfput_mod.$(OBJEXT)
 piolib_mod.mod: piolib_mod.$(OBJEXT)
@@ -77,7 +77,8 @@ include_HEADERS = $(MODFILES)
 # pre-processor. These will only be used by doxygen when --enable-docs
 # is used at configure.
 if BUILD_DOCS
-BUILT_SOURCES += piodarray.f90 piolib_mod.f90 pionfatt_mod.f90 pionfget_mod.f90 pionfput_mod.f90 pionfatt_mod_2.f90 pionfget_mod_2.f90
+BUILT_SOURCES += piodarray.f90 piolib_mod.f90 pionfatt_mod.f90 pionfget_mod.f90 \
+pionfput_mod.f90 pionfatt_mod_2.f90 pionfget_mod_2.f90
 piodarray.f90: piodarray.F90
 	$(CC) -E $< > $@
 piolib_mod.f90: piolib_mod.F90

--- a/src/flib/Makefile.am
+++ b/src/flib/Makefile.am
@@ -32,7 +32,7 @@ libpio_types_la_SOURCES = pio_types.F90
 libpio_support_la_SOURCES = pio_support.F90
 libpio_nf_la_SOURCES = pio_nf.F90
 libpiodarray_la_SOURCES = piodarray.F90
-libpionfatt_la_SOURCES = p1ionfatt_mod.f901
+libpionfatt_la_SOURCES = pionfatt_mod.F90
 libpionfget_la_SOURCES = pionfget_mod.F90
 libpionfput_la_SOURCES = pionfput_mod.F90
 libpiolib_mod_la_SOURCES = piolib_mod.F90
@@ -55,7 +55,7 @@ pio_types.mod: pio_types.$(OBJEXT)
 pio_support.mod: pio_support.$(OBJEXT)
 pio_nf.mod: pio_nf.$(OBJEXT)
 piodarray.mod: piodarray.F90 piodarray.$(OBJEXT)
-pionfatt_mod.mod: pionfatt_mod.f90 pionfatt_mod.$(OBJEXT)
+pionfatt_mod.mod: pionfatt_mod.F90 pionfatt_mod.$(OBJEXT)
 pionfget_mod.mod: pionfget_mod.F90 pionfget_mod.$(OBJEXT)
 pionfput_mod.mod: pionfput_mod.F90 pionfput_mod.$(OBJEXT)
 piolib_mod.mod: piolib_mod.$(OBJEXT)

--- a/src/flib/piolib_mod.F90
+++ b/src/flib/piolib_mod.F90
@@ -345,7 +345,7 @@ contains
          integer(C_INT), value :: frame
        end function PIOc_setframe
     end interface
-    iframe = frame-1
+    iframe = int(frame-1)
     ierr = PIOc_setframe(file%fh, vardesc%varid-1, iframe)
   end subroutine setframe
 
@@ -1448,7 +1448,6 @@ contains
     integer, intent(in) :: iotype
     character(len=*), intent(in)  :: fname
     integer, optional, intent(in) :: mode
-    integer :: iorank
     interface
        integer(C_INT) function PIOc_openfile(iosysid, fh, iotype, fname,mode) &
             bind(C,NAME='PIOc_openfile')

--- a/src/flib/piolib_mod.F90
+++ b/src/flib/piolib_mod.F90
@@ -553,7 +553,6 @@ contains
   subroutine initdecomp_2dof_bin_i4(iosystem,basepiotype,dims,lenblocks,compdof,iodofr,iodofw,iodesc)
     type (iosystem_desc_t), intent(in) :: iosystem
     integer(i4), intent(in)           :: basepiotype
-    integer(i4)                       :: basetype
     integer(i4), intent(in)           :: dims(:)
     integer (i4), intent(in)          :: lenblocks
     integer (i4), intent(in)          :: compdof(:)   !> global degrees of freedom for computational decomposition
@@ -702,8 +701,6 @@ contains
     type (io_desc_t), intent(inout)     :: iodesc
 
     integer(PIO_OFFSET_KIND), intent(in) :: start(:), count(:)
-    type (io_desc_t) :: tmp
-
 
     call pio_initdecomp(iosystem, basepiotype,dims,lenblocks,int(compdof,PIO_OFFSET_KIND),int(iodofr,PIO_OFFSET_KIND), &
          int(iodofw,PIO_OFFSET_KIND),start,count,iodesc)
@@ -780,7 +777,6 @@ contains
     integer (i4), intent(in)          :: compdof(:)   ! global degrees of freedom for computational decomposition
     integer (i4), intent(in)          :: iodof(:)     ! global degrees of freedom for io decomposition
     type (io_desc_t), intent(inout)     :: iodesc
-    integer :: piotype
     integer(PIO_OFFSET_KIND), intent(in) :: start(:), count(:)
 
     call initdecomp_1dof_nf_i8(iosystem, basepiotype,dims,lenblocks,int(compdof,PIO_OFFSET_KIND),int(iodof,PIO_OFFSET_KIND),&
@@ -814,7 +810,6 @@ contains
     integer (PIO_OFFSET_KIND), intent(in)          :: compdof(:)   ! global degrees of freedom for computational decomposition
     integer (PIO_OFFSET_KIND), intent(in)          :: iodof(:)     ! global degrees of freedom for io decomposition
     type (io_desc_t), intent(inout)     :: iodesc
-    integer :: piotype
     integer(PIO_OFFSET_KIND), intent(in) :: start(:), count(:)
 
     if(any(iodof/=compdof)) then

--- a/src/flib/pionfatt_mod.F90.in
+++ b/src/flib/pionfatt_mod.F90.in
@@ -240,7 +240,6 @@ contains
     character(len=*), intent(in) :: name
     integer, intent(in) :: arrlen
     character(len=*), intent(in) :: values(arrlen)
-    integer :: vallen
 
 
     ierr = PIOc_put_att_text (ncid,varid-1,trim(name)//C_NULL_CHAR, int(arrlen,C_SIZE_T),values(1))

--- a/src/flib/pionfatt_mod.F90.in
+++ b/src/flib/pionfatt_mod.F90.in
@@ -199,7 +199,7 @@ contains
     clen = len_trim(values)
     allocate(cvar(clen+1))
     cvar = C_NULL_CHAR
-    do i=1,clen
+    do i=1,int(clen)
        cvar(i) = values(i:i)
     end do
     ierr = PIOc_put_att_text (ncid,varid-1,trim(name)//C_NULL_CHAR, clen, cvar(1))

--- a/tests/unit/basic_tests.F90
+++ b/tests/unit/basic_tests.F90
@@ -33,7 +33,7 @@ module basic_tests
 
       ! Local Vars
       character(len=str_len) :: filename
-      integer                :: iotype, ret_val, ret_val2, pio_dim
+      integer                :: iotype, ret_val, ret_val2
 
       err_msg = "no_error"
 
@@ -146,12 +146,6 @@ module basic_tests
       integer                        :: pio_dim
       integer :: unlimdimid
       type(var_desc_t)               :: pio_var
-
-      ! These will be used to set chunk cache sizes in netCDF-4/HDF5
-      ! files.
-      integer(kind=PIO_OFFSET_KIND) :: chunk_cache_size
-      integer(kind=PIO_OFFSET_KIND) :: chunk_cache_nelems
-      real :: chunk_cache_preemption
 
       err_msg = "no_error"
       dims(1) = 3*ntasks

--- a/tests/unit/ncdf_tests.F90
+++ b/tests/unit/ncdf_tests.F90
@@ -268,7 +268,6 @@ Contains
     ! Local Vars
     character(len=str_len) :: filename
     integer                :: iotype, ret_val
-    integer                :: ret_val1
 
     ! Data used to test writing
     integer,          dimension(2) :: data_to_write, compdof
@@ -282,10 +281,6 @@ Contains
     integer :: shuffle
     integer :: deflate
     integer :: my_deflate_level, deflate_level, deflate_level_2
-
-    ! These will be used to test the chunksizes for netCDF-4 files.
-    integer :: storage
-    integer, dimension(1) :: chunksizes
 
     ! These will be used to set chunk cache sizes in netCDF-4/HDF5
     ! files.


### PR DESCRIPTION
Fixes #1504 
Fixes #1508 
Fixes #1513 
Fixes #1507 

Some fixes for Fortran warnings. Warnings are a reminder that programmers need to work harder. Soon we will have a warning-free build, I hope, and we can enforce that in Travis.