### PR TITLE
PIO/NetCDF integration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,18 @@ test "x$enable_pnetcdf" = xno || enable_pnetcdf=yes
 AC_MSG_RESULT([$enable_pnetcdf])
 AM_CONDITIONAL(BUILD_PNETCDF, [test "x$enable_pnetcdf" = xyes])
 
+# Does the user want to build netcdf-c integration layer?
+AC_MSG_CHECKING([whether netcdf-c integration layer should be build])
+AC_ARG_ENABLE([netcdf-integration],
+              [AS_HELP_STRING([--enable-netcdf-integration],
+                              [enable building of netCDF C API integration.])])
+test "x$enable_netcdf_integration" = xyes || enable_netcdf_integration=no
+AC_MSG_RESULT([$enable_netcdf_integration])
+if test "x$enable_netcdf_integration" = xyes -a "x$enable_timing" = xyes; then
+   AC_MSG_ERROR([Cannot use GPTL timing library with netCDF interation.])
+fi
+AM_CONDITIONAL(BUILD_NCINT, [test "x$enable_netcdf_integration" = xyes])
+
 # Does the user want to build documentation?
 AC_MSG_CHECKING([whether documentation should be build (requires doxygen)])
 AC_ARG_ENABLE([docs],
@@ -273,6 +285,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_OUTPUT(Makefile
           src/Makefile
           src/clib/Makefile
+          src/ncint/Makefile
           src/flib/Makefile
           src/gptl/Makefile
           tests/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -293,6 +293,7 @@ AC_OUTPUT(Makefile
           src/gptl/Makefile
           tests/Makefile
           tests/cunit/Makefile
+          tests/ncint/Makefile
           tests/unit/Makefile
           tests/general/Makefile
           tests/general/util/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -124,18 +124,6 @@ test "x$enable_pnetcdf" = xno || enable_pnetcdf=yes
 AC_MSG_RESULT([$enable_pnetcdf])
 AM_CONDITIONAL(BUILD_PNETCDF, [test "x$enable_pnetcdf" = xyes])
 
-# Does the user want to build netcdf-c integration layer?
-AC_MSG_CHECKING([whether netcdf-c integration layer should be build])
-AC_ARG_ENABLE([netcdf-integration],
-              [AS_HELP_STRING([--enable-netcdf-integration],
-                              [enable building of netCDF C API integration.])])
-test "x$enable_netcdf_integration" = xyes || enable_netcdf_integration=no
-AC_MSG_RESULT([$enable_netcdf_integration])
-if test "x$enable_netcdf_integration" = xyes -a "x$enable_timing" = xyes; then
-   AC_MSG_ERROR([Cannot use GPTL timing library with netCDF interation.])
-fi
-AM_CONDITIONAL(BUILD_NCINT, [test "x$enable_netcdf_integration" = xyes])
-
 # Does the user want to build documentation?
 AC_MSG_CHECKING([whether documentation should be build (requires doxygen)])
 AC_ARG_ENABLE([docs],
@@ -273,6 +261,21 @@ if test "x$enable_timing" = xyes; then
    AC_MSG_RESULT($have_papi)
 fi
 AM_CONDITIONAL([HAVE_PAPI], [test "x$have_papi" = xyes])
+
+# Does the user want to build netcdf-c integration layer?
+AC_MSG_CHECKING([whether netcdf-c integration layer should be build])
+AC_ARG_ENABLE([netcdf-integration],
+              [AS_HELP_STRING([--enable-netcdf-integration],
+                              [enable building of netCDF C API integration.])])
+test "x$enable_netcdf_integration" = xyes || enable_netcdf_integration=no
+AC_MSG_RESULT([$enable_netcdf_integration])
+if test "x$enable_netcdf_integration" = xyes -a "x$enable_timing" = xyes; then
+   AC_MSG_ERROR([Cannot use GPTL timing library with netCDF interation.])
+fi
+if test "x$enable_netcdf_integration" = xyes -a "x$have_netcdf_par" = xno; then
+   AC_MSG_ERROR([Cannot use netCDF integration unless netCDF library was built for parallel I/O.])
+fi
+AM_CONDITIONAL(BUILD_NCINT, [test "x$enable_netcdf_integration" = xyes])
 
 AC_CONFIG_FILES([tests/general/pio_tutil.F90:tests/general/util/pio_tutil.F90])
 

--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,7 @@ fi
 # versions of netCDF. */
 if test "x$enable_netcdf_integration" = xyes; then
   AC_DEFINE([HDF5_PARALLEL],[1],[Does HDF5 library provide parallel access])
+  AC_DEFINE([USE_NETCDF4],[1],[Does HDF5 library provide parallel access])
 fi
 
 AM_CONDITIONAL(BUILD_NCINT, [test "x$enable_netcdf_integration" = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -275,6 +275,12 @@ fi
 if test "x$enable_netcdf_integration" = xyes -a "x$have_netcdf_par" = xno; then
    AC_MSG_ERROR([Cannot use netCDF integration unless netCDF library was built for parallel I/O.])
 fi
+# These are needed by ncdispatch.h. Only build with HDF5 parallel
+# versions of netCDF. */
+if test "x$enable_netcdf_integration" = xyes; then
+   AC_SUBST([HDF5_PARALLEL], [1])
+fi
+
 AM_CONDITIONAL(BUILD_NCINT, [test "x$enable_netcdf_integration" = xyes])
 
 AC_CONFIG_FILES([tests/general/pio_tutil.F90:tests/general/util/pio_tutil.F90])

--- a/configure.ac
+++ b/configure.ac
@@ -278,7 +278,7 @@ fi
 # These are needed by ncdispatch.h. Only build with HDF5 parallel
 # versions of netCDF. */
 if test "x$enable_netcdf_integration" = xyes; then
-   AC_SUBST([HDF5_PARALLEL], [1])
+  AC_DEFINE([HDF5_PARALLEL],[1],[Does HDF5 library provide parallel access])
 fi
 
 AM_CONDITIONAL(BUILD_NCINT, [test "x$enable_netcdf_integration" = xyes])

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -104,7 +104,7 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
     /* int expected[DIM_LEN_X];        /\* Data values we expect to find. *\/ */
 
     /* Open the file. */
-    if ((ret = PIOc_openfile_retry(iosysid, &ncid, &iotype, filename, 0, 0)))
+    if ((ret = PIOc_openfile_retry(iosysid, &ncid, &iotype, filename, 0, 0, 0)))
         return ret;
     /* printf("opened file %s ncid = %d\n", filename, ncid); */
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,10 +7,16 @@ if BUILD_FORTRAN
 FLIB = flib
 endif
 
+# Are we building with the GPTL timing library?
 if USE_GPTL
 GPTL = gptl
 endif
 
-SUBDIRS = clib ${GPTL} $(FLIB)
+# Are we building with netCDF integration?
+if BUILD_NCINT
+NCINT = ncint
+endif # BUILD_NCINT
+
+SUBDIRS = clib ${NCINT} ${GPTL} $(FLIB)
 
 EXTRA_DIST = CMakeLists.txt

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,7 @@ if BUILD_NCINT
 NCINT = ncint
 endif # BUILD_NCINT
 
-SUBDIRS = clib ${NCINT} ${GPTL} $(FLIB)
+# Build these subdirectories.
+SUBDIRS = ${NCINT} clib ${GPTL} $(FLIB)
 
 EXTRA_DIST = CMakeLists.txt

--- a/src/clib/Makefile.am
+++ b/src/clib/Makefile.am
@@ -4,6 +4,11 @@
 # The library we are building.
 lib_LTLIBRARIES = libpioc.la
 
+# Are we building with netCDF integration?
+if BUILD_NCINT
+libpioc_la_LIBADD = ../ncint/libncint.la
+endif # BUILD_NCINT
+
 # These linker flags specify libtool version info.
 # See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 # for information regarding incrementing `-version-info`.

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1252,6 +1252,10 @@ extern "C" {
 
     int nc_free_iosystem(int iosysid);
 
+    int nc_init_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen,
+                       int maplen, const size_t *compmap, int *ioidp,
+                       int rearranger, const size_t *iostart,
+                       const size_t *iocount);
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1250,6 +1250,8 @@ extern "C" {
     int nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
                           int *iosysidp);
 
+    int nc_free_iosystem(int iosysid);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1245,6 +1245,11 @@ extern "C" {
                                const long long *op);
     int PIOc_put_vard_ulonglong(int ncid, int varid, int decompid, const PIO_Offset recnum,
                                 const unsigned long long *op);
+
+
+    int nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
+                          int *iosysidp);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1259,6 +1259,9 @@ extern "C" {
 
     int nc_free_decomp(int ioid);
 
+    int nc_put_vard_int(int ncid, int varid, int decompid, const size_t recnum,
+                        const int *op);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1256,6 +1256,9 @@ extern "C" {
                        int maplen, const size_t *compmap, int *ioidp,
                        int rearranger, const size_t *iostart,
                        const size_t *iocount);
+
+    int nc_free_decomp(int ioid);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1246,7 +1246,7 @@ extern "C" {
     int PIOc_put_vard_ulonglong(int ncid, int varid, int decompid, const PIO_Offset recnum,
                                 const unsigned long long *op);
 
-
+    /* These functions are for the netCDF integration layer. */
     int nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
                           int *iosysidp);
 

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -187,27 +187,24 @@ PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
  * @author Ed Hartnett
  */
 int
-PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
+PIOc_create(int iosysid, const char *path, int cmode, int *ncidp)
 {
     int iotype;            /* The PIO IO type. */
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    int ret;
 
-    /* Figure out the iotype. */
-    if (cmode & NC_NETCDF4)
-    {
-        if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
-            iotype = PIO_IOTYPE_NETCDF4P;
-        else
-            iotype = PIO_IOTYPE_NETCDF4C;
-    }
-    else
-    {
-        if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
-            iotype = PIO_IOTYPE_PNETCDF;
-        else
-            iotype = PIO_IOTYPE_NETCDF;
-    }
+    PLOG((1, "PIOc_create iosysid = %d path = %s cmode = %x", iosysid, path,
+          cmode));
 
-    return PIOc_createfile_int(iosysid, ncidp, &iotype, filename, cmode);
+    /* Get the IO system info from the id. */
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+    /* Find the IOTYPE from the mode flag. */
+    if ((ret = find_iotype_from_cmode(cmode, &iotype)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+
+    return PIOc_createfile_int(iosysid, ncidp, &iotype, path, cmode);
 }
 
 /**

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -56,7 +56,7 @@ int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
 {
     LOG((1, "PIOc_openfile iosysid %d *iotype %d filename %s mode %d", iosysid,
          iotype ? *iotype: 0, filename, mode));
-    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1);
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1, 0);
 }
 
 /**
@@ -83,7 +83,7 @@ int PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
 {
     LOG((1, "PIOc_openfile2 iosysid %d *iotype %d filename %s mode %d", iosysid,
          iotype ? *iotype : 0, filename, mode));
-    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 0);
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 0, 0);
 }
 
 /**
@@ -123,7 +123,7 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
 
     /* Open the file. If the open fails, do not retry as serial
      * netCDF. Just return the error code. */
-    return PIOc_openfile_retry(iosysid, ncidp, &iotype, path, mode, 0);
+    return PIOc_openfile_retry(iosysid, ncidp, &iotype, path, mode, 0, 0);
 }
 
 /**

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -57,7 +57,7 @@ PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
 {
     PLOG((1, "PIOc_openfile iosysid %d *iotype %d filename %s mode %d", iosysid,
           iotype ? *iotype: 0, filename, mode));
-    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1);
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1, 0);
 }
 
 /**
@@ -85,7 +85,7 @@ PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
 {
     PLOG((1, "PIOc_openfile2 iosysid %d *iotype %d filename %s mode %d", iosysid,
           iotype ? *iotype : 0, filename, mode));
-    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 0);
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 0, 0);
 }
 
 /**

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -51,7 +51,8 @@ extern int event_num[2][NUM_EVENTS];
  * @ingroup PIO_open_file_c
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
+int
+PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
                   int mode)
 {
     LOG((1, "PIOc_openfile iosysid %d *iotype %d filename %s mode %d", iosysid,
@@ -78,7 +79,8 @@ int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
  * @ingroup PIO_open_file_c
  * @author Ed Hartnett
  */
-int PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
+int
+PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
                    int mode)
 {
     LOG((1, "PIOc_openfile2 iosysid %d *iotype %d filename %s mode %d", iosysid,
@@ -99,27 +101,23 @@ int PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
  * @ingroup PIO_open_file_c
  * @author Ed Hartnett
  */
-int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
+int
+PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
 {
     int iotype;
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    int ret;
 
-    LOG((1, "PIOc_open iosysid = %d path = %s mode = %x", iosysid, path, mode));
+    LOG((1, "PIOc_open iosysid = %d path = %s mode = %x", iosysid, path,
+         mode));
 
-    /* Figure out the iotype. */
-    if (mode & NC_NETCDF4)
-    {
-        if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
-            iotype = PIO_IOTYPE_NETCDF4P;
-        else
-            iotype = PIO_IOTYPE_NETCDF4C;
-    }
-    else
-    {
-        if (mode & NC_PNETCDF || mode & NC_MPIIO)
-            iotype = PIO_IOTYPE_PNETCDF;
-        else
-            iotype = PIO_IOTYPE_NETCDF;
-    }
+    /* Get the IO system info from the id. */
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+    /* Find the IOTYPE from the mode flag. */
+    if ((ret = find_iotype_from_omode(mode, &iotype)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Open the file. If the open fails, do not retry as serial
      * netCDF. Just return the error code. */
@@ -144,7 +142,8 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
  * @ingroup PIO_create_file_c
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
+int
+PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
                     int mode)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
@@ -188,7 +187,8 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
  * @ingroup PIO_create_file_c
  * @author Ed Hartnett
  */
-int PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
+int
+PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
 {
     int iotype;            /* The PIO IO type. */
 
@@ -219,7 +219,8 @@ int PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
  * @ingroup PIO_close_file_c
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_closefile(int ncid)
+int
+PIOc_closefile(int ncid)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -318,7 +319,8 @@ int PIOc_closefile(int ncid)
  * @returns PIO_NOERR for success, error code otherwise.
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_deletefile(int iosysid, const char *filename)
+int
+PIOc_deletefile(int iosysid, const char *filename)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */
@@ -395,7 +397,8 @@ int PIOc_deletefile(int iosysid, const char *filename)
  * @ingroup PIO_sync_file_c
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_sync(int ncid)
+int
+PIOc_sync(int ncid)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -156,7 +156,7 @@ PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
           iosysid, *iotype, filename, mode));
 
     /* Create the file. */
-    if ((ret = PIOc_createfile_int(iosysid, ncidp, iotype, filename, mode)))
+    if ((ret = PIOc_createfile_int(iosysid, ncidp, iotype, filename, mode, 0)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Run this on all tasks if async is not in use, but only on
@@ -204,7 +204,7 @@ PIOc_create(int iosysid, const char *path, int cmode, int *ncidp)
     if ((ret = find_iotype_from_cmode(cmode, &iotype)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
-    return PIOc_createfile_int(iosysid, ncidp, &iotype, path, cmode);
+    return PIOc_createfile_int(iosysid, ncidp, &iotype, path, cmode, 0);
 }
 
 /**

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -192,7 +192,7 @@ extern "C" {
     /* Open a file with optional retry as netCDF-classic if first
      * iotype does not work. */
     int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename, int mode,
-                            int retry);
+                            int retry, int use_ext_ncid);
 
     /* Given PIO type, find MPI type and type size. */
     int find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size);

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -187,7 +187,8 @@ extern "C" {
     int delete_var_desc(int varid, var_desc_t **varlist);
 
     /* Create a file (internal function). */
-    int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename, int mode);
+    int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
+                            int mode, int use_ext_ncid);
 
     /* Open a file with optional retry as netCDF-classic if first
      * iotype does not work. */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -197,6 +197,9 @@ extern "C" {
     /* Give the mode flag from an open, determine the IOTYPE. */
     int find_iotype_from_omode(int mode, int *iotype);
 
+    /* Give the mode flag from an nc_create call, determine the IOTYPE. */
+    int find_iotype_from_cmode(int cmode, int *iotype);
+
     /* Given PIO type, find MPI type and type size. */
     int find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size);
 

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -194,6 +194,9 @@ extern "C" {
     int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename, int mode,
                             int retry, int use_ext_ncid);
 
+    /* Give the mode flag from an open, determine the IOTYPE. */
+    int find_iotype_from_omode(int mode, int *iotype);
+
     /* Given PIO type, find MPI type and type size. */
     int find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size);
 

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -1972,9 +1972,9 @@ int open_file_handler(iosystem_desc_t *ios)
     LOG((2, "open_file_handler got parameters len = %d filename = %s iotype = %d mode = %d",
          len, filename, iotype, mode));
 
-    /* Call the open file function. Errors are handling within
+    /* Call the open file function. Errors are handled within
      * function, so return code can be ignored. */
-    PIOc_openfile_retry(ios->iosysid, &ncid, &iotype, filename, mode, 0);
+    PIOc_openfile_retry(ios->iosysid, &ncid, &iotype, filename, mode, 0, 0);
 
     return PIO_NOERR;
 }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1,7 +1,7 @@
 /** @file
  * Support functions for the PIO library.
  */
-#include <config.h>
+#include "config.h"
 #if PIO_ENABLE_LOGGING
 #include <stdarg.h>
 #include <unistd.h>
@@ -2390,6 +2390,41 @@ find_iotype_from_omode(int mode, int *iotype)
     else
     {
         if (mode & NC_PNETCDF || mode & NC_MPIIO)
+            *iotype = PIO_IOTYPE_PNETCDF;
+        else
+            *iotype = PIO_IOTYPE_NETCDF;
+    }
+
+    return PIO_NOERR;
+}
+
+
+/**
+ * Find the appropriate IOTYPE from mode flags to nc_create().
+ *
+ * @param mode the mode flag from nc_create().
+ * @param iotype pointer that gets the IOTYPE.
+ *
+ * @return 0 on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+find_iotype_from_cmode(int cmode, int *iotype)
+{
+    /* Check inputs. */
+    pioassert(iotype, "pointer to iotype must be provided", __FILE__, __LINE__);
+
+    /* Figure out the iotype. */
+    if (cmode & NC_NETCDF4)
+    {
+        if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
+            *iotype = PIO_IOTYPE_NETCDF4P;
+        else
+            *iotype = PIO_IOTYPE_NETCDF4C;
+    }
+    else
+    {
+        if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
             *iotype = PIO_IOTYPE_PNETCDF;
         else
             *iotype = PIO_IOTYPE_NETCDF;

--- a/src/ncint/Makefile.am
+++ b/src/ncint/Makefile.am
@@ -9,4 +9,5 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/clib
 noinst_LTLIBRARIES = libncint.la
 
 # The source files.
-libncint_la_SOURCES = ncintdispatch.c ncintdispatch.h ncint_pio.c
+libncint_la_SOURCES = ncintdispatch.c ncintdispatch.h ncint_pio.c	\
+ncint_vard.c

--- a/src/ncint/Makefile.am
+++ b/src/ncint/Makefile.am
@@ -2,22 +2,8 @@
 ## layer.
 # Ed Hartnett 7/3/19
 
-# The library we are building.
-#lib_LTLIBRARIES = libpioc.la
+# This is our output. The ncint convenience library.
+noinst_LTLIBRARIES = libncint.la
 
-# These linker flags specify libtool version info.
-# See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
-# for information regarding incrementing `-version-info`.
-#libpioc_la_LDFLAGS = -version-info 2:0:1
-
-# The library header file will be installed in include dir.
-#include_HEADERS = pio.h uthash.h
-
-# The library soure files.
-# libpioc_la_SOURCES = bget.c pioc_sc.c pio_darray.c pio_file.c		\
-# pio_getput_int.c pio_msg.c pio_nc.c pio_rearrange.c pioc.c		\
-# pioc_support.c pio_darray_int.c pio_get_nc.c pio_lists.c pio_nc4.c	\
-# pio_put_nc.c pio_spmd.c pio_get_vard.c pio_put_vard.c pio_internal.h	\
-# bget.h uthash.h pio_error.h
-
-EXTRA_DIST = Makefile.am
+# The source files.
+libncint_la_SOURCES = ncintdispatch.c ncintdispatch.h

--- a/src/ncint/Makefile.am
+++ b/src/ncint/Makefile.am
@@ -1,0 +1,23 @@
+## This is the automake file to build the PIO netCDF integration
+## layer.
+# Ed Hartnett 7/3/19
+
+# The library we are building.
+#lib_LTLIBRARIES = libpioc.la
+
+# These linker flags specify libtool version info.
+# See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
+# for information regarding incrementing `-version-info`.
+#libpioc_la_LDFLAGS = -version-info 2:0:1
+
+# The library header file will be installed in include dir.
+#include_HEADERS = pio.h uthash.h
+
+# The library soure files.
+# libpioc_la_SOURCES = bget.c pioc_sc.c pio_darray.c pio_file.c		\
+# pio_getput_int.c pio_msg.c pio_nc.c pio_rearrange.c pioc.c		\
+# pioc_support.c pio_darray_int.c pio_get_nc.c pio_lists.c pio_nc4.c	\
+# pio_put_nc.c pio_spmd.c pio_get_vard.c pio_put_vard.c pio_internal.h	\
+# bget.h uthash.h pio_error.h
+
+EXTRA_DIST = Makefile.am

--- a/src/ncint/Makefile.am
+++ b/src/ncint/Makefile.am
@@ -2,8 +2,11 @@
 ## layer.
 # Ed Hartnett 7/3/19
 
+# Find pio.h.
+AM_CPPFLAGS = -I$(top_srcdir)/src/clib
+
 # This is our output. The ncint convenience library.
 noinst_LTLIBRARIES = libncint.la
 
 # The source files.
-libncint_la_SOURCES = ncintdispatch.c ncintdispatch.h
+libncint_la_SOURCES = ncintdispatch.c ncintdispatch.h ncint_pio.c

--- a/src/ncint/ncint_pio.c
+++ b/src/ncint/ncint_pio.c
@@ -10,6 +10,9 @@
 #include <pio_internal.h>
 #include "ncintdispatch.h"
 
+/* The default io system id. */
+extern int diosysid;
+
 /**
  * Same as PIOc_Init_Intracomm().
  *
@@ -19,7 +22,16 @@ int
 nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
                   int *iosysidp)
 {
-    return PIOc_Init_Intracomm(comp_comm, num_iotasks, stride, base, rearr, iosysidp);
+    int ret;
+
+    if ((ret = PIOc_Init_Intracomm(comp_comm, num_iotasks, stride, base, rearr,
+                                   iosysidp)))
+        return ret;
+
+    /* Remember the io system id. */
+    diosysid = *iosysidp;
+
+    return PIO_NOERR;
 }
 
 /**

--- a/src/ncint/ncint_pio.c
+++ b/src/ncint/ncint_pio.c
@@ -19,5 +19,5 @@ int
 nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
                   int *iosysidp)
 {
-    return PIO_NOERR;
+    return PIOc_Init_Intracomm(comp_comm, num_iotasks, stride, base, rearr, iosysidp);
 }

--- a/src/ncint/ncint_pio.c
+++ b/src/ncint/ncint_pio.c
@@ -44,3 +44,20 @@ nc_free_iosystem(int iosysid)
 {
     return PIOc_free_iosystem(iosysid);
 }
+
+/**
+ * Same as PIOc_init_decomp()
+ *
+ * @author Ed Hartnett
+ */
+int
+nc_init_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen,
+               int maplen, const size_t *compmap, int *ioidp,
+               int rearranger, const size_t *iostart,
+               const size_t *iocount)
+{
+    return PIOc_init_decomp(iosysid, pio_type, ndims, gdimlen, maplen,
+                            (const PIO_Offset *)compmap, ioidp, rearranger,
+                            (const PIO_Offset *)iostart,
+                            (const PIO_Offset *)iocount);
+}

--- a/src/ncint/ncint_pio.c
+++ b/src/ncint/ncint_pio.c
@@ -46,7 +46,7 @@ nc_free_iosystem(int iosysid)
 }
 
 /**
- * Same as PIOc_init_decomp()
+ * Same as PIOc_init_decomp().
  *
  * @author Ed Hartnett
  */
@@ -60,4 +60,15 @@ nc_init_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen,
                             (const PIO_Offset *)compmap, ioidp, rearranger,
                             (const PIO_Offset *)iostart,
                             (const PIO_Offset *)iocount);
+}
+
+/**
+ * Same as PIOc_freedecomp().
+ *
+ * @author Ed Hartnett
+ */
+int
+nc_free_decomp(int ioid)
+{
+    return PIOc_freedecomp(diosysid, ioid);
 }

--- a/src/ncint/ncint_pio.c
+++ b/src/ncint/ncint_pio.c
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * @internal Additional nc_* functions to support netCDF integration.
+ *
+ * @author Ed Hartnett
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include <pio_internal.h>
+#include "ncintdispatch.h"
+
+/**
+ * Same as PIOc_Init_Intracomm().
+ *
+ * @author Ed Hartnett
+ */
+int
+nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
+                  int *iosysidp)
+{
+    return PIO_NOERR;
+}

--- a/src/ncint/ncint_pio.c
+++ b/src/ncint/ncint_pio.c
@@ -21,3 +21,14 @@ nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int
 {
     return PIOc_Init_Intracomm(comp_comm, num_iotasks, stride, base, rearr, iosysidp);
 }
+
+/**
+ * Same as PIOc_free_iosystem().
+ *
+ * @author Ed Hartnett
+ */
+int
+nc_free_iosystem(int iosysid)
+{
+    return PIOc_free_iosystem(iosysid);
+}

--- a/src/ncint/ncint_vard.c
+++ b/src/ncint/ncint_vard.c
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * @internal The nc_versions of the vard functions.
+ *
+ * @author Ed Hartnett
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include <pio_internal.h>
+#include "ncintdispatch.h"
+
+/**
+ * Same as PIOc_put_vard_int().
+ *
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_int(int ncid, int varid, int decompid, const size_t recnum,
+                const int *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, (PIO_Offset)recnum, NC_INT,
+                            op);
+}

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -127,3 +127,42 @@ NC_NCINT_finalize(void)
 {
     return NC_NOERR;
 }
+
+#define TEST_VAL_42 42
+int
+tst_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
+             void *parameters, const NC_Dispatch *dispatch, NC *nc_file)
+{
+   return NC_NOERR;
+}
+
+int
+tst_abort(int ncid)
+{
+   return TEST_VAL_42;
+}
+
+int
+tst_close(int ncid, void *v)
+{
+   return NC_NOERR;
+}
+
+int
+tst_inq_format(int ncid, int *formatp)
+{
+   return TEST_VAL_42;
+}
+
+int
+tst_inq_format_extended(int ncid, int *formatp, int *modep)
+{
+   return TEST_VAL_42;
+}
+
+int
+tst_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
+             void *value, nc_type t)
+{
+   return TEST_VAL_42;
+}

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -20,7 +20,7 @@ int diosysid;
  * functions that make up the NCINT dispatch interface. */
 NC_Dispatch NCINT_dispatcher = {
 
-    NC_FORMATX_NC_UDF0,
+    NC_FORMATX_UDF0,
 
     NC_NCINT_create,
     NC_NCINT_open,
@@ -189,16 +189,16 @@ NC_NCINT_create(const char* path, int cmode, size_t initialsz, int basepe,
     cmode = cmode & ~NC_UDF0;
 
     /* Find the IOTYPE from the mode flag. */
-    if ((ret = find_iotype_from_omode(mode, &iotype)))
+    if ((ret = find_iotype_from_omode(cmode, &iotype)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Add necessary structs to hold netcdf-4 file data. */
-    if ((ret = nc4_nc4f_list_add(nc_file, path, mode)))
+    if ((ret = nc4_nc4f_list_add(nc_file, path, cmode)))
         return ret;
 
     /* Open the file with PIO. Tell openfile_retry to accept the
      * externally assigned ncid. */
-    if ((ret = PIOc_createfile_int(diosysid,  &nc_file->ext_ncid, iotype,
+    if ((ret = PIOc_createfile_int(diosysid,  &nc_file->ext_ncid, &iotype,
                                    path, cmode)))
         return ret;
 

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -39,7 +39,7 @@ NC_Dispatch NCINT_dispatcher = {
     NC4_inq,
     NC4_inq_type,
 
-    NC_RO_def_dim,
+    NC_NCINT_def_dim,
     NC4_inq_dimid,
     NC4_inq_dim,
     NC4_inq_unlimdim,
@@ -53,7 +53,7 @@ NC_Dispatch NCINT_dispatcher = {
     NC4_get_att,
     NC_RO_put_att,
 
-    NC_RO_def_var,
+    NC_NCINT_def_var,
     NC4_inq_varid,
     NC_RO_rename_var,
     NC_NCINT_get_vara,
@@ -203,6 +203,19 @@ NC_NCINT_create(const char* path, int cmode, size_t initialsz, int basepe,
         return ret;
 
     return PIO_NOERR;
+}
+
+int
+NC_NCINT_def_dim(int ncid, const char *name, size_t len, int *idp)
+{
+    return PIOc_def_dim(ncid, name, len, idp);
+}
+
+int
+NC_NCINT_def_var(int ncid, const char *name, nc_type xtype, int ndims,
+                 const int *dimidsp, int *varidp)
+{
+    return PIOc_def_var(ncid, name, xtype, ndims, dimidsp, varidp);
 }
 
 int

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -140,8 +140,16 @@ NC_NCINT_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
     int ret;
     nc_file->int_ncid = nc_file->ext_ncid;
 
-    if ((ret = PIOc_open(diosysid, path, mode, &nc_file->ext_ncid)))
-        return ret;
+    /* Turn of NC_UDF0 in the mode flag. */
+    mode = mode & ~NC_UDF0;
+
+    /* /\* Add necessary structs to hold netcdf-4 file data. *\/ */
+    /* if ((retval = nc4_nc4f_list_add(nc_file, path, mode))) */
+    /*     return retval; */
+
+    /* /\* Open the file with PIO. *\/ */
+    /* if ((ret = PIOc_open(diosysid, path, mode, &nc_file->ext_ncid))) */
+    /*     return ret; */
 
     return NC_NOERR;
 }

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -11,7 +11,7 @@
 
 /* This is the dispatch object that holds pointers to all the
  * functions that make up the NCINT dispatch interface. */
-static const NC_Dispatch NCINT_dispatcher = {
+NC_Dispatch NCINT_dispatcher = {
 
     NC_FORMATX_NC_HDF4,
 
@@ -130,38 +130,38 @@ NC_NCINT_finalize(void)
 
 #define TEST_VAL_42 42
 int
-tst_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
+NC_NCINT_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
              void *parameters, const NC_Dispatch *dispatch, NC *nc_file)
 {
    return NC_NOERR;
 }
 
 int
-tst_abort(int ncid)
+NC_NCINT_abort(int ncid)
 {
    return TEST_VAL_42;
 }
 
 int
-tst_close(int ncid, void *v)
+NC_NCINT_close(int ncid, void *v)
 {
    return NC_NOERR;
 }
 
 int
-tst_inq_format(int ncid, int *formatp)
+NC_NCINT_inq_format(int ncid, int *formatp)
 {
    return TEST_VAL_42;
 }
 
 int
-tst_inq_format_extended(int ncid, int *formatp, int *modep)
+NC_NCINT_inq_format_extended(int ncid, int *formatp, int *modep)
 {
    return TEST_VAL_42;
 }
 
 int
-tst_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
+NC_NCINT_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
              void *value, nc_type t)
 {
    return TEST_VAL_42;

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -8,6 +8,7 @@
 #include "config.h"
 #include <stdlib.h>
 #include "ncintdispatch.h"
+#include "pio.h"
 
 /* This is the dispatch object that holds pointers to all the
  * functions that make up the NCINT dispatch interface. */
@@ -128,41 +129,50 @@ NC_NCINT_finalize(void)
     return NC_NOERR;
 }
 
+/** Default iosysid. */
+int diosysid;
+
 #define TEST_VAL_42 42
 int
 NC_NCINT_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
-             void *parameters, const NC_Dispatch *dispatch, NC *nc_file)
+              void *parameters, const NC_Dispatch *dispatch, NC *nc_file)
 {
-   return NC_NOERR;
+    int ret;
+    nc_file->int_ncid = nc_file->ext_ncid;
+
+    if ((ret = PIOc_open(diosysid, path, mode, &nc_file->ext_ncid)))
+        return ret;
+
+    return NC_NOERR;
 }
 
 int
 NC_NCINT_abort(int ncid)
 {
-   return TEST_VAL_42;
+    return TEST_VAL_42;
 }
 
 int
 NC_NCINT_close(int ncid, void *v)
 {
-   return NC_NOERR;
+    return NC_NOERR;
 }
 
 int
 NC_NCINT_inq_format(int ncid, int *formatp)
 {
-   return TEST_VAL_42;
+    return TEST_VAL_42;
 }
 
 int
 NC_NCINT_inq_format_extended(int ncid, int *formatp, int *modep)
 {
-   return TEST_VAL_42;
+    return TEST_VAL_42;
 }
 
 int
 NC_NCINT_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
-             void *value, nc_type t)
+                  void *value, nc_type t)
 {
-   return TEST_VAL_42;
+    return TEST_VAL_42;
 }

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -199,7 +199,7 @@ NC_NCINT_create(const char* path, int cmode, size_t initialsz, int basepe,
     /* Open the file with PIO. Tell openfile_retry to accept the
      * externally assigned ncid. */
     if ((ret = PIOc_createfile_int(diosysid,  &nc_file->ext_ncid, &iotype,
-                                   path, cmode)))
+                                   path, cmode, 1)))
         return ret;
 
     return PIO_NOERR;

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -1,0 +1,129 @@
+/**
+ * @file
+ * @internal Dispatch layer for netcdf PIO integration.
+ *
+ * @author Ed Hartnett
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include "ncintdispatch.h"
+
+/* This is the dispatch object that holds pointers to all the
+ * functions that make up the NCINT dispatch interface. */
+static const NC_Dispatch NCINT_dispatcher = {
+
+    NC_FORMATX_NC_HDF4,
+
+    NC_RO_create,
+    NC_NCINT_open,
+
+    NC_RO_redef,
+    NC_RO__enddef,
+    NC_RO_sync,
+    NC_NCINT_abort,
+    NC_NCINT_close,
+    NC_RO_set_fill,
+    NC_NOTNC3_inq_base_pe,
+    NC_NOTNC3_set_base_pe,
+    NC_NCINT_inq_format,
+    NC_NCINT_inq_format_extended,
+
+    NC4_inq,
+    NC4_inq_type,
+
+    NC_RO_def_dim,
+    NC4_inq_dimid,
+    NC4_inq_dim,
+    NC4_inq_unlimdim,
+    NC_RO_rename_dim,
+
+    NC4_inq_att,
+    NC4_inq_attid,
+    NC4_inq_attname,
+    NC_RO_rename_att,
+    NC_RO_del_att,
+    NC4_get_att,
+    NC_RO_put_att,
+
+    NC_RO_def_var,
+    NC4_inq_varid,
+    NC_RO_rename_var,
+    NC_NCINT_get_vara,
+    NC_RO_put_vara,
+    NCDEFAULT_get_vars,
+    NCDEFAULT_put_vars,
+    NCDEFAULT_get_varm,
+    NCDEFAULT_put_varm,
+
+    NC4_inq_var_all,
+
+    NC_NOTNC4_var_par_access,
+    NC_RO_def_var_fill,
+
+    NC4_show_metadata,
+    NC4_inq_unlimdims,
+
+    NC4_inq_ncid,
+    NC4_inq_grps,
+    NC4_inq_grpname,
+    NC4_inq_grpname_full,
+    NC4_inq_grp_parent,
+    NC4_inq_grp_full_ncid,
+    NC4_inq_varids,
+    NC4_inq_dimids,
+    NC4_inq_typeids,
+    NC4_inq_type_equal,
+    NC_NOTNC4_def_grp,
+    NC_NOTNC4_rename_grp,
+    NC4_inq_user_type,
+    NC4_inq_typeid,
+
+    NC_NOTNC4_def_compound,
+    NC_NOTNC4_insert_compound,
+    NC_NOTNC4_insert_array_compound,
+    NC_NOTNC4_inq_compound_field,
+    NC_NOTNC4_inq_compound_fieldindex,
+    NC_NOTNC4_def_vlen,
+    NC_NOTNC4_put_vlen_element,
+    NC_NOTNC4_get_vlen_element,
+    NC_NOTNC4_def_enum,
+    NC_NOTNC4_insert_enum,
+    NC_NOTNC4_inq_enum_member,
+    NC_NOTNC4_inq_enum_ident,
+    NC_NOTNC4_def_opaque,
+    NC_NOTNC4_def_var_deflate,
+    NC_NOTNC4_def_var_fletcher32,
+    NC_NOTNC4_def_var_chunking,
+    NC_NOTNC4_def_var_endian,
+    NC_NOTNC4_def_var_filter,
+    NC_NOTNC4_set_var_chunk_cache,
+    NC_NOTNC4_get_var_chunk_cache
+};
+
+const NC_Dispatch* NCINT_dispatch_table = NULL;
+
+/**
+ * @internal Initialize NCINT dispatch layer.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+NC_NCINT_initialize(void)
+{
+    NCINT_dispatch_table = &NCINT_dispatcher;
+    return NC_NOERR;
+}
+
+/**
+ * @internal Finalize NCINT dispatch layer.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+NC_NCINT_finalize(void)
+{
+    return NC_NOERR;
+}

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -179,7 +179,7 @@ NC_NCINT_abort(int ncid)
 int
 NC_NCINT_close(int ncid, void *v)
 {
-    return NC_NOERR;
+    return PIOc_closefile(ncid);
 }
 
 int

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -41,6 +41,11 @@ extern "C" {
                   void *parameters, const NC_Dispatch *, NC *);
 
     extern int
+    NC_NCINT_create(const char* path, int cmode, size_t initialsz, int basepe,
+                    size_t *chunksizehintp, void *parameters,
+                    const NC_Dispatch *dispatch, NC *nc_file);
+
+    extern int
     NC_NCINT_abort(int ncid);
 
     extern int

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -8,8 +8,9 @@
 #define _NCINTDISPATCH_H
 
 #include "config.h"
-#include "ncdispatch.h"
-#include "nc4dispatch.h"
+#include <ncdispatch.h>
+#include <nc4dispatch.h>
+#include <netcdf_dispatch.h>
 
 /** This is the max size of an SD dataset name in HDF4 (from HDF4
  * documentation).*/

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -1,0 +1,62 @@
+/**
+ * @file @internal This header file contains the prototypes for the
+ * PIO netCDF integration layer.
+ *
+ * Ed Hartnett
+ */
+#ifndef _NCINTDISPATCH_H
+#define _NCINTDISPATCH_H
+
+#include "config.h"
+#include "ncdispatch.h"
+#include "nc4dispatch.h"
+
+/** This is the max size of an SD dataset name in HDF4 (from HDF4
+ * documentation).*/
+#define NC_MAX_HDF4_NAME 64
+
+/** This is the max number of dimensions for a HDF4 SD dataset (from
+ * HDF4 documentation). */
+#define NC_MAX_HDF4_DIMS 32
+
+/* Stuff below is for hdf4 files. */
+typedef struct NC_VAR_HDF4_INFO
+{
+    int sdsid;
+    int hdf4_data_type;
+} NC_VAR_HDF4_INFO_T;
+
+typedef struct NC_HDF4_FILE_INFO
+{
+    int sdid;
+} NC_HDF4_FILE_INFO_T;
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+    extern int
+    NC_NCINT_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
+                  void *parameters, const NC_Dispatch *, NC *);
+
+    extern int
+    NC_NCINT_abort(int ncid);
+
+    extern int
+    NC_NCINT_close(int ncid, void *ignore);
+
+    extern int
+    NC_NCINT_inq_format(int ncid, int *formatp);
+
+    extern int
+    NC_NCINT_inq_format_extended(int ncid, int *formatp, int *modep);
+
+    extern int
+    NC_NCINT_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
+                      void *value, nc_type);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /*_NCINTDISPATCH_H */

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -46,6 +46,13 @@ extern "C" {
                     const NC_Dispatch *dispatch, NC *nc_file);
 
     extern int
+    NC_NCINT_def_var(int ncid, const char *name, nc_type xtype, int ndims,
+                     const int *dimidsp, int *varidp);
+
+    extern int
+    NC_NCINT_def_dim(int ncid, const char *name, size_t len, int *idp);
+
+    extern int
     NC_NCINT_abort(int ncid);
 
     extern int

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,11 +8,18 @@
 if BUILD_FORTRAN
 UNIT = unit
 GENERAL = general
+# If GPTL us used, also add the performance directory.
 if USE_GPTL
 PERFORMANCE = performance
-endif
-endif
+endif # USE_GPTL
+endif # BUILD_FORTRAN
 
-SUBDIRS = cunit ${UNIT} ${GENERAL} ${PERFORMANCE}
+# Are we building with netCDF integration?
+if BUILD_NCINT
+NCINT = ncint
+endif # BUILD_NCINT
+
+# Build in these subdirs.
+SUBDIRS = cunit ${UNIT} ${NCINT} ${GENERAL} ${PERFORMANCE}
 
 EXTRA_DIST = CMakeLists.txt

--- a/tests/ncint/Makefile.am
+++ b/tests/ncint/Makefile.am
@@ -1,0 +1,21 @@
+## This is the automake file for building the netCDF integration layer
+## tests.
+
+# Ed Hartnett 7/3/19
+
+# Put together AM_CPPFLAGS and AM_LDFLAGS.
+include $(top_srcdir)/set_flags.am
+
+# Build the test for make check.
+check_PROGRAMS = tst_pio_udf
+
+# if RUN_TESTS
+# # Tests will run from a bash script.
+# TESTS = run_tests.sh
+# endif # RUN_TESTS
+
+# Distribute the test script.
+#EXTRA_DIST = CMakeLists.txt run_tests.sh input.nl
+
+# Clean up files produced during testing.
+#CLEANFILES = *.nc *.log

--- a/tests/ncint/Makefile.am
+++ b/tests/ncint/Makefile.am
@@ -4,12 +4,16 @@
 # Ed Hartnett 7/3/19
 
 # Put together AM_CPPFLAGS and AM_LDFLAGS.
-include $(top_srcdir)/set_flags.am
+AM_CPPFLAGS = -I$(top_srcdir)/src/clib
 LDADD = ${top_builddir}/src/clib/libpioc.la
 
 # Build the test for make check.
 check_PROGRAMS = tst_pio_udf
-TESTS = tst_pio_udf
+
+if RUN_TESTS
+# Tests will run from a bash script.
+TESTS = run_tests.sh
+endif # RUN_TESTS
 
 # if RUN_TESTS
 # # Tests will run from a bash script.
@@ -17,7 +21,7 @@ TESTS = tst_pio_udf
 # endif # RUN_TESTS
 
 # Distribute the test script.
-#EXTRA_DIST = CMakeLists.txt run_tests.sh input.nl
+EXTRA_DIST = run_tests.sh
 
 # Clean up files produced during testing.
 #CLEANFILES = *.nc *.log

--- a/tests/ncint/Makefile.am
+++ b/tests/ncint/Makefile.am
@@ -8,6 +8,7 @@ include $(top_srcdir)/set_flags.am
 
 # Build the test for make check.
 check_PROGRAMS = tst_pio_udf
+TESTS = tst_pio_udf
 
 # if RUN_TESTS
 # # Tests will run from a bash script.

--- a/tests/ncint/Makefile.am
+++ b/tests/ncint/Makefile.am
@@ -5,6 +5,7 @@
 
 # Put together AM_CPPFLAGS and AM_LDFLAGS.
 include $(top_srcdir)/set_flags.am
+LDADD = ${top_builddir}/src/clib/libpioc.la
 
 # Build the test for make check.
 check_PROGRAMS = tst_pio_udf

--- a/tests/ncint/run_tests.sh
+++ b/tests/ncint/run_tests.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# This is a test script for PIO.
+# Ed Hartnett
+
+# Stop execution of script if error is returned.
+set -e
+
+# Stop loop if ctrl-c is pressed.
+trap exit INT TERM
+
+printf 'running PIO tests...\n'
+
+PIO_TESTS='tst_pio_udf'
+
+success1=true
+success2=true
+for TEST in $PIO_TESTS
+do
+    success1=false
+    echo "running ${TEST}"
+    mpiexec -n 4 ./${TEST} && success1=true
+    if test $success1 = false; then
+        break
+    fi
+done
+
+# PIO_TESTS_8='test_async_multi2  test_async_manyproc'
+
+# for TEST in $PIO_TESTS_8
+# do
+#     success2=false
+#     echo "running ${TEST}"
+#     mpiexec -n 8 ./${TEST} && success2=true
+#     if test $success2 = false; then
+#         break
+#     fi
+# done
+
+# Did we succeed?
+if test x$success1 = xtrue -a x$success2 = xtrue; then
+    exit 0
+fi
+exit 1

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -36,9 +36,10 @@ main(int argc, char **argv)
         NC_Dispatch *disp_in;
 
         /* Create an empty file to play with. */
-        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
-        if (nc_close(ncid)) ERR;
+        /* if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR; */
+        /* if (nc_close(ncid)) ERR; */
 
+        PIOc_set_log_level(3);
         /* Initialize the intracomm. */
         if (nc_init_intracomm(MPI_COMM_WORLD, 1, 1, 0, 0, &iosysid)) ERR;
 
@@ -46,13 +47,12 @@ main(int argc, char **argv)
         if (nc_def_user_format(NC_UDF0, &NCINT_dispatcher, NULL)) ERR;
 
         /* Create an empty file to play with. */
-        /* if (nc_create(FILE_NAME, NC_UDF0, &ncid)) ERR; */
-        /* if (nc_close(ncid)) ERR; */
+        if (nc_create(FILE_NAME, NC_UDF0, &ncid)) ERR;
+        if (nc_close(ncid)) ERR;
 
         /* Check that our user-defined format has been added. */
         if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;
         if (disp_in != &NCINT_dispatcher) ERR;
-        PIOc_set_log_level(3);
 
         /* Open file with our defined functions. */
         if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -53,11 +53,11 @@ main(int argc, char **argv)
         if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
         if (nc_close(ncid)) ERR;
 
-        /* Open file again and abort, which is the same as closing it. */
-        if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
-        if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
-        if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
-        if (nc_abort(ncid) != TEST_VAL_42) ERR;
+        /* /\* Open file again and abort, which is the same as closing it. *\/ */
+        /* if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR; */
+        /* if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR; */
+        /* if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR; */
+        /* if (nc_abort(ncid) != TEST_VAL_42) ERR; */
 
         /* Close the iosystem. */
         if (nc_free_iosystem(iosysid)) ERR;

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -48,6 +48,7 @@ main(int argc, char **argv)
         /* Check that our user-defined format has been added. */
         if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;
         if (disp_in != &NCINT_dispatcher) ERR;
+        PIOc_set_log_level(3);
 
         /* Open file with our defined functions. */
         /* if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR; */

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -1,8 +1,4 @@
-/* This is part of the netCDF package. Copyright 2005-2018 University
-   Corporation for Atmospheric Research/Unidata. See COPYRIGHT file
-   for conditions of use.
-
-   Test user-defined formats.
+/* Test netcdf integration layer.
 
    Ed Hartnett
 */
@@ -13,15 +9,7 @@
 #include "netcdf.h"
 #include "nc4dispatch.h"
 
-#define FILE_NAME "tst_udf.nc"
-
-#if defined(_WIN32) || defined(_WIN64)
-int
-NC4_show_metadata(int ncid)
-{
-   return 0;
-}
-#endif
+#define FILE_NAME "tst_pio_udf.nc"
 
 int
 tst_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
@@ -153,87 +141,35 @@ NC_NOTNC4_set_var_chunk_cache,
 NC_NOTNC4_get_var_chunk_cache
 };
 
-#define NUM_UDFS 2
-
-int mode[NUM_UDFS] = {NC_UDF0, NC_UDF1};
-
 int
 main(int argc, char **argv)
 {
-   printf("\n*** Testing user-defined formats.\n");
-   printf("*** testing simple user-defined format...");
+   printf("\n*** Testing netCDF integration layer.\n");
+   printf("*** testing simple use of netCDF integration layer format...");
    {
       int ncid;
       NC_Dispatch *disp_in;
-      int i;
 
       /* Create an empty file to play with. */
       if (nc_create(FILE_NAME, 0, &ncid)) ERR;
       if (nc_close(ncid)) ERR;
 
-      /* Test all available user-defined format slots. */
-      for (i = 0; i < NUM_UDFS; i++)
-      {
-         /* Add our user defined format. */
-         if (nc_def_user_format(mode[i], &tst_dispatcher, NULL)) ERR;
+      /* Add our user defined format. */
+      if (nc_def_user_format(NC_UDF0, &tst_dispatcher, NULL)) ERR;
 
-         /* Check that our user-defined format has been added. */
-         if (nc_inq_user_format(mode[i], &disp_in, NULL)) ERR;
-         if (disp_in != &tst_dispatcher) ERR;
+      /* Check that our user-defined format has been added. */
+      if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;
+      if (disp_in != &tst_dispatcher) ERR;
 
-         /* Open file with our defined functions. */
-         if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
-         if (nc_close(ncid)) ERR;
+      /* Open file with our defined functions. */
+      if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
 
          /* Open file again and abort, which is the same as closing it. */
-         if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
-         if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
-         if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
-         if (nc_abort(ncid) != TEST_VAL_42) ERR;
-      }
-   }
-   SUMMARIZE_ERR;
-   printf("*** testing user-defined format with magic number...");
-   {
-      int ncid;
-      NC_Dispatch *disp_in;
-      char magic_number[5] = "1111";
-      char dummy_data[11] = "0123456789";
-      char magic_number_in[NC_MAX_MAGIC_NUMBER_LEN];
-      FILE *FP;
-      int i;
-
-      /* Create a file with magic number at start. */
-      if (!(FP = fopen(FILE_NAME, "w"))) ERR;
-      if (fwrite(magic_number, sizeof(char), strlen(magic_number), FP)
-          != strlen(magic_number)) ERR;
-      if (fwrite(dummy_data, sizeof(char), strlen(dummy_data), FP)
-          != strlen(dummy_data)) ERR;
-      if (fclose(FP)) ERR;
-
-      /* Test all available user-defined format slots. */
-      for (i = 0; i < NUM_UDFS; i++)
-      {
-         /* Add our test user defined format. */
-         if (nc_def_user_format(mode[i], &tst_dispatcher, magic_number)) ERR;
-
-         /* Check that our user-defined format has been added. */
-         if (nc_inq_user_format(mode[i], &disp_in, magic_number_in)) ERR;
-         if (disp_in != &tst_dispatcher) ERR;
-         if (strncmp(magic_number, magic_number_in, strlen(magic_number))) ERR;
-
-         /* Open file with our defined functions. */
-         if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
-         if (nc_close(ncid)) ERR;
-
-         /* Open file again and abort, which is the same as closing
-          * it. This time we don't specify a mode, because the magic
-          * number is used to identify the file. */
-         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
-         if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
-         if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
-         if (nc_abort(ncid) != TEST_VAL_42) ERR;
-      }
+      if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
+      if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
+      if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
+      if (nc_abort(ncid) != TEST_VAL_42) ERR;
    }
    SUMMARIZE_ERR;
    FINAL_RESULTS;

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -12,6 +12,9 @@
 #include <mpi.h>
 
 #define FILE_NAME "tst_pio_udf.nc"
+#define VAR_NAME "data_var"
+#define DIM_NAME "dim_x"
+#define DIM_LEN 16
 
 extern NC_Dispatch NCINT_dispatcher;
 
@@ -32,6 +35,7 @@ main(int argc, char **argv)
     printf("*** testing simple use of netCDF integration layer format...");
     {
         int ncid;
+        int dimid, varid;
         int iosysid;
         NC_Dispatch *disp_in;
 
@@ -48,6 +52,8 @@ main(int argc, char **argv)
 
         /* Create an empty file to play with. */
         if (nc_create(FILE_NAME, NC_UDF0, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM_NAME, DIM_LEN, &dimid)) ERR;
+        if (nc_def_var(ncid, VAR_NAME, NC_INT, 1, &dimid, &varid)) ERR;
         if (nc_close(ncid)) ERR;
 
         /* Check that our user-defined format has been added. */

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -1,0 +1,240 @@
+/* This is part of the netCDF package. Copyright 2005-2018 University
+   Corporation for Atmospheric Research/Unidata. See COPYRIGHT file
+   for conditions of use.
+
+   Test user-defined formats.
+
+   Ed Hartnett
+*/
+
+#include "config.h"
+#include <nc_tests.h>
+#include "err_macros.h"
+#include "netcdf.h"
+#include "nc4dispatch.h"
+
+#define FILE_NAME "tst_udf.nc"
+
+#if defined(_WIN32) || defined(_WIN64)
+int
+NC4_show_metadata(int ncid)
+{
+   return 0;
+}
+#endif
+
+int
+tst_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
+             void *parameters, const NC_Dispatch *dispatch, NC *nc_file)
+{
+   return NC_NOERR;
+}
+
+int
+tst_abort(int ncid)
+{
+   return TEST_VAL_42;
+}
+
+int
+tst_close(int ncid, void *v)
+{
+   return NC_NOERR;
+}
+
+int
+tst_inq_format(int ncid, int *formatp)
+{
+   return TEST_VAL_42;
+}
+
+int
+tst_inq_format_extended(int ncid, int *formatp, int *modep)
+{
+   return TEST_VAL_42;
+}
+
+int
+tst_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
+             void *value, nc_type t)
+{
+   return TEST_VAL_42;
+}
+
+/* This is the dispatch object that holds pointers to all the
+ * functions that make up the HDF4 dispatch interface. */
+static NC_Dispatch tst_dispatcher = {
+
+NC_FORMATX_UDF0,
+
+NC_RO_create,
+tst_open,
+
+NC_RO_redef,
+NC_RO__enddef,
+NC_RO_sync,
+tst_abort,
+tst_close,
+NC_RO_set_fill,
+NC_NOTNC3_inq_base_pe,
+NC_NOTNC3_set_base_pe,
+tst_inq_format,
+tst_inq_format_extended,
+
+NC4_inq,
+NC4_inq_type,
+
+NC_RO_def_dim,
+NC4_inq_dimid,
+NC4_inq_dim,
+NC4_inq_unlimdim,
+NC_RO_rename_dim,
+
+NC4_inq_att,
+NC4_inq_attid,
+NC4_inq_attname,
+NC_RO_rename_att,
+NC_RO_del_att,
+NC4_get_att,
+NC_RO_put_att,
+
+NC_RO_def_var,
+NC4_inq_varid,
+NC_RO_rename_var,
+tst_get_vara,
+NC_RO_put_vara,
+NCDEFAULT_get_vars,
+NCDEFAULT_put_vars,
+NCDEFAULT_get_varm,
+NCDEFAULT_put_varm,
+
+NC4_inq_var_all,
+
+NC_NOTNC4_var_par_access,
+NC_RO_def_var_fill,
+
+NC4_show_metadata,
+NC4_inq_unlimdims,
+
+NC4_inq_ncid,
+NC4_inq_grps,
+NC4_inq_grpname,
+NC4_inq_grpname_full,
+NC4_inq_grp_parent,
+NC4_inq_grp_full_ncid,
+NC4_inq_varids,
+NC4_inq_dimids,
+NC4_inq_typeids,
+NC4_inq_type_equal,
+NC_NOTNC4_def_grp,
+NC_NOTNC4_rename_grp,
+NC4_inq_user_type,
+NC4_inq_typeid,
+
+NC_NOTNC4_def_compound,
+NC_NOTNC4_insert_compound,
+NC_NOTNC4_insert_array_compound,
+NC_NOTNC4_inq_compound_field,
+NC_NOTNC4_inq_compound_fieldindex,
+NC_NOTNC4_def_vlen,
+NC_NOTNC4_put_vlen_element,
+NC_NOTNC4_get_vlen_element,
+NC_NOTNC4_def_enum,
+NC_NOTNC4_insert_enum,
+NC_NOTNC4_inq_enum_member,
+NC_NOTNC4_inq_enum_ident,
+NC_NOTNC4_def_opaque,
+NC_NOTNC4_def_var_deflate,
+NC_NOTNC4_def_var_fletcher32,
+NC_NOTNC4_def_var_chunking,
+NC_NOTNC4_def_var_endian,
+NC_NOTNC4_def_var_filter,
+NC_NOTNC4_set_var_chunk_cache,
+NC_NOTNC4_get_var_chunk_cache
+};
+
+#define NUM_UDFS 2
+
+int mode[NUM_UDFS] = {NC_UDF0, NC_UDF1};
+
+int
+main(int argc, char **argv)
+{
+   printf("\n*** Testing user-defined formats.\n");
+   printf("*** testing simple user-defined format...");
+   {
+      int ncid;
+      NC_Dispatch *disp_in;
+      int i;
+
+      /* Create an empty file to play with. */
+      if (nc_create(FILE_NAME, 0, &ncid)) ERR;
+      if (nc_close(ncid)) ERR;
+
+      /* Test all available user-defined format slots. */
+      for (i = 0; i < NUM_UDFS; i++)
+      {
+         /* Add our user defined format. */
+         if (nc_def_user_format(mode[i], &tst_dispatcher, NULL)) ERR;
+
+         /* Check that our user-defined format has been added. */
+         if (nc_inq_user_format(mode[i], &disp_in, NULL)) ERR;
+         if (disp_in != &tst_dispatcher) ERR;
+
+         /* Open file with our defined functions. */
+         if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
+         if (nc_close(ncid)) ERR;
+
+         /* Open file again and abort, which is the same as closing it. */
+         if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
+         if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
+         if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
+         if (nc_abort(ncid) != TEST_VAL_42) ERR;
+      }
+   }
+   SUMMARIZE_ERR;
+   printf("*** testing user-defined format with magic number...");
+   {
+      int ncid;
+      NC_Dispatch *disp_in;
+      char magic_number[5] = "1111";
+      char dummy_data[11] = "0123456789";
+      char magic_number_in[NC_MAX_MAGIC_NUMBER_LEN];
+      FILE *FP;
+      int i;
+
+      /* Create a file with magic number at start. */
+      if (!(FP = fopen(FILE_NAME, "w"))) ERR;
+      if (fwrite(magic_number, sizeof(char), strlen(magic_number), FP)
+          != strlen(magic_number)) ERR;
+      if (fwrite(dummy_data, sizeof(char), strlen(dummy_data), FP)
+          != strlen(dummy_data)) ERR;
+      if (fclose(FP)) ERR;
+
+      /* Test all available user-defined format slots. */
+      for (i = 0; i < NUM_UDFS; i++)
+      {
+         /* Add our test user defined format. */
+         if (nc_def_user_format(mode[i], &tst_dispatcher, magic_number)) ERR;
+
+         /* Check that our user-defined format has been added. */
+         if (nc_inq_user_format(mode[i], &disp_in, magic_number_in)) ERR;
+         if (disp_in != &tst_dispatcher) ERR;
+         if (strncmp(magic_number, magic_number_in, strlen(magic_number))) ERR;
+
+         /* Open file with our defined functions. */
+         if (nc_open(FILE_NAME, mode[i], &ncid)) ERR;
+         if (nc_close(ncid)) ERR;
+
+         /* Open file again and abort, which is the same as closing
+          * it. This time we don't specify a mode, because the magic
+          * number is used to identify the file. */
+         if (nc_open(FILE_NAME, 0, &ncid)) ERR;
+         if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
+         if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
+         if (nc_abort(ncid) != TEST_VAL_42) ERR;
+      }
+   }
+   SUMMARIZE_ERR;
+   FINAL_RESULTS;
+}

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -13,8 +13,11 @@
 
 #define FILE_NAME "tst_pio_udf.nc"
 #define VAR_NAME "data_var"
-#define DIM_NAME "dim_x"
-#define DIM_LEN 16
+#define DIM_NAME_X "dim_x"
+#define DIM_NAME_Y "dim_y"
+#define DIM_LEN_X 4
+#define DIM_LEN_Y 4
+#define NDIM2 2
 
 extern NC_Dispatch NCINT_dispatcher;
 
@@ -35,7 +38,7 @@ main(int argc, char **argv)
     printf("*** testing simple use of netCDF integration layer format...");
     {
         int ncid;
-        int dimid, varid;
+        int dimid[NDIM2], varid;
         int iosysid;
         NC_Dispatch *disp_in;
 
@@ -50,10 +53,11 @@ main(int argc, char **argv)
         /* Add our user defined format. */
         if (nc_def_user_format(NC_UDF0, &NCINT_dispatcher, NULL)) ERR;
 
-        /* Create an empty file to play with. */
+        /* Create a file to play with. */
         if (nc_create(FILE_NAME, NC_UDF0, &ncid)) ERR;
-        if (nc_def_dim(ncid, DIM_NAME, DIM_LEN, &dimid)) ERR;
-        if (nc_def_var(ncid, VAR_NAME, NC_INT, 1, &dimid, &varid)) ERR;
+        if (nc_def_dim(ncid, DIM_NAME_X, DIM_LEN_X, &dimid[0])) ERR;
+        if (nc_def_dim(ncid, DIM_NAME_Y, DIM_LEN_Y, &dimid[1])) ERR;
+        if (nc_def_var(ncid, VAR_NAME, NC_INT, NDIM2, dimid, &varid)) ERR;
         if (nc_close(ncid)) ERR;
 
         /* Check that our user-defined format has been added. */

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -11,43 +11,43 @@
 
 #define FILE_NAME "tst_pio_udf.nc"
 
-int
-tst_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
-             void *parameters, const NC_Dispatch *dispatch, NC *nc_file)
-{
-   return NC_NOERR;
-}
+/* int */
+/* tst_open(const char *path, int mode, int basepe, size_t *chunksizehintp, */
+/*              void *parameters, const NC_Dispatch *dispatch, NC *nc_file) */
+/* { */
+/*    return NC_NOERR; */
+/* } */
 
-int
-tst_abort(int ncid)
-{
-   return TEST_VAL_42;
-}
+/* int */
+/* tst_abort(int ncid) */
+/* { */
+/*    return TEST_VAL_42; */
+/* } */
 
-int
-tst_close(int ncid, void *v)
-{
-   return NC_NOERR;
-}
+/* int */
+/* tst_close(int ncid, void *v) */
+/* { */
+/*    return NC_NOERR; */
+/* } */
 
-int
-tst_inq_format(int ncid, int *formatp)
-{
-   return TEST_VAL_42;
-}
+/* int */
+/* tst_inq_format(int ncid, int *formatp) */
+/* { */
+/*    return TEST_VAL_42; */
+/* } */
 
-int
-tst_inq_format_extended(int ncid, int *formatp, int *modep)
-{
-   return TEST_VAL_42;
-}
+/* int */
+/* tst_inq_format_extended(int ncid, int *formatp, int *modep) */
+/* { */
+/*    return TEST_VAL_42; */
+/* } */
 
-int
-tst_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
-             void *value, nc_type t)
-{
-   return TEST_VAL_42;
-}
+/* int */
+/* tst_get_vara(int ncid, int varid, const size_t *start, const size_t *count, */
+/*              void *value, nc_type t) */
+/* { */
+/*    return TEST_VAL_42; */
+/* } */
 
 /* This is the dispatch object that holds pointers to all the
  * functions that make up the HDF4 dispatch interface. */
@@ -155,7 +155,7 @@ main(int argc, char **argv)
       if (nc_close(ncid)) ERR;
 
       /* Add our user defined format. */
-      if (nc_def_user_format(NC_UDF0, &tst_dispatcher, NULL)) ERR;
+      if (nc_def_user_format(NC_UDF0, &NCINT_dispatcher, NULL)) ERR;
 
       /* Check that our user-defined format has been added. */
       if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -58,6 +58,9 @@ main(int argc, char **argv)
         if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
         if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
         if (nc_abort(ncid) != TEST_VAL_42) ERR;
+
+        /* Close the iosystem. */
+        if (nc_free_iosystem(iosysid)) ERR;
     }
     SUMMARIZE_ERR;
 

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -36,7 +36,7 @@ main(int argc, char **argv)
         NC_Dispatch *disp_in;
 
         /* Create an empty file to play with. */
-        if (nc_create(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_create(FILE_NAME, NC_CLOBBER, &ncid)) ERR;
         if (nc_close(ncid)) ERR;
 
         /* Initialize the intracomm. */
@@ -44,6 +44,10 @@ main(int argc, char **argv)
 
         /* Add our user defined format. */
         if (nc_def_user_format(NC_UDF0, &NCINT_dispatcher, NULL)) ERR;
+
+        /* Create an empty file to play with. */
+        /* if (nc_create(FILE_NAME, NC_UDF0, &ncid)) ERR; */
+        /* if (nc_close(ncid)) ERR; */
 
         /* Check that our user-defined format has been added. */
         if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -8,6 +8,8 @@
 #include "err_macros.h"
 #include "netcdf.h"
 #include "nc4dispatch.h"
+#include <pio.h>
+#include <mpi.h>
 
 #define FILE_NAME "tst_pio_udf.nc"
 
@@ -16,37 +18,50 @@ extern NC_Dispatch NCINT_dispatcher;
 int
 main(int argc, char **argv)
 {
-   printf("\n*** Testing netCDF integration layer.\n");
-   printf("*** testing simple use of netCDF integration layer format...");
-   {
-      int ncid;
-      int iosysid;
-      NC_Dispatch *disp_in;
+    int my_rank;
+    int ntasks;
 
-      /* Create an empty file to play with. */
-      if (nc_create(FILE_NAME, 0, &ncid)) ERR;
-      if (nc_close(ncid)) ERR;
+    /* Initialize MPI. */
+    if (MPI_Init(&argc, &argv)) ERR;
 
-      /* Initialize the intracomm. */
-      if (nc_init_intracomm(NULL, 1, 1, 0, 0, &iosysid)) ERR;
+    /* Learn my rank and the total number of processors. */
+    if (MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)) ERR;
+    if (MPI_Comm_size(MPI_COMM_WORLD, &ntasks)) ERR;
 
-      /* Add our user defined format. */
-      if (nc_def_user_format(NC_UDF0, &NCINT_dispatcher, NULL)) ERR;
+    printf("\n*** Testing netCDF integration layer.\n");
+    printf("*** testing simple use of netCDF integration layer format...");
+    {
+        int ncid;
+        int iosysid;
+        NC_Dispatch *disp_in;
 
-      /* Check that our user-defined format has been added. */
-      if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;
-      if (disp_in != &NCINT_dispatcher) ERR;
+        /* Create an empty file to play with. */
+        if (nc_create(FILE_NAME, 0, &ncid)) ERR;
+        if (nc_close(ncid)) ERR;
 
-      /* Open file with our defined functions. */
-      if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
-      if (nc_close(ncid)) ERR;
+        /* Initialize the intracomm. */
+        if (nc_init_intracomm(MPI_COMM_WORLD, 1, 1, 0, 0, &iosysid)) ERR;
 
-         /* Open file again and abort, which is the same as closing it. */
-      if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
-      if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
-      if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
-      if (nc_abort(ncid) != TEST_VAL_42) ERR;
-   }
-   SUMMARIZE_ERR;
-   FINAL_RESULTS;
+        /* Add our user defined format. */
+        if (nc_def_user_format(NC_UDF0, &NCINT_dispatcher, NULL)) ERR;
+
+        /* Check that our user-defined format has been added. */
+        if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;
+        if (disp_in != &NCINT_dispatcher) ERR;
+
+        /* Open file with our defined functions. */
+        if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
+        if (nc_close(ncid)) ERR;
+
+        /* Open file again and abort, which is the same as closing it. */
+        if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
+        if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR;
+        if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR;
+        if (nc_abort(ncid) != TEST_VAL_42) ERR;
+    }
+    SUMMARIZE_ERR;
+
+    /* Finalize MPI. */
+    MPI_Finalize();
+    FINAL_RESULTS;
 }

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -50,8 +50,8 @@ main(int argc, char **argv)
         if (disp_in != &NCINT_dispatcher) ERR;
 
         /* Open file with our defined functions. */
-        if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
-        if (nc_close(ncid)) ERR;
+        /* if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR; */
+        /* if (nc_close(ncid)) ERR; */
 
         /* /\* Open file again and abort, which is the same as closing it. *\/ */
         /* if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR; */

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -11,6 +11,8 @@
 
 #define FILE_NAME "tst_pio_udf.nc"
 
+extern NC_Dispatch NCINT_dispatcher;
+
 /* int */
 /* tst_open(const char *path, int mode, int basepe, size_t *chunksizehintp, */
 /*              void *parameters, const NC_Dispatch *dispatch, NC *nc_file) */
@@ -51,95 +53,95 @@
 
 /* This is the dispatch object that holds pointers to all the
  * functions that make up the HDF4 dispatch interface. */
-static NC_Dispatch tst_dispatcher = {
+/* static NC_Dispatch tst_dispatcher = { */
 
-NC_FORMATX_UDF0,
+/* NC_FORMATX_UDF0, */
 
-NC_RO_create,
-tst_open,
+/* NC_RO_create, */
+/* tst_open, */
 
-NC_RO_redef,
-NC_RO__enddef,
-NC_RO_sync,
-tst_abort,
-tst_close,
-NC_RO_set_fill,
-NC_NOTNC3_inq_base_pe,
-NC_NOTNC3_set_base_pe,
-tst_inq_format,
-tst_inq_format_extended,
+/* NC_RO_redef, */
+/* NC_RO__enddef, */
+/* NC_RO_sync, */
+/* tst_abort, */
+/* tst_close, */
+/* NC_RO_set_fill, */
+/* NC_NOTNC3_inq_base_pe, */
+/* NC_NOTNC3_set_base_pe, */
+/* tst_inq_format, */
+/* tst_inq_format_extended, */
 
-NC4_inq,
-NC4_inq_type,
+/* NC4_inq, */
+/* NC4_inq_type, */
 
-NC_RO_def_dim,
-NC4_inq_dimid,
-NC4_inq_dim,
-NC4_inq_unlimdim,
-NC_RO_rename_dim,
+/* NC_RO_def_dim, */
+/* NC4_inq_dimid, */
+/* NC4_inq_dim, */
+/* NC4_inq_unlimdim, */
+/* NC_RO_rename_dim, */
 
-NC4_inq_att,
-NC4_inq_attid,
-NC4_inq_attname,
-NC_RO_rename_att,
-NC_RO_del_att,
-NC4_get_att,
-NC_RO_put_att,
+/* NC4_inq_att, */
+/* NC4_inq_attid, */
+/* NC4_inq_attname, */
+/* NC_RO_rename_att, */
+/* NC_RO_del_att, */
+/* NC4_get_att, */
+/* NC_RO_put_att, */
 
-NC_RO_def_var,
-NC4_inq_varid,
-NC_RO_rename_var,
-tst_get_vara,
-NC_RO_put_vara,
-NCDEFAULT_get_vars,
-NCDEFAULT_put_vars,
-NCDEFAULT_get_varm,
-NCDEFAULT_put_varm,
+/* NC_RO_def_var, */
+/* NC4_inq_varid, */
+/* NC_RO_rename_var, */
+/* tst_get_vara, */
+/* NC_RO_put_vara, */
+/* NCDEFAULT_get_vars, */
+/* NCDEFAULT_put_vars, */
+/* NCDEFAULT_get_varm, */
+/* NCDEFAULT_put_varm, */
 
-NC4_inq_var_all,
+/* NC4_inq_var_all, */
 
-NC_NOTNC4_var_par_access,
-NC_RO_def_var_fill,
+/* NC_NOTNC4_var_par_access, */
+/* NC_RO_def_var_fill, */
 
-NC4_show_metadata,
-NC4_inq_unlimdims,
+/* NC4_show_metadata, */
+/* NC4_inq_unlimdims, */
 
-NC4_inq_ncid,
-NC4_inq_grps,
-NC4_inq_grpname,
-NC4_inq_grpname_full,
-NC4_inq_grp_parent,
-NC4_inq_grp_full_ncid,
-NC4_inq_varids,
-NC4_inq_dimids,
-NC4_inq_typeids,
-NC4_inq_type_equal,
-NC_NOTNC4_def_grp,
-NC_NOTNC4_rename_grp,
-NC4_inq_user_type,
-NC4_inq_typeid,
+/* NC4_inq_ncid, */
+/* NC4_inq_grps, */
+/* NC4_inq_grpname, */
+/* NC4_inq_grpname_full, */
+/* NC4_inq_grp_parent, */
+/* NC4_inq_grp_full_ncid, */
+/* NC4_inq_varids, */
+/* NC4_inq_dimids, */
+/* NC4_inq_typeids, */
+/* NC4_inq_type_equal, */
+/* NC_NOTNC4_def_grp, */
+/* NC_NOTNC4_rename_grp, */
+/* NC4_inq_user_type, */
+/* NC4_inq_typeid, */
 
-NC_NOTNC4_def_compound,
-NC_NOTNC4_insert_compound,
-NC_NOTNC4_insert_array_compound,
-NC_NOTNC4_inq_compound_field,
-NC_NOTNC4_inq_compound_fieldindex,
-NC_NOTNC4_def_vlen,
-NC_NOTNC4_put_vlen_element,
-NC_NOTNC4_get_vlen_element,
-NC_NOTNC4_def_enum,
-NC_NOTNC4_insert_enum,
-NC_NOTNC4_inq_enum_member,
-NC_NOTNC4_inq_enum_ident,
-NC_NOTNC4_def_opaque,
-NC_NOTNC4_def_var_deflate,
-NC_NOTNC4_def_var_fletcher32,
-NC_NOTNC4_def_var_chunking,
-NC_NOTNC4_def_var_endian,
-NC_NOTNC4_def_var_filter,
-NC_NOTNC4_set_var_chunk_cache,
-NC_NOTNC4_get_var_chunk_cache
-};
+/* NC_NOTNC4_def_compound, */
+/* NC_NOTNC4_insert_compound, */
+/* NC_NOTNC4_insert_array_compound, */
+/* NC_NOTNC4_inq_compound_field, */
+/* NC_NOTNC4_inq_compound_fieldindex, */
+/* NC_NOTNC4_def_vlen, */
+/* NC_NOTNC4_put_vlen_element, */
+/* NC_NOTNC4_get_vlen_element, */
+/* NC_NOTNC4_def_enum, */
+/* NC_NOTNC4_insert_enum, */
+/* NC_NOTNC4_inq_enum_member, */
+/* NC_NOTNC4_inq_enum_ident, */
+/* NC_NOTNC4_def_opaque, */
+/* NC_NOTNC4_def_var_deflate, */
+/* NC_NOTNC4_def_var_fletcher32, */
+/* NC_NOTNC4_def_var_chunking, */
+/* NC_NOTNC4_def_var_endian, */
+/* NC_NOTNC4_def_var_filter, */
+/* NC_NOTNC4_set_var_chunk_cache, */
+/* NC_NOTNC4_get_var_chunk_cache */
+/* }; */
 
 int
 main(int argc, char **argv)
@@ -159,7 +161,7 @@ main(int argc, char **argv)
 
       /* Check that our user-defined format has been added. */
       if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;
-      if (disp_in != &tst_dispatcher) ERR;
+      if (disp_in != &NCINT_dispatcher) ERR;
 
       /* Open file with our defined functions. */
       if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -83,6 +83,9 @@ main(int argc, char **argv)
         if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
         if (nc_close(ncid)) ERR;
 
+        /* Free the decomposition. */
+        if (nc_free_decomp(ioid)) ERR;
+
         /* Close the iosystem. */
         if (nc_free_iosystem(iosysid)) ERR;
     }

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -51,14 +51,8 @@ main(int argc, char **argv)
         PIOc_set_log_level(3);
 
         /* Open file with our defined functions. */
-        /* if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR; */
-        /* if (nc_close(ncid)) ERR; */
-
-        /* /\* Open file again and abort, which is the same as closing it. *\/ */
-        /* if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR; */
-        /* if (nc_inq_format(ncid, NULL) != TEST_VAL_42) ERR; */
-        /* if (nc_inq_format_extended(ncid, NULL, NULL) != TEST_VAL_42) ERR; */
-        /* if (nc_abort(ncid) != TEST_VAL_42) ERR; */
+        if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
+        if (nc_close(ncid)) ERR;
 
         /* Close the iosystem. */
         if (nc_free_iosystem(iosysid)) ERR;

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -13,136 +13,6 @@
 
 extern NC_Dispatch NCINT_dispatcher;
 
-/* int */
-/* tst_open(const char *path, int mode, int basepe, size_t *chunksizehintp, */
-/*              void *parameters, const NC_Dispatch *dispatch, NC *nc_file) */
-/* { */
-/*    return NC_NOERR; */
-/* } */
-
-/* int */
-/* tst_abort(int ncid) */
-/* { */
-/*    return TEST_VAL_42; */
-/* } */
-
-/* int */
-/* tst_close(int ncid, void *v) */
-/* { */
-/*    return NC_NOERR; */
-/* } */
-
-/* int */
-/* tst_inq_format(int ncid, int *formatp) */
-/* { */
-/*    return TEST_VAL_42; */
-/* } */
-
-/* int */
-/* tst_inq_format_extended(int ncid, int *formatp, int *modep) */
-/* { */
-/*    return TEST_VAL_42; */
-/* } */
-
-/* int */
-/* tst_get_vara(int ncid, int varid, const size_t *start, const size_t *count, */
-/*              void *value, nc_type t) */
-/* { */
-/*    return TEST_VAL_42; */
-/* } */
-
-/* This is the dispatch object that holds pointers to all the
- * functions that make up the HDF4 dispatch interface. */
-/* static NC_Dispatch tst_dispatcher = { */
-
-/* NC_FORMATX_UDF0, */
-
-/* NC_RO_create, */
-/* tst_open, */
-
-/* NC_RO_redef, */
-/* NC_RO__enddef, */
-/* NC_RO_sync, */
-/* tst_abort, */
-/* tst_close, */
-/* NC_RO_set_fill, */
-/* NC_NOTNC3_inq_base_pe, */
-/* NC_NOTNC3_set_base_pe, */
-/* tst_inq_format, */
-/* tst_inq_format_extended, */
-
-/* NC4_inq, */
-/* NC4_inq_type, */
-
-/* NC_RO_def_dim, */
-/* NC4_inq_dimid, */
-/* NC4_inq_dim, */
-/* NC4_inq_unlimdim, */
-/* NC_RO_rename_dim, */
-
-/* NC4_inq_att, */
-/* NC4_inq_attid, */
-/* NC4_inq_attname, */
-/* NC_RO_rename_att, */
-/* NC_RO_del_att, */
-/* NC4_get_att, */
-/* NC_RO_put_att, */
-
-/* NC_RO_def_var, */
-/* NC4_inq_varid, */
-/* NC_RO_rename_var, */
-/* tst_get_vara, */
-/* NC_RO_put_vara, */
-/* NCDEFAULT_get_vars, */
-/* NCDEFAULT_put_vars, */
-/* NCDEFAULT_get_varm, */
-/* NCDEFAULT_put_varm, */
-
-/* NC4_inq_var_all, */
-
-/* NC_NOTNC4_var_par_access, */
-/* NC_RO_def_var_fill, */
-
-/* NC4_show_metadata, */
-/* NC4_inq_unlimdims, */
-
-/* NC4_inq_ncid, */
-/* NC4_inq_grps, */
-/* NC4_inq_grpname, */
-/* NC4_inq_grpname_full, */
-/* NC4_inq_grp_parent, */
-/* NC4_inq_grp_full_ncid, */
-/* NC4_inq_varids, */
-/* NC4_inq_dimids, */
-/* NC4_inq_typeids, */
-/* NC4_inq_type_equal, */
-/* NC_NOTNC4_def_grp, */
-/* NC_NOTNC4_rename_grp, */
-/* NC4_inq_user_type, */
-/* NC4_inq_typeid, */
-
-/* NC_NOTNC4_def_compound, */
-/* NC_NOTNC4_insert_compound, */
-/* NC_NOTNC4_insert_array_compound, */
-/* NC_NOTNC4_inq_compound_field, */
-/* NC_NOTNC4_inq_compound_fieldindex, */
-/* NC_NOTNC4_def_vlen, */
-/* NC_NOTNC4_put_vlen_element, */
-/* NC_NOTNC4_get_vlen_element, */
-/* NC_NOTNC4_def_enum, */
-/* NC_NOTNC4_insert_enum, */
-/* NC_NOTNC4_inq_enum_member, */
-/* NC_NOTNC4_inq_enum_ident, */
-/* NC_NOTNC4_def_opaque, */
-/* NC_NOTNC4_def_var_deflate, */
-/* NC_NOTNC4_def_var_fletcher32, */
-/* NC_NOTNC4_def_var_chunking, */
-/* NC_NOTNC4_def_var_endian, */
-/* NC_NOTNC4_def_var_filter, */
-/* NC_NOTNC4_set_var_chunk_cache, */
-/* NC_NOTNC4_get_var_chunk_cache */
-/* }; */
-
 int
 main(int argc, char **argv)
 {
@@ -150,11 +20,15 @@ main(int argc, char **argv)
    printf("*** testing simple use of netCDF integration layer format...");
    {
       int ncid;
+      int iosysid;
       NC_Dispatch *disp_in;
 
       /* Create an empty file to play with. */
       if (nc_create(FILE_NAME, 0, &ncid)) ERR;
       if (nc_close(ncid)) ERR;
+
+      /* Initialize the intracomm. */
+      if (nc_init_intracomm(NULL, 1, 1, 0, 0, &iosysid)) ERR;
 
       /* Add our user defined format. */
       if (nc_def_user_format(NC_UDF0, &NCINT_dispatcher, NULL)) ERR;


### PR DESCRIPTION
Part of #1555 

This is the beginning of netCDF integration.

These features are, at the moment, only build with the --enable-netcdf-integration option to configure. They require the current master of netCDF.