### PR TITLE
Rest of PIO functions in netcdf integration

### DIFF
--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -63,7 +63,7 @@ NC_Dispatch NCINT_dispatcher = {
     PIO_NCINT_rename_var,
     PIO_NCINT_get_vara,
     PIO_NCINT_put_vara,
-    NCDEFAULT_get_vars,
+    PIO_NCINT_get_vars,
     NCDEFAULT_put_vars,
     NCDEFAULT_get_varm,
     NCDEFAULT_put_varm,
@@ -215,6 +215,140 @@ PIO_NCINT_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
         return ret;
 
     return NC_NOERR;
+}
+
+/**
+ * @internal This just calls nc_enddef, ignoring the extra parameters.
+ *
+ * @param ncid File and group ID.
+ * @param h_minfree Ignored.
+ * @param v_align Ignored.
+ * @param v_minfree Ignored.
+ * @param r_align Ignored.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT__enddef(int ncid, size_t h_minfree, size_t v_align,
+                  size_t v_minfree, size_t r_align)
+{
+    return PIOc_enddef(ncid);
+}
+
+/**
+ * @internal Put the file back in redef mode. This is done
+ * automatically for netcdf-4 files, if the user forgets.
+ *
+ * @param ncid File and group ID.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_redef(int ncid)
+{
+    return PIOc_redef(ncid);
+}
+
+/**
+ * @internal Flushes all buffers associated with the file, after
+ * writing all changed metadata. This may only be called in data mode.
+ *
+ * @param ncid File and group ID.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_EINDEFINE Classic model file is in define mode.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_sync(int ncid)
+{
+    return PIOc_sync(ncid);
+}
+
+int
+PIO_NCINT_abort(int ncid)
+{
+    return TEST_VAL_42;
+}
+
+int
+PIO_NCINT_close(int ncid, void *v)
+{
+    return PIOc_closefile(ncid);
+}
+
+/**
+ * @internal Set fill mode.
+ *
+ * @param ncid File ID.
+ * @param fillmode File mode.
+ * @param old_modep Pointer that gets old mode. Ignored if NULL.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_set_fill(int ncid, int fillmode, int *old_modep)
+{
+    return PIOc_set_fill(ncid, fillmode, old_modep);
+}
+
+int
+PIO_NCINT_inq_format(int ncid, int *formatp)
+{
+    return TEST_VAL_42;
+}
+
+int
+PIO_NCINT_inq_format_extended(int ncid, int *formatp, int *modep)
+{
+    return TEST_VAL_42;
+}
+
+/**
+ * @internal Learn number of dimensions, variables, global attributes,
+ * and the ID of the first unlimited dimension (if any).
+ *
+ * @note It's possible for any of these pointers to be NULL, in which
+ * case don't try to figure out that value.
+ *
+ * @param ncid File and group ID.
+ * @param ndimsp Pointer that gets number of dimensions.
+ * @param nvarsp Pointer that gets number of variables.
+ * @param nattsp Pointer that gets number of global attributes.
+ * @param unlimdimidp Pointer that gets first unlimited dimension ID,
+ * or -1 if there are no unlimied dimensions.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp)
+{
+    return PIOc_inq(ncid, ndimsp, nvarsp, nattsp, unlimdimidp);
+}
+
+/**
+ * @internal Get the name and size of a type. For strings, 1 is
+ * returned. For VLEN the base type len is returned.
+ *
+ * @param ncid File and group ID.
+ * @param typeid1 Type ID.
+ * @param name Gets the name of the type.
+ * @param size Gets the size of one element of the type in bytes.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_EBADTYPE Type not found.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_type(int ncid, nc_type typeid1, char *name, size_t *size)
+{
+    return PIOc_inq_type(ncid, typeid1, name, (PIO_Offset *)size);
 }
 
 int
@@ -539,136 +673,39 @@ PIO_NCINT_put_vara(int ncid, int varid, const size_t *startp,
 }
 
 /**
- * @internal This just calls nc_enddef, ignoring the extra parameters.
- *
- * @param ncid File and group ID.
- * @param h_minfree Ignored.
- * @param v_align Ignored.
- * @param v_minfree Ignored.
- * @param r_align Ignored.
- *
- * @return ::NC_NOERR No error.
- * @author Ed Hartnett
- */
-int
-PIO_NCINT__enddef(int ncid, size_t h_minfree, size_t v_align,
-                  size_t v_minfree, size_t r_align)
-{
-    return PIOc_enddef(ncid);
-}
-
-/**
- * @internal Put the file back in redef mode. This is done
- * automatically for netcdf-4 files, if the user forgets.
- *
- * @param ncid File and group ID.
- *
- * @return ::NC_NOERR No error.
- * @author Ed Hartnett
- */
-int
-PIO_NCINT_redef(int ncid)
-{
-    return PIOc_redef(ncid);
-}
-
-/**
- * @internal Flushes all buffers associated with the file, after
- * writing all changed metadata. This may only be called in data mode.
- *
- * @param ncid File and group ID.
- *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
- * @return ::NC_EINDEFINE Classic model file is in define mode.
- * @author Ed Hartnett
- */
-int
-PIO_NCINT_sync(int ncid)
-{
-    return PIOc_sync(ncid);
-}
-
-int
-PIO_NCINT_abort(int ncid)
-{
-    return TEST_VAL_42;
-}
-
-int
-PIO_NCINT_close(int ncid, void *v)
-{
-    return PIOc_closefile(ncid);
-}
-
-/**
- * @internal Set fill mode.
+ * @internal Read a strided array of data from a variable. This is
+ * called by nc_get_vars() for netCDF-4 files, as well as all the
+ * other nc_get_vars_* functions.
  *
  * @param ncid File ID.
- * @param fillmode File mode.
- * @param old_modep Pointer that gets old mode. Ignored if NULL.
+ * @param varid Variable ID.
+ * @param startp Array of start indices. Must be provided for
+ * non-scalar vars.
+ * @param countp Array of counts. Will default to counts of extent of
+ * dimension if NULL.
+ * @param stridep Array of strides. Will default to strides of 1 if
+ * NULL.
+ * @param data The data to be written.
+ * @param mem_nc_type The type of the data in memory. (Convert to this
+ * type from file type.)
  *
- * @return ::NC_NOERR No error.
- * @author Ed Hartnett
+ * @returns ::NC_NOERR No error.
+ * @returns ::NC_EBADID Bad ncid.
+ * @returns ::NC_ENOTVAR Var not found.
+ * @returns ::NC_EHDFERR HDF5 function returned error.
+ * @returns ::NC_EINVALCOORDS Incorrect start.
+ * @returns ::NC_EEDGE Incorrect start/count.
+ * @returns ::NC_ENOMEM Out of memory.
+ * @returns ::NC_EMPI MPI library error (parallel only)
+ * @returns ::NC_ECANTEXTEND Can't extend dimension for write.
+ * @returns ::NC_ERANGE Data conversion error.
+ * @author Ed Hartnett, Dennis Heimbigner
  */
 int
-PIO_NCINT_set_fill(int ncid, int fillmode, int *old_modep)
+PIO_NCINT_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
+                   const ptrdiff_t *stridep, void *data, nc_type mem_nc_type)
 {
-    return PIOc_set_fill(ncid, fillmode, old_modep);
+    return PIOc_get_vars_tc(ncid, varid, (PIO_Offset *)startp,
+                            (PIO_Offset *)countp, (PIO_Offset *)stridep,
+                            mem_nc_type, data);
 }
-
-int
-PIO_NCINT_inq_format(int ncid, int *formatp)
-{
-    return TEST_VAL_42;
-}
-
-int
-PIO_NCINT_inq_format_extended(int ncid, int *formatp, int *modep)
-{
-    return TEST_VAL_42;
-}
-
-/**
- * @internal Learn number of dimensions, variables, global attributes,
- * and the ID of the first unlimited dimension (if any).
- *
- * @note It's possible for any of these pointers to be NULL, in which
- * case don't try to figure out that value.
- *
- * @param ncid File and group ID.
- * @param ndimsp Pointer that gets number of dimensions.
- * @param nvarsp Pointer that gets number of variables.
- * @param nattsp Pointer that gets number of global attributes.
- * @param unlimdimidp Pointer that gets first unlimited dimension ID,
- * or -1 if there are no unlimied dimensions.
- *
- * @return ::NC_NOERR No error.
- * @author Ed Hartnett
- */
-int
-PIO_NCINT_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp)
-{
-    return PIOc_inq(ncid, ndimsp, nvarsp, nattsp, unlimdimidp);
-}
-
-/**
- * @internal Get the name and size of a type. For strings, 1 is
- * returned. For VLEN the base type len is returned.
- *
- * @param ncid File and group ID.
- * @param typeid1 Type ID.
- * @param name Gets the name of the type.
- * @param size Gets the size of one element of the type in bytes.
- *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
- * @return ::NC_EBADTYPE Type not found.
- * @author Ed Hartnett
- */
-int
-PIO_NCINT_inq_type(int ncid, nc_type typeid1, char *name, size_t *size)
-{
-    return PIOc_inq_type(ncid, typeid1, name, (PIO_Offset *)size);
-}
-

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -64,7 +64,7 @@ NC_Dispatch NCINT_dispatcher = {
     PIO_NCINT_get_vara,
     PIO_NCINT_put_vara,
     PIO_NCINT_get_vars,
-    NCDEFAULT_put_vars,
+    PIO_NCINT_put_vars,
     NCDEFAULT_get_varm,
     NCDEFAULT_put_varm,
 
@@ -583,6 +583,7 @@ PIO_NCINT_def_var(int ncid, const char *name, nc_type xtype, int ndims,
  * @returns ::NC_NOERR No error.
  * @returns ::NC_EBADID Bad ncid.
  * @returns ::NC_ENOTVAR Bad variable ID.
+ * @author Ed Hartnett
  */
 int
 PIO_NCINT_inq_varid(int ncid, const char *name, int *varidp)
@@ -614,12 +615,6 @@ PIO_NCINT_inq_varid(int ncid, const char *name, int *varidp)
  * @param name New name of the variable.
  *
  * @returns ::NC_NOERR No error.
- * @returns ::NC_EBADID Bad ncid.
- * @returns ::NC_ENOTVAR Invalid variable ID.
- * @returns ::NC_EBADNAME Bad name.
- * @returns ::NC_EMAXNAME Name is too long.
- * @returns ::NC_ENAMEINUSE Name in use.
- * @returns ::NC_ENOMEM Out of memory.
  * @author Ed Hartnett
  */
 int
@@ -639,7 +634,7 @@ PIO_NCINT_rename_var(int ncid, int varid, const char *name)
  * @param memtype The type of these data in memory.
  *
  * @returns ::NC_NOERR for success
- * @author Ed Hartnett, Dennis Heimbigner
+ * @author Ed Hartnett
  */
 int
 PIO_NCINT_get_vara(int ncid, int varid, const size_t *start,
@@ -662,7 +657,7 @@ PIO_NCINT_get_vara(int ncid, int varid, const size_t *start,
  * @param memtype The type of these data in memory.
  *
  * @returns ::NC_NOERR for success
- * @author Ed Hartnett, Dennis Heimbigner
+ * @author Ed Hartnett
  */
 int
 PIO_NCINT_put_vara(int ncid, int varid, const size_t *startp,
@@ -690,22 +685,42 @@ PIO_NCINT_put_vara(int ncid, int varid, const size_t *startp,
  * type from file type.)
  *
  * @returns ::NC_NOERR No error.
- * @returns ::NC_EBADID Bad ncid.
- * @returns ::NC_ENOTVAR Var not found.
- * @returns ::NC_EHDFERR HDF5 function returned error.
- * @returns ::NC_EINVALCOORDS Incorrect start.
- * @returns ::NC_EEDGE Incorrect start/count.
- * @returns ::NC_ENOMEM Out of memory.
- * @returns ::NC_EMPI MPI library error (parallel only)
- * @returns ::NC_ECANTEXTEND Can't extend dimension for write.
- * @returns ::NC_ERANGE Data conversion error.
- * @author Ed Hartnett, Dennis Heimbigner
+ * @author Ed Hartnett
  */
 int
 PIO_NCINT_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
                    const ptrdiff_t *stridep, void *data, nc_type mem_nc_type)
 {
     return PIOc_get_vars_tc(ncid, varid, (PIO_Offset *)startp,
+                            (PIO_Offset *)countp, (PIO_Offset *)stridep,
+                            mem_nc_type, data);
+}
+
+/**
+ * @internal Write a strided array of data to a variable. This is
+ * called by nc_put_vars() and other nc_put_vars_* functions, for
+ * netCDF-4 files. Also the nc_put_vara() calls end up calling this
+ * with a NULL stride parameter.
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param startp Array of start indices. Must always be provided by
+ * caller for non-scalar vars.
+ * @param countp Array of counts. Will default to counts of full
+ * dimension size if NULL.
+ * @param stridep Array of strides. Will default to strides of 1 if
+ * NULL.
+ * @param data The data to be written.
+ * @param mem_nc_type The type of the data in memory.
+ *
+ * @returns ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
+                   const ptrdiff_t *stridep, const void *data, nc_type mem_nc_type)
+{
+    return PIOc_put_vars_tc(ncid, varid, (PIO_Offset *)startp,
                             (PIO_Offset *)countp, (PIO_Offset *)stridep,
                             mem_nc_type, data);
 }

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -68,7 +68,7 @@ NC_Dispatch NCINT_dispatcher = {
     NCDEFAULT_get_varm,
     NCDEFAULT_put_varm,
 
-    NC4_inq_var_all,
+    PIO_NCINT_inq_var_all,
 
     NC_NOTNC4_var_par_access,
     NC_RO_def_var_fill,
@@ -455,7 +455,7 @@ PIO_NCINT_rename_dim(int ncid, int dimid, const char *name)
  */
 int
 PIO_NCINT_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
-                 size_t *lenp)
+                  size_t *lenp)
 {
     return PIOc_inq_att(ncid, varid, name, xtypep, (PIO_Offset *)lenp);
 }
@@ -546,7 +546,7 @@ PIO_NCINT_del_att(int ncid, int varid, const char *name)
  */
 int
 PIO_NCINT_get_att(int ncid, int varid, const char *name, void *value,
-                 nc_type memtype)
+                  nc_type memtype)
 {
     return PIOc_get_att_tc(ncid, varid, name, memtype, value);
 }
@@ -559,7 +559,7 @@ PIO_NCINT_get_att(int ncid, int varid, const char *name, void *value,
  */
 int
 PIO_NCINT_put_att(int ncid, int varid, const char *name, nc_type file_type,
-              size_t len, const void *data, nc_type mem_type)
+                  size_t len, const void *data, nc_type mem_type)
 {
     return PIOc_put_att_tc(ncid, varid, name, file_type, (PIO_Offset)len,
                            mem_type,  data);
@@ -723,4 +723,43 @@ PIO_NCINT_put_vars(int ncid, int varid, const size_t *startp, const size_t *coun
     return PIOc_put_vars_tc(ncid, varid, (PIO_Offset *)startp,
                             (PIO_Offset *)countp, (PIO_Offset *)stridep,
                             mem_nc_type, data);
+}
+/**
+ * @internal Get all the information about a variable. Pass NULL for
+ * whatever you don't care about.
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param name Gets name.
+ * @param xtypep Gets type.
+ * @param ndimsp Gets number of dims.
+ * @param dimidsp Gets array of dim IDs.
+ * @param nattsp Gets number of attributes.
+ * @param shufflep Gets shuffle setting.
+ * @param deflatep Gets deflate setting.
+ * @param deflate_levelp Gets deflate level.
+ * @param fletcher32p Gets fletcher32 setting.
+ * @param contiguousp Gets contiguous setting.
+ * @param chunksizesp Gets chunksizes.
+ * @param no_fill Gets fill mode.
+ * @param fill_valuep Gets fill value.
+ * @param endiannessp Gets one of ::NC_ENDIAN_BIG ::NC_ENDIAN_LITTLE
+ * ::NC_ENDIAN_NATIVE
+ * @param idp Pointer to memory to store filter id.
+ * @param nparamsp Pointer to memory to store filter parameter count.
+ * @param params Pointer to vector of unsigned integers into which
+ * to store filter parameters.
+ *
+ * @returns ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
+                      int *ndimsp, int *dimidsp, int *nattsp,
+                      int *shufflep, int *deflatep, int *deflate_levelp,
+                      int *fletcher32p, int *contiguousp, size_t *chunksizesp,
+                      int *no_fill, void *fill_valuep, int *endiannessp,
+                      unsigned int *idp, size_t *nparamsp, unsigned int *params)
+{
+    return PIOc_inq_var(ncid, varid, name, xtypep, ndimsp, dimidsp, nattsp);
 }

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -71,7 +71,7 @@ NC_Dispatch NCINT_dispatcher = {
     PIO_NCINT_inq_var_all,
 
     NC_NOTNC4_var_par_access,
-    NC_RO_def_var_fill,
+    PIO_NCINT_def_var_fill,
 
     NC4_show_metadata,
     NC4_inq_unlimdims,
@@ -762,4 +762,23 @@ PIO_NCINT_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
                       unsigned int *idp, size_t *nparamsp, unsigned int *params)
 {
     return PIOc_inq_var(ncid, varid, name, xtypep, ndimsp, dimidsp, nattsp);
+}
+
+/**
+ * @internal This functions sets fill value and no_fill mode for a
+ * netCDF-4 variable. It is called by nc_def_var_fill().
+ *
+ * @note All pointer parameters may be NULL, in which case they are ignored.
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param no_fill No_fill setting.
+ * @param fill_value Pointer to fill value.
+ *
+ * @returns ::NC_NOERR for success
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
+{
+    return PIOc_def_var_fill(ncid, varid, no_fill, fill_value);
 }

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -74,7 +74,7 @@ NC_Dispatch NCINT_dispatcher = {
     PIO_NCINT_def_var_fill,
 
     NC4_show_metadata,
-    NC4_inq_unlimdims,
+    PIO_NCINT_inq_unlimdims,
 
     NC4_inq_ncid,
     NC4_inq_grps,
@@ -781,4 +781,25 @@ int
 PIO_NCINT_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
 {
     return PIOc_def_var_fill(ncid, varid, no_fill, fill_value);
+}
+
+/**
+ * @internal Returns an array of unlimited dimension ids.The user can
+ * get the number of unlimited dimensions by first calling this with
+ * NULL for the second pointer.
+ *
+ * @param ncid File and group ID.
+ * @param nunlimdimsp Pointer that gets the number of unlimited
+ * dimensions. Ignored if NULL.
+ * @param unlimdimidsp Pointer that gets arrray of unlimited dimension
+ * ID. Ignored if NULL.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @author Ed Hartnett, Dennis Heimbigner
+ */
+int
+PIO_NCINT_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
+{
+    return PIOc_inq_unlimdims(ncid, nunlimdimsp, unlimdimidsp);
 }

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -122,11 +122,19 @@ extern "C" {
     PIO_NCINT_put_att(int ncid, int varid, const char *name, nc_type file_type,
                       size_t len, const void *data, nc_type mem_type);
 
+    extern int
+    PIO_NCINT_inq_varid(int ncid, const char *name, int *varidp);
+
+    extern int
+    PIO_NCINT_rename_var(int ncid, int varid, const char *name);
 
     extern int
     PIO_NCINT_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
                        void *value, nc_type t);
 
+    extern int
+    PIO_NCINT_put_vara(int ncid, int varid, const size_t *startp,
+                       const size_t *countp, const void *op, int memtype);
 
 #if defined(__cplusplus)
 }

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -156,6 +156,10 @@ extern "C" {
     extern int
     PIO_NCINT_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value);
 
+    extern int
+    PIO_NCINT_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp);
+
+
 
 #if defined(__cplusplus)
 }

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -153,6 +153,10 @@ extern "C" {
                           int *no_fill, void *fill_valuep, int *endiannessp,
                           unsigned int *idp, size_t *nparamsp, unsigned int *params);
 
+    extern int
+    PIO_NCINT_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value);
+
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -145,6 +145,13 @@ extern "C" {
                        const ptrdiff_t *stridep, const void *data, nc_type mem_nc_type);
 
 
+    extern int
+    PIO_NCINT_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
+                          int *ndimsp, int *dimidsp, int *nattsp,
+                          int *shufflep, int *deflatep, int *deflate_levelp,
+                          int *fletcher32p, int *contiguousp, size_t *chunksizesp,
+                          int *no_fill, void *fill_valuep, int *endiannessp,
+                          unsigned int *idp, size_t *nparamsp, unsigned int *params);
 
 #if defined(__cplusplus)
 }

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -140,6 +140,11 @@ extern "C" {
     PIO_NCINT_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
                        const ptrdiff_t *stridep, void *data, nc_type mem_nc_type);
 
+    extern int
+    PIO_NCINT_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
+                       const ptrdiff_t *stridep, const void *data, nc_type mem_nc_type);
+
+
 
 #if defined(__cplusplus)
 }

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -136,6 +136,11 @@ extern "C" {
     PIO_NCINT_put_vara(int ncid, int varid, const size_t *startp,
                        const size_t *countp, const void *op, int memtype);
 
+    extern int
+    PIO_NCINT_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
+                       const ptrdiff_t *stridep, void *data, nc_type mem_nc_type);
+
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
Part of #1556 

This PR contains mapping for the rest of the PIO functions into the netcdf integration. All remaining functions in the dispatch table are not implement in PIO.
