### PR TITLE
moved netcdf integration to separate fortran file ncint_mod.F90

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,7 @@ if test "x$enable_netcdf_integration" = xyes; then
 fi
 
 AM_CONDITIONAL(BUILD_NCINT, [test "x$enable_netcdf_integration" = xyes])
+AM_CONDITIONAL(NETCDF_INTEGRATION, [test "x$enable_netcdf_integration" = xyes])
 
 AC_CONFIG_FILES([tests/general/pio_tutil.F90:tests/general/util/pio_tutil.F90])
 

--- a/src/flib/Makefile.am
+++ b/src/flib/Makefile.am
@@ -17,7 +17,12 @@ libpiof_la_LDFLAGS = -version-info 2:0:1
 # The library soure files.
 libpiof_la_LIBADD = libpio_nf.la libpio_kinds.la libpio_support.la	\
 libpiodarray.la libpionfatt.la libpionfget.la libpionfput.la		\
-libpiolib_mod.la libpio.la
+libpiolib_mod.la
+
+if NETCDF_INTEGRATION
+libpiof_la_LIBADD += libncint_mod.la
+endif
+libpiof_la_LIBADD +=  libpio.la
 
 libpiof_la_SOURCES = pio_types.F90
 
@@ -25,6 +30,9 @@ libpiof_la_SOURCES = pio_types.F90
 noinst_LTLIBRARIES = libpio_kinds.la libpio_types.la		\
 libpio_support.la libpio_nf.la libpiodarray.la libpionfatt.la	\
 libpionfget.la libpionfput.la libpiolib_mod.la libpio.la
+if NETCDF_INTEGRATION
+noinst_LTLIBRARIES += libncint_mod.la
+endif
 
 # The convenience libraries depends on their source.
 libpio_kinds_la_SOURCES = pio_kinds.F90
@@ -36,6 +44,7 @@ libpionfatt_la_SOURCES = pionfatt_mod.F90
 libpionfget_la_SOURCES = pionfget_mod.F90
 libpionfput_la_SOURCES = pionfput_mod.F90
 libpiolib_mod_la_SOURCES = piolib_mod.F90
+libncint_mod_la_SOURCES = ncint_mod.F90
 libpio_la_SOURCES = pio.F90
 
 # These F90 files are generated from .F90.in files, using the script
@@ -59,16 +68,24 @@ pionfatt_mod.mod: pionfatt_mod.F90 pionfatt_mod.$(OBJEXT)
 pionfget_mod.mod: pionfget_mod.F90 pionfget_mod.$(OBJEXT)
 pionfput_mod.mod: pionfput_mod.F90 pionfput_mod.$(OBJEXT)
 piolib_mod.mod: piolib_mod.$(OBJEXT)
+ncint_mod.mod: ncint_mod.$(OBJEXT)
 pio.mod: pio.$(OBJEXT)
 
 # Some mod files depend on other mod files.
-pio.$(OBJEXT): pio_kinds.mod piolib_mod.mod pio_types.mod piodarray.mod \
+DEPEND_FILES = pio_kinds.mod piolib_mod.mod pio_types.mod piodarray.mod \
 pio_nf.mod pionfatt_mod.mod pionfget_mod.mod pionfput_mod.mod pio_support.mod
+if NETCDF_INTEGRATION
+DEPEND_FILES += ncint_mod.mod
+endif
+pio.$(OBJEXT): $(DEPEND_FILES)
 
 # Mod files are built and then installed as headers.
 MODFILES = pio_kinds.mod pio_types.mod pio_support.mod pio_nf.mod	\
 piodarray.mod pionfatt_mod.mod pionfget_mod.mod pionfput_mod.mod	\
 piolib_mod.mod pio.mod
+if NETCDF_INTEGRATION
+MODFILES += ncint_mod.mod
+endif
 BUILT_SOURCES = $(MODFILES)
 include_HEADERS = $(MODFILES)
 

--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -1,0 +1,98 @@
+#include "config.h"
+!>
+!! @file
+!! Initialization Routines for PIO.
+!!
+!<
+
+!>
+!! @defgroup PIO_ncint NetCDF Integration
+!! Integrate netCDF and PIO code.
+!!
+module ncint_mod
+  use iso_c_binding
+  !--------------
+  use pio_kinds
+  !--------------
+  use pio_types, only : file_desc_t, iosystem_desc_t, var_desc_t, io_desc_t, &
+       pio_iotype_netcdf, pio_iotype_pnetcdf, pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
+       pio_noerr, pio_rearr_subset, pio_rearr_opt_t
+  !--------------
+  use pio_support, only : piodie, debug, debugio, debugasync, checkmpireturn
+  use pio_nf, only : pio_set_log_level
+  use piolib_mod, only : pio_init
+  !
+
+#ifdef TIMING
+  use perf_mod, only : t_startf, t_stopf     ! _EXTERNAL
+#endif
+#ifndef NO_MPIMOD
+  use mpi    ! _EXTERNAL
+#endif
+  implicit none
+  private
+#ifdef NO_MPIMOD
+  include 'mpif.h'    ! _EXTERNAL
+#endif
+  ! !public member functions:
+
+  public :: nf_init_intracom
+
+  interface nf_init_intracom
+     module procedure nf_init_intracom
+  end interface nf_init_intracom
+
+contains
+
+  !>
+  !! @public
+  !! @ingroup PIO_init
+  !! Initialize the pio subsystem. This is a collective call. Input
+  !! parameters are read on comp_rank=0 values on other tasks are
+  !! ignored. This variation of PIO_init locates the IO tasks on a
+  !! subset of the compute tasks.
+  !!
+  !! @param comp_rank mpi rank of each participating task,
+  !! @param comp_comm the mpi communicator which defines the
+  !! collective.
+  !! @param num_iotasks the number of iotasks to define.
+  !! @param num_aggregator the mpi aggregator count
+  !! @param stride the stride in the mpi rank between io tasks.
+  !! @param rearr @copydoc PIO_rearr_method
+  !! @param iosystem a derived type which can be used in subsequent
+  !! pio operations (defined in PIO_types).
+  !! @param base @em optional argument can be used to offset the first
+  !! io task - default base is task 1.
+  !! @param rearr_opts the rearranger options.
+  !! @author Ed Hartnett
+  !<
+  subroutine nf_init_intracom(comp_rank, comp_comm, num_iotasks, num_aggregator, stride,  rearr, iosystem,base, rearr_opts)
+    use pio_types, only : pio_internal_error, pio_rearr_opt_t
+    use iso_c_binding
+
+    integer(i4), intent(in) :: comp_rank
+    integer(i4), intent(in) :: comp_comm
+    integer(i4), intent(in) :: num_iotasks
+    integer(i4), intent(in) :: num_aggregator
+    integer(i4), intent(in) :: stride
+    integer(i4), intent(in) :: rearr
+    type (iosystem_desc_t), intent(out)  :: iosystem  ! io descriptor to initalize
+    integer(i4), intent(in),optional :: base
+    type (pio_rearr_opt_t), intent(in), optional :: rearr_opts
+    integer :: ierr
+
+    interface
+       integer(C_INT) function nc_set_iosystem(iosystemid) &
+            bind(C,name="nc_set_iosystem")
+         use iso_c_binding
+         integer(C_INT), intent(in), value :: iosystemid
+       end function nc_set_iosystem
+    end interface
+
+    call PIO_init(comp_rank, comp_comm, num_iotasks, num_aggregator, stride,  rearr, iosystem,base, rearr_opts)
+
+    ierr = nc_set_iosystem(iosystem%iosysid)
+
+  end subroutine nf_init_intracom
+
+end module ncint_mod

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -22,13 +22,11 @@ module pio
        pio_freedecomp, pio_syncfile, &
        pio_finalize, pio_set_hint, pio_getnumiotasks, pio_file_is_open, &
        PIO_deletefile, PIO_get_numiotasks, PIO_iotype_available, &
-!#ifdef NETCDF_INTEGRATION
-!       nf_init_intracom, &
-!#endif
        pio_set_rearr_opts
-! #ifdef NETCDF_INTEGRATION
-!        nf_init_intracom, &
-! #endif
+
+#ifdef NETCDF_INTEGRATION
+  use ncint_mod, only: nf_init_intracom
+#endif
 
   use pio_types, only : io_desc_t, file_desc_t, var_desc_t, iosystem_desc_t, &
        pio_rearr_opt_t, pio_rearr_comm_fc_opt_t, pio_rearr_comm_fc_2d_enable,&

--- a/src/flib/piolib_mod.F90
+++ b/src/flib/piolib_mod.F90
@@ -98,9 +98,6 @@ module piolib_mod
        PIO_deletefile, &
        PIO_get_numiotasks, &
        PIO_iotype_available, &
-#ifdef NETCDF_INTEGRATION
-       nf_init_intracom, &
-#endif
        PIO_set_rearr_opts
 
   !-----------------------------------------------------------------------
@@ -136,12 +133,6 @@ module piolib_mod
   interface PIO_setframe
      module procedure setframe
   end interface PIO_setframe
-
-#ifdef NETCDF_INTEGRATION
-  interface nf_init_intracom
-     module procedure nf_init_intracom
-  end interface nf_init_intracom
-#endif
 
   !>
   !! Increment the record number for a future read/write of distributed
@@ -980,59 +971,6 @@ contains
     call t_stopf("PIO:init")
 #endif
   end subroutine init_intracom
-
-#ifdef NETCDF_INTEGRATION
-  !>
-  !! @public
-  !! @ingroup PIO_init
-  !! Initialize the pio subsystem. This is a collective call. Input
-  !! parameters are read on comp_rank=0 values on other tasks are
-  !! ignored. This variation of PIO_init locates the IO tasks on a
-  !! subset of the compute tasks.
-  !!
-  !! @param comp_rank mpi rank of each participating task,
-  !! @param comp_comm the mpi communicator which defines the
-  !! collective.
-  !! @param num_iotasks the number of iotasks to define.
-  !! @param num_aggregator the mpi aggregator count
-  !! @param stride the stride in the mpi rank between io tasks.
-  !! @param rearr @copydoc PIO_rearr_method
-  !! @param iosystem a derived type which can be used in subsequent
-  !! pio operations (defined in PIO_types).
-  !! @param base @em optional argument can be used to offset the first
-  !! io task - default base is task 1.
-  !! @param rearr_opts the rearranger options.
-  !! @author Jim Edwards
-  !<
-  subroutine nf_init_intracom(comp_rank, comp_comm, num_iotasks, num_aggregator, stride,  rearr, iosystem,base, rearr_opts)
-    use pio_types, only : pio_internal_error, pio_rearr_opt_t
-    use iso_c_binding
-
-    integer(i4), intent(in) :: comp_rank
-    integer(i4), intent(in) :: comp_comm
-    integer(i4), intent(in) :: num_iotasks
-    integer(i4), intent(in) :: num_aggregator
-    integer(i4), intent(in) :: stride
-    integer(i4), intent(in) :: rearr
-    type (iosystem_desc_t), intent(out)  :: iosystem  ! io descriptor to initalize
-    integer(i4), intent(in),optional :: base
-    type (pio_rearr_opt_t), intent(in), optional :: rearr_opts
-    integer :: ierr
-
-    interface
-       integer(C_INT) function nc_set_iosystem(iosystemid) &
-            bind(C,name="nc_set_iosystem")
-         use iso_c_binding
-         integer(C_INT), intent(in), value :: iosystemid
-       end function nc_set_iosystem
-    end interface
-
-    call init_intracom(comp_rank, comp_comm, num_iotasks, num_aggregator, stride,  rearr, iosystem,base, rearr_opts)
-
-    ierr = nc_set_iosystem(iosystem%iosysid)
-
-  end subroutine nf_init_intracom
-#endif
 
   !! @public
   !! @ingroup PIO_init


### PR DESCRIPTION
Part of #1555.

In this PR I move the netcdf integration code in Fortran out of piolib_mod.F90 and into new file ncint_mod.F90. This allows the code for the new nf_ functions to be kept separate from the rest of the PIO functions, which all start with PIO_.