### PR TITLE
getting nf_free_iosystem working in fortran API

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1250,7 +1250,12 @@ extern "C" {
     int nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
                           int *iosysidp);
 
+    /* Set the default IOsystem ID. */
     int nc_set_iosystem(int iosysid);
+
+    /* Get the default IOsystem ID. */
+    int nc_get_iosystem(int *iosysid);
+
     int nc_free_iosystem(int iosysid);
 
     int nc_init_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen,

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -87,7 +87,8 @@ PIOc_strerror(int pioerr, char *errmsg)
     PLOG((1, "PIOc_strerror pioerr = %d", pioerr));
 
     /* Caller must provide this. */
-    pioassert(errmsg, "pointer to errmsg string must be provided", __FILE__, __LINE__);
+    pioassert(errmsg, "pointer to errmsg string must be provided", __FILE__,
+              __LINE__);
 
     /* System error? NetCDF and pNetCDF errors are always negative. */
     if (pioerr > 0)

--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -91,14 +91,14 @@ contains
 
     interface
        integer(C_INT) function nc_set_iosystem(iosystemid) &
-            bind(C,name="nc_set_iosystem")
+            bind(C, name="nc_set_iosystem")
          use iso_c_binding
          integer(C_INT), intent(in), value :: iosystemid
        end function nc_set_iosystem
     end interface
 
     call PIO_init(comp_rank, comp_comm, num_iotasks, num_aggregator, &
-         stride,  rearr, iosystem, base, rearr_opts)
+         stride, rearr, iosystem, base, rearr_opts)
 
     ierr = nc_set_iosystem(iosystem%iosysid)
 
@@ -115,13 +115,13 @@ contains
   !<
   subroutine nf_free_iosystem()
     integer(i4) :: ierr
-    integer(i4) :: iosysid = 0;
+    integer(i4) :: iosysid;
 
     interface
        integer(C_INT) function nc_get_iosystem(iosysid) &
             bind(C, name="nc_get_iosystem")
          use iso_c_binding
-         integer(C_INT), intent(in), value :: iosysid
+         integer(C_INT), intent(out) :: iosysid
        end function nc_get_iosystem
     end interface
 

--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -113,10 +113,28 @@ contains
   !! @retval ierr @copydoc error_return
   !! @author Ed Hartnett
   !<
-  subroutine nf_free_iosystem(iosystem, ierr)
-    type (iosystem_desc_t), intent(inout) :: iosystem
-    integer(i4), intent(out) :: ierr
-    call PIO_finalize(iosystem, ierr)
+  subroutine nf_free_iosystem()
+    integer(i4) :: ierr
+    integer(i4) :: iosysid = 0;
+
+    interface
+       integer(C_INT) function nc_get_iosystem(iosysid) &
+            bind(C, name="nc_get_iosystem")
+         use iso_c_binding
+         integer(C_INT), intent(in), value :: iosysid
+       end function nc_get_iosystem
+    end interface
+
+    interface
+       integer(C_INT) function PIOc_finalize(iosysid) &
+            bind(C, name="PIOc_finalize")
+         use iso_c_binding
+         integer(C_INT), intent(in), value :: iosysid
+       end function PIOc_finalize
+    end interface
+
+    ierr = nc_get_iosystem(iosysid)
+    ierr = PIOc_finalize(iosysid)
   end subroutine nf_free_iosystem
 
 end module ncint_mod

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -25,7 +25,7 @@ module pio
        pio_set_rearr_opts
 
 #ifdef NETCDF_INTEGRATION
-  use ncint_mod, only: nf_init_intracom
+  use ncint_mod, only: nf_init_intracom, nf_free_iosystem
 #endif
 
   use pio_types, only : io_desc_t, file_desc_t, var_desc_t, iosystem_desc_t, &

--- a/src/ncint/ncint_pio.c
+++ b/src/ncint/ncint_pio.c
@@ -41,6 +41,9 @@ nc_init_intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int
 /**
  * Set the default iosystemID.
  *
+ * @param iosysid The IO system ID to set.
+ *
+ * @return PIO_NOERR for success.
  * @author Ed Hartnett
  */
 int
@@ -48,6 +51,26 @@ nc_set_iosystem(int iosysid)
 {
     /* Remember the io system id. */
     diosysid = iosysid;
+
+    return PIO_NOERR;
+}
+
+/**
+ * Get the default iosystemID.
+ *
+ * @param iosysid Pointer that gets The IO system ID.
+ *
+ * @return PIO_NOERR for success.
+ * @author Ed Hartnett
+ */
+int
+nc_get_iosystem(int *iosysid)
+{
+    pioassert(iosysid, "pointer to iosysid must be provided", __FILE__,
+              __LINE__);
+
+    /* Remember the io system id. */
+    *iosysid = diosysid;
 
     return PIO_NOERR;
 }

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -27,7 +27,7 @@ program ftst_pio
   ierr = nf_create(FILE_NAME, 64, ncid)
   ierr = nf_close(ncid)
 
-  call PIO_finalize(ioSystem, ierr)
+  call nf_free_iosystem()
   call MPI_Finalize(ierr)
   if (myRank .eq. 0) then
      print *, '*** SUCCESS running ftst_pio!'

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -37,6 +37,16 @@ main(int argc, char **argv)
     if (MPI_Comm_size(MPI_COMM_WORLD, &ntasks)) ERR;
 
     printf("\n*** Testing netCDF integration layer.\n");
+    printf("*** testing getting/setting of default iosystemid...");
+    {
+        int iosysid;
+
+        if (nc_set_iosystem(TEST_VAL_42)) ERR;
+        if (nc_get_iosystem(&iosysid)) ERR;
+        if (iosysid != TEST_VAL_42) ERR;
+    }
+    SUMMARIZE_ERR;
+
     printf("*** testing simple use of netCDF integration layer format...");
     {
         int ncid, ioid;


### PR DESCRIPTION
Part of #1555.

Getting nf_free_iosystem() to work better.