### PR TITLE
converted nf_ procedures into functions

### DIFF
--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -34,20 +34,8 @@ module ncint_mod
 #ifdef NO_MPIMOD
   include 'mpif.h'    ! _EXTERNAL
 #endif
-  ! !public member functions:
 
   public :: nf_init_intracom, nf_free_iosystem
-
-  interface nf_init_intracom
-     module procedure nf_init_intracom
-  end interface nf_init_intracom
-
-  !>
-  !! Shuts down an IOSystem and associated resources.
-  !<
-  interface nf_free_iosystem
-     module procedure nf_free_iosystem
-  end interface nf_free_iosystem
 
 contains
 
@@ -113,9 +101,10 @@ contains
   !! @retval ierr @copydoc error_return
   !! @author Ed Hartnett
   !<
-  subroutine nf_free_iosystem()
+  function nf_free_iosystem() result(status)
     integer(i4) :: ierr
     integer(i4) :: iosysid;
+    integer :: status
 
     interface
        integer(C_INT) function nc_get_iosystem(iosysid) &
@@ -135,6 +124,7 @@ contains
 
     ierr = nc_get_iosystem(iosysid)
     ierr = PIOc_finalize(iosysid)
-  end subroutine nf_free_iosystem
+    status = ierr
+  end function nf_free_iosystem
 
 end module ncint_mod

--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -61,8 +61,8 @@ contains
   !! @param rearr_opts the rearranger options.
   !! @author Ed Hartnett
   !<
-  subroutine nf_init_intracom(comp_rank, comp_comm, num_iotasks, &
-       num_aggregator, stride,  rearr, iosystem, base, rearr_opts)
+  function nf_init_intracom(comp_rank, comp_comm, num_iotasks, &
+       num_aggregator, stride,  rearr, iosystem, base, rearr_opts) result(ierr)
     use pio_types, only : pio_internal_error, pio_rearr_opt_t
     use iso_c_binding
 
@@ -90,7 +90,7 @@ contains
 
     ierr = nc_set_iosystem(iosystem%iosysid)
 
-  end subroutine nf_init_intracom
+  end function nf_init_intracom
 
   !>
   !! @public

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -27,7 +27,7 @@ program ftst_pio
   ierr = nf_create(FILE_NAME, 64, ncid)
   ierr = nf_close(ncid)
 
-  call nf_free_iosystem()
+  ierr = nf_free_iosystem()
   call MPI_Finalize(ierr)
   if (myRank .eq. 0) then
      print *, '*** SUCCESS running ftst_pio!'

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -21,7 +21,7 @@ program ftst_pio
 
   ierr = pio_set_log_level(2)
   ierr = nf_set_log_level(2)
-  call nf_init_intracom(myRank, MPI_COMM_WORLD, niotasks, numAggregator, &
+  ierr = nf_init_intracom(myRank, MPI_COMM_WORLD, niotasks, numAggregator, &
        stride, PIO_rearr_subset, ioSystem, base)
 
   ierr = nf_create(FILE_NAME, 64, ncid)


### PR DESCRIPTION
Part of #1555.

To match the netCDF Fortran 77 api, all nf_* calls should be functions that return an integer. In this PR I convert nf_init_intracom and nf_free_iosystem to functions.