### PR TITLE
nf_def_decomp() added to fortran API in support of netcdf integration

### DIFF
--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -173,18 +173,21 @@ contains
   !! @author Jim Edwards
   !<
   function nf_def_decomp(iosystem, basepiotype, dims, compdof, &
-       iodesc, rearr, iostart, iocount) result(status)
+       decompid, rearr, iostart, iocount) result(status)
     type (iosystem_desc_t), intent(in) :: iosystem
     integer(i4), intent(in) :: basepiotype
     integer(i4), intent(in) :: dims(:)
     integer (PIO_OFFSET_KIND), intent(in) :: compdof(:)
     integer, optional, target :: rearr
     integer (PIO_OFFSET_KIND), optional :: iostart(:), iocount(:)
-    type (io_desc_t), intent(inout) :: iodesc
+    integer(i4), intent(inout) :: decompid
+    type (io_desc_t) :: iodesc
     integer :: status
 
     call PIO_initdecomp(iosystem, basepiotype, dims, compdof, &
          iodesc, rearr, iostart, iocount)
+    decompid = iodesc%ioid
+
     status = 0
   end function nf_def_decomp
 

--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -15,12 +15,10 @@
 module ncint_mod
   use iso_c_binding
   use pio_kinds
-  use pio_types, only : file_desc_t, iosystem_desc_t, var_desc_t, io_desc_t, &
-       pio_iotype_netcdf, pio_iotype_pnetcdf, pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
-       pio_noerr, pio_rearr_subset, pio_rearr_opt_t
+  use pio_types
   use pio_support, only : piodie, debug, debugio, debugasync, checkmpireturn
   use pio_nf, only : pio_set_log_level
-  use piolib_mod, only : pio_init, pio_finalize
+  use piolib_mod, only : pio_init, pio_finalize, pio_initdecomp
 
 #ifndef NO_MPIMOD
   use mpi    ! _EXTERNAL
@@ -31,7 +29,7 @@ module ncint_mod
   include 'mpif.h'    ! _EXTERNAL
 #endif
 
-  public :: nf_def_iosystem, nf_free_iosystem, nf_free_decomp
+  public :: nf_def_iosystem, nf_free_iosystem, nf_def_decomp, nf_free_decomp
 
 contains
 
@@ -150,36 +148,44 @@ contains
     status = ierr
   end function nf_free_decomp
 
-  ! !>
-  ! !! @public
-  ! !! @ingroup ncint
-  ! !! Implements the block-cyclic decomposition for PIO_initdecomp.
-  ! !! This provides the ability to describe a computational
-  ! !! decomposition in PIO that has a block-cyclic form. That is
-  ! !! something that can be described using start and count arrays.
-  ! !! Optional parameters for this subroutine allows for the
-  ! !! specification of io decomposition using iostart and iocount
-  ! !! arrays. If iostart and iocount arrays are not specified by the
-  ! !! user, and rearrangement is turned on then PIO will calculate a
-  ! !! suitable IO decomposition
-  ! !!
-  ! !! @param iosystem @copydoc iosystem_desc_t
-  ! !! @param basepiotype @copydoc use_PIO_kinds
-  ! !! @param dims An array of the global length of each dimesion of the
-  ! !! variable(s)
-  ! !! @param compstart The start index into the block-cyclic
-  ! !! computational decomposition
-  ! !! @param compcount The count for the block-cyclic computational
-  ! !! decomposition
-  ! !! @param iodesc @copydoc iodesc_generate
-  ! !! @author Jim Edwards
-  ! !<
-  ! function nf_init_decomp(iosystem,basepiotype,dims,compstart,compcount,iodesc)
-  !   type (iosystem_desc_t), intent(inout) :: iosystem
-  !   integer(i4), intent(in)               :: basepiotype
-  !   integer(i4), intent(in)               :: dims(:)
-  !   integer (kind=PIO_OFFSET_KIND)             :: compstart(:)
-  !   integer (kind=PIO_OFFSET_KIND)             :: compcount(:)
-  !   type (IO_desc_t), intent(out)         :: iodesc
+  !>
+  !! @public
+  !! @ingroup ncint
+  !! Implements the block-cyclic decomposition for PIO_initdecomp.
+  !! This provides the ability to describe a computational
+  !! decomposition in PIO that has a block-cyclic form. That is
+  !! something that can be described using start and count arrays.
+  !! Optional parameters for this subroutine allows for the
+  !! specification of io decomposition using iostart and iocount
+  !! arrays. If iostart and iocount arrays are not specified by the
+  !! user, and rearrangement is turned on then PIO will calculate a
+  !! suitable IO decomposition
+  !!
+  !! @param iosystem @copydoc iosystem_desc_t
+  !! @param basepiotype @copydoc use_PIO_kinds
+  !! @param dims An array of the global length of each dimesion of the
+  !! variable(s)
+  !! @param compstart The start index into the block-cyclic
+  !! computational decomposition
+  !! @param compcount The count for the block-cyclic computational
+  !! decomposition
+  !! @param iodesc @copydoc iodesc_generate
+  !! @author Jim Edwards
+  !<
+  function nf_def_decomp(iosystem, basepiotype, dims, compdof, &
+       iodesc, rearr, iostart, iocount) result(status)
+    type (iosystem_desc_t), intent(in) :: iosystem
+    integer(i4), intent(in) :: basepiotype
+    integer(i4), intent(in) :: dims(:)
+    integer (PIO_OFFSET_KIND), intent(in) :: compdof(:)
+    integer, optional, target :: rearr
+    integer (PIO_OFFSET_KIND), optional :: iostart(:), iocount(:)
+    type (io_desc_t), intent(inout) :: iodesc
+    integer :: status
+
+    call PIO_initdecomp(iosystem, basepiotype, dims, compdof, &
+         iodesc, rearr, iostart, iocount)
+    status = 0
+  end function nf_def_decomp
 
   end module ncint_mod

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -25,7 +25,8 @@ module pio
        pio_set_rearr_opts
 
 #ifdef NETCDF_INTEGRATION
-  use ncint_mod, only: nf_def_iosystem, nf_free_iosystem, nf_free_decomp
+  use ncint_mod, only: nf_def_iosystem, nf_free_iosystem, &
+       nf_def_decomp, nf_free_decomp
 #endif
 
   use pio_types, only : io_desc_t, file_desc_t, var_desc_t, iosystem_desc_t, &

--- a/src/flib/piolib_mod.F90
+++ b/src/flib/piolib_mod.F90
@@ -879,7 +879,8 @@ contains
   !! @ingroup PIO_initdecomp
   !! I8 version of PIO_initdecomp_dof_i4.
   !! @author Jim Edwards
-  subroutine PIO_initdecomp_dof_i8(iosystem,basepiotype,dims,compdof, iodesc, rearr, iostart, iocount)
+  subroutine PIO_initdecomp_dof_i8(iosystem, basepiotype, dims, compdof, &
+       iodesc, rearr, iostart, iocount)
     type (iosystem_desc_t), intent(in) :: iosystem
     integer(i4), intent(in)           :: basepiotype
     integer(i4), intent(in)           :: dims(:)
@@ -895,7 +896,8 @@ contains
 
     maplen = size(compdof)
 
-    call PIO_initdecomp_internal(iosystem, basepiotype, dims, maplen, compdof, iodesc, rearr, iostart,iocount)
+    call PIO_initdecomp_internal(iosystem, basepiotype, dims, maplen, &
+         compdof, iodesc, rearr, iostart, iocount)
 
 #ifdef TIMING
     call t_stopf("PIO:initdecomp_dof")

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -13,7 +13,7 @@ program ftst_pio
   integer :: ncid
   character*(*) FILE_NAME
   parameter (FILE_NAME='ftst_pio.nc')
-  integer, dimension(3) :: data_buffer, compdof
+  integer(kind=PIO_OFFSET_KIND), dimension(3) :: data_buffer, compdof
   integer, dimension(1) :: dims
   type(io_desc_t) :: iodesc
   integer :: decompid
@@ -35,7 +35,7 @@ program ftst_pio
   ! Define a decomposition.
   dims(1) = 3 * ntasks
   compdof = 3 * myRank + (/1, 2, 3/)  ! Where in the global array each task writes
-  call PIO_initdecomp(ioSystem, PIO_int, dims, compdof, iodesc)
+  ierr = nf_def_decomp(ioSystem, PIO_int, dims, compdof, iodesc)
   decompid = iodesc%ioid
 
   ! Create a file.
@@ -48,7 +48,6 @@ program ftst_pio
 
   ! Free resources.
   ierr = nf_free_decomp(decompid)
-!  call PIO_freedecomp(ioSystem, iodesc_nCells)
   ierr = nf_free_iosystem()
 
   ! We're done!

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -1,5 +1,5 @@
-  !> This is a test program for the Fortran API use of the netCDF
-  !! integration layer.
+!> This is a test program for the Fortran API use of the netCDF
+!! integration layer.
 
 program ftst_pio
   use pio
@@ -15,7 +15,6 @@ program ftst_pio
   parameter (FILE_NAME='ftst_pio.nc')
   integer(kind=PIO_OFFSET_KIND), dimension(3) :: data_buffer, compdof
   integer, dimension(1) :: dims
-  type(io_desc_t) :: iodesc
   integer :: decompid
   integer :: ierr
 
@@ -35,8 +34,7 @@ program ftst_pio
   ! Define a decomposition.
   dims(1) = 3 * ntasks
   compdof = 3 * myRank + (/1, 2, 3/)  ! Where in the global array each task writes
-  ierr = nf_def_decomp(ioSystem, PIO_int, dims, compdof, iodesc)
-  decompid = iodesc%ioid
+  ierr = nf_def_decomp(ioSystem, PIO_int, dims, compdof, decompid)
 
   ! Create a file.
   ierr = nf_create(FILE_NAME, 64, ncid)


### PR DESCRIPTION
Part of #1555.
nf_def_decomp() added to fortran API in support of netcdf integration.

