### PR TITLE
starting to get nf_put_vard_* functions working

### DIFF
--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -170,11 +170,11 @@ contains
   !! @param compcount The count for the block-cyclic computational
   !! decomposition
   !! @param iodesc @copydoc iodesc_generate
-  !! @author Jim Edwards
+  !! @author Ed Hartnett
   !<
-  function nf_def_decomp(iosystem, basepiotype, dims, compdof, &
+  function nf_def_decomp(iosysid, basepiotype, dims, compdof, &
        decompid, rearr, iostart, iocount) result(status)
-    type (iosystem_desc_t), intent(in) :: iosystem
+    integer(i4), intent(in) :: iosysid
     integer(i4), intent(in) :: basepiotype
     integer(i4), intent(in) :: dims(:)
     integer (PIO_OFFSET_KIND), intent(in) :: compdof(:)
@@ -182,8 +182,10 @@ contains
     integer (PIO_OFFSET_KIND), optional :: iostart(:), iocount(:)
     integer(i4), intent(inout) :: decompid
     type (io_desc_t) :: iodesc
+    type (iosystem_desc_t) :: iosystem
     integer :: status
 
+    iosystem%iosysid = iosysid
     call PIO_initdecomp(iosystem, basepiotype, dims, compdof, &
          iodesc, rearr, iostart, iocount)
     decompid = iodesc%ioid

--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -48,15 +48,14 @@ contains
   !! @param num_aggregator the mpi aggregator count
   !! @param stride the stride in the mpi rank between io tasks.
   !! @param rearr @copydoc PIO_rearr_method
-  !! @param iosystem a derived type which can be used in subsequent
-  !! pio operations (defined in PIO_types).
+  !! @param iosysid the ID of the IOSystem.
   !! @param base @em optional argument can be used to offset the first
   !! io task - default base is task 1.
   !! @param rearr_opts the rearranger options.
   !! @author Ed Hartnett
   !<
   function nf_def_iosystem(comp_rank, comp_comm, num_iotasks, &
-       num_aggregator, stride,  rearr, iosystem, base, rearr_opts) result(ierr)
+       num_aggregator, stride,  rearr, iosysid, base, rearr_opts) result(ierr)
     use pio_types, only : pio_internal_error, pio_rearr_opt_t
     use iso_c_binding
 
@@ -66,9 +65,10 @@ contains
     integer(i4), intent(in) :: num_aggregator
     integer(i4), intent(in) :: stride
     integer(i4), intent(in) :: rearr
-    type (iosystem_desc_t), intent(out)  :: iosystem  ! io descriptor to initalize
+    integer(i4), intent(out) :: iosysid
     integer(i4), intent(in),optional :: base
     type (pio_rearr_opt_t), intent(in), optional :: rearr_opts
+    type (iosystem_desc_t) :: iosystem
     integer :: ierr
 
     interface
@@ -82,7 +82,8 @@ contains
     call PIO_init(comp_rank, comp_comm, num_iotasks, num_aggregator, &
          stride, rearr, iosystem, base, rearr_opts)
 
-    ierr = nc_set_iosystem(iosystem%iosysid)
+    iosysid = iosystem%iosysid
+    ierr = nc_set_iosystem(iosysid)
 
   end function nf_def_iosystem
 

--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -29,7 +29,8 @@ module ncint_mod
   include 'mpif.h'    ! _EXTERNAL
 #endif
 
-  public :: nf_def_iosystem, nf_free_iosystem, nf_def_decomp, nf_free_decomp
+  public :: nf_def_iosystem, nf_free_iosystem, nf_def_decomp, nf_free_decomp, &
+       nf_put_vard_int
 
 contains
 
@@ -214,20 +215,23 @@ contains
     use iso_c_binding
     integer, intent(in):: ncid, varid, decompid, recnum
     integer, intent(in):: ivals(*)
+    integer(c_int64_t):: lrecnum
     integer(c_int):: ierr
     integer:: status
 
     interface
-       function nc_put_vard_int(ncid, varid, decompid, recnum, op) bind(c)
+       function nc_put_vard_int(ncid, varid, decompid, lrecnum, op) bind(c)
          use iso_c_binding
          integer(c_int), value, intent(in) :: ncid, varid, decompid
-         integer(c_int64_t), value, intent(in) :: recnum
+         integer(c_int64_t), value, intent(in) :: lrecnum
          integer(c_int), intent(in) :: op(*)
          integer(c_int) :: nc_put_vard_int
        end function nc_put_vard_int
     end interface
 
-    status = 0
+    lrecnum = recnum - 1 ! c functions are 0-based
+    ierr = nc_put_vard_int(ncid, varid - 1, decompid, lrecnum, ivals)
+    status = ierr
   end function nf_put_vard_int
 
   end module ncint_mod

--- a/src/flib/ncint_mod.F90
+++ b/src/flib/ncint_mod.F90
@@ -194,4 +194,40 @@ contains
     status = 0
   end function nf_def_decomp
 
+  !>
+  !! @public
+  !! @ingroup ncint
+  !! Put distributed array subset of an integer variable.
+  !!
+  !! This routine is called collectively by all tasks in the
+  !! communicator ios.union_comm.
+  !!
+  !! @param ncid identifies the netCDF file
+  !! @param varid the variable ID number
+  !! @param decompid the decomposition ID.
+  !! @param recnum the record number.
+  !! @param op pointer to the data to be written.
+  !! @return PIO_NOERR on success, error code otherwise.
+  !! @author Ed Hartnett
+  !<
+  function nf_put_vard_int(ncid, varid, decompid, recnum, ivals) result(status)
+    use iso_c_binding
+    integer, intent(in):: ncid, varid, decompid, recnum
+    integer, intent(in):: ivals(*)
+    integer(c_int):: ierr
+    integer:: status
+
+    interface
+       function nc_put_vard_int(ncid, varid, decompid, recnum, op) bind(c)
+         use iso_c_binding
+         integer(c_int), value, intent(in) :: ncid, varid, decompid
+         integer(c_int64_t), value, intent(in) :: recnum
+         integer(c_int), intent(in) :: op(*)
+         integer(c_int) :: nc_put_vard_int
+       end function nc_put_vard_int
+    end interface
+
+    status = 0
+  end function nf_put_vard_int
+
   end module ncint_mod

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -26,7 +26,7 @@ module pio
 
 #ifdef NETCDF_INTEGRATION
   use ncint_mod, only: nf_def_iosystem, nf_free_iosystem, &
-       nf_def_decomp, nf_free_decomp
+       nf_def_decomp, nf_free_decomp, nf_put_vard_int
 #endif
 
   use pio_types, only : io_desc_t, file_desc_t, var_desc_t, iosystem_desc_t, &

--- a/src/ncint/nc_put_vard.c
+++ b/src/ncint/nc_put_vard.c
@@ -1,11 +1,11 @@
 /**
-  * @file
-  * PIO functions to write data with distributed arrays.
-  *
-  * @author Ed Hartnett
-  * @date 2019
-  * @see https://github.com/NCAR/ParallelIO
-  */
+ * @file
+ * PIO functions to write data with distributed arrays.
+ *
+ * @author Ed Hartnett
+ * @date 2019
+ * @see https://github.com/NCAR/ParallelIO
+ */
 #include <config.h>
 #include <pio.h>
 #include <pio_internal.h>
@@ -32,7 +32,7 @@
  */
 int
 nc_put_vard_text(int ncid, int varid, int decompid, const size_t recnum,
-                   const char *op)
+                 const char *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_CHAR, op);
 }
@@ -53,7 +53,7 @@ nc_put_vard_text(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
-                    const unsigned char *op)
+                  const unsigned char *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_UBYTE, op);
 }
@@ -74,7 +74,7 @@ nc_put_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
-                    const signed char *op)
+                  const signed char *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_BYTE, op);
 }
@@ -96,7 +96,7 @@ nc_put_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
-                     const unsigned short *op)
+                   const unsigned short *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_USHORT, op);
 }
@@ -117,7 +117,7 @@ nc_put_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_short(int ncid, int varid, int decompid, const size_t recnum,
-                    const short *op)
+                  const short *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_SHORT, op);
 }
@@ -139,7 +139,7 @@ nc_put_vard_short(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
-                   const unsigned int *op)
+                 const unsigned int *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_UINT, op);
 }
@@ -160,7 +160,7 @@ nc_put_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_int(int ncid, int varid, int decompid, const size_t recnum,
-                  const int *op)
+                const int *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_INT, op);
 }
@@ -202,7 +202,7 @@ nc_put_vard_int(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_float(int ncid, int varid, int decompid, const size_t recnum,
-                    const float *op)
+                  const float *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_FLOAT, op);
 }
@@ -224,7 +224,7 @@ nc_put_vard_float(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
-                       const long long *op)
+                     const long long *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_INT64, op);
 }
@@ -246,7 +246,7 @@ nc_put_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_double(int ncid, int varid, int decompid, const size_t recnum,
-                     const double *op)
+                   const double *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_DOUBLE, op);
 }
@@ -268,7 +268,7 @@ nc_put_vard_double(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
-                        const unsigned long long *op)
+                      const unsigned long long *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_UINT64, op);
 }
@@ -289,7 +289,7 @@ nc_put_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
  */
 int
 nc_put_vard(int ncid, int varid, int decompid, const size_t recnum,
-              const void *op)
+            const void *op)
 {
     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_NAT, op);
 }

--- a/tests/fncint/Makefile.am
+++ b/tests/fncint/Makefile.am
@@ -13,8 +13,9 @@ LDADD += -lnetcdff
 AM_FCFLAGS = -I${top_builddir}/src/flib ${CPPFLAGS}
 
 # Build the test for make check.
-check_PROGRAMS = ftst_pio
+check_PROGRAMS = ftst_pio ftst_pio_orig
 ftst_pio_SOURCES = ftst_pio.f90
+ftst_pio_orig_SOURCES = ftst_pio_orig.f90
 
 if RUN_TESTS
 # Tests will run from a bash script.

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -68,10 +68,13 @@ program ftst_pio
   if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! Define a data variable.
-  ierr = nf_def_var(ncid, VAR_NAME, NF_REAL, NDIM3, var_dim, varid)
+  ierr = nf_def_var(ncid, VAR_NAME, NF_INT, NDIM3, var_dim, varid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  ierr = nf_enddef(ncid)
   if (ierr .ne. nf_noerr) call handle_err(ierr)
 
-  ierr = nf_enddef(ncid)
+  ! Write 1st record with distributed arrays.
+  ierr = nf_put_vard_int(ncid, varid, decompid, 1, data_buffer)
   if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! Close the file.

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -11,15 +11,16 @@ program ftst_pio
 
   character*(*) FILE_NAME
   parameter (FILE_NAME = 'ftst_pio.nc')
-  integer :: NDIM3 = 3, NRECS = 2, NLAT = 6, NLON = 12
+  integer :: NDIM3 = 3, NRECS = 2, NLAT = 4, NLON = 4
   character*(*) LAT_NAME, LON_NAME, REC_NAME, VAR_NAME
   parameter (LAT_NAME = 'latitude', LON_NAME = 'longitude', &
        REC_NAME = 'time', VAR_NAME = 'some_data_var')
   integer :: myRank, ntasks
   integer :: niotasks = 1, numAggregator = 0, stride = 1, base = 0
   integer :: ncid
-  integer(kind = PIO_OFFSET_KIND), dimension(3) :: data_buffer, compdof
-  integer, dimension(1) :: dims
+  integer(kind = PIO_OFFSET_KIND), dimension(3) :: data_buffer
+  integer(kind = PIO_OFFSET_KIND), dimension(1) :: compdof
+  integer, dimension(2) :: dims
   integer, dimension(3) :: var_dim
   integer :: decompid, iosysid
   integer :: varid
@@ -40,9 +41,10 @@ program ftst_pio
        stride, PIO_rearr_subset, iosysid, base)
   if (ierr .ne. nf_noerr) call handle_err(ierr)
 
-  ! Define a decomposition.
-  dims(1) = 3 * ntasks
-  compdof = 3 * myRank + (/1, 2, 3/)  ! Where in the global array each task writes
+  ! Define a 2D decomposition.
+  dims(1) = NLAT / ntasks
+  dims(2) = NLON / ntasks
+  compdof(1) = myRank
   ierr = nf_def_decomp(iosysid, PIO_int, dims, compdof, decompid)
   if (ierr .ne. nf_noerr) call handle_err(ierr)
 

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -15,7 +15,7 @@ program ftst_pio
   parameter (FILE_NAME='ftst_pio.nc')
   integer(kind=PIO_OFFSET_KIND), dimension(3) :: data_buffer, compdof
   integer, dimension(1) :: dims
-  integer :: decompid
+  integer :: decompid, iosysid
   integer :: ierr
 
   ! Set up MPI.
@@ -34,7 +34,7 @@ program ftst_pio
   ! Define a decomposition.
   dims(1) = 3 * ntasks
   compdof = 3 * myRank + (/1, 2, 3/)  ! Where in the global array each task writes
-  ierr = nf_def_decomp(ioSystem, PIO_int, dims, compdof, decompid)
+  ierr = nf_def_decomp(ioSystem%iosysid, PIO_int, dims, compdof, decompid)
 
   ! Create a file.
   ierr = nf_create(FILE_NAME, 64, ncid)

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -9,22 +9,20 @@ program ftst_pio
   include 'mpif.h'
   include 'netcdf.inc'
 
+  character*(*) FILE_NAME
+  parameter (FILE_NAME = 'ftst_pio.nc')
+  integer :: NDIM3 = 3, NRECS = 2, NLAT = 6, NLON = 12
+  character*(*) LAT_NAME, LON_NAME, REC_NAME, VAR_NAME
+  parameter (LAT_NAME = 'latitude', LON_NAME = 'longitude', &
+       REC_NAME = 'time', VAR_NAME = 'some_data_var')
   integer :: myRank, ntasks
   integer :: niotasks = 1, numAggregator = 0, stride = 1, base = 0
   integer :: ncid
-  character*(*) FILE_NAME
-  parameter (FILE_NAME = 'ftst_pio.nc')
   integer(kind = PIO_OFFSET_KIND), dimension(3) :: data_buffer, compdof
   integer, dimension(1) :: dims
-  integer, dimension(3) :: var_dims
+  integer, dimension(3) :: var_dim
   integer :: decompid, iosysid
-  integer :: NDIMS, NRECS
-  parameter (NDIMS = 4, NRECS = 2)
-  integer NLATS, NLONS
-  parameter (NLATS = 6, NLONS = 12)
-  character*(*) LAT_NAME, LON_NAME, REC_NAME
-  parameter (LAT_NAME = 'latitude', LON_NAME = 'longitude', REC_NAME = 'time')
-  integer :: lon_dimid, lat_dimid, rec_dimid
+  integer :: varid
   integer :: ierr
 
   ! Set up MPI.
@@ -53,14 +51,22 @@ program ftst_pio
   if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! Define dimensions.
-  ierr = nf_def_dim(ncid, LAT_NAME, NLATS, lat_dimid)
+  ierr = nf_def_dim(ncid, LAT_NAME, NLAT, var_dim(1))
   if (ierr .ne. nf_noerr) call handle_err(ierr)
-  ierr = nf_def_dim(ncid, LON_NAME, NLONS, lon_dimid)
+  ierr = nf_def_dim(ncid, LON_NAME, NLON, var_dim(2))
   if (ierr .ne. nf_noerr) call handle_err(ierr)
-  ierr = nf_def_dim(ncid, REC_NAME, NF_UNLIMITED, rec_dimid)
+  ierr = nf_def_dim(ncid, REC_NAME, NF_UNLIMITED, var_dim(3))
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Define a data variable.
+  ierr = nf_def_var(ncid, VAR_NAME, NF_REAL, NDIM3, var_dim, varid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ierr = nf_enddef(ncid)
   if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   data_buffer = myRank
+
 
   ! Close the file.
   ierr = nf_close(ncid)

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -18,8 +18,8 @@ program ftst_pio
   integer :: my_rank, ntasks
   integer :: niotasks = 1, numAggregator = 0, stride = 1, base = 0
   integer :: ncid
-  integer(kind = PIO_OFFSET_KIND), dimension(3) :: data_buffer
   integer(kind = PIO_OFFSET_KIND), dimension(:), allocatable :: compdof
+  integer, dimension(:), allocatable :: data_buffer
   integer, dimension(2) :: dims
   integer, dimension(3) :: var_dim
   integer :: maplen
@@ -47,8 +47,10 @@ program ftst_pio
   dims(2) = NLON / ntasks
   maplen = dims(1) * dims(2)
   allocate(compdof(maplen))
+  allocate(data_buffer(maplen))
   do i = 1, maplen
      compdof(i) = i + (my_rank - 1) * maplen
+     data_buffer(i) = (my_rank - 1) * 10 + i
   end do
   ierr = nf_def_decomp(iosysid, PIO_int, dims, compdof, decompid)
   if (ierr .ne. nf_noerr) call handle_err(ierr)
@@ -72,9 +74,6 @@ program ftst_pio
   ierr = nf_enddef(ncid)
   if (ierr .ne. nf_noerr) call handle_err(ierr)
 
-  data_buffer = my_rank
-
-
   ! Close the file.
   ierr = nf_close(ncid)
   if (ierr .ne. nf_noerr) call handle_err(ierr)
@@ -84,6 +83,8 @@ program ftst_pio
   if (ierr .ne. nf_noerr) call handle_err(ierr)
   ierr = nf_free_iosystem()
   if (ierr .ne. nf_noerr) call handle_err(ierr)
+  deallocate(compdof)
+  deallocate(data_buffer)
 
   ! We're done!
   call MPI_Finalize(ierr)

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -40,28 +40,37 @@ program ftst_pio
   ! Define an IOSystem.
   ierr = nf_def_iosystem(myRank, MPI_COMM_WORLD, niotasks, numAggregator, &
        stride, PIO_rearr_subset, iosysid, base)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! Define a decomposition.
   dims(1) = 3 * ntasks
   compdof = 3 * myRank + (/1, 2, 3/)  ! Where in the global array each task writes
   ierr = nf_def_decomp(iosysid, PIO_int, dims, compdof, decompid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! Create a file.
   ierr = nf_create(FILE_NAME, 64, ncid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! Define dimensions.
   ierr = nf_def_dim(ncid, LAT_NAME, NLATS, lat_dimid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
   ierr = nf_def_dim(ncid, LON_NAME, NLONS, lon_dimid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
   ierr = nf_def_dim(ncid, REC_NAME, NF_UNLIMITED, rec_dimid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   data_buffer = myRank
 
   ! Close the file.
   ierr = nf_close(ncid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! Free resources.
   ierr = nf_free_decomp(decompid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
   ierr = nf_free_iosystem()
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! We're done!
   call MPI_Finalize(ierr)

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -1,5 +1,7 @@
 !> This is a test program for the Fortran API use of the netCDF
 !! integration layer.
+!!
+!! @author Ed Hartnett, 7/19/19
 
 program ftst_pio
   use pio
@@ -8,14 +10,21 @@ program ftst_pio
   include 'netcdf.inc'
 
   integer :: myRank, ntasks
-  type(iosystem_desc_t) :: ioSystem
   integer :: niotasks = 1, numAggregator = 0, stride = 1, base = 0
   integer :: ncid
   character*(*) FILE_NAME
-  parameter (FILE_NAME='ftst_pio.nc')
-  integer(kind=PIO_OFFSET_KIND), dimension(3) :: data_buffer, compdof
+  parameter (FILE_NAME = 'ftst_pio.nc')
+  integer(kind = PIO_OFFSET_KIND), dimension(3) :: data_buffer, compdof
   integer, dimension(1) :: dims
+  integer, dimension(3) :: var_dims
   integer :: decompid, iosysid
+  integer :: NDIMS, NRECS
+  parameter (NDIMS = 4, NRECS = 2)
+  integer NLATS, NLONS
+  parameter (NLATS = 6, NLONS = 12)
+  character*(*) LAT_NAME, LON_NAME, REC_NAME
+  parameter (LAT_NAME = 'latitude', LON_NAME = 'longitude', REC_NAME = 'time')
+  integer :: lon_dimid, lat_dimid, rec_dimid
   integer :: ierr
 
   ! Set up MPI.
@@ -26,6 +35,7 @@ program ftst_pio
   ! These control logging in the PIO and netCDF libraries.
   ierr = pio_set_log_level(3)
   ierr = nf_set_log_level(2)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
 
   ! Define an IOSystem.
   ierr = nf_def_iosystem(myRank, MPI_COMM_WORLD, niotasks, numAggregator, &
@@ -38,6 +48,11 @@ program ftst_pio
 
   ! Create a file.
   ierr = nf_create(FILE_NAME, 64, ncid)
+
+  ! Define dimensions.
+  ierr = nf_def_dim(ncid, LAT_NAME, NLATS, lat_dimid)
+  ierr = nf_def_dim(ncid, LON_NAME, NLONS, lon_dimid)
+  ierr = nf_def_dim(ncid, REC_NAME, NF_UNLIMITED, rec_dimid)
 
   data_buffer = myRank
 
@@ -54,3 +69,12 @@ program ftst_pio
      print *, '*** SUCCESS running ftst_pio!'
   endif
 end program ftst_pio
+
+subroutine handle_err(errcode)
+  implicit none
+  include 'netcdf.inc'
+  integer errcode
+
+  print *, 'Error: ', nf_strerror(errcode)
+  stop 2
+end subroutine handle_err

--- a/tests/fncint/ftst_pio.f90
+++ b/tests/fncint/ftst_pio.f90
@@ -29,12 +29,12 @@ program ftst_pio
 
   ! Define an IOSystem.
   ierr = nf_def_iosystem(myRank, MPI_COMM_WORLD, niotasks, numAggregator, &
-       stride, PIO_rearr_subset, ioSystem, base)
+       stride, PIO_rearr_subset, iosysid, base)
 
   ! Define a decomposition.
   dims(1) = 3 * ntasks
   compdof = 3 * myRank + (/1, 2, 3/)  ! Where in the global array each task writes
-  ierr = nf_def_decomp(ioSystem%iosysid, PIO_int, dims, compdof, decompid)
+  ierr = nf_def_decomp(iosysid, PIO_int, dims, compdof, decompid)
 
   ! Create a file.
   ierr = nf_create(FILE_NAME, 64, ncid)

--- a/tests/fncint/run_tests.sh
+++ b/tests/fncint/run_tests.sh
@@ -10,7 +10,8 @@ trap exit INT TERM
 
 printf 'running Fortran tests for PIO netCDF integration...\n'
 
-PIO_TESTS='ftst_pio'
+#PIO_TESTS='ftst_pio_orig ftst_pio'
+PIO_TESTS='ftst_pio_orig'
 
 success1=true
 for TEST in $PIO_TESTS


### PR DESCRIPTION
Part of #1555.

Changes to the netcdf integration functions in fortran to use IDs instead of custom PIO types iodesc_t and iosystem_t.

Starting to get the vard functions working in the fortran API.