### PR TITLE
must allocate on ioroot for serial io

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -265,7 +265,7 @@ PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
      * large as the largest used to accommodate this serial io
      * method.  */
     rlen = 0;
-    if (iodesc->llen > 0)
+    if (iodesc->llen > 0 || (file->iotype==PIO_IOTYPE_NETCDF || file->iotype == PIO_IOTYPE_NETCDF4C) && ios->iomaster)
         rlen = iodesc->maxiobuflen * nvars;
 
     /* Allocate iobuf. */


### PR DESCRIPTION
When writing with netcdf or netcdf4c the ioroot buffer must be maxiobuflen so that it can receive from all iotasks.