### PR TITLE
fix cmake build in autotools dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,4 +12,4 @@ endif
 
 SUBDIRS = src tests examples ${DOC} scripts
 
-EXTRA_DIST = CMakeLists.txt set_flags.am COPYRIGHT config.h.in
+EXTRA_DIST = CMakeLists.txt set_flags.am COPYRIGHT cmake_config.h.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,6 @@ if BUILD_DOCS
 DOC = doc
 endif
 
-SUBDIRS = src tests examples ${DOC} scripts
+SUBDIRS = src tests examples ${DOC} scripts cmake
 
 EXTRA_DIST = CMakeLists.txt set_flags.am COPYRIGHT cmake_config.h.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,5 +12,4 @@ endif
 
 SUBDIRS = src tests examples ${DOC} scripts
 
-EXTRA_DIST = CMakeLists.txt set_flags.am COPYRIGHT
-
+EXTRA_DIST = CMakeLists.txt set_flags.am COPYRIGHT config.h.in

--- a/cmake/Makefile.am
+++ b/cmake/Makefile.am
@@ -1,0 +1,13 @@
+## This is the automake file for the cmake directory of the PIO
+## libraries. This directory holds files needed for the CMake build,
+## but not the autotools build.
+
+# Ed Hartnett 8/19/19
+
+# Cmake needs all these extra files to build.
+EXTRA_DIST = FindGPTL.cmake FindHDF5.cmake FindLIBRT.cmake		\
+FindLIBZ.cmake FindMPE.cmake FindMPISERIAL.cmake FindNetCDF.cmake	\
+FindPAPI.cmake FindPnetCDF.cmake FindSZIP.cmake LibCheck.cmake		\
+LibFind.cmake LibMPI.cmake Makefile.am mpiexec.alcf mpiexec.ncsa	\
+mpiexec.nersc mpiexec.nwscla mpiexec.olcf TryHDF5_HAS_SZIP.c		\
+TryNetCDF_DAP.c TryNetCDF_PARALLEL.c TryNetCDF_PNETCDF.c

--- a/configure.ac
+++ b/configure.ac
@@ -314,4 +314,5 @@ AC_OUTPUT(Makefile
           examples/Makefile
           examples/c/Makefile
           examples/f03/Makefile
+          cmake/Makefile
           scripts/Makefile)

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -7,3 +7,5 @@ F03 = f03
 endif # BUILD_FORTRAN
 
 SUBDIRS = c ${F03}
+
+EXTRA_DIST = CMakeLists.txt

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -37,9 +37,9 @@ ADD_EXECUTABLE(darray_no_async darray_no_async.c)
 TARGET_LINK_LIBRARIES(darray_no_async pioc)
 add_dependencies(tests darray_no_async)
 
-ADD_EXECUTABLE(darray_async darray_async.c)
-TARGET_LINK_LIBRARIES(darray_async pioc)
-add_dependencies(tests darray_async)
+# ADD_EXECUTABLE(darray_async darray_async.c)
+# TARGET_LINK_LIBRARIES(darray_async pioc)
+# add_dependencies(tests darray_async)
 
 if (PIO_USE_MPISERIAL)
   add_test(NAME examplePio COMMAND examplePio)

--- a/examples/c/Makefile.am
+++ b/examples/c/Makefile.am
@@ -16,7 +16,7 @@ TESTS = run_tests.sh
 endif # RUN_TESTS
 
 # Distribute the test script.
-EXTRA_DIST = run_tests.sh
+EXTRA_DIST = run_tests.sh CMakeLists.txt example2.c
 
 # Clean up files produced during testing.
 CLEANFILES = *.nc *.log *.clog2 *.slog2

--- a/src/clib/Makefile.am
+++ b/src/clib/Makefile.am
@@ -25,4 +25,4 @@ pioc_support.c pio_darray_int.c pio_get_nc.c pio_lists.c pio_nc4.c	\
 pio_put_nc.c pio_spmd.c pio_get_vard.c pio_put_vard.c pio_internal.h	\
 bget.h uthash.h pio_error.h
 
-EXTRA_DIST = CMakeLists.txt
+EXTRA_DIST = CMakeLists.txt topology.c

--- a/src/gptl/Makefile.am
+++ b/src/gptl/Makefile.am
@@ -20,4 +20,6 @@ perf_mod.mod: perf_mod.$(OBJEXT)
 #if BUILD_FORTRAN
 #endif
 
-EXTRA_DIST = CMakeLists.txt
+EXTRA_DIST = CMakeLists.txt GPTLget_memusage.c GPTLprint_memusage.c	\
+GPTLutil.c f_wrappers.c gptl.c gptl_papi.c threadutil.c gptl.inc	\
+gptl.h private.h

--- a/tests/cunit/Makefile.am
+++ b/tests/cunit/Makefile.am
@@ -66,7 +66,7 @@ test_async_perf_SOURCES = test_async_perf.c test_common.c pio_tests.h
 test_darray_vard_SOURCES = test_darray_vard.c test_common.c pio_tests.h
 
 # Distribute the test script.
-EXTRA_DIST = run_tests.sh
+EXTRA_DIST = run_tests.sh CMakeLists.txt test_darray_frame.c
 
 # Clean up files produced during testing.
 CLEANFILES = *.nc *.log decomp*.txt *.clog2 *.slog2

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -30,7 +30,7 @@ TESTS = run_tests.sh
 endif # RUN_TESTS
 
 # Distribute the test script.
-EXTRA_DIST = CMakeLists.txt run_tests.sh input.nl
+EXTRA_DIST = CMakeLists.txt run_tests.sh input.nl not_netcdf.ieee
 
 # Clean up files produced during testing.
 CLEANFILES = *.nc *.log *.mod


### PR DESCRIPTION
After this PR, the cmake builds works from the autotools distribution.

Part of #1585 