### PR TITLE
Some minor fixes to netcdf integration code to get it past all my CI jobs

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -42,6 +42,8 @@ extern int pio_next_ncid;
 /** The default error handler used when iosystem cannot be located. */
 extern int default_error_handler;
 
+/** This prototype from netCDF is required for netCDF integration to
+ * work. */
 int nc4_file_change_ncid(int ncid, unsigned short new_ncid_index);
 
 /**

--- a/tests/fncint/Makefile.am
+++ b/tests/fncint/Makefile.am
@@ -23,10 +23,10 @@ check_PROGRAMS = ftst_pio ftst_pio_orig tst_c_pio
 ftst_pio_SOURCES = ftst_pio.f90
 ftst_pio_orig_SOURCES = ftst_pio_orig.f90
 
-# if RUN_TESTS
-# # Tests will run from a bash script.
-# TESTS = run_tests.sh
-# endif # RUN_TESTS
+if RUN_TESTS
+# Tests will run from a bash script.
+TESTS = run_tests.sh
+endif # RUN_TESTS
 
 # Distribute the test script.
 EXTRA_DIST = run_tests.sh


### PR DESCRIPTION
Part of #1555.

Some minor fixes in support of some CI jobs. In this PR I fix a doc problem and turn on fortran netcdf integration tests.

