### PR TITLE
Now store ndims in var_desc_t struct; we no longer need to look it up in read_darray()

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -134,6 +134,9 @@ typedef struct var_desc_t
     /** Holds the fill value of this var. */
     void *fillvalue;
 
+    /** Number of dimensions for this var. */
+    int ndims;
+
     /** Non-zero if fill mode is turned on for this var. */
     int use_fill;
 

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1189,8 +1189,10 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
     ndims = iodesc->ndims;
 
     /* Get the number of dims for this var in the file. */
-    if ((ierr = PIOc_inq_varndims(file->pio_ncid, vid, &fndims)))
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+    /* if ((ierr = PIOc_inq_varndims(file->pio_ncid, vid, &fndims))) */
+    /*     return pio_err(ios, file, ierr, __FILE__, __LINE__); */
+    fndims = vdesc->ndims;
+    PLOG((3, "fndims %d vdesc->ndims %d", fndims, vdesc->ndims));
 #if USE_VARD_READ
     if(!ios->async || !ios->ioproc)
         ierr = get_gdim0(file, iodesc, vid, fndims, &gdim0);
@@ -1461,15 +1463,17 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
     ndims = iodesc->ndims;
 
     /* Get number of dims for this var. */
-    if ((ierr = PIOc_inq_varndims(file->pio_ncid, vid, &fndims)))
-        return pio_err(ios, file, ierr, __FILE__, __LINE__);
+    fndims = vdesc->ndims;
+    /* if ((ierr = PIOc_inq_varndims(file->pio_ncid, vid, &fndims))) */
+    /*     return pio_err(ios, file, ierr, __FILE__, __LINE__); */
 
     /* If setframe was not called, use a default value of 0. This is
      * required for backward compatibility. */
     if (fndims == ndims + 1 && vdesc->record < 0)
         vdesc->record = 0;
-    PLOG((3, "fndims %d ndims %d vdesc->record %d", fndims, ndims,
-          vdesc->record));
+    PLOG((3, "fndims %d ndims %d vdesc->record %d vdesc->ndims %d", fndims,
+          ndims, vdesc->record, vdesc->ndims));
+    /* pioassert(fndims == vdesc->ndims, "bad ndims", __FILE__, __LINE__); */
 
     /* Confirm that we are being called with the correct ndims. */
     pioassert((fndims == ndims && vdesc->record < 0) ||

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -182,7 +182,8 @@ extern "C" {
 
     /* List operations for var_desc_t list. */
     int add_to_varlist(int varid, int rec_var, int pio_type, int pio_type_size,
-                       MPI_Datatype mpi_type, int mpi_type_size, var_desc_t **varlist);
+                       MPI_Datatype mpi_type, int mpi_type_size, int ndim,
+                       var_desc_t **varlist);
     int get_var_desc(int varid, var_desc_t **varlist, var_desc_t **var_desc);
     int delete_var_desc(int varid, var_desc_t **varlist);
 

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -303,13 +303,15 @@ pio_delete_iodesc_from_list(int ioid)
  * @param pio_type_size size of the PIO type in bytes
  * @param mpi_type the MPI type.
  * @param mpi_type_size size of the MPI type in bytes.
+ * @param ndims the number of dims for this var.
  * @param varlist pointer to list to add to.
  * @returns 0 for success, error code otherwise.
  * @author Ed Hartnett
  */
 int
 add_to_varlist(int varid, int rec_var, int pio_type, int pio_type_size,
-               MPI_Datatype mpi_type, int mpi_type_size, var_desc_t **varlist)
+               MPI_Datatype mpi_type, int mpi_type_size, int ndims,
+               var_desc_t **varlist)
 {
     var_desc_t *var_desc;
 
@@ -327,6 +329,7 @@ add_to_varlist(int varid, int rec_var, int pio_type, int pio_type_size,
     var_desc->pio_type_size = pio_type_size;
     var_desc->mpi_type = mpi_type;
     var_desc->mpi_type_size = mpi_type_size;
+    var_desc->ndims = ndims;
     var_desc->record = -1;
 
     HASH_ADD_INT(*varlist, varid, var_desc);

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -318,6 +318,10 @@ add_to_varlist(int varid, int rec_var, int pio_type, int pio_type_size,
     /* Check inputs. */
     pioassert(varid >= 0 && varlist, "invalid input", __FILE__, __LINE__);
 
+    PLOG((4, "add_to_varlist varid %d rec_var %d pio_type %d pio_type_size %d "
+          "mpi_type %d mpi_type_size %d ndims %d", varid, rec_var, pio_type,
+          pio_type_size, mpi_type, mpi_type_size, ndims));
+
     /* Allocate storage. */
     if (!(var_desc = calloc(1, sizeof(var_desc_t))))
         return PIO_ENOMEM;

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2109,7 +2109,7 @@ PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
 }
 
 /**
- * The PIO-C interface for the NetCDF function nc_def_var.
+ * The PIO-C interface for the NetCDF function nc_def_var
  *
  * This routine is called collectively by all tasks in the communicator
  * ios.union_comm. For more information on the underlying NetCDF commmand
@@ -2302,7 +2302,7 @@ PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 
     /* Add to the list of var_desc_t structs for this file. */
     if ((ierr = add_to_varlist(varid, rec_var, xtype, (int)pio_type_size, mpi_type,
-                               mpi_type_size, &file->varlist)))
+                               mpi_type_size, ndims, &file->varlist)))
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     file->nvars++;
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2235,7 +2235,7 @@ check_unlim_use(int ncid)
 static int
 inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
                   int **rec_var, int **pio_type, int **pio_type_size,
-                  MPI_Datatype **mpi_type, int **mpi_type_size, int **ndim)
+                  MPI_Datatype **mpi_type, int **mpi_type_size, int **ndims)
 {
     int nunlimdims = 0;        /* The number of unlimited dimensions. */
     int unlimdimid;
@@ -2274,7 +2274,7 @@ inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
             return PIO_ENOMEM;
         if (!(*mpi_type_size = malloc(*nvars * sizeof(int))))
             return PIO_ENOMEM;
-        if (!(*ndim = malloc(*nvars * sizeof(int))))
+        if (!(*ndims = malloc(*nvars * sizeof(int))))
             return PIO_ENOMEM;
     }
 
@@ -2335,6 +2335,7 @@ inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
             if ((ret = ncmpi_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
                 return pio_err(NULL, file, ret, __FILE__, __LINE__);
             (*pio_type)[v] = (int)my_type;
+            (*ndims)[v] = var_ndims;
             if ((ret = pioc_pnetcdf_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
                 return check_netcdf(file, ret, __FILE__, __LINE__);
             (*pio_type_size)[v] = type_size;
@@ -2347,7 +2348,7 @@ inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
             if ((ret = nc_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
                 return pio_err(NULL, file, ret, __FILE__, __LINE__);
             (*pio_type)[v] = (int)my_type;
-            (*ndim)[v] = var_ndims;
+            (*ndims)[v] = var_ndims;
             if ((ret = nc_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
                 return check_netcdf(file, ret, __FILE__, __LINE__);
             (*pio_type_size)[v] = type_size;
@@ -2529,7 +2530,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
     int *pio_type_size = NULL;
     MPI_Datatype *mpi_type = NULL;
     int *mpi_type_size = NULL;
-    int *ndim = NULL;
+    int *ndims = NULL;
     int mpierr = MPI_SUCCESS, mpierr2;  /** Return code from MPI function codes. */
     int ierr = PIO_NOERR;      /* Return code from function calls. */
 
@@ -2621,7 +2622,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
             if ((ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4P,
                                           &nvars, &rec_var, &pio_type,
                                           &pio_type_size, &mpi_type,
-                                          &mpi_type_size, &ndim)))
+                                          &mpi_type_size, &ndims)))
                 break;
             PLOG((2, "PIOc_openfile_retry:nc_open_par filename = %s mode = %d "
                   "imode = %d ierr = %d", filename, mode, imode, ierr));
@@ -2639,7 +2640,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
                 ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4C,
                                          &nvars, &rec_var, &pio_type,
                                          &pio_type_size, &mpi_type,
-                                         &mpi_type_size, &ndim);
+                                         &mpi_type_size, &ndims);
             }
             break;
 #endif /* _NETCDF4 */
@@ -2652,7 +2653,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
                 ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
                                          &nvars, &rec_var, &pio_type,
                                          &pio_type_size, &mpi_type,
-                                         &mpi_type_size, &ndim);
+                                         &mpi_type_size, &ndims);
             }
             break;
 
@@ -2674,7 +2675,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
                 ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_PNETCDF,
                                          &nvars, &rec_var, &pio_type,
                                          &pio_type_size, &mpi_type,
-                                         &mpi_type_size, &ndim);
+                                         &mpi_type_size, &ndims);
             break;
 #endif
 
@@ -2707,7 +2708,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
                         ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
                                                  &nvars, &rec_var, &pio_type,
                                                  &pio_type_size, &mpi_type,
-                                                 &mpi_type_size, &ndim);
+                                                 &mpi_type_size, &ndims);
                 }
                 else
                     file->do_io = 0;
@@ -2760,7 +2761,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
         if (!(mpi_type_size = malloc(nvars * sizeof(int))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        if (!(ndim = malloc(nvars * sizeof(int))))
+        if (!(ndims = malloc(nvars * sizeof(int))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
     }
     if (nvars)
@@ -2775,7 +2776,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(mpi_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(ndim, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+        if ((mpierr = MPI_Bcast(ndims, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
@@ -2811,7 +2812,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
     /* Add info about the variables to the file_desc_t struct. */
     for (int v = 0; v < nvars; v++)
         if ((ierr = add_to_varlist(v, rec_var[v], pio_type[v], pio_type_size[v],
-                                   mpi_type[v], mpi_type_size[v], ndim[v],
+                                   mpi_type[v], mpi_type_size[v], ndims[v],
                                    &file->varlist)))
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     file->nvars = nvars;
@@ -2829,8 +2830,8 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
             free(mpi_type);
         if (mpi_type_size)
             free(mpi_type_size);
-        if (ndim)
-            free(ndim);
+        if (ndims)
+            free(ndims);
     }
 
 #ifdef USE_MPE

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2810,8 +2810,9 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
 
     /* Add info about the variables to the file_desc_t struct. */
     for (int v = 0; v < nvars; v++)
-        if ((ierr = add_to_varlist(v, rec_var[v], pio_type[v], pio_type_size[v], mpi_type[v],
-                                   mpi_type_size[v], &file->varlist)))
+        if ((ierr = add_to_varlist(v, rec_var[v], pio_type[v], pio_type_size[v],
+                                   mpi_type[v], mpi_type_size[v], ndim[v],
+                                   &file->varlist)))
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     file->nvars = nvars;
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2225,12 +2225,14 @@ check_unlim_use(int ncid)
  * @param mpi_type_size gets an array (length nvars) of the size of
  * the MPI type for each var in the file. This array must be freed by
  * caller.
+ * @param ndim gets an array (length nvars) with the number of
+ * dimensions of each var.
  *
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_openfile_c
  * @author Ed Hartnett
  */
-int
+static int
 inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
                   int **rec_var, int **pio_type, int **pio_type_size,
                   MPI_Datatype **mpi_type, int **mpi_type_size)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2205,7 +2205,8 @@ check_unlim_use(int ncid)
 /**
  * Internal function used when opening an existing file. This function
  * is called by PIOc_openfile_retry(). It learns some things about the
- * metadata in that file. The results end up in the file_desc_t.
+ * metadata in that file. The results end up in the file_desc_t and
+ * var_desc_t structs for this file and the vars in it.
  *
  * @param file pointer to the file_desc_t for this file.
  * @param ncid the ncid assigned to the file when opened.
@@ -2230,8 +2231,9 @@ check_unlim_use(int ncid)
  * @author Ed Hartnett
  */
 int
-inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int **rec_var,
-                  int **pio_type, int **pio_type_size, MPI_Datatype **mpi_type, int **mpi_type_size)
+inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
+                  int **rec_var, int **pio_type, int **pio_type_size,
+                  MPI_Datatype **mpi_type, int **mpi_type_size)
 {
     int nunlimdims = 0;        /* The number of unlimited dimensions. */
     int unlimdimid;
@@ -2239,6 +2241,11 @@ inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int **rec
     int mpierr;
     int ret;
 
+    /* Check inputs. */
+    pioassert(rec_var && pio_type && pio_type_size && mpi_type && mpi_type_size,
+              "pointers must be provided", __FILE__, __LINE__);
+
+    /* How many vars in the file? */
     if (iotype == PIO_IOTYPE_PNETCDF)
     {
 #ifdef _PNETCDF
@@ -2252,6 +2259,7 @@ inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int **rec
             return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
     }
 
+    /* Allocate storage for info about each var. */
     if (*nvars)
     {
         if (!(*rec_var = malloc(*nvars * sizeof(int))))

--- a/tests/cunit/test_async_1d.c
+++ b/tests/cunit/test_async_1d.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
     /* Make sure we have 4 tasks. */
     if (ntasks != TARGET_NTASKS) ERR(ERR_WRONG);
 
-    PIOc_set_log_level(4);
+    /* PIOc_set_log_level(4); */
 
     /* Change error handling so we can test inval parameters. */
     if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))
@@ -87,7 +87,8 @@ int main(int argc, char **argv)
         int gdimlen[NDIM1] = {DIM_LEN_1};
         PIO_Offset compmap[MAPLEN];
         int varid;
-        int data, data_in;
+        int data;
+        /* int data_in; */
         int ioid;
 
         /* Create a file. */

--- a/tests/cunit/test_darray.c
+++ b/tests/cunit/test_darray.c
@@ -230,7 +230,6 @@ int test_darray(int iosysid, int ioid, int num_flavors, int *flavor, int my_rank
                     if (PIOc_write_darray_multi(ncid, &varid_big, ioid, 1, arraylen, test_data, &frame,
                                                 fillvalue, flushtodisk) != PIO_ENOTVAR)
                         ERR(ERR_WRONG);
-//		    pio_setloglevel(3);
                     if (PIOc_write_darray_multi(ncid, &wrong_varid, ioid, 1, arraylen, test_data, &frame,
                                                 fillvalue, flushtodisk) != PIO_ENOTVAR)
                         ERR(ERR_WRONG);

--- a/tests/cunit/test_spmd.c
+++ b/tests/cunit/test_spmd.c
@@ -323,14 +323,15 @@ int test_varlists()
         return ERR_WRONG;
 
     /* Add a var to the list. */
-    if ((ret = add_to_varlist(0, 1, PIO_INT, 4, MPI_INT, 4, &varlist)))
+    if ((ret = add_to_varlist(0, 1, PIO_INT, 4, MPI_INT, 4, 2, &varlist)))
         return ret;
 
     /* Find that var_desc_t. */
     if ((ret = get_var_desc(0, &varlist, &var_desc)))
         return ret;
     if (var_desc->varid != 0 || !var_desc->rec_var || var_desc->pio_type != PIO_INT ||
-        var_desc->pio_type_size != 4 || var_desc->mpi_type != MPI_INT || var_desc->mpi_type_size != 4)
+        var_desc->pio_type_size != 4 || var_desc->mpi_type != MPI_INT ||
+        var_desc->mpi_type_size != 4 || var_desc->ndims != 2)
         return ERR_WRONG;
 
     /* Try to delete a non-existing var - should fail. */
@@ -360,30 +361,30 @@ int test_varlists2()
     int ret;
 
     /* Add some vars to the list. */
-    if ((ret = add_to_varlist(0, 1, PIO_INT, 4, MPI_INT, 4, &varlist)))
+    if ((ret = add_to_varlist(0, 1, PIO_INT, 4, MPI_INT, 4, 0, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(1, 0, PIO_DOUBLE, 8, MPI_DOUBLE, 8, &varlist)))
+    if ((ret = add_to_varlist(1, 0, PIO_DOUBLE, 8, MPI_DOUBLE, 8, 1, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(2, 1, PIO_BYTE, 1, MPI_CHAR, 1, &varlist)))
+    if ((ret = add_to_varlist(2, 1, PIO_BYTE, 1, MPI_CHAR, 1, 2, &varlist)))
         return ret;
 
     /* Find those var_desc_t. */
     if ((ret = get_var_desc(0, &varlist, &var_desc)))
         return ret;
     if (var_desc->varid != 0 || !var_desc->rec_var || var_desc->pio_type != PIO_INT ||
-        var_desc->pio_type_size != 4 || var_desc->mpi_type != MPI_INT)
+        var_desc->pio_type_size != 4 || var_desc->mpi_type != MPI_INT || var_desc->ndims != 0)
         return ERR_WRONG;
 
     if ((ret = get_var_desc(1, &varlist, &var_desc)))
         return ret;
     if (var_desc->varid != 1 || var_desc->rec_var || var_desc->pio_type != PIO_DOUBLE ||
-        var_desc->pio_type_size != 8)
+        var_desc->pio_type_size != 8 || var_desc->ndims != 1)
         return ERR_WRONG;
 
     if ((ret = get_var_desc(2, &varlist, &var_desc)))
         return ret;
     if (var_desc->varid != 2 || !var_desc->rec_var || var_desc->pio_type != PIO_BYTE ||
-        var_desc->pio_type_size != 1)
+        var_desc->pio_type_size != 1 || var_desc->ndims != 2)
         return ERR_WRONG;
 
     /* Try to delete a non-existing var - should fail. */
@@ -432,13 +433,13 @@ int test_varlists3()
     int ret;
 
     /* Add some vars to the list. */
-    if ((ret = add_to_varlist(0, 1, PIO_INT, 4, MPI_INT, 4, &varlist)))
+    if ((ret = add_to_varlist(0, 1, PIO_INT, 4, MPI_INT, 4, 0, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(1, 0, PIO_INT, 4, MPI_INT, 4, &varlist)))
+    if ((ret = add_to_varlist(1, 0, PIO_INT, 4, MPI_INT, 4, 1, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(2, 1, PIO_INT, 4, MPI_INT, 4, &varlist)))
+    if ((ret = add_to_varlist(2, 1, PIO_INT, 4, MPI_INT, 4, 2, &varlist)))
         return ret;
-    if ((ret = add_to_varlist(3, 0, PIO_INT, 4, MPI_INT, 4, &varlist)))
+    if ((ret = add_to_varlist(3, 0, PIO_INT, 4, MPI_INT, 4, 3, &varlist)))
         return ret;
 
     /* Delete one of the vars. */

--- a/tests/ncint/tst_pio_async.c
+++ b/tests/ncint/tst_pio_async.c
@@ -76,13 +76,13 @@ main(int argc, char **argv)
 
             /* Calculate a decomposition for distributed arrays. */
             elements_per_pe = DIM_LEN_X * DIM_LEN_Y / (ntasks - num_io_procs);
-            printf("my_rank %d elements_per_pe %ld\n", my_rank, elements_per_pe);
+            /* printf("my_rank %d elements_per_pe %ld\n", my_rank, elements_per_pe); */
             if (!(compdof = malloc(elements_per_pe * sizeof(size_t))))
                 PERR;
             for (i = 0; i < elements_per_pe; i++)
             {
                 compdof[i] = (my_rank - num_io_procs) * elements_per_pe + i;
-                printf("my_rank %d compdof[%d]=%ld\n", my_rank, i, compdof[i]);
+                /* printf("my_rank %d compdof[%d]=%ld\n", my_rank, i, compdof[i]); */
             }
 
             /* Create the PIO decomposition for this test. */
@@ -121,7 +121,7 @@ main(int argc, char **argv)
                 for (i = 0; i < elements_per_pe; i++)
                 {
                     compdof2[i] = (my_rank - num_io_procs) * elements_per_pe + i;
-                    printf("my_rank %d compdof2[%d]=%lld\n", my_rank, i, compdof2[i]);
+                    /* printf("my_rank %d compdof2[%d]=%lld\n", my_rank, i, compdof2[i]); */
                 }
 
                 if (PIOc_init_decomp(iosysid, PIO_INT, NDIM2, &dimlen[1], elements_per_pe, compdof2,

--- a/tests/ncint/tst_pio_udf.c
+++ b/tests/ncint/tst_pio_udf.c
@@ -61,7 +61,7 @@ main(int argc, char **argv)
         int i;
 
         /* Turn on logging for PIO library. */
-        PIOc_set_log_level(3);
+        /* PIOc_set_log_level(3); */
 
         /* Initialize the intracomm. */
         if (nc_def_iosystemm(MPI_COMM_WORLD, 1, 1, 0, 0, &iosysid)) PERR;


### PR DESCRIPTION
Fixes #1599 

We know the value of ndims for each var when we open a file or define a var. So we just need to remember it instead of looking it up again later. This will make #1598 easier.
