### PR TITLE
Install uthash.h when building ParallelIO using CMake

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -49,8 +49,8 @@ endif()
 # Library
 install (TARGETS pioc DESTINATION lib)
 
-# Include/Header File
-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/pio.h DESTINATION include)
+# Include/Header Files
+install (FILES pio.h uthash.h DESTINATION include)
 
 #==============================================================================
 #  DEFINE THE DEPENDENCIES


### PR DESCRIPTION
This pull request fixes #1551 in the CMake build system (#1552 did the same for autoconf).

Note that relative paths specified in `install(FILES ...)` are interpreted as relative to the current source directory, so `${CMAKE_CURRENT_SOURCE_DIR}` is not needed.