### PR TITLE
Fix an off-by-one error in PIOc_InitDecomp_bc()

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -869,7 +869,7 @@ PIOc_InitDecomp_bc(int iosysid, int pio_type, int ndims, const int *gdimlen,
     }
     for (i = 0; i < maplen; i++)
     {
-        compmap[i] = 0;
+        compmap[i] = 1;
         for (n = ndims - 1; n >= 0; n--)
             compmap[i] += (start[n] + loc[n]) * prod[n];
 


### PR DESCRIPTION
`PIOc_InitDecomp_bc()` computes a zero-based `compmap` and passes it to `PIOc_InitDecomp()`, which expects a one-based `compmap`.