### PR TITLE
move reliance on ifdefs out of pio.h

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -18,13 +18,6 @@
 
 #include <netcdf.h>
 
-#ifndef MPI_OFFSET
-/** MPI_OFFSET is an integer type of size sufficient to represent the
- * size (in bytes) of the largest file supported by MPI. In some MPI
- * implementations MPI_OFFSET is not properly defined.  */
-#define MPI_OFFSET  MPI_LONG_LONG
-#endif
-
 /** PIO_OFFSET is an integer type of size sufficient to represent the
  * size (in bytes) of the largest file supported by MPI. This is not
  * actually used by the code. */

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -16,15 +16,7 @@
 #include <mpi.h>
 #include <uthash.h>
 
-#ifdef _NETCDF
 #include <netcdf.h>
-#ifdef _NETCDF4
-#include <netcdf_par.h>
-#endif
-#endif
-#ifdef _PNETCDF
-#include <pnetcdf.h>
-#endif
 
 #ifndef MPI_OFFSET
 /** MPI_OFFSET is an integer type of size sufficient to represent the

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -30,6 +30,13 @@
 #include <mpe.h>
 #endif /* USE_MPE */
 
+#ifndef MPI_OFFSET
+/** MPI_OFFSET is an integer type of size sufficient to represent the
+ * size (in bytes) of the largest file supported by MPI. In some MPI
+ * implementations MPI_OFFSET is not properly defined.  */
+#define MPI_OFFSET  MPI_LONG_LONG
+#endif
+
 /* These are the sizes of types in netCDF files. Do not replace these
  * constants with sizeof() calls for C types. They are not the
  * same. Even on a system where sizeof(short) is 4, the size of a

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -16,6 +16,12 @@
 #include <bget.h>
 #include <limits.h>
 #include <math.h>
+#ifdef _NETCDF4
+#include <netcdf_par.h>
+#endif
+#ifdef _PNETCDF
+#include <pnetcdf.h>
+#endif
 #ifdef TIMING
 #include <gptl.h>
 #endif


### PR DESCRIPTION
Fixes #1608 

In this PR I move some code that depends on ifdefs out of pio.h.

pio.h is our public header, we cannot count on these ifdefs being defined by the user. We must confine out use of these ifdefs to files that include config.h, and our public header cannot include that file.

