### PR TITLE
changed version numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project (PIO C Fortran)
 # The project version number.
 set(VERSION_MAJOR   2   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   5   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   0-development   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 # The size of the data buffer for write/read_darray().

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AM_INIT_AUTOMAKE([foreign serial-tests])
 # The PIO version, again.
 AC_DEFINE([PIO_VERSION_MAJOR], [2], [PIO major version])
 AC_DEFINE([PIO_VERSION_MINOR], [5], [PIO minor version])
-AC_DEFINE([PIO_VERSION_PATCH], [0-development], [PIO patch version])
+AC_DEFINE([PIO_VERSION_PATCH], [0], [PIO patch version])
 
 # Once more for the documentation.
 AC_SUBST([VERSION_MAJOR], [2])

--- a/configure.ac
+++ b/configure.ac
@@ -2,19 +2,19 @@
 ## Ed Hartnett 8/16/17
 
 # Initialize autoconf and automake.
-AC_INIT(pio, 2.5.0)
+AC_INIT(pio, 2.5.0-development)
 AC_CONFIG_SRCDIR(src/clib/pio_darray.c)
 AM_INIT_AUTOMAKE([foreign serial-tests])
 
 # The PIO version, again.
 AC_DEFINE([PIO_VERSION_MAJOR], [2], [PIO major version])
 AC_DEFINE([PIO_VERSION_MINOR], [5], [PIO minor version])
-AC_DEFINE([PIO_VERSION_PATCH], [0], [PIO patch version])
+AC_DEFINE([PIO_VERSION_PATCH], [0-development], [PIO patch version])
 
 # Once more for the documentation.
 AC_SUBST([VERSION_MAJOR], [2])
 AC_SUBST([VERSION_MINOR], [5])
-AC_SUBST([VERSION_PATCH], [0])
+AC_SUBST([VERSION_PATCH], [0-development])
 
 # The m4 directory holds macros for autoconf.
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Release is complete, has been announced and documentation updated.

In this PR I add "-development" to the version number for PIO development until the next version.

Fixes #1607 