### PR TITLE
if rindex is null and debug is enabled this will segfault

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -731,8 +731,9 @@ PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, int ma
           iodesc->ioid, iodesc->nrecvs, iodesc->ndof, iodesc->ndims, iodesc->num_aiotasks,
           iodesc->rearranger, iodesc->maxregions, iodesc->needsfill, iodesc->llen,
           iodesc->maxiobuflen));
-    for (int j = 0; j < iodesc->llen; j++)
-        PLOG((3, "rindex[%d] = %lld", j, iodesc->rindex[j]));
+    if (iodesc->rindex)
+	for (int j = 0; j < iodesc->llen; j++)
+	    PLOG((3, "rindex[%d] = %lld", j, iodesc->rindex[j]));
 #endif /* PIO_ENABLE_LOGGING */
 
     /* This function only does something if pre-processor macro


### PR DESCRIPTION
Adding an if in a PIO_ENABLE_LOGGING clause to prevent core dump when rindex is not allocated. 