### PR TITLE
Fix multiple definition errors with GCC>=10.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ add_subdirectory (src)
 
 # Custom "piotests" target (builds the test executables)
 add_custom_target (tests)
+add_dependencies (tests pioc piof)
 
 # Custom "check" target that depends upon "tests"
 add_custom_target (check COMMAND ${CMAKE_CTEST_COMMAND})

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -9,7 +9,7 @@ project (PIOC C)
 add_library (pioc topology.c pio_file.c pioc_support.c pio_lists.c
   pioc.c pioc_sc.c pio_spmd.c pio_rearrange.c pio_nc4.c bget.c
   pio_nc.c pio_put_nc.c pio_get_nc.c pio_getput_int.c pio_msg.c
-  pio_darray.c pio_darray_int.c pio_get_vard.c pio_put_vard.c)
+  pio_darray.c pio_darray_int.c pio_get_vard.c pio_put_vard.c pio_error.c)
 
 # set up include-directories
 include_directories(

--- a/src/clib/Makefile.am
+++ b/src/clib/Makefile.am
@@ -22,7 +22,7 @@ include_HEADERS = pio.h uthash.h pio_meta.h
 libpioc_la_SOURCES = bget.c pioc_sc.c pio_darray.c pio_file.c		\
 pio_getput_int.c pio_msg.c pio_nc.c pio_rearrange.c pioc.c		\
 pioc_support.c pio_darray_int.c pio_get_nc.c pio_lists.c pio_nc4.c	\
-pio_put_nc.c pio_spmd.c pio_get_vard.c pio_put_vard.c pio_internal.h	\
-bget.h uthash.h pio_error.h
+pio_put_nc.c pio_spmd.c pio_get_vard.c pio_put_vard.c pio_error.c	\
+pio_internal.h bget.h uthash.h pio_error.h
 
 EXTRA_DIST = CMakeLists.txt topology.c pio_meta.h.in

--- a/src/clib/pio_error.c
+++ b/src/clib/pio_error.c
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * Definition for Macros to handle errors in tests or libray code.
+ * @author Ed Hartnett
+ * @date 2020
+ *
+ * @see https://github.com/NCAR/ParallelIO
+ */
+
+#include <pio_error.h>
+
+/**
+ * Global err buffer for MPI. When there is an MPI error, this buffer
+ * is used to store the error message that is associated with the MPI
+ * error.
+ */
+char err_buffer[MPI_MAX_ERROR_STRING];
+
+/**
+ * This is the length of the most recent MPI error message, stored
+ * int the global error string.
+ */
+int resultlen;

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -74,12 +74,12 @@
  * is used to store the error message that is associated with the MPI
  * error.
  */
-char err_buffer[MPI_MAX_ERROR_STRING];
+extern char err_buffer[MPI_MAX_ERROR_STRING];
 
 /**
  * This is the length of the most recent MPI error message, stored
  * int the global error string.
  */
-int resultlen;
+extern int resultlen;
 
 #endif /* __PIO_ERROR__ */

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -5,6 +5,7 @@
  */
 #include <config.h>
 #include <pio.h>
+#include <pio_error.h>
 #include <pio_internal.h>
 #include <pio_tests.h>
 

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -56,11 +56,13 @@ endif()
 # Test Timeout (4 min = 240 sec)
 set (DEFAULT_TEST_TIMEOUT 480)
 
+add_library(pio_tutil util/pio_tutil.F90)
+target_link_libraries(pio_tutil piof pioc)
+
 #===== pio_init_finalize =====
 add_executable (pio_init_finalize EXCLUDE_FROM_ALL
-  pio_init_finalize.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_init_finalize piof)
+  pio_init_finalize.F90)
+target_link_libraries (pio_init_finalize pio_tutil)
 add_dependencies (tests pio_init_finalize)
 
 if (PIO_USE_MPISERIAL)
@@ -98,9 +100,8 @@ endif ()
 
 #===== pio_file_simple_tests =====
 add_executable (pio_file_simple_tests EXCLUDE_FROM_ALL
-  pio_file_simple_tests.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_file_simple_tests piof)
+  pio_file_simple_tests.F90)
+target_link_libraries (pio_file_simple_tests pio_tutil)
 add_dependencies (tests pio_file_simple_tests)
 
 if (PIO_USE_MPISERIAL)
@@ -117,9 +118,8 @@ endif ()
 
 #===== pio_file_fail =====
 add_executable (pio_file_fail EXCLUDE_FROM_ALL
-  pio_file_fail.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_file_fail piof)
+  pio_file_fail.F90)
+target_link_libraries (pio_file_fail pio_tutil)
 if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
   target_compile_options (pio_init_finalize
     PRIVATE -ffree-line-length-none)
@@ -140,9 +140,8 @@ endif ()
 
 #===== ncdf_simple_tests =====
 add_executable (ncdf_simple_tests EXCLUDE_FROM_ALL
-  ncdf_simple_tests.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (ncdf_simple_tests piof)
+  ncdf_simple_tests.F90)
+target_link_libraries (ncdf_simple_tests pio_tutil)
 add_dependencies (tests ncdf_simple_tests)
 
 if (PIO_USE_MPISERIAL)
@@ -159,9 +158,8 @@ endif ()
 
 #===== ncdf_get_put =====
 add_executable (ncdf_get_put EXCLUDE_FROM_ALL
-  ncdf_get_put.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (ncdf_get_put piof)
+  ncdf_get_put.F90)
+target_link_libraries (ncdf_get_put pio_tutil)
 add_dependencies (tests ncdf_get_put)
 
 if (PIO_USE_MPISERIAL)
@@ -186,9 +184,8 @@ endif ()
 
 #===== ncdf_fail =====
 add_executable (ncdf_fail EXCLUDE_FROM_ALL
-  ncdf_fail.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (ncdf_fail piof)
+  ncdf_fail.F90)
+target_link_libraries (ncdf_fail pio_tutil)
 add_dependencies (tests ncdf_fail)
 
 if (PIO_USE_MPISERIAL)
@@ -205,9 +202,8 @@ endif ()
 
 #===== ncdf_inq =====
 add_executable (ncdf_inq EXCLUDE_FROM_ALL
-  ncdf_inq.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (ncdf_inq piof)
+  ncdf_inq.F90)
+target_link_libraries (ncdf_inq pio_tutil)
 add_dependencies (tests ncdf_inq)
 
 if (PIO_USE_MPISERIAL)
@@ -224,9 +220,8 @@ endif ()
 
 #===== pio_rearr =====
 add_executable (pio_rearr EXCLUDE_FROM_ALL
-    pio_rearr.F90
-    ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_rearr piof)
+    pio_rearr.F90)
+target_link_libraries (pio_rearr pio_tutil)
 add_dependencies (tests pio_rearr)
 
 if (PIO_USE_MPISERIAL)
@@ -243,9 +238,8 @@ endif ()
 
 #===== pio_rearr_opts =====
 add_executable (pio_rearr_opts EXCLUDE_FROM_ALL
-    pio_rearr_opts.F90
-    ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_rearr_opts piof)
+    pio_rearr_opts.F90)
+target_link_libraries (pio_rearr_opts pio_tutil)
 add_dependencies (tests pio_rearr_opts)
 
 if (PIO_USE_MPISERIAL)
@@ -262,9 +256,8 @@ endif ()
 
 #===== pio_rearr_opts2 =====
 add_executable (pio_rearr_opts2 EXCLUDE_FROM_ALL
-    pio_rearr_opts2.F90
-    ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_rearr_opts2 piof)
+    pio_rearr_opts2.F90)
+target_link_libraries (pio_rearr_opts2 pio_tutil)
 add_dependencies (tests pio_rearr_opts2)
 
 if (PIO_USE_MPISERIAL)
@@ -289,9 +282,8 @@ endif ()
 
 #===== pio_decomp_tests =====
 add_executable (pio_decomp_tests EXCLUDE_FROM_ALL
-  pio_decomp_tests.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_decomp_tests piof)
+  pio_decomp_tests.F90)
+target_link_libraries (pio_decomp_tests pio_tutil)
 add_dependencies (tests pio_decomp_tests)
 
 if (PIO_USE_MPISERIAL)
@@ -402,9 +394,8 @@ endif ()
 
 #===== pio_decomp_tests_1d =====
 add_executable (pio_decomp_tests_1d EXCLUDE_FROM_ALL
-  pio_decomp_tests_1d.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_decomp_tests_1d piof)
+  pio_decomp_tests_1d.F90)
+target_link_libraries (pio_decomp_tests_1d pio_tutil)
 add_dependencies (tests pio_decomp_tests_1d)
 
 if (PIO_USE_MPISERIAL)
@@ -515,9 +506,8 @@ endif ()
 
 #===== pio_decomp_tests_2d =====
 add_executable (pio_decomp_tests_2d EXCLUDE_FROM_ALL
-  pio_decomp_tests_2d.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_decomp_tests_2d piof)
+  pio_decomp_tests_2d.F90)
+target_link_libraries (pio_decomp_tests_2d pio_tutil)
 add_dependencies (tests pio_decomp_tests_2d)
 
 if (PIO_USE_MPISERIAL)
@@ -628,9 +618,8 @@ endif ()
 
 #===== pio_decomp_tests_3d =====
 add_executable (pio_decomp_tests_3d EXCLUDE_FROM_ALL
-  pio_decomp_tests_3d.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_decomp_tests_3d piof)
+  pio_decomp_tests_3d.F90)
+target_link_libraries (pio_decomp_tests_3d pio_tutil)
 add_dependencies (tests pio_decomp_tests_3d)
 
 if (PIO_USE_MPISERIAL)
@@ -741,9 +730,8 @@ endif ()
 
 #===== pio_decomp_frame_tests =====
 add_executable (pio_decomp_frame_tests EXCLUDE_FROM_ALL
-  pio_decomp_frame_tests.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_decomp_frame_tests piof)
+  pio_decomp_frame_tests.F90)
+target_link_libraries (pio_decomp_frame_tests pio_tutil)
 add_dependencies (tests pio_decomp_frame_tests)
 
 if (PIO_USE_MPISERIAL)
@@ -760,9 +748,8 @@ endif ()
 
 #===== pio_decomp_fillval =====
 add_executable (pio_decomp_fillval EXCLUDE_FROM_ALL
-  pio_decomp_fillval.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_decomp_fillval piof)
+  pio_decomp_fillval.F90)
+target_link_libraries (pio_decomp_fillval pio_tutil)
 add_dependencies (tests pio_decomp_fillval)
 
 if (PIO_USE_MPISERIAL)
@@ -779,9 +766,8 @@ endif ()
 
 #===== pio_iosystems_test =====
 add_executable (pio_iosystem_tests EXCLUDE_FROM_ALL
-  pio_iosystem_tests.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_iosystem_tests piof)
+  pio_iosystem_tests.F90)
+target_link_libraries (pio_iosystem_tests pio_tutil)
 add_dependencies (tests pio_iosystem_tests)
 
 if (PIO_USE_MPISERIAL)
@@ -799,9 +785,8 @@ endif ()
 
 #===== pio_iosystems_test2 =====
 add_executable (pio_iosystem_tests2 EXCLUDE_FROM_ALL
-  pio_iosystem_tests2.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_iosystem_tests2 piof)
+  pio_iosystem_tests2.F90)
+target_link_libraries (pio_iosystem_tests2 pio_tutil)
 add_dependencies (tests pio_iosystem_tests2)
 
 if (PIO_USE_MPISERIAL)
@@ -818,9 +803,8 @@ endif ()
 
 #===== pio_iosystems_test3 =====
 add_executable (pio_iosystem_tests3 EXCLUDE_FROM_ALL
-  pio_iosystem_tests3.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
-target_link_libraries (pio_iosystem_tests3 piof)
+  pio_iosystem_tests3.F90)
+target_link_libraries (pio_iosystem_tests3 pio_tutil)
 add_dependencies (tests pio_iosystem_tests3)
 
 if (PIO_USE_MPISERIAL)


### PR DESCRIPTION
This is #1662 with the Makefile.am fix.