### PR TITLE
enable doc build

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -41,7 +41,7 @@ jobs:
     - name: configure
       run: |
         ./configure --enable-docs
+        cat config.log
     - name: make check
       run: |
-        cat config.log
         make check

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -39,6 +39,6 @@ jobs:
     - name: autoreconf
       run: autoreconf -i
     - name: configure
-      run: ./configure
-    - name: make distcheck
-      run: make distcheck
+      run: ./configure --enable-docs
+    - name: make check
+      run: make check

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -39,6 +39,9 @@ jobs:
     - name: autoreconf
       run: autoreconf -i
     - name: configure
-      run: ./configure --enable-docs
+      run: |
+        ./configure --enable-docs
     - name: make check
-      run: make check
+      run: |
+        cat config.log
+        make check


### PR DESCRIPTION
Fixes #1681 
Part of #1675

Turn on doc build in autotools GitHub action.