### PR TITLE
fixed creation of config.h on read-only filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,5 @@ INSTALL(FILES "${PIO_BINARY_DIR}/libpio.settings"
 #####
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/clib/pio_meta.h.in
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/clib/pio_meta.h @ONLY)
+  ${CMAKE_CURRENT_BINARY_DIR}/src/clib/pio_meta.h @ONLY)
 
-FILE(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/clib/pio_meta.h
-  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/src/clib/)


### PR DESCRIPTION
Fixes #1712 