### PR TITLE
Adding cmake build of C library to openmpi GitHub actions testing workflow, also allow setting of mpiexec command at configure

### DIFF
--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev  -DMPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
+        cmake -Wno-dev  -DWITH_MPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
         ls -l tests/cunit
         cat tests/cunit/run_tests.sh
         make VERBOSE=1

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        export LD_LIBRARY_PATH="/home/runner/netcdf-c/lib:$LD_LIBRARY_PATH"
+        export LD_LIBRARY_PATH="/home/runner/netcdf-c/lib:/home/runner/pnetcdf/lib:/home/runner/hdf5/lib:/home/runner/openmpi/lib:$LD_LIBRARY_PATH"
         cmake -Wno-dev -DWITH_MPIEXEC='/home/runner/openmpi/bin/mpiexec;--oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
         make VERBOSE=1
         make tests VERBOSE=1

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -126,7 +126,7 @@ jobs:
         mkdir build
         cd build
         cmake -Wno-dev  -DMPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
-        cat /tests/unit/run_tests.sh
+        cat tests/unit/run_tests.sh
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -126,6 +126,7 @@ jobs:
         mkdir build
         cd build
         cmake -Wno-dev  -DMPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
+        cat /tests/unit/run_tests.sh
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev --trace-source=CMakeLists.txt -DWITH_MPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
+        cmake -Wno-dev --trace-source=cmake/LibMPI.cmake -DWITH_MPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev --trace-source=cmake/LibMPI.cmake -DWITH_MPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
+        cmake -Wno-dev -DWITH_MPIEXEC='/home/runner/openmpi/bin/mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -117,6 +117,18 @@ jobs:
         make
         sudo make install
         popd
+    - name: cmake build
+      run: |
+        set -x
+        echo 'export PATH=/home/runner/openmpi/bin:$PATH' > .bashrc
+        source .bashrc
+        export CC=/home/runner/openmpi/bin/mpicc
+        mkdir build
+        cd build
+        cmake -Wno-dev -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..
+        make VERBOSE=1
+        make tests VERBOSE=1
+        ctest -VV
     - name: autotools build
       run: |
         set -x
@@ -130,18 +142,6 @@ jobs:
         ./configure --with-mpiexec='mpiexec --oversubscribe'
         which mpiexec
         make check
-    - name: cmake build
-      run: |
-        set -x
-        echo 'export PATH=/home/runner/openmpi/bin:$PATH' > .bashrc
-        source .bashrc
-        export CC=/home/runner/openmpi/bin/mpicc
-        mkdir build
-        cd build
-        cmake -Wno-dev -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..
-        make VERBOSE=1
-        make tests VERBOSE=1
-        ctest -VV
 
         
         

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev  --debug-output --trace-source=/usr/local/share/cmake-3.17/Modules/TestBigEndian.cmake -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && CMakeFiles/CMakeError.log
+        cmake -Wno-dev  -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,8 +125,8 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        ls -l /home/runner/netcdf/lib
-        cmake -Wno-dev  -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log
+        ls -l /home/runner/netcdf-c/lib
+        cmake -Wno-dev  -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,6 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
+        export LD_LIBRARY_PATH="/home/runner/netcdf-c/lib:$LD_LIBRARY_PATH"
         cmake -Wno-dev -DWITH_MPIEXEC='/home/runner/openmpi/bin/mpiexec;--oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
         make VERBOSE=1
         make tests VERBOSE=1

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev  --debug-output --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log
+        cmake -Wno-dev  --debug-output --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && CMakeFiles/CMakeError.log
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,9 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev  -DWITH_MPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
-        ls -l tests/cunit
-        cat tests/cunit/run_tests.sh
+        cmake -Wno-dev --trace-source=CMakeLists.txt -DWITH_MPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev  --debug-output --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..
+        cmake -Wno-dev  --debug-output --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -122,7 +122,7 @@ jobs:
         set -x
         echo 'export PATH=/home/runner/openmpi/bin:$PATH' > .bashrc
         source .bashrc
-        export CC=/home/runner/openmpi/bin/mpicc
+        export CC=mpicc
         mkdir build
         cd build
         cmake -Wno-dev --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..
+        cmake -Wno-dev  --debug-output --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,6 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
+        ls -l /home/runner/netcdf/lib
         cmake -Wno-dev  -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log
         make VERBOSE=1
         make tests VERBOSE=1

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -126,7 +126,8 @@ jobs:
         mkdir build
         cd build
         cmake -Wno-dev  -DMPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
-        cat tests/unit/run_tests.sh
+        ls -l tests/cunit
+        cat tests/cunit/run_tests.sh
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,8 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        ls -l /home/runner/netcdf-c/lib
-        cmake -Wno-dev  -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log
+        cmake -Wno-dev  -DMPIEXEC='mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev  --debug-output --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && CMakeFiles/CMakeError.log
+        cmake -Wno-dev  --debug-output --trace-source=/usr/local/share/cmake-3.17/Modules/TestBigEndian.cmake -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || cat CMakeFiles/CMakeOutput.log && CMakeFiles/CMakeError.log
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -138,5 +138,10 @@ jobs:
         export CC=/home/runner/openmpi/bin/mpicc
         mkdir build
         cd build
+        cmake -Wno-dev -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..
+        make VERBOSE=1
+        make tests VERBOSE=1
+        ctest -VV
+
         
         

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -1,4 +1,4 @@
-name: netcdf-4.7.4_pnetcdf-12.1_ncint
+name: netcdf-4.7.4_pnetcdf-12.1_ncint_openmpi_4.0.4
 
 on:
   push:
@@ -117,9 +117,7 @@ jobs:
         make
         sudo make install
         popd
-    - name: autoreconf
-      run: autoreconf -i
-    - name: pio build
+    - name: autotools build
       run: |
         set -x
         echo 'export PATH=/home/runner/openmpi/bin:$PATH' > .bashrc
@@ -128,8 +126,17 @@ jobs:
         source .bashrc
         export PATH="/home/runner/openmpi/bin:$PATH"
         export CC=/home/runner/openmpi/bin/mpicc
+        autoreconf -i
         ./configure --with-mpiexec='mpiexec --oversubscribe'
         which mpiexec
         make check
+    - name: cmake build
+      run: |
+        set -x
+        echo 'export PATH=/home/runner/openmpi/bin:$PATH' > .bashrc
+        source .bashrc
+        export CC=/home/runner/openmpi/bin/mpicc
+        mkdir build
+        cd build
         
         

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=/home/runner/openmpi/bin/mpicc
         mkdir build
         cd build
-        cmake -Wno-dev -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..
+        cmake -Wno-dev --trace-source=src/CMakeLists.txt -DNetCDF_C_LIBRARY=/home/runner/netcdf/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off ..
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/.github/workflows/a3.yml
+++ b/.github/workflows/a3.yml
@@ -125,7 +125,7 @@ jobs:
         export CC=mpicc
         mkdir build
         cd build
-        cmake -Wno-dev -DWITH_MPIEXEC='/home/runner/openmpi/bin/mpiexec --oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
+        cmake -Wno-dev -DWITH_MPIEXEC='/home/runner/openmpi/bin/mpiexec;--oversubscribe' -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_HDF5_LOGGING=On -DPIO_USE_MALLOC=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
         make VERBOSE=1
         make tests VERBOSE=1
         ctest -VV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,7 +451,7 @@ cmake_print_variables(WITH_MPIEXEC)
 if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
-set(MPIEXEC "${WITH_MPIEXEC}" CACHE STRING "mpiexec")
+set(MPIEXEC "${WITH_MPIEXEC}" CACHE INTERNAL)
 cmake_print_variables(MPIEXEC)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,7 +451,7 @@ cmake_print_variables(WITH_MPIEXEC)
 if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
-set(MPIEXEC "${WITH_MPIEXEC}" CACHE INTERNAL)
+set(MPIEXEC "${WITH_MPIEXEC}" CACHE INTERNAL "")
 cmake_print_variables(MPIEXEC)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,7 +451,7 @@ cmake_print_variables(WITH_MPIEXEC)
 if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
-set(MPIEXEC WITH_MPIEXEC)
+set(MPIEXEC ${WITH_MPIEXEC})
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in
   ${CMAKE_CURRENT_BINARY_DIR}/tests/cunit/run_tests.sh @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ endif ()
 # System Name
 string (TOUPPER "${CMAKE_SYSTEM_NAME}" CMAKE_SYSTEM_NAME_CAPS)
 set (CMAKE_SYSTEM_DIRECTIVE "${CMAKE_SYSTEM_NAME_CAPS}"
-  CACHE STRING "System name preprocessor directive")
+  CACHE STRING "System name preprocessor directive" FORCE)
 
 # C Compiler Name
 string (TOUPPER "${CMAKE_C_COMPILER_ID}" CMAKE_C_COMPILER_NAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,7 +451,7 @@ cmake_print_variables(WITH_MPIEXEC)
 if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
-set(MPIEXEC ${WITH_MPIEXEC})
+set(MPIEXEC "${WITH_MPIEXEC}")
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in
   ${CMAKE_CURRENT_BINARY_DIR}/tests/cunit/run_tests.sh @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,9 @@
+# This is part of the PIO library.
+
+# This is the CMake build file for the main directory.
+
+# Jim Edwards
+
 cmake_minimum_required (VERSION 2.8.12)
 project (PIO C Fortran)
 #cmake_policy(VERSION 3.5.2)
@@ -198,7 +204,7 @@ endif ()
 # System Name
 string (TOUPPER "${CMAKE_SYSTEM_NAME}" CMAKE_SYSTEM_NAME_CAPS)
 set (CMAKE_SYSTEM_DIRECTIVE "${CMAKE_SYSTEM_NAME_CAPS}"
-  CACHE STRING "System name preprocessor directive" FORCE)
+  CACHE STRING "System name preprocessor directive")
 
 # C Compiler Name
 string (TOUPPER "${CMAKE_C_COMPILER_ID}" CMAKE_C_COMPILER_NAME)
@@ -447,16 +453,8 @@ configure_file (
   )
 
 # Configure test scripts.
-cmake_print_variables(WITH_MPIEXEC)
 if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
 set(MPIEXEC "${WITH_MPIEXEC}" CACHE INTERNAL "")
 set_property(GLOBAL PROPERTY WITH_MPIEXEC "${WITH_MPIEXEC}")
-cmake_print_variables(MPIEXEC)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in
-  ${CMAKE_CURRENT_BINARY_DIR}/tests/cunit/run_tests.sh @ONLY)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/examples/c/run_tests.sh.in
-  ${CMAKE_CURRENT_BINARY_DIR}/examples/c/run_tests.sh @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ set(PIO_VERSION_PATCH ${VERSION_PATCH})
 # This is needed for the libpio.settings file.
 SET(PACKAGE_VERSION ${PIO_VERSION_MAJOR}.${PIO_VERSION_MINOR}.${PIO_VERSION_PATCH})
 
+# This provides cmake_print_variables() function for debugging.
+include(CMakePrintHelpers)
+
 # Determine the configure date.
 IF(DEFINED ENV{SOURCE_DATE_EPOCH})
         EXECUTE_PROCESS(
@@ -444,8 +447,9 @@ configure_file (
   )
 
 # Configure test scripts.
-if (NOT MPIEXEC)
-  set(MPIEXEC mpiexec)
+cmake_print_variables(WITH_MPIEXEC)
+if (NOT WITH_MPIEXEC)
+  set(WITH_MPIEXEC mpiexec)
 endif()
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,7 @@ if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
 set(MPIEXEC "${WITH_MPIEXEC}" CACHE INTERNAL "")
+set_property(GLOBAL PROPERTY WITH_MPIEXEC "${WITH_MPIEXEC}")
 cmake_print_variables(MPIEXEC)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,6 +451,7 @@ cmake_print_variables(WITH_MPIEXEC)
 if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
+set(MPIEXEC WITH_MPIEXEC)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in
   ${CMAKE_CURRENT_BINARY_DIR}/tests/cunit/run_tests.sh @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,7 +451,7 @@ cmake_print_variables(WITH_MPIEXEC)
 if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
-set(MPIEXEC "${WITH_MPIEXEC}")
+set(MPIEXEC "${WITH_MPIEXEC}" CACHE STRING "mpiexec")
 cmake_print_variables(MPIEXEC)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,9 @@ configure_file (
   )
 
 # Configure test scripts.
-set(MPIEXEC mpiexec)
+if (NOT MPIEXEC)
+  set(MPIEXEC mpiexec)
+endif()
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in
   ${CMAKE_CURRENT_BINARY_DIR}/tests/cunit/run_tests.sh @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,7 @@ if (NOT WITH_MPIEXEC)
   set(WITH_MPIEXEC mpiexec)
 endif()
 set(MPIEXEC "${WITH_MPIEXEC}")
+cmake_print_variables(MPIEXEC)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/cunit/run_tests.sh.in
   ${CMAKE_CURRENT_BINARY_DIR}/tests/cunit/run_tests.sh @ONLY)

--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -1,6 +1,8 @@
-# This provides cmake_print_variables() function for debugging.
-include(CMakePrintHelpers)
+# This is part of the PIO library.
 
+# THis file contains CMake code related to MPI.
+
+# Jim Edwards
 include (CMakeParseArguments)
 
 # Find Valgrind to perform memory leak check
@@ -94,11 +96,9 @@ function (add_mpi_test TESTNAME)
     platform_name (PLATFORM)
 
     get_property(WITH_MPIEXEC GLOBAL PROPERTY WITH_MPIEXEC)
-    cmake_print_variables(WITH_MPIEXEC MPIEXEC exec_file num_procs)
     if (WITH_MPIEXEC)
       set(MPIEXEC "${WITH_MPIEXEC}")
     endif ()
-    cmake_print_variables(WITH_MPIEXEC MPIEXEC exec_file num_procs)
 
     # Default ("unknown" platform) execution
     if (PLATFORM STREQUAL "unknown")
@@ -116,8 +116,6 @@ function (add_mpi_test TESTNAME)
 
     endif ()
 
-    cmake_print_variables(EXE_CMD)
-    
     # Add the test to CTest
     add_test(NAME ${TESTNAME} COMMAND ${EXE_CMD})
 

--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -93,7 +93,12 @@ function (add_mpi_test TESTNAME)
     # Get the platform name
     platform_name (PLATFORM)
 
-    cmake_print_variables(MPIEXEC exec_file num_procs)
+    get_property(WITH_MPIEXEC GLOBAL PROPERTY WITH_MPIEXEC)
+    cmake_print_variables(WITH_MPIEXEC MPIEXEC exec_file num_procs)
+    if (WITH_MPIEXEC)
+      set(MPIEXEC "${WITH_MPIEXEC}")
+    endif ()
+    cmake_print_variables(WITH_MPIEXEC MPIEXEC exec_file num_procs)
 
     # Default ("unknown" platform) execution
     if (PLATFORM STREQUAL "unknown")

--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -1,3 +1,6 @@
+# This provides cmake_print_variables() function for debugging.
+include(CMakePrintHelpers)
+
 include (CMakeParseArguments)
 
 # Find Valgrind to perform memory leak check
@@ -89,6 +92,8 @@ function (add_mpi_test TESTNAME)
 
     # Get the platform name
     platform_name (PLATFORM)
+
+    cmake_print_variables(MPIEXEC exec_file num_procs)
 
     # Default ("unknown" platform) execution
     if (PLATFORM STREQUAL "unknown")

--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -116,6 +116,8 @@ function (add_mpi_test TESTNAME)
 
     endif ()
 
+    cmake_print_variables(EXE_CMD)
+    
     # Add the test to CTest
     add_test(NAME ${TESTNAME} COMMAND ${EXE_CMD})
 

--- a/configure.ac
+++ b/configure.ac
@@ -207,9 +207,9 @@ AC_MSG_CHECKING([whether a user specified program to run mpi programs])
 AC_ARG_WITH([mpiexec],
               [AS_HELP_STRING([--with-mpiexec=<command>],
                               [Specify command to launch MPI parallel tests.])],
-            [MPIEXEC=$with_mpiexec], [MPIEXEC=mpiexec])
-AC_MSG_RESULT([$MPIEXEC])
-AC_SUBST([MPIEXEC], [$MPIEXEC])
+            [WITH_MPIEXEC=$with_mpiexec], [WITH_MPIEXEC=mpiexec])
+AC_MSG_RESULT([$WITH_MPIEXEC])
+AC_SUBST([WITH_MPIEXEC], [$WITH_MPIEXEC])
 
 # Is doxygen installed?
 AC_CHECK_PROGS([DOXYGEN], [doxygen])

--- a/examples/c/run_tests.sh.in
+++ b/examples/c/run_tests.sh.in
@@ -19,7 +19,7 @@ for EXAMPLE in $PIO_EXAMPLES
 do
     success1=false
     echo "running ${EXAMPLE}"
-    @MPIEXEC@ -n 4 ./${EXAMPLE} && success1=true
+    @WITH_MPIEXEC@ -n 4 ./${EXAMPLE} && success1=true
     if test $success1 = false; then
         break
     fi
@@ -29,7 +29,7 @@ for EXAMPLE in $PIO_EXAMPLES_16
 do
     success2=false
     echo "running ${EXAMPLE}"
-    @MPIEXEC@ -n 16 ./${EXAMPLE} && success2=true
+    @WITH_MPIEXEC@ -n 16 ./${EXAMPLE} && success2=true
     if test $success2 = false; then
         break
     fi

--- a/tests/cunit/run_tests.sh.in
+++ b/tests/cunit/run_tests.sh.in
@@ -26,7 +26,7 @@ for TEST in $PIO_TESTS
 do
     success1=false
     echo "running ${TEST}"
-    @MPIEXEC@ -n 4 ./${TEST} && success1=true
+    @WITH_MPIEXEC@ -n 4 ./${TEST} && success1=true
     if test $success1 = false; then
         break
     fi
@@ -38,7 +38,7 @@ for TEST in $PIO_TESTS_8
 do
     success2=false
     echo "running ${TEST}"
-    @MPIEXEC@ -n 8 ./${TEST} && success2=true
+    @WITH_MPIEXEC@ -n 8 ./${TEST} && success2=true
     if test $success2 = false; then
         break
     fi


### PR DESCRIPTION
Fixes  #1732 
Fixes #1282
Fixes #1423
Fixes #1730
Part of #1675 

Currently the netcdf-4.7.4_pnetcdf-12.1_ncint_openmpi_4.0.4 test only builds with autotools, the C library and tests only. In this PR I add CMake builds of the C library as well.

With openmpi, this means the --with-mpiexec= option must be working, so that I can pass the --oversubscribe option to mpiexec.