### PR TITLE
removed unused VARN pre-processor defines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -249,8 +249,6 @@ fi
 # If we have parallel-netcdf, then set these as well.
 if test x$ac_cv_lib_pnetcdf_ncmpi_create = xyes; then
    AC_DEFINE([_PNETCDF], [1], [parallel-netcdf library available])
-   AC_DEFINE([USE_PNETCDF_VARN], [1], [defined by CMake build])
-   AC_DEFINE([USE_PNETCDF_VARN_ON_READ], [1], [defined by CMake build])
 fi
 
 # Do we have netCDF-4?

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -112,12 +112,12 @@ if (PnetCDF_C_FOUND)
 
   # Check library for varn functions
   set (CMAKE_REQUIRED_LIBRARIES ${PnetCDF_C_LIBRARY})
-  check_function_exists (ncmpi_get_varn PnetCDF_C_HAS_VARN)
-  if (PnetCDF_C_HAS_VARN)
-    target_compile_definitions(pioc
-      PUBLIC USE_PNETCDF_VARN
-      PUBLIC USE_PNETCDF_VARN_ON_READ)
-  endif()
+  # check_function_exists (ncmpi_get_varn PnetCDF_C_HAS_VARN)
+  # if (PnetCDF_C_HAS_VARN)
+  #   target_compile_definitions(pioc
+  #     PUBLIC USE_PNETCDF_VARN
+  #     PUBLIC USE_PNETCDF_VARN_ON_READ)
+  # endif()
 endif ()
 
 #===== Add EXTRAs =====


### PR DESCRIPTION
Fixes #1686 

In this PR I remove the last two flags set by our cmake build which are not in config.h. The defines were never used in any code anyway.

Config.h is our one-stop shopping for all pre-processor defines, in C and Fortran.

