### PR TITLE
Adding deflate to netCDF integration layer

### DIFF
--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -21,8 +21,7 @@
  *
  * @param ncid the ncid of the open file.
  * @param varid the ID of the variable.
- * @param shuffle non-zero to turn on shuffle filter (can be good for
- * integer data).
+ * @param shuffle non-zero to turn on shuffle filter.
  * @param deflate non-zero to turn on zlib compression for this
  * variable.
  * @param deflate_level 1 to 9, with 1 being faster and 9 being more

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -880,6 +880,9 @@ PIO_NCINT_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
 
     if (!ret)
 	ret = PIOc_inq_var_deflate(ncid, varid, shufflep, deflatep, deflate_levelp);
+
+    if (!ret)
+	ret = PIOc_inq_var_endian(ncid, varid, endiannessp);
     
     return ret;
 }

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -111,8 +111,8 @@ NC_Dispatch NCINT_dispatcher = {
     NC_NOTNC4_def_opaque,
     PIO_NCINT_def_var_deflate,
     NC_NOTNC4_def_var_fletcher32,
-    NC_NOTNC4_def_var_chunking,
-    NC_NOTNC4_def_var_endian,
+    PIO_NCINT_def_var_chunking,
+    PIOc_def_var_endian,
     NC_NOTNC4_def_var_filter,
     NC_NOTNC4_set_var_chunk_cache,
     NC_NOTNC4_get_var_chunk_cache,
@@ -974,3 +974,32 @@ PIO_NCINT_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
     return PIOc_def_var_deflate(ncid, varid, shuffle, deflate, deflate_level);
 }
 
+/**
+ * @internal Set chunksizes for a variable.
+ *
+ * This function only applies to netCDF-4 files. When used with netCDF
+ * classic files, the error PIO_ENOTNC4 will be returned.
+ *
+ * Chunksizes have important performance repercussions. NetCDF
+ * attempts to choose sensible chunk sizes by default, but for best
+ * performance check chunking against access patterns.
+ *
+ * See the <a
+ * href="http://www.unidata.ucar.edu/software/netcdf/docs/group__variables.html">netCDF
+ * variable documentation</a> for details about the operation of this
+ * function.
+ *
+ * @param ncid the ncid of the open file.
+ * @param varid the ID of the variable to set chunksizes for.
+ * @param storage NC_CONTIGUOUS or NC_CHUNKED.
+ * @param chunksizesp an array of chunksizes. Must have a chunksize for
+ * every variable dimension.
+ * @return PIO_NOERR for success, otherwise an error code.
+ * @ingroup PIO_def_var_c
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_def_var_chunking(int ncid, int varid, int storage, const size_t *chunksizesp)
+{
+    return PIOc_def_var_chunking(ncid, varid, storage, (const PIO_Offset *)chunksizesp);
+}

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -109,7 +109,7 @@ NC_Dispatch NCINT_dispatcher = {
     NC_NOTNC4_inq_enum_member,
     NC_NOTNC4_inq_enum_ident,
     NC_NOTNC4_def_opaque,
-    NC_NOTNC4_def_var_deflate,
+    PIO_NCINT_def_var_deflate,
     NC_NOTNC4_def_var_fletcher32,
     NC_NOTNC4_def_var_chunking,
     NC_NOTNC4_def_var_endian,
@@ -951,3 +951,26 @@ PIO_NCINT_inq_type_equal(int ncid1, nc_type typeid1, int ncid2,
         *equalp = typeid1 == typeid2 ? 1 : 0;
     return NC_NOERR;
 }
+
+/**
+ * @internal This functions sets deflate settings for a
+ * netCDF-4 variable. It is called by nc_def_var_deflate().
+ *
+ * @param ncid the ncid of the open file.
+ * @param varid the ID of the variable.
+ * @param shuffle non-zero to turn on shuffle filter.
+ * @param deflate non-zero to turn on zlib compression for this
+ * variable.
+ * @param deflate_level 1 to 9, with 1 being faster and 9 being more
+ * compressed.
+ *
+ * @returns ::NC_NOERR for success
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
+			  int deflate_level)
+{
+    return PIOc_def_var_deflate(ncid, varid, shuffle, deflate, deflate_level);
+}
+

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -871,7 +871,17 @@ PIO_NCINT_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
                       int *no_fill, void *fill_valuep, int *endiannessp,
                       unsigned int *idp, size_t *nparamsp, unsigned int *params)
 {
-    return PIOc_inq_var(ncid, varid, name, xtypep, ndimsp, dimidsp, nattsp);
+    int ret;
+
+    ret = PIOc_inq_var(ncid, varid, name, xtypep, ndimsp, dimidsp, nattsp);
+
+    if (!ret)
+	ret = PIOc_inq_var_chunking(ncid, varid, contiguousp, (MPI_Offset *)chunksizesp);
+
+    if (!ret)
+	ret = PIOc_inq_var_deflate(ncid, varid, shufflep, deflatep, deflate_levelp);
+    
+    return ret;
 }
 
 /**

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -148,7 +148,10 @@ extern "C" {
     extern int
     PIO_NCINT_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
 			      int deflate_level);
-    
+
+    extern int
+    PIO_NCINT_def_var_chunking(int ncid, int varid, int storage, const size_t *chunksizesp);
+
 
 #if defined(__cplusplus)
 }

--- a/src/ncint/ncintdispatch.h
+++ b/src/ncint/ncintdispatch.h
@@ -145,6 +145,11 @@ extern "C" {
     PIO_NCINT_inq_type_equal(int ncid1, nc_type typeid1, int ncid2,
                              nc_type typeid2, int *equalp);
 
+    extern int
+    PIO_NCINT_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
+			      int deflate_level);
+    
+
 #if defined(__cplusplus)
 }
 #endif

--- a/tests/ncint/CMakeLists.txt
+++ b/tests/ncint/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories("${CMAKE_SOURCE_DIR}/tests/ncint")
 include_directories("${CMAKE_BINARY_DIR}")
 
 set (my_tests tst_async_multi tst_ncint_async_perf
-  tst_ncint_perf tst_pio_async tst_pio_udf)
+  tst_ncint_perf tst_pio_async tst_pio_udf tst_var_compress)
 
 # Test Timeout in seconds.
 if (PIO_VALGRIND_CHECK)

--- a/tests/ncint/Makefile.am
+++ b/tests/ncint/Makefile.am
@@ -9,7 +9,7 @@ LDADD = ${top_builddir}/src/clib/libpioc.la
 
 # Build the test for make check.
 check_PROGRAMS = tst_pio_udf tst_pio_async tst_async_multi	\
-tst_ncint_async_perf tst_ncint_perf
+tst_ncint_async_perf tst_ncint_perf tst_var_compress
 
 tst_pio_udf_SOURCES = tst_pio_udf.c pio_err_macros.h
 tst_pio_async_SOURCES = tst_pio_async.c pio_err_macros.h

--- a/tests/ncint/run_tests.sh.in
+++ b/tests/ncint/run_tests.sh.in
@@ -10,7 +10,7 @@ trap exit INT TERM
 
 printf 'running PIO tests...\n'
 
-PIO_TESTS='tst_pio_udf tst_pio_async tst_async_multi'
+PIO_TESTS='tst_pio_udf tst_pio_async tst_async_multi tst_var_compress'
 
 success1=true
 success2=true

--- a/tests/ncint/tst_var_compress.c
+++ b/tests/ncint/tst_var_compress.c
@@ -45,6 +45,7 @@ run_var_compress_test(int my_rank, int ntasks, int iosysid)
     if (nc_def_var(ncid, VAR_NAME, NC_INT, NDIM3, dimid, &varid)) PERR;
     if (nc_def_var_deflate(ncid, varid, 1, 1, DEFLATE_LEVEL)) PERR;
     if (nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksizes)) PERR;
+    if (nc_def_var_endian(ncid, varid, NC_ENDIAN_BIG)) PERR;
 
     /* Calculate a decomposition for distributed arrays. */
     elements_per_pe = DIM_LEN_X * DIM_LEN_Y / ntasks;
@@ -84,10 +85,8 @@ run_var_compress_test(int my_rank, int ntasks, int iosysid)
 	/* Check the chunking. */
 	if (nc_inq_var_chunking(ncid, 0, &storage_in, chunksizes_in)) PERR;
 	for (d = 0; d < NDIM3; d++)
-	{
-	    printf("chunksizes_in[%d] = %ld\n", d, chunksizes_in[d]);	
-	    /* if (chunksizes_in[0] != chunksizes[0]) PERR; */
-	}
+	    if (chunksizes_in[d] != chunksizes[d]) PERR;
+	if (storage_in != NC_CHUNKED) PERR;
 	
 	/* Read distributed arrays. */
 	if (!(data_in = malloc(elements_per_pe * sizeof(int)))) PERR;

--- a/tests/ncint/tst_var_compress.c
+++ b/tests/ncint/tst_var_compress.c
@@ -1,0 +1,129 @@
+/* Test netcdf integration layer of the PIO library.
+
+   Test variable compression settings with the netCDF integration
+   layer.
+
+   Ed Hartnett, 9/3/20
+*/
+
+#include "config.h"
+#include "pio_err_macros.h"
+#include <pio.h>
+
+#define FILE_NAME "tst_var_compress.nc"
+#define VAR_NAME "data_var"
+#define DIM_NAME_UNLIMITED "dim_unlimited"
+#define DIM_NAME_X "dim_x"
+#define DIM_NAME_Y "dim_y"
+#define DIM_LEN_X 4
+#define DIM_LEN_Y 4
+#define NDIM2 2
+#define NDIM3 3
+#define TEST_VAL_42 42
+
+extern NC_Dispatch NCINT_dispatcher;
+
+int
+main(int argc, char **argv)
+{
+    int my_rank;
+    int ntasks;
+
+    /* Initialize MPI. */
+    if (MPI_Init(&argc, &argv)) PERR;
+
+    /* Learn my rank and the total number of processors. */
+    if (MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)) PERR;
+    if (MPI_Comm_size(MPI_COMM_WORLD, &ntasks)) PERR;
+
+    if (!my_rank)
+        printf("\n*** Testing netCDF integration layer.\n");
+    if (!my_rank)
+        printf("*** testing getting/setting of default iosystemid...");
+    {
+        int iosysid;
+
+        if (nc_set_iosystem(TEST_VAL_42)) PERR;
+        if (nc_get_iosystem(&iosysid)) PERR;
+        if (iosysid != TEST_VAL_42) PERR;
+    }
+    PSUMMARIZE_ERR;
+
+    if (!my_rank)
+        printf("*** testing simple use of netCDF integration layer format...");
+    {
+        int ncid, ioid;
+        int dimid[NDIM3], varid;
+        int dimlen[NDIM3] = {NC_UNLIMITED, DIM_LEN_X, DIM_LEN_Y};
+        int iosysid;
+        NC_Dispatch *disp_in;
+        size_t elements_per_pe;
+        size_t *compdof; /* The decomposition mapping. */
+        int *my_data;
+        int *data_in;
+        int i;
+
+        /* Turn on logging for PIO library. */
+        /* PIOc_set_log_level(3); */
+
+        /* Initialize the intracomm. */
+        if (nc_def_iosystem(MPI_COMM_WORLD, 1, 1, 0, 0, &iosysid)) PERR;
+
+        /* Create a file with a 3D record var. */
+        if (nc_create(FILE_NAME, NC_PIO, &ncid)) PERR;
+        if (nc_def_dim(ncid, DIM_NAME_UNLIMITED, dimlen[0], &dimid[0])) PERR;
+        if (nc_def_dim(ncid, DIM_NAME_X, dimlen[1], &dimid[1])) PERR;
+        if (nc_def_dim(ncid, DIM_NAME_Y, dimlen[2], &dimid[2])) PERR;
+        if (nc_def_var(ncid, VAR_NAME, NC_INT, NDIM3, dimid, &varid)) PERR;
+
+        /* Calculate a decomposition for distributed arrays. */
+        elements_per_pe = DIM_LEN_X * DIM_LEN_Y / ntasks;
+        if (!(compdof = malloc(elements_per_pe * sizeof(size_t))))
+            PERR;
+        for (i = 0; i < elements_per_pe; i++)
+            compdof[i] = my_rank * elements_per_pe + i;
+
+        /* Create the PIO decomposition for this test. */
+        if (nc_def_decomp(iosysid, PIO_INT, NDIM2, &dimlen[1], elements_per_pe,
+                          compdof, &ioid, 1, NULL, NULL)) PERR;
+        free(compdof);
+
+        /* Create some data on this processor. */
+        if (!(my_data = malloc(elements_per_pe * sizeof(int)))) PERR;
+        for (i = 0; i < elements_per_pe; i++)
+            my_data[i] = my_rank * 10 + i;
+
+        /* Write some data with distributed arrays. */
+        if (nc_put_vard_int(ncid, varid, ioid, 0, my_data)) PERR;
+        if (nc_close(ncid)) PERR;
+
+        /* Check that our user-defined format has been added. */
+        if (nc_inq_user_format(NC_PIO, &disp_in, NULL)) PERR;
+        if (disp_in != &NCINT_dispatcher) PERR;
+
+        /* Open the file. */
+        if (nc_open(FILE_NAME, NC_PIO, &ncid)) PERR;
+
+        /* Read distributed arrays. */
+        if (!(data_in = malloc(elements_per_pe * sizeof(int)))) PERR;
+        if (nc_get_vard_int(ncid, varid, ioid, 0, data_in)) PERR;
+
+        /* Check results. */
+        for (i = 0; i < elements_per_pe; i++)
+            if (data_in[i] != my_data[i]) PERR;
+
+        /* Close file. */
+        if (nc_close(ncid)) PERR;
+
+        /* Free resources. */
+        free(data_in);
+        free(my_data);
+        if (nc_free_decomp(ioid)) PERR;
+        if (nc_free_iosystem(iosysid)) PERR;
+    }
+    PSUMMARIZE_ERR;
+
+    /* Finalize MPI. */
+    MPI_Finalize();
+    PFINAL_RESULTS;
+}

--- a/tests/ncint/tst_var_compress.c
+++ b/tests/ncint/tst_var_compress.c
@@ -72,6 +72,7 @@ run_var_compress_test(int my_rank, int ntasks, int iosysid)
 	int shuffle_in, deflate_in, deflate_level_in, storage_in;
 	int *data_in;
 	size_t chunksizes_in[NDIM3];
+	int endian_in;
 	int d;
 	
 	/* Open the file. */
@@ -87,6 +88,10 @@ run_var_compress_test(int my_rank, int ntasks, int iosysid)
 	for (d = 0; d < NDIM3; d++)
 	    if (chunksizes_in[d] != chunksizes[d]) PERR;
 	if (storage_in != NC_CHUNKED) PERR;
+
+	/* Check the endianness. */
+	if (nc_inq_var_endian(ncid, 0, &endian_in)) PERR;
+	if (endian_in != NC_ENDIAN_BIG) PERR;
 	
 	/* Read distributed arrays. */
 	if (!(data_in = malloc(elements_per_pe * sizeof(int)))) PERR;

--- a/tests/ncint/tst_var_compress.c
+++ b/tests/ncint/tst_var_compress.c
@@ -21,11 +21,75 @@
 #define NDIM3 3
 #define TEST_VAL_42 42
 
-extern NC_Dispatch NCINT_dispatcher;
+int
+run_var_compress_test(int my_rank, int ntasks, int iosysid)
+{
+    int ncid, ioid;
+    int dimid[NDIM3], varid;
+    int dimlen[NDIM3] = {NC_UNLIMITED, DIM_LEN_X, DIM_LEN_Y};
+    size_t elements_per_pe;
+    size_t *compdof; /* The decomposition mapping. */
+    int *my_data;
+    int *data_in;
+    int i;
+
+    /* Turn on logging for PIO library. */
+    /* PIOc_set_log_level(3); */
+
+    /* Create a file with a 3D record var. */
+    if (nc_create(FILE_NAME, NC_PIO, &ncid)) PERR;
+    if (nc_def_dim(ncid, DIM_NAME_UNLIMITED, dimlen[0], &dimid[0])) PERR;
+    if (nc_def_dim(ncid, DIM_NAME_X, dimlen[1], &dimid[1])) PERR;
+    if (nc_def_dim(ncid, DIM_NAME_Y, dimlen[2], &dimid[2])) PERR;
+    if (nc_def_var(ncid, VAR_NAME, NC_INT, NDIM3, dimid, &varid)) PERR;
+
+    /* Calculate a decomposition for distributed arrays. */
+    elements_per_pe = DIM_LEN_X * DIM_LEN_Y / ntasks;
+    if (!(compdof = malloc(elements_per_pe * sizeof(size_t))))
+	PERR;
+    for (i = 0; i < elements_per_pe; i++)
+	compdof[i] = my_rank * elements_per_pe + i;
+
+    /* Create the PIO decomposition for this test. */
+    if (nc_def_decomp(iosysid, PIO_INT, NDIM2, &dimlen[1], elements_per_pe,
+		      compdof, &ioid, 1, NULL, NULL)) PERR;
+    free(compdof);
+
+    /* Create some data on this processor. */
+    if (!(my_data = malloc(elements_per_pe * sizeof(int)))) PERR;
+    for (i = 0; i < elements_per_pe; i++)
+	my_data[i] = my_rank * 10 + i;
+
+    /* Write some data with distributed arrays. */
+    if (nc_put_vard_int(ncid, varid, ioid, 0, my_data)) PERR;
+    if (nc_close(ncid)) PERR;
+
+    /* Open the file. */
+    if (nc_open(FILE_NAME, NC_PIO, &ncid)) PERR;
+
+    /* Read distributed arrays. */
+    if (!(data_in = malloc(elements_per_pe * sizeof(int)))) PERR;
+    if (nc_get_vard_int(ncid, varid, ioid, 0, data_in)) PERR;
+
+    /* Check results. */
+    for (i = 0; i < elements_per_pe; i++)
+	if (data_in[i] != my_data[i]) PERR;
+
+    /* Close file. */
+    if (nc_close(ncid)) PERR;
+
+    /* Free resources. */
+    free(data_in);
+    free(my_data);
+    if (nc_free_decomp(ioid)) PERR;
+
+    return 0;
+}
 
 int
 main(int argc, char **argv)
 {
+    int iosysid;
     int my_rank;
     int ntasks;
 
@@ -38,89 +102,16 @@ main(int argc, char **argv)
 
     if (!my_rank)
         printf("\n*** Testing netCDF integration layer.\n");
-    if (!my_rank)
-        printf("*** testing getting/setting of default iosystemid...");
-    {
-        int iosysid;
-
-        if (nc_set_iosystem(TEST_VAL_42)) PERR;
-        if (nc_get_iosystem(&iosysid)) PERR;
-        if (iosysid != TEST_VAL_42) PERR;
-    }
-    PSUMMARIZE_ERR;
 
     if (!my_rank)
-        printf("*** testing simple use of netCDF integration layer format...");
-    {
-        int ncid, ioid;
-        int dimid[NDIM3], varid;
-        int dimlen[NDIM3] = {NC_UNLIMITED, DIM_LEN_X, DIM_LEN_Y};
-        int iosysid;
-        NC_Dispatch *disp_in;
-        size_t elements_per_pe;
-        size_t *compdof; /* The decomposition mapping. */
-        int *my_data;
-        int *data_in;
-        int i;
+        printf("*** testing var compression with netCDF integration layer...");
 
-        /* Turn on logging for PIO library. */
-        /* PIOc_set_log_level(3); */
+    /* Initialize the intracomm. */
+    if (nc_def_iosystem(MPI_COMM_WORLD, 1, 1, 0, 0, &iosysid)) PERR;
 
-        /* Initialize the intracomm. */
-        if (nc_def_iosystem(MPI_COMM_WORLD, 1, 1, 0, 0, &iosysid)) PERR;
+    if (run_var_compress_test(my_rank, ntasks, iosysid)) PERR;
 
-        /* Create a file with a 3D record var. */
-        if (nc_create(FILE_NAME, NC_PIO, &ncid)) PERR;
-        if (nc_def_dim(ncid, DIM_NAME_UNLIMITED, dimlen[0], &dimid[0])) PERR;
-        if (nc_def_dim(ncid, DIM_NAME_X, dimlen[1], &dimid[1])) PERR;
-        if (nc_def_dim(ncid, DIM_NAME_Y, dimlen[2], &dimid[2])) PERR;
-        if (nc_def_var(ncid, VAR_NAME, NC_INT, NDIM3, dimid, &varid)) PERR;
-
-        /* Calculate a decomposition for distributed arrays. */
-        elements_per_pe = DIM_LEN_X * DIM_LEN_Y / ntasks;
-        if (!(compdof = malloc(elements_per_pe * sizeof(size_t))))
-            PERR;
-        for (i = 0; i < elements_per_pe; i++)
-            compdof[i] = my_rank * elements_per_pe + i;
-
-        /* Create the PIO decomposition for this test. */
-        if (nc_def_decomp(iosysid, PIO_INT, NDIM2, &dimlen[1], elements_per_pe,
-                          compdof, &ioid, 1, NULL, NULL)) PERR;
-        free(compdof);
-
-        /* Create some data on this processor. */
-        if (!(my_data = malloc(elements_per_pe * sizeof(int)))) PERR;
-        for (i = 0; i < elements_per_pe; i++)
-            my_data[i] = my_rank * 10 + i;
-
-        /* Write some data with distributed arrays. */
-        if (nc_put_vard_int(ncid, varid, ioid, 0, my_data)) PERR;
-        if (nc_close(ncid)) PERR;
-
-        /* Check that our user-defined format has been added. */
-        if (nc_inq_user_format(NC_PIO, &disp_in, NULL)) PERR;
-        if (disp_in != &NCINT_dispatcher) PERR;
-
-        /* Open the file. */
-        if (nc_open(FILE_NAME, NC_PIO, &ncid)) PERR;
-
-        /* Read distributed arrays. */
-        if (!(data_in = malloc(elements_per_pe * sizeof(int)))) PERR;
-        if (nc_get_vard_int(ncid, varid, ioid, 0, data_in)) PERR;
-
-        /* Check results. */
-        for (i = 0; i < elements_per_pe; i++)
-            if (data_in[i] != my_data[i]) PERR;
-
-        /* Close file. */
-        if (nc_close(ncid)) PERR;
-
-        /* Free resources. */
-        free(data_in);
-        free(my_data);
-        if (nc_free_decomp(ioid)) PERR;
-        if (nc_free_iosystem(iosysid)) PERR;
-    }
+    if (nc_free_iosystem(iosysid)) PERR;
     PSUMMARIZE_ERR;
 
     /* Finalize MPI. */


### PR DESCRIPTION
Part of #1654 

Adding functions to netCDF implementation layer for variable deflate settings.

nc_inq_var_chunking is still not working, and I will also add some fortran tests...