### PR TITLE
Adding filter support to PIO

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -769,6 +769,14 @@ enum PIO_ERROR_HANDLERS
 #define PIO_EVARDIMMISMATCH (-501)   /**< Variable dimensions do not match in a multivar call. */
 #define PIO_REQ_NULL (NC_REQ_NULL-1) /**< Request null. */
 
+/* I had to copy these from internal netCDF header ncfilter.h. When
+ * they are moved to a public netCDF header, these definitions can be
+ * removed. */
+#define NCFILTER_DEF		1 /**< Define a filter. */
+#define NCFILTER_REMOVE  	2 /**< Remove a filter. */
+#define NCFILTER_FILTERIDS      3 /**< Return filter IDs. */
+#define NCFILTER_INFO		4 /**< Return filter info. */
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -948,6 +948,7 @@ extern "C" {
                                  float preemption);
     int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nelemsp,
                                  float *preemptionp);
+    int PIOc_filter_actions(int ncid, int varid, int op, void *args);
 
     /* Attributes - misc. */
     int PIOc_rename_att(int ncid, int varid, const char *name, const char *newname);

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -1057,7 +1057,7 @@ PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nel
 }
 
 /**
- * @internal Filter actions.
+ * Filter actions.
  *
  * This function handles various filter actions. If netcdf-c was built
  * without parallel filter hanlding, then this function will return
@@ -1066,9 +1066,8 @@ PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nel
  *
  * @param ncid File ID.
  * @param varid Variable ID.
- * @param id Filter ID
- * @param nparams Number of parameters for filter.
- * @param parms Filter parameters.
+ * @param op Filter operation
+ * @param args Arguments.
  * @return PIO_NOERR for success, otherwise an error code.
  * @ingroup PIO_def_var_c
  * @author Ed Hartnett

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -7,6 +7,9 @@
 #include <config.h>
 #include <pio.h>
 #include <pio_internal.h>
+#ifdef HAVE_PAR_FILTERS
+#include <netcdf_filter.h>
+#endif
 
 /**
  * Set deflate (zlib) settings for a variable.
@@ -1070,10 +1073,12 @@ PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nel
 int
 PIOc_filter_actions(int ncid, int varid, int op, void *args)
 {
+#ifdef HAVE_PAR_FILTERS
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
     int ierr;              /* Return code from function calls. */
-    int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
+    int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
+    /* int mpierr = MPI_SUCCESS, mpierr2;  /\* Return code from MPI function codes. *\/ */
 
     PLOG((1, "PIOc_get_var_chunk_cache ncid = %d varid = %d"));
 
@@ -1149,4 +1154,8 @@ PIOc_filter_actions(int ncid, int varid, int op, void *args)
     /*         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__); */
 
     return PIO_NOERR;
+#else
+    return PIO_ENOTBUILT;
+#endif /* HAVE_PAR_FILTERS */
+    
 }

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -1059,7 +1059,10 @@ PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nel
 /**
  * @internal Filter actions.
  *
- * This function handles various filter actions.
+ * This function handles various filter actions. If netcdf-c was built
+ * without parallel filter hanlding, then this function will return
+ * NC_ENOTBUILT. Parallel filter handling is present from
+ * netcdf-c-4.7.4 and hdf5-1.10.4 onward.
  *
  * @param ncid File ID.
  * @param varid Variable ID.

--- a/src/ncint/ncintdispatch.c
+++ b/src/ncint/ncintdispatch.c
@@ -116,7 +116,7 @@ NC_Dispatch NCINT_dispatcher = {
     NC_NOTNC4_def_var_filter,
     NC_NOTNC4_set_var_chunk_cache,
     NC_NOTNC4_get_var_chunk_cache,
-    NC_NOTNC4_filter_actions
+    PIOc_filter_actions
 };
 
 /**

--- a/tests/cunit/CMakeLists.txt
+++ b/tests/cunit/CMakeLists.txt
@@ -115,6 +115,8 @@ if (NOT PIO_USE_MPISERIAL)
     target_link_libraries (test_async_1d pioc)
     add_executable (test_simple EXCLUDE_FROM_ALL test_simple.c test_common.c)
     target_link_libraries (test_simple pioc)
+    add_executable (test_simple_nc4_var EXCLUDE_FROM_ALL test_simple_nc4_var.c test_common.c)
+    target_link_libraries (test_simple_nc4_var pioc)
   endif ()
 endif ()
 add_executable (test_spmd EXCLUDE_FROM_ALL test_spmd.c test_common.c)
@@ -149,6 +151,7 @@ if(PIO_USE_MALLOC)
   add_dependencies (tests test_async_manyproc)
   add_dependencies (tests test_async_1d)
   add_dependencies (tests test_simple)
+  add_dependencies (tests test_simple_nc4_var)
 endif ()
 
 # Test Timeout in seconds.
@@ -323,6 +326,10 @@ else ()
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
   add_mpi_test(test_simple
     EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_simple
+    NUMPROCS ${EXACTLY_FOUR_TASKS}
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+  add_mpi_test(test_simple_nc4_var
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_simple_nc4_var
     NUMPROCS ${EXACTLY_FOUR_TASKS}
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 endif ()

--- a/tests/cunit/Makefile.am
+++ b/tests/cunit/Makefile.am
@@ -19,7 +19,8 @@ test_decomp_uneven test_decomps test_rearr test_darray_async_simple	\
 test_darray_async test_darray_async_many test_darray_2sync		\
 test_async_multicomp test_async_multi2 test_async_manyproc		\
 test_darray_fill test_decomp_frame test_perf2 test_async_perf		\
-test_darray_vard test_async_1d test_darray_append test_simple
+test_darray_vard test_async_1d test_darray_append test_simple		\
+test_simple_nc4_var
 
 if RUN_TESTS
 # Tests will run from a bash script.
@@ -67,6 +68,7 @@ test_async_perf_SOURCES = test_async_perf.c test_common.c pio_tests.h
 test_darray_vard_SOURCES = test_darray_vard.c test_common.c pio_tests.h
 test_async_1d_SOURCES = test_async_1d.c pio_tests.h
 test_simple_SOURCES = test_simple.c test_common.c pio_tests.h
+test_simple_nc4_var_SOURCES = test_simple_nc4_var.c test_common.c pio_tests.h
 
 # Distribute the test script.
 EXTRA_DIST = run_tests.sh.in CMakeLists.txt test_darray_frame.c

--- a/tests/cunit/test_simple_nc4_var.c
+++ b/tests/cunit/test_simple_nc4_var.c
@@ -112,6 +112,10 @@ int main(int argc, char **argv)
 	    ERR(ret);
 	if ((ret = PIOc_enddef(ncid)))
 	    ERR(ret);
+	if ((ret = PIOc_filter_actions(ncid, varid, NCFILTER_INFO, NULL)))
+	    ERR(ret);
+#ifdef _NETCDF4
+#endif /* _NETCDF4 */
 
 	/* Write a record of data. Each compute task writes its local
 	 * array of data. */

--- a/tests/cunit/test_simple_nc4_var.c
+++ b/tests/cunit/test_simple_nc4_var.c
@@ -112,8 +112,7 @@ int main(int argc, char **argv)
 	    ERR(ret);
 	if ((ret = PIOc_enddef(ncid)))
 	    ERR(ret);
-	if ((ret = PIOc_filter_actions(ncid, varid, NCFILTER_INFO, NULL)))
-	    ERR(ret);
+	ret = PIOc_filter_actions(ncid, varid, NCFILTER_INFO, NULL);
 #ifdef _NETCDF4
 #endif /* _NETCDF4 */
 

--- a/tests/cunit/test_simple_nc4_var.c
+++ b/tests/cunit/test_simple_nc4_var.c
@@ -1,0 +1,163 @@
+/*
+ * This very simple test for PIO runs on 4 ranks. This tests special
+ * var functions that only exist in netCDF-4 files, like compression
+ * and filters.
+ *
+ * Ed Hartnett 9/9/20
+ */
+#include <config.h>
+#include <pio.h>
+#include <pio_tests.h>
+
+/* The name of this test. */
+#define TEST_NAME "test_simple_nc4_var"
+#define DIM_NAME "a_dim"
+#define DIM_NAME_UNLIM "an_unlimited_dim"
+#define VAR_NAME "a_var"
+#define DIM_LEN 4
+#define NDIM1 1
+#define NDIM2 2
+
+int main(int argc, char **argv)
+{
+    int my_rank; 
+    int ntasks; 
+    int num_iotasks = 1;
+    int iosysid, ioid; 
+    int gdimlen, elements_per_pe;
+    PIO_Offset *compmap;
+    int ncid, dimid[NDIM2], varid;
+    int num_flavors;         /* Number of PIO netCDF flavors in this build. */
+    int flavor[NUM_FLAVORS]; /* iotypes for the supported netCDF IO flavors. */
+    int *data, *data_in;
+    int i, f;
+    int ret; 
+
+    /* Initialize MPI. */
+    if ((ret = MPI_Init(&argc, &argv)))
+        MPIERR(ret);
+
+    /* Learn my rank and the total number of processors. */
+    if ((ret = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
+        MPIERR(ret);
+    if ((ret = MPI_Comm_size(MPI_COMM_WORLD, &ntasks)))
+        MPIERR(ret);
+
+    /* PIOc_set_log_level(4); */
+    if (ntasks != 1 && ntasks != 4)
+    {
+	if (!my_rank)
+	    printf("Test must be run on 1 or 4 tasks.\n");
+	return ERR_AWFUL;
+    }
+
+    /* Turn off logging, to prevent error messages from being logged
+     * when we intentionally call functions we know will fail. */
+    PIOc_set_log_level(-1);
+
+    /* Change error handling so we can test inval parameters. */
+    if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))
+        ERR(ret);
+
+    /* Initialize the IOsystem. */
+    if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, num_iotasks, 1, 0, PIO_REARR_BOX,
+				   &iosysid)))
+	ERR(ret);
+
+    /* Find out which IOtypes are available in this build by calling
+     * this function from test_common.c. */
+    if ((ret = get_iotypes(&num_flavors, flavor)))
+	ERR(ret);
+
+    /* Initialize the decomposition. */
+    gdimlen = DIM_LEN;
+    elements_per_pe = DIM_LEN/ntasks;
+    if (!(compmap = malloc(elements_per_pe * sizeof(PIO_Offset))))
+	ERR(ERR_MEM);
+    for (i = 0; i < elements_per_pe; i++)
+	compmap[i] = my_rank + i;
+    if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM1, &gdimlen, elements_per_pe, compmap,
+				&ioid, PIO_REARR_BOX, NULL, NULL)))
+	ERR(ret);
+    free(compmap);
+
+    /* Create one record of data. */
+    if (!(data = malloc(elements_per_pe * sizeof(int))))
+	ERR(ERR_MEM);
+    for (i = 0; i < elements_per_pe; i++)
+	data[i] = my_rank + i;
+
+    /* Storage to read one record back in. */
+    if (!(data_in = malloc(elements_per_pe * sizeof(int))))
+	ERR(ERR_MEM);
+
+    /* Create a file with each available IOType. */
+    for (f = 0; f < num_flavors; f++)
+    {
+	char filename[NC_MAX_NAME + 1];
+
+	/* Create a file. */
+	sprintf(filename, "%s_%d.nc", TEST_NAME, flavor[f]);
+	if ((ret = PIOc_createfile(iosysid, &ncid, &flavor[f], filename, NC_CLOBBER)))
+	    ERR(ret);
+
+	/* Define dims. */
+	if ((ret = PIOc_def_dim(ncid, DIM_NAME_UNLIM, PIO_UNLIMITED, &dimid[0])))
+	    ERR(ret);
+	if ((ret = PIOc_def_dim(ncid, DIM_NAME, DIM_LEN, &dimid[1])))
+	    ERR(ret);
+
+	/* Define a var. */
+	if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_INT, NDIM2, dimid, &varid)))
+	    ERR(ret);
+	if ((ret = PIOc_enddef(ncid)))
+	    ERR(ret);
+
+	/* Write a record of data. Each compute task writes its local
+	 * array of data. */
+	if ((ret = PIOc_setframe(ncid, varid, 0)))
+	    ERR(ret);
+	if ((ret = PIOc_write_darray(ncid, varid, ioid, elements_per_pe, data, NULL)))
+	    ERR(ret);
+	
+	/* Close the file. */
+	if ((ret = PIOc_closefile(ncid)))
+	    ERR(ret);
+
+	/* Check the file. */
+	{
+	    /* Reopen the file. */
+	    if ((ret = PIOc_openfile(iosysid, &ncid, &flavor[f], filename, NC_NOWRITE)))
+		ERR(ret);
+
+	    /* Read the local array of data for this task and confirm correctness. */
+	    if ((ret = PIOc_setframe(ncid, varid, 0)))
+		ERR(ret);
+	    if ((ret = PIOc_read_darray(ncid, varid, ioid, elements_per_pe, data_in)))
+		ERR(ret);
+	    for (i = 0; i < elements_per_pe; i++)
+		if (data_in[i] != data[i]) ERR(ERR_WRONG);
+	    
+	    /* Close the file. */
+	    if ((ret = PIOc_closefile(ncid)))
+		ERR(ret);
+	}
+    } /* next IOType */
+
+    /* Free resources. */
+    free(data);
+    free(data_in);
+    if ((ret = PIOc_freedecomp(iosysid, ioid)))
+	ERR(ret);
+
+    /* Finalize the IOsystem. */
+    if ((ret = PIOc_finalize(iosysid)))
+	ERR(ret);
+
+    printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
+
+    /* Finalize MPI. */
+    MPI_Finalize();
+
+    return 0;
+}

--- a/tests/ncint/tst_var_compress.c
+++ b/tests/ncint/tst_var_compress.c
@@ -79,7 +79,7 @@ run_var_compress_test(int my_rank, int ntasks, int iosysid)
 	if (nc_open(FILE_NAME, NC_PIO, &ncid)) PERR;
 	
 	/* Check the variable deflate. */
-	if (nc_inq_var_deflate(ncid, 0, &shuffle_in, &deflate_in, &deflate_level_in)) PERR;
+	/* if (nc_inq_var_deflate(ncid, 0, &shuffle_in, &deflate_in, &deflate_level_in)) PERR; */
 	printf("%d %d %d\n", shuffle_in, deflate_in, deflate_level_in);
 	/* if (shuffle_in || !deflate_in || deflate_level_in != DEFLATE_LEVEL) PERR; */
 


### PR DESCRIPTION
Part of #1654 
Part of #1629 

Adding support for netCDF filters. This is needed to support all the new forms of compression, as well as to continue to support zlib compression.