### PR TITLE
change waitany to waitsome to avoid message starving

### DIFF
--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -2620,9 +2620,10 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
     iosystem_desc_t *my_iosys;
     int msg = PIO_MSG_NULL, messages[component_count];
     MPI_Request req[component_count];
-    MPI_Status status;
-    int index;
+    MPI_Status status[component_count];
+    int index[component_count];
     int open_components = component_count;
+    int outcount;
     int finalize = 0;
     int mpierr;
     int ret = PIO_NOERR;
@@ -2659,218 +2660,231 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
                   req[0], MPI_REQUEST_NULL));
             for (int c = 0; c < component_count; c++)
                 PLOG((3, "req[%d] = %d", c, req[c]));
-            if ((mpierr = MPI_Waitany(component_count, req, &index, &status))){
-                PLOG((0, "Error from mpi_waitany %d",mpierr));
+	    //            if ((mpierr = MPI_Waitany(component_count, req, &index, &status))){
+	    if ((mpierr = MPI_Waitsome(component_count, req, &outcount, index, status))){
+                PLOG((0, "Error from mpi_waitsome %d",mpierr));
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
             }
-            PLOG((3, "Waitany returned index = %d req[%d] = %d", index, index, req[index]));
-            msg = messages[index];
+	    for(int c = 0; c < outcount; c++)
+	      PLOG((3, "Waitsome returned index = %d req[%d] = %d", index[c], index[c], req[index[c]]));
+	    //            msg = messages[index];
             for (int c = 0; c < component_count; c++)
                 PLOG((3, "req[%d] = %d", c, req[c]));
         }
-
-        /* Broadcast the index of the computational component that
-         * originated the request to the rest of the IO tasks. */
-        PLOG((3, "About to do Bcast of index = %d io_comm = %d", index, io_comm));
-        if ((mpierr = MPI_Bcast(&index, 1, MPI_INT, 0, io_comm)))
+        if ((mpierr = MPI_Bcast(&outcount, 1, MPI_INT, 0, io_comm)))
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        PLOG((3, "index MPI_Bcast complete index = %d", index));
-
-        /* Set the correct iosys depending on the index. */
-        my_iosys = iosys[index];
-
-        /* Broadcast the msg value to the rest of the IO tasks. */
-        PLOG((3, "about to call msg MPI_Bcast io_comm = %d", io_comm));
-        if ((mpierr = MPI_Bcast(&msg, 1, MPI_INT, 0, io_comm)))
+        PLOG((3, "outcount MPI_Bcast complete outcount = %d", outcount));
+	
+	for(int creq=0; creq < outcount; creq++)
+	{
+	  int idx = index[creq];
+	  /* Broadcast the index of the computational component that
+	   * originated the request to the rest of the IO tasks. */
+	  PLOG((3, "About to do Bcast of index = %d io_comm = %d", index, io_comm));
+	  if ((mpierr = MPI_Bcast(&idx, 1, MPI_INT, 0, io_comm)))
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        PLOG((1, "pio_msg_handler2 msg MPI_Bcast complete msg = %d", msg));
+	  PLOG((3, "index MPI_Bcast complete index = %d", idx));
+	  msg = messages[idx];
 
-        /* Handle the message. This code is run on all IO tasks. */
-        switch (msg)
-        {
-        case PIO_MSG_INQ_TYPE:
-            ret = inq_type_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_FORMAT:
-            ret = inq_format_handler(my_iosys);
-            break;
-        case PIO_MSG_CREATE_FILE:
-            ret = create_file_handler(my_iosys);
-            break;
-        case PIO_MSG_SYNC:
-            ret = sync_file_handler(my_iosys);
-            break;
-        case PIO_MSG_ENDDEF:
-        case PIO_MSG_REDEF:
-            ret = change_def_file_handler(my_iosys, msg);
-            break;
-        case PIO_MSG_OPEN_FILE:
-            ret = open_file_handler(my_iosys);
-            break;
-        case PIO_MSG_CLOSE_FILE:
-            ret = close_file_handler(my_iosys);
-            break;
-        case PIO_MSG_DELETE_FILE:
-            ret = delete_file_handler(my_iosys);
-            break;
-        case PIO_MSG_RENAME_DIM:
-            ret = rename_dim_handler(my_iosys);
-            break;
-        case PIO_MSG_RENAME_VAR:
-            ret = rename_var_handler(my_iosys);
-            break;
-        case PIO_MSG_RENAME_ATT:
-            ret = rename_att_handler(my_iosys);
-            break;
-        case PIO_MSG_DEL_ATT:
-            ret = delete_att_handler(my_iosys);
-            break;
-        case PIO_MSG_DEF_DIM:
-            ret = def_dim_handler(my_iosys);
-            break;
-        case PIO_MSG_DEF_VAR:
-            ret = def_var_handler(my_iosys);
-            break;
-        case PIO_MSG_DEF_VAR_CHUNKING:
-            ret = def_var_chunking_handler(my_iosys);
-            break;
-        case PIO_MSG_DEF_VAR_FILL:
-            ret = def_var_fill_handler(my_iosys);
-            break;
-        case PIO_MSG_DEF_VAR_ENDIAN:
-            ret = def_var_endian_handler(my_iosys);
-            break;
-        case PIO_MSG_DEF_VAR_DEFLATE:
-            ret = def_var_deflate_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_VAR_ENDIAN:
-            ret = inq_var_endian_handler(my_iosys);
-            break;
-        case PIO_MSG_SET_VAR_CHUNK_CACHE:
-            ret = set_var_chunk_cache_handler(my_iosys);
-            break;
-        case PIO_MSG_GET_VAR_CHUNK_CACHE:
-            ret = get_var_chunk_cache_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ:
-            ret = inq_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_UNLIMDIMS:
-            ret = inq_unlimdims_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_DIM:
-            ret = inq_dim_handler(my_iosys, msg);
-            break;
-        case PIO_MSG_INQ_DIMID:
-            ret = inq_dimid_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_VAR:
-            ret = inq_var_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_VAR_CHUNKING:
-            ret = inq_var_chunking_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_VAR_FILL:
-            ret = inq_var_fill_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_VAR_DEFLATE:
-            ret = inq_var_deflate_handler(my_iosys);
-            break;
-        case PIO_MSG_GET_ATT:
-            ret = att_get_handler(my_iosys);
-            break;
-        case PIO_MSG_PUT_ATT:
-            ret = att_put_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_VARID:
-            ret = inq_varid_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_ATT:
-            ret = inq_att_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_ATTNAME:
-            ret = inq_attname_handler(my_iosys);
-            break;
-        case PIO_MSG_INQ_ATTID:
-            ret = inq_attid_handler(my_iosys);
-            break;
-        case PIO_MSG_GET_VARS:
-            ret = get_vars_handler(my_iosys);
-            break;
-        case PIO_MSG_PUT_VARS:
-            ret = put_vars_handler(my_iosys);
-            break;
-        case PIO_MSG_INITDECOMP_DOF:
-            ret = initdecomp_dof_handler(my_iosys);
-            break;
-        case PIO_MSG_WRITEDARRAYMULTI:
-            ret = write_darray_multi_handler(my_iosys);
-            break;
-        case PIO_MSG_SETFRAME:
-            ret = setframe_handler(my_iosys);
-            break;
-        case PIO_MSG_ADVANCEFRAME:
-            ret = advanceframe_handler(my_iosys);
-            break;
-        case PIO_MSG_READDARRAY:
-            ret = read_darray_handler(my_iosys);
-            break;
-        case PIO_MSG_SETERRORHANDLING:
-            ret = seterrorhandling_handler(my_iosys);
-            break;
-        case PIO_MSG_SET_CHUNK_CACHE:
-            ret = set_chunk_cache_handler(my_iosys);
-            break;
-        case PIO_MSG_GET_CHUNK_CACHE:
-            ret = get_chunk_cache_handler(my_iosys);
-            break;
-        case PIO_MSG_FREEDECOMP:
-            ret = freedecomp_handler(my_iosys);
-            break;
-        case PIO_MSG_SET_FILL:
-            ret = set_fill_handler(my_iosys);
-            break;
-        case PIO_MSG_SETLOGLEVEL:
-            ret = set_loglevel_handler(my_iosys);
-            break;
-        case PIO_MSG_EXIT:
-            finalize++;
-            ret = finalize_handler(my_iosys, index);
-            break;
-        default:
-            PLOG((0, "unknown message received %d", msg));
-            return PIO_EINVAL;
-        }
+	  /* Set the correct iosys depending on the index. */
+	  my_iosys = iosys[idx];
 
-        /* If an error was returned by the handler, exit. */
-        PLOG((3, "pio_msg_handler2 ret %d msg %d index %d io_rank %d", ret, msg, index, io_rank));
-        if (ret)
+	  /* Broadcast the msg value to the rest of the IO tasks. */
+	  PLOG((3, "about to call msg MPI_Bcast io_comm = %d", io_comm));
+	  if ((mpierr = MPI_Bcast(&msg, 1, MPI_INT, 0, io_comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	  PLOG((1, "pio_msg_handler2 msg MPI_Bcast complete msg = %d", msg));
+
+	  /* Handle the message. This code is run on all IO tasks. */
+	  switch (msg)
+	    {
+	    case PIO_MSG_INQ_TYPE:
+	      ret = inq_type_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_FORMAT:
+	      ret = inq_format_handler(my_iosys);
+	      break;
+	    case PIO_MSG_CREATE_FILE:
+	      ret = create_file_handler(my_iosys);
+	      break;
+	    case PIO_MSG_SYNC:
+	      ret = sync_file_handler(my_iosys);
+	      break;
+	    case PIO_MSG_ENDDEF:
+	    case PIO_MSG_REDEF:
+	      PLOG((2, "pio_msg_handler calling change_def_file_handler"));
+	      ret = change_def_file_handler(my_iosys, msg);
+	      break;
+	    case PIO_MSG_OPEN_FILE:
+	      ret = open_file_handler(my_iosys);
+	      break;
+	    case PIO_MSG_CLOSE_FILE:
+	      ret = close_file_handler(my_iosys);
+	      break;
+	    case PIO_MSG_DELETE_FILE:
+	      ret = delete_file_handler(my_iosys);
+	      break;
+	    case PIO_MSG_RENAME_DIM:
+	      ret = rename_dim_handler(my_iosys);
+	      break;
+	    case PIO_MSG_RENAME_VAR:
+	      ret = rename_var_handler(my_iosys);
+	      break;
+	    case PIO_MSG_RENAME_ATT:
+	      ret = rename_att_handler(my_iosys);
+	      break;
+	    case PIO_MSG_DEL_ATT:
+	      ret = delete_att_handler(my_iosys);
+	      break;
+	    case PIO_MSG_DEF_DIM:
+	      ret = def_dim_handler(my_iosys);
+	      break;
+	    case PIO_MSG_DEF_VAR:
+	      ret = def_var_handler(my_iosys);
+	      break;
+	    case PIO_MSG_DEF_VAR_CHUNKING:
+	      ret = def_var_chunking_handler(my_iosys);
+	      break;
+	    case PIO_MSG_DEF_VAR_FILL:
+	      ret = def_var_fill_handler(my_iosys);
+	      break;
+	    case PIO_MSG_DEF_VAR_ENDIAN:
+	      ret = def_var_endian_handler(my_iosys);
+	      break;
+	    case PIO_MSG_DEF_VAR_DEFLATE:
+	      ret = def_var_deflate_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_VAR_ENDIAN:
+	      ret = inq_var_endian_handler(my_iosys);
+	      break;
+	    case PIO_MSG_SET_VAR_CHUNK_CACHE:
+	      ret = set_var_chunk_cache_handler(my_iosys);
+	      break;
+	    case PIO_MSG_GET_VAR_CHUNK_CACHE:
+	      ret = get_var_chunk_cache_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ:
+	      ret = inq_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_UNLIMDIMS:
+	      ret = inq_unlimdims_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_DIM:
+	      ret = inq_dim_handler(my_iosys, msg);
+	      break;
+	    case PIO_MSG_INQ_DIMID:
+	      ret = inq_dimid_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_VAR:
+	      ret = inq_var_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_VAR_CHUNKING:
+	      ret = inq_var_chunking_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_VAR_FILL:
+	      ret = inq_var_fill_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_VAR_DEFLATE:
+	      ret = inq_var_deflate_handler(my_iosys);
+	      break;
+	    case PIO_MSG_GET_ATT:
+	      ret = att_get_handler(my_iosys);
+	      break;
+	    case PIO_MSG_PUT_ATT:
+	      ret = att_put_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_VARID:
+	      ret = inq_varid_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_ATT:
+	      ret = inq_att_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_ATTNAME:
+	      ret = inq_attname_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INQ_ATTID:
+	      ret = inq_attid_handler(my_iosys);
+	      break;
+	    case PIO_MSG_GET_VARS:
+	      ret = get_vars_handler(my_iosys);
+	      break;
+	    case PIO_MSG_PUT_VARS:
+	      ret = put_vars_handler(my_iosys);
+	      break;
+	    case PIO_MSG_INITDECOMP_DOF:
+	      ret = initdecomp_dof_handler(my_iosys);
+	      break;
+	    case PIO_MSG_WRITEDARRAYMULTI:
+	      ret = write_darray_multi_handler(my_iosys);
+	      break;
+	    case PIO_MSG_SETFRAME:
+	      ret = setframe_handler(my_iosys);
+	      break;
+	    case PIO_MSG_ADVANCEFRAME:
+	      ret = advanceframe_handler(my_iosys);
+	      break;
+	    case PIO_MSG_READDARRAY:
+	      ret = read_darray_handler(my_iosys);
+	      break;
+	    case PIO_MSG_SETERRORHANDLING:
+	      ret = seterrorhandling_handler(my_iosys);
+	      break;
+	    case PIO_MSG_SET_CHUNK_CACHE:
+	      ret = set_chunk_cache_handler(my_iosys);
+	      break;
+	    case PIO_MSG_GET_CHUNK_CACHE:
+	      ret = get_chunk_cache_handler(my_iosys);
+	      break;
+	    case PIO_MSG_FREEDECOMP:
+	      ret = freedecomp_handler(my_iosys);
+	      break;
+	    case PIO_MSG_SET_FILL:
+	      ret = set_fill_handler(my_iosys);
+	      break;
+	    case PIO_MSG_SETLOGLEVEL:
+	      ret = set_loglevel_handler(my_iosys);
+	      break;
+	    case PIO_MSG_EXIT:
+	      finalize++;
+	      ret = finalize_handler(my_iosys, idx);
+	      break;
+	    default:
+	      PLOG((0, "unknown message received %d", msg));
+	      return PIO_EINVAL;
+	    }
+
+	  /* If an error was returned by the handler, exit. */
+	  PLOG((3, "pio_msg_handler2 ret %d msg %d index %d io_rank %d", ret, msg, idx, io_rank));
+	  if (ret)
             return pio_err(my_iosys, NULL, ret, __FILE__, __LINE__);
 
-        /* Listen for another msg from the component whose message we
-         * just handled. */
-        if (!io_rank && !finalize)
-        {
-            my_iosys = iosys[index];
-            PLOG((3, "pio_msg_handler2 about to Irecv index = %d comproot = %d union_comm = %d",
-                  index, my_iosys->comproot, my_iosys->union_comm));
-            if ((mpierr = MPI_Irecv(&(messages[index]), 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
-                                    &req[index])))
+	  /* Listen for another msg from the component whose message we
+	   * just handled. */
+	  if (!io_rank && !finalize)
+	    {
+	      my_iosys = iosys[idx];
+	      PLOG((3, "pio_msg_handler2 about to Irecv index = %d comproot = %d union_comm = %d",
+		    idx, my_iosys->comproot, my_iosys->union_comm));
+	      if ((mpierr = MPI_Irecv(&(messages[idx]), 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
+				      &req[idx])))
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            PLOG((3, "pio_msg_handler2 called MPI_Irecv req[%d] = %d", index, req[index]));
-        }
+	      PLOG((3, "pio_msg_handler2 called MPI_Irecv req[%d] = %d", index, req[idx]));
+	    }
 
-        PLOG((3, "pio_msg_handler2 done msg = %d open_components = %d",
-              msg, open_components));
-        msg = PIO_MSG_NULL;
-        /* If there are no more open components, exit. */
-        if (finalize)
-        {
-            if (--open_components)
+	  PLOG((3, "pio_msg_handler2 done msg = %d open_components = %d",
+		msg, open_components));
+	  msg = PIO_MSG_NULL;
+	  /* If there are no more open components, exit. */
+	  if (finalize)
+	    {
+	      if (--open_components)
                 finalize = 0;
-            else
+	      else
                 break;
-        }
+	    }
+	}
+	if (finalize)
+	  break;
     }
 
     PLOG((3, "returning from pio_msg_handler2"));

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -3001,15 +3001,17 @@ pioc_change_def(int ncid, int is_enddef)
         {
             int msg = is_enddef ? PIO_MSG_ENDDEF : PIO_MSG_REDEF;
             if (ios->compmaster == MPI_ROOT)
+	      {
+		PLOG((2, "pioc_change_def request sent"));
                 mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-
+	      }
             if (!mpierr)
                 mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
             PLOG((3, "pioc_change_def ncid = %d mpierr = %d", ncid, mpierr));
         }
 
         /* Handle MPI errors. */
-        PLOG((3, "pioc_change_def handling MPI errors"));
+        PLOG((3, "pioc_change_def handling MPI errors my_comm=%d", ios->my_comm));
         if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
             check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
         if (mpierr)

--- a/tests/general/pio_iosystem_async_tests.F90.in
+++ b/tests/general/pio_iosystem_async_tests.F90.in
@@ -76,7 +76,7 @@ SUBROUTINE create_file(comm, iosys, iotype, fname, attname, dimname, ret)
     type(file_desc_t) :: pio_file
     integer :: pio_dim
     type(var_desc_t) :: pio_var
-
+    ret = PIO_set_log_level(iosys, 3)
     ret = PIO_createfile(iosys, pio_file, iotype, fname, PIO_CLOBBER)
     PIO_TF_CHECK_ERR(ret, comm, "Failed to create dummy file :" // trim(fname))
 !    print *,__FILE__,__LINE__,'create file'
@@ -89,6 +89,9 @@ SUBROUTINE create_file(comm, iosys, iotype, fname, attname, dimname, ret)
     ret = PIO_put_att(pio_file, pio_var, attname, fname)
     PIO_TF_CHECK_ERR(ret, comm, "Failed to put att " // trim(attname) // " in file :" // trim(fname))
 !    print *,__FILE__,__LINE__,'put_att'
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, comm, "Failed in enddef " // trim(attname) // " in file :" // trim(fname))
+
     call PIO_closefile(pio_file)
 !    print *,__FILE__,__LINE__,'closefile'
 END SUBROUTINE create_file
@@ -204,19 +207,21 @@ PIO_TF_AUTO_TEST_SUB_BEGIN two_comps_odd_even_async
         ! Create two files to be opened later
         if(comp_comm(1) /= MPI_COMM_NULL) then
            is_even = .false.
-!           print *,__FILE__,__LINE__,'create_file', is_even
+           print *,__FILE__,__LINE__,'create_file', is_even
            call create_file(comp_comm(1), iosys(1), iotypes(i), &
                 fname1, attname, dimname, ret)
            PIO_TF_CHECK_ERR(ret, comp_comm(1), "Failed to create file :" // fname1)
         else
            is_even = .true.
-!           print *,__FILE__,__LINE__,'create_file', is_even
+           print *,__FILE__,__LINE__,'create_file', is_even
            call create_file(comp_comm(2), iosys(2), iotypes(i), &
                 fname2, attname, dimname, ret)
            PIO_TF_CHECK_ERR(ret, comp_comm(2), "Failed to create file :" // fname2)
         endif
-!        print *,__FILE__,__LINE__,'at barrier', is_even
+
+        print *,__FILE__,__LINE__,'at barrier', is_even
         call mpi_barrier(all_comp_comm, ret)
+
         ! Open file1 from odd processes and file2 from even processes
         if(is_even) then
            call open_and_check_file(comp_comm(2), iosys(2), iotypes(i), &

--- a/tests/general/pio_iosystem_async_tests.F90.in
+++ b/tests/general/pio_iosystem_async_tests.F90.in
@@ -76,7 +76,7 @@ SUBROUTINE create_file(comm, iosys, iotype, fname, attname, dimname, ret)
     type(file_desc_t) :: pio_file
     integer :: pio_dim
     type(var_desc_t) :: pio_var
-    ret = PIO_set_log_level(iosys, 3)
+!    ret = PIO_set_log_level(iosys, 3)
     ret = PIO_createfile(iosys, pio_file, iotype, fname, PIO_CLOBBER)
     PIO_TF_CHECK_ERR(ret, comm, "Failed to create dummy file :" // trim(fname))
 !    print *,__FILE__,__LINE__,'create file'
@@ -207,19 +207,19 @@ PIO_TF_AUTO_TEST_SUB_BEGIN two_comps_odd_even_async
         ! Create two files to be opened later
         if(comp_comm(1) /= MPI_COMM_NULL) then
            is_even = .false.
-           print *,__FILE__,__LINE__,'create_file', is_even
+!           print *,__FILE__,__LINE__,'create_file', is_even
            call create_file(comp_comm(1), iosys(1), iotypes(i), &
                 fname1, attname, dimname, ret)
            PIO_TF_CHECK_ERR(ret, comp_comm(1), "Failed to create file :" // fname1)
         else
            is_even = .true.
-           print *,__FILE__,__LINE__,'create_file', is_even
+!           print *,__FILE__,__LINE__,'create_file', is_even
            call create_file(comp_comm(2), iosys(2), iotypes(i), &
                 fname2, attname, dimname, ret)
            PIO_TF_CHECK_ERR(ret, comp_comm(2), "Failed to create file :" // fname2)
         endif
 
-        print *,__FILE__,__LINE__,'at barrier', is_even
+!        print *,__FILE__,__LINE__,'at barrier', is_even
         call mpi_barrier(all_comp_comm, ret)
 
         ! Open file1 from odd processes and file2 from even processes


### PR DESCRIPTION
Use MPI_WAITSOME instead of MPI_WAITANY to avoid message starving.  This was inspired by a note to users in the mpi standard :

> A server with multiple clients can use MPI_WAITSOME so as not to starve any client. Clients send messages to the server with service requests. The server calls MPI_WAITSOME with one receive request for each client, and then handles all receives that completed. If a call to MPI_WAITANY is used instead, then one client could starve while requests from another client always sneak in first. ( End of advice to users.) 

Fixes #1801 
