### PR TITLE
fix error handling in async tests

### DIFF
--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -17,7 +17,7 @@
  * Handle non-MPI errors by printing error message, setting error
  * code, and goto exit. This is used in test code.
  */
-#define PBAIL(e) do {							\
+#define PBAIL(e) do {                                                   \
         fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
         ret = e;                                                        \
         goto exit;                                                      \
@@ -27,9 +27,9 @@
  * Handle non-MPI errors by calling pio_err(), setting return code,
  * and goto exit. This is used in library code.
  */
-#define EXIT(ios, e) do {					\
-        ret = pio_err(NULL, NULL, e, __FILE__, __LINE__);	\
-        goto exit;						\
+#define EXIT(ios, e) do {                                       \
+        ret = pio_err(NULL, NULL, e, __FILE__, __LINE__);       \
+        goto exit;                                              \
     } while (0)
 
 /**
@@ -49,11 +49,23 @@
 
 /**
  * For async tests, handle non-MPI errors by finalizing the IOsystem
- * and exiting with an exit code.
+ * and exiting with an exit code. This macro works for tests with one
+ * iosystemid.
  */
-#define AERR(e) do {                                                     \
+#define AERR(e) do {							\
         fprintf(stderr, "%d Async Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
-	PIOc_free_iosystem(iosysid);                                    \
+        PIOc_free_iosystem(iosysid);                                    \
+        return e;                                                       \
+    } while (0)
+
+/**
+ * For async tests, handle non-MPI errors by finalizing the IOsystem
+ * and exiting with an exit code. This macro works for tests with more
+ * than one iosystemid.
+ */
+#define AERR2(e, i) do {                                                \
+        fprintf(stderr, "%d Async Error %d in iosysid %d, %s, line %d\n", my_rank, e, i, __FILE__, __LINE__); \
+        PIOc_free_iosystem(i);                                          \
         return e;                                                       \
     } while (0)
 

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -14,8 +14,8 @@
 #include <pio.h>
 
 /**
- * Handle non-MPI errors by printing error message and goto exit. This
- * is used in test code.
+ * Handle non-MPI errors by printing error message, setting error
+ * code, and goto exit. This is used in test code.
  */
 #define PBAIL(e) do {							\
         fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -19,6 +19,7 @@
  */
 #define PBAIL(e) do {                                                    \
         fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
+	ret = e;                                                        \
         goto exit;                                                      \
     } while (0)
 

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -48,6 +48,16 @@
     } while (0)
 
 /**
+ * For async tests, handle non-MPI errors by finalizing the MPI
+ * library and exiting with an exit code.
+ */
+#define AERR(e) do {                                                     \
+        fprintf(stderr, "%d Async Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
+	PIOc_free_iosystem(iosysid);                                    \
+        return e;                                                       \
+    } while (0)
+
+/**
  * Handle MPI errors. This should only be used with MPI library
  * function calls. Print error message, finalize MPI and return error
  * code.

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -48,8 +48,8 @@
     } while (0)
 
 /**
- * For async tests, handle non-MPI errors by finalizing the MPI
- * library and exiting with an exit code.
+ * For async tests, handle non-MPI errors by finalizing the IOsystem
+ * and exiting with an exit code.
  */
 #define AERR(e) do {                                                     \
         fprintf(stderr, "%d Async Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \

--- a/src/clib/pio_error.h
+++ b/src/clib/pio_error.h
@@ -17,9 +17,9 @@
  * Handle non-MPI errors by printing error message and goto exit. This
  * is used in test code.
  */
-#define PBAIL(e) do {                                                    \
+#define PBAIL(e) do {							\
         fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
-	ret = e;                                                        \
+        ret = e;                                                        \
         goto exit;                                                      \
     } while (0)
 
@@ -27,9 +27,9 @@
  * Handle non-MPI errors by calling pio_err(), setting return code,
  * and goto exit. This is used in library code.
  */
-#define EXIT(ios, e) do {                                               \
-        ret = pio_err(NULL, NULL, e, __FILE__, __LINE__);        \
-        goto exit;                                                      \
+#define EXIT(ios, e) do {					\
+        ret = pio_err(NULL, NULL, e, __FILE__, __LINE__);	\
+        goto exit;						\
     } while (0)
 
 /**

--- a/tests/cunit/test_async_1d.c
+++ b/tests/cunit/test_async_1d.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
 
         /* Shut down the IO system. */
         if ((ret = PIOc_finalize(iosysid)))
-            AERR(ret);
+            ERR(ret);
     }
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/cunit/test_async_1d.c
+++ b/tests/cunit/test_async_1d.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
     if ((ret = PIOc_init_async(MPI_COMM_WORLD, NUM_IO_TASKS, NULL, COMPONENT_COUNT,
                                num_procs_per_comp, NULL, NULL, NULL,
                                PIO_REARR_BOX, &iosysid)))
-        ERR(ret);
+        AERR(ret);
 
     /* Only computational processors run this code. */
     if (my_rank)
@@ -93,17 +93,17 @@ int main(int argc, char **argv)
 
         /* Create a file. */
         if ((ret = PIOc_createfile(iosysid, &ncid, &iotype, FILE_NAME, 0)))
-            ERR(ret);
+            AERR(ret);
         if ((ret = PIOc_def_dim(ncid, DIM_NAME_0, PIO_UNLIMITED, &dimid[0])))
-            ERR(ret);
+            AERR(ret);
         if ((ret = PIOc_def_dim(ncid, DIM_NAME_1, DIM_LEN_1, &dimid[1])))
-            ERR(ret);
+            AERR(ret);
         if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_INT, NDIM2, dimid, &varid)))
-            ERR(ret);
+            AERR(ret);
         if ((ret = PIOc_def_var_fill(ncid, varid, PIO_NOFILL, NULL)))
-            ERR(ret);
+            AERR(ret);
         if ((ret = PIOc_enddef(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Set up a decomposition. Each of the 3 computational procs
          * will write one value, to get the 3-values of each
@@ -111,41 +111,41 @@ int main(int argc, char **argv)
         compmap[0] = my_rank - 1;
         if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM1, gdimlen, MAPLEN,
                                     compmap, &ioid, PIO_REARR_BOX, NULL, NULL)))
-            ERR(ret);
+            AERR(ret);
 
         /* Write a record of data. */
         data = my_rank;
         if ((ret = PIOc_setframe(ncid, 0, 0)))
-            ERR(ret);
+            AERR(ret);
         if ((ret = PIOc_write_darray(ncid, 0, ioid, MAPLEN, &data, NULL)))
-            ERR(ret);
+            AERR(ret);
 
         /* Close the file. */
         if ((ret = PIOc_closefile(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Reopen the file and check. */
         if ((ret = PIOc_openfile(iosysid, &ncid, &iotype, FILE_NAME, 0)))
-            ERR(ret);
+            AERR(ret);
 
         /* Read the data. */
         if ((ret = PIOc_setframe(ncid, 0, 0)))
-            ERR(ret);
+            AERR(ret);
         if ((ret = PIOc_read_darray(ncid, 0, ioid, MAPLEN, &data_in)))
-            ERR(ret);
+            AERR(ret);
         if (data_in != data) ERR(ERR_WRONG);
 
         /* Close the file. */
         if ((ret = PIOc_closefile(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Free the decomposition. */
         if ((ret = PIOc_freedecomp(iosysid, ioid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Shut down the IO system. */
         if ((ret = PIOc_finalize(iosysid)))
-            ERR(ret);
+            AERR(ret);
     }
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);

--- a/tests/cunit/test_async_3proc.c
+++ b/tests/cunit/test_async_3proc.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
                 for (int c = 0; c < COMPONENT_COUNT; c++)
                 {
                     if ((ret = PIOc_free_iosystem(iosysid[c])))
-			ERR(ret);
+                        ERR(ret);
                 }
             } /* endif comp_task */
 

--- a/tests/cunit/test_async_3proc.c
+++ b/tests/cunit/test_async_3proc.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
                 for (int c = 0; c < COMPONENT_COUNT; c++)
                 {
                     if ((ret = PIOc_free_iosystem(iosysid[c])))
-			AERR2(ret, iosysid[c]);
+			ERR(ret);
                 }
             } /* endif comp_task */
 

--- a/tests/cunit/test_async_3proc.c
+++ b/tests/cunit/test_async_3proc.c
@@ -85,11 +85,11 @@ int main(int argc, char **argv)
 
                         /* Create sample file. */
                         if ((ret = create_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-                            ERR(ret);
+                            AERR2(ret, iosysid[my_comp_idx]);
 
                         /* Check the file for correctness. */
                         if ((ret = check_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-                            ERR(ret);
+                            AERR2(ret, iosysid[my_comp_idx]);
                     }
                 } /* next netcdf flavor */
 
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
                 for (int c = 0; c < COMPONENT_COUNT; c++)
                 {
                     if ((ret = PIOc_free_iosystem(iosysid[c])))
-                        ERR(ret);
+			AERR2(ret, iosysid[c]);
                 }
             } /* endif comp_task */
 

--- a/tests/cunit/test_async_4proc.c
+++ b/tests/cunit/test_async_4proc.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
                     /* Finalize the IO system. Only call this from the computation tasks. */
                     for (int c = 0; c < COMPONENT_COUNT; c++)
                         if ((ret = PIOc_free_iosystem(iosysid[c])))
-			    AERR2(ret, iosysid[c]);
+			    ERR(ret);
                 } /* endif comp_task */
 
                 /* Wait for everyone to catch up. */

--- a/tests/cunit/test_async_4proc.c
+++ b/tests/cunit/test_async_4proc.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
                     /* Finalize the IO system. Only call this from the computation tasks. */
                     for (int c = 0; c < COMPONENT_COUNT; c++)
                         if ((ret = PIOc_free_iosystem(iosysid[c])))
-			    ERR(ret);
+                            ERR(ret);
                 } /* endif comp_task */
 
                 /* Wait for everyone to catch up. */

--- a/tests/cunit/test_async_4proc.c
+++ b/tests/cunit/test_async_4proc.c
@@ -90,18 +90,18 @@ int main(int argc, char **argv)
 
                             /* Create sample file. */
                             if ((ret = create_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-                                ERR(ret);
+                                AERR2(ret, iosysid[my_comp_idx]);
 
                             /* Check the file for correctness. */
                             if ((ret = check_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-                                ERR(ret);
+                                AERR2(ret, iosysid[my_comp_idx]);
                         }
                     } /* next netcdf flavor */
 
                     /* Finalize the IO system. Only call this from the computation tasks. */
                     for (int c = 0; c < COMPONENT_COUNT; c++)
                         if ((ret = PIOc_free_iosystem(iosysid[c])))
-                            ERR(ret);
+			    AERR2(ret, iosysid[c]);
                 } /* endif comp_task */
 
                 /* Wait for everyone to catch up. */

--- a/tests/cunit/test_async_manyproc.c
+++ b/tests/cunit/test_async_manyproc.c
@@ -86,18 +86,18 @@ int main(int argc, char **argv)
                 /* Create sample file. */
                 if ((ret = create_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                               filename, TEST_NAME, 0, 0, 0)))
-                    ERR(ret);
-
+		    AERR2(ret, iosysid[my_comp_idx]);
+		
                 /* Check the file for correctness. */
                 if ((ret = check_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                              filename, 0, 0, 0)))
-                    ERR(ret);
+		    AERR2(ret, iosysid[my_comp_idx]);
             } /* next netcdf iotype */
 
             /* Finalize the IO system. Only call this from the computation tasks. */
             for (int c = 0; c < COMPONENT_COUNT; c++)
                 if ((ret = PIOc_free_iosystem(iosysid[c])))
-                    ERR(ret);
+		    AERR2(ret, iosysid[c]);
         } /* endif comp_task */
     } /* endif my_rank < TARGET_NTASKS */
 

--- a/tests/cunit/test_async_manyproc.c
+++ b/tests/cunit/test_async_manyproc.c
@@ -48,9 +48,9 @@ int main(int argc, char **argv)
                               -1, &test_comm)))
         ERR(ERR_INIT);
 
-    /* Is the current process a computation task? */    
+    /* Is the current process a computation task? */
     int comp_task = my_rank < NUM_IO_PROCS ? 0 : 1;
-    
+
     /* Only do something on TARGET_NTASKS tasks. */
     if (my_rank < TARGET_NTASKS)
     {
@@ -86,18 +86,18 @@ int main(int argc, char **argv)
                 /* Create sample file. */
                 if ((ret = create_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                               filename, TEST_NAME, 0, 0, 0)))
-		    AERR2(ret, iosysid[my_comp_idx]);
-		
+                    AERR2(ret, iosysid[my_comp_idx]);
+
                 /* Check the file for correctness. */
                 if ((ret = check_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                              filename, 0, 0, 0)))
-		    AERR2(ret, iosysid[my_comp_idx]);
+                    AERR2(ret, iosysid[my_comp_idx]);
             } /* next netcdf iotype */
 
             /* Finalize the IO system. Only call this from the computation tasks. */
             for (int c = 0; c < COMPONENT_COUNT; c++)
                 if ((ret = PIOc_free_iosystem(iosysid[c])))
-		    AERR2(ret, iosysid[c]);
+                    AERR2(ret, iosysid[c]);
         } /* endif comp_task */
     } /* endif my_rank < TARGET_NTASKS */
 

--- a/tests/cunit/test_async_multi2.c
+++ b/tests/cunit/test_async_multi2.c
@@ -87,12 +87,12 @@ int main(int argc, char **argv)
                 /* Create sample file. */
                 if ((ret = create_nc_sample_4(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                               filename, TEST_NAME, 0, num_types)))
-                    ERR(ret);
+		    AERR2(ret, iosysid[my_comp_idx]);
 
                 /* Check the file for correctness. */
                 if ((ret = check_nc_sample_4(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                              filename, 0, num_types)))
-                    ERR(ret);
+		    AERR2(ret, iosysid[my_comp_idx]);
 
                 /* Free the decompositions. */
                 /* for (int t = 0; t < num_types; t++) */

--- a/tests/cunit/test_async_multi2.c
+++ b/tests/cunit/test_async_multi2.c
@@ -41,9 +41,9 @@ int main(int argc, char **argv)
                               -1, &test_comm)))
         ERR(ERR_INIT);
 
-    /* Is the current process a computation task? */    
+    /* Is the current process a computation task? */
     int comp_task = my_rank < NUM_IO_PROCS ? 0 : 1;
-    
+
     /* Only do something on TARGET_NTASKS tasks. */
     if (my_rank < TARGET_NTASKS)
     {
@@ -83,16 +83,16 @@ int main(int argc, char **argv)
                 /* for (int t = 0; t < num_types; t++) */
                 /*     if ((ret = create_decomposition_2d(NUM_COMP_PROCS, my_rank, iosysid[my_comp_idx], dim_len_2d, &ioid[t], pio_type[t]))) */
                 /*         ERR(ret); */
-            
+
                 /* Create sample file. */
                 if ((ret = create_nc_sample_4(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                               filename, TEST_NAME, 0, num_types)))
-		    AERR2(ret, iosysid[my_comp_idx]);
+                    AERR2(ret, iosysid[my_comp_idx]);
 
                 /* Check the file for correctness. */
                 if ((ret = check_nc_sample_4(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                              filename, 0, num_types)))
-		    AERR2(ret, iosysid[my_comp_idx]);
+                    AERR2(ret, iosysid[my_comp_idx]);
 
                 /* Free the decompositions. */
                 /* for (int t = 0; t < num_types; t++) */

--- a/tests/cunit/test_async_multicomp.c
+++ b/tests/cunit/test_async_multicomp.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 
                     if ((ret = create_decomposition_2d(NUM_COMP_PROCS, my_rank, iosysid[my_comp_idx], dim_len_2d,
                                                        &ioid, PIO_SHORT)))
-			AERR2(ret, iosysid[my_comp_idx]);
+                        AERR2(ret, iosysid[my_comp_idx]);
 
 #ifndef USE_MPE /* For some reason MPE logging breaks this test! */
                 /* Test with and without darrays. */
@@ -102,18 +102,18 @@ int main(int argc, char **argv)
                         /* Create sample file. */
                         if ((ret = create_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                                       filename, TEST_NAME, 0, use_darray, ioid)))
-			    AERR2(ret, iosysid[my_comp_idx]);
+                            AERR2(ret, iosysid[my_comp_idx]);
 
                         /* Check the file for correctness. */
                         if ((ret = check_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                                      filename, 0, 0, ioid)))
-			    AERR2(ret, iosysid[my_comp_idx]);
+                            AERR2(ret, iosysid[my_comp_idx]);
                     } /* next use_darray */
 #endif /* USE_MPE */
 
                     /* Free the decomposition. */
                     if ((ret = PIOc_freedecomp(iosysid[my_comp_idx], ioid)))
-			AERR2(ret, iosysid[my_comp_idx]);
+                        AERR2(ret, iosysid[my_comp_idx]);
 
                 } /* next netcdf iotype */
 

--- a/tests/cunit/test_async_multicomp.c
+++ b/tests/cunit/test_async_multicomp.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 
                     if ((ret = create_decomposition_2d(NUM_COMP_PROCS, my_rank, iosysid[my_comp_idx], dim_len_2d,
                                                        &ioid, PIO_SHORT)))
-                        ERR(ret);
+			AERR2(ret, iosysid[my_comp_idx]);
 
 #ifndef USE_MPE /* For some reason MPE logging breaks this test! */
                 /* Test with and without darrays. */
@@ -102,18 +102,18 @@ int main(int argc, char **argv)
                         /* Create sample file. */
                         if ((ret = create_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                                       filename, TEST_NAME, 0, use_darray, ioid)))
-                            ERR(ret);
+			    AERR2(ret, iosysid[my_comp_idx]);
 
                         /* Check the file for correctness. */
                         if ((ret = check_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
                                                      filename, 0, 0, ioid)))
-                            ERR(ret);
+			    AERR2(ret, iosysid[my_comp_idx]);
                     } /* next use_darray */
 #endif /* USE_MPE */
 
                     /* Free the decomposition. */
                     if ((ret = PIOc_freedecomp(iosysid[my_comp_idx], ioid)))
-                        ERR(ret);
+			AERR2(ret, iosysid[my_comp_idx]);
 
                 } /* next netcdf iotype */
 

--- a/tests/cunit/test_async_perf.c
+++ b/tests/cunit/test_async_perf.c
@@ -114,7 +114,7 @@ create_decomposition_3d(int ntasks, int my_rank, int rearr, int iosysid, int *io
     /* Create the PIO decomposition for this test. */
     if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM3, dim_len_3d, my_elem_per_pe,
                                 compdof, ioid, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
 
     /* Free the mapping. */
     free(compdof);

--- a/tests/cunit/test_async_simple.c
+++ b/tests/cunit/test_async_simple.c
@@ -100,11 +100,11 @@ int main(int argc, char **argv)
 
                     /* Create sample file. */
                     if ((ret = create_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-			AERR2(ret, iosysid[my_comp_idx]);
+                        AERR2(ret, iosysid[my_comp_idx]);
 
                     /* Check the file for correctness. */
                     if ((ret = check_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-			AERR2(ret, iosysid[my_comp_idx]);
+                        AERR2(ret, iosysid[my_comp_idx]);
                 }
             } /* next netcdf flavor */
 

--- a/tests/cunit/test_async_simple.c
+++ b/tests/cunit/test_async_simple.c
@@ -100,11 +100,11 @@ int main(int argc, char **argv)
 
                     /* Create sample file. */
                     if ((ret = create_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-                        ERR(ret);
+			AERR2(ret, iosysid[my_comp_idx]);
 
                     /* Check the file for correctness. */
                     if ((ret = check_nc_sample(sample, iosysid[my_comp_idx], flavor[flv], filename, my_rank, NULL)))
-                        ERR(ret);
+			AERR2(ret, iosysid[my_comp_idx]);
                 }
             } /* next netcdf flavor */
 

--- a/tests/cunit/test_darray_2sync.c
+++ b/tests/cunit/test_darray_2sync.c
@@ -31,7 +31,7 @@
 #ifdef _NETCDF4
 #define MAX_NUM_TYPES 11
 int test_type[MAX_NUM_TYPES] = {PIO_BYTE, PIO_CHAR, PIO_SHORT, PIO_INT, PIO_FLOAT, PIO_DOUBLE,
-                                    PIO_UBYTE, PIO_USHORT, PIO_UINT, PIO_INT64, PIO_UINT64};
+                                PIO_UBYTE, PIO_USHORT, PIO_UINT, PIO_INT64, PIO_UINT64};
 #else
 #define MAX_NUM_TYPES 6
 int test_type[MAX_NUM_TYPES] = {PIO_BYTE, PIO_CHAR, PIO_SHORT, PIO_INT, PIO_FLOAT, PIO_DOUBLE};
@@ -72,7 +72,7 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
             long long default_fill_int64 = PIO_FILL_INT64;
             unsigned long long default_fill_uint64 = PIO_FILL_UINT64;
 #endif /* _NETCDF4 */
-            
+
             /* Some incorrect fill values. */
             signed char wrong_fill_byte = TEST_VAL_42;
             unsigned char wrong_fill_char = TEST_VAL_42;
@@ -229,7 +229,7 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
              * fixed.) */
             if (PIOc_write_darray(ncid, varid, ioid, LEN2, test_data, wrong_fillvalue) != PIO_EINVAL)
                 ERR(ERR_WRONG);
-            
+
             /* Write the data. There are 3 procs with data, each writes 2
              * values. */
             if ((ret = PIOc_write_darray(ncid, varid, ioid, LEN2, test_data, default_fillvalue)))
@@ -484,7 +484,7 @@ int run_darray_tests(int iosysid, int my_rank, int num_iotypes, int *iotype, int
     /* Run the darray fill value tests. */
     if ((ret = darray_fill_test(iosysid, my_rank, num_iotypes, iotype, async)))
         return ret;
-    
+
     return PIO_NOERR;
 }
 

--- a/tests/cunit/test_darray_2sync.c
+++ b/tests/cunit/test_darray_2sync.c
@@ -179,23 +179,23 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
 
             /* Create the test file. */
             if ((ret = PIOc_createfile(iosysid, &ncid, &iotype[iot], filename, PIO_CLOBBER)))
-                ERR(ret);
+                AERR(ret);
 
             /* Define a dimension. */
             if ((ret = PIOc_def_dim(ncid, DIM_NAME, DIM_LEN, &dimid)))
-                ERR(ret);
+                AERR(ret);
 
             /* Define a 1D var. */
             if ((ret = PIOc_def_var(ncid, VAR_NAME, test_type[t], NDIM1, &dimid, &varid)))
-                ERR(ret);
+                AERR(ret);
 
             /* Turn on fill mode for this var. */
             if ((ret = PIOc_def_var_fill(ncid, varid, 0, default_fillvalue)))
-                ERR(ret);
+                AERR(ret);
 
             /* End define mode. */
             if ((ret = PIOc_enddef(ncid)))
-                ERR(ret);
+                AERR(ret);
 
             /* Create the PIO decomposition for this test. */
             int elements_per_pe = LEN2;
@@ -218,11 +218,11 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
              * decomposition uses the fill value. */
             if ((ret = PIOc_init_decomp(iosysid, test_type[t], NDIM1, &gdimlen, elements_per_pe,
                                         compdof, &ioid, PIO_REARR_BOX, NULL, NULL)))
-                ERR(ret);
+                AERR(ret);
 
             /* Set the record number for the unlimited dimension. */
             if ((ret = PIOc_setframe(ncid, varid, 0)))
-                ERR(ret);
+                AERR(ret);
 
             /* This should not work, because fill value is
              * incorrect. (Test turned off until Fortran API/tests are
@@ -233,15 +233,15 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
             /* Write the data. There are 3 procs with data, each writes 2
              * values. */
             if ((ret = PIOc_write_darray(ncid, varid, ioid, LEN2, test_data, default_fillvalue)))
-                ERR(ret);
+                AERR(ret);
 
             /* Close the test file. */
             if ((ret = PIOc_closefile(ncid)))
-                ERR(ret);
+                AERR(ret);
 
             /* Free decomposition. */
             if ((ret = PIOc_freedecomp(iosysid, ioid)))
-                ERR(ret);
+                AERR(ret);
 
             /* Check the file. */
             {
@@ -249,7 +249,7 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
 
                 /* Reopen the file. */
                 if ((ret = PIOc_openfile2(iosysid, &ncid2, &iotype[iot], filename, PIO_NOWRITE)))
-                    ERR(ret);
+                    AERR(ret);
 
                 /* Read the data. */
                 switch(test_type[t])
@@ -258,10 +258,10 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
                 {
                     signed char data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_schar(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
                 case PIO_CHAR:
@@ -270,40 +270,40 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
                 {
                     short data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_short(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
                 case PIO_INT:
                 {
                     int data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_int(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
                 case PIO_FLOAT:
                 {
                     float data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_float(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
                 case PIO_DOUBLE:
                 {
                     double data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_double(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
 #ifdef _NETCDF4
@@ -311,50 +311,50 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
                 {
                     unsigned char data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_uchar(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
                 case PIO_USHORT:
                 {
                     unsigned short data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_ushort(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
                 case PIO_UINT:
                 {
                     unsigned int data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_uint(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
                 case PIO_INT64:
                 {
                     long long data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_longlong(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
                 case PIO_UINT64:
                 {
                     unsigned long long data_in[elements_per_pe * NUM_COMPUTATION_PROCS];
                     if ((ret = PIOc_get_var_ulonglong(ncid2, 0, data_in)))
-                        ERR(ret);
+                        AERR(ret);
                     if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                         data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                        ERR(ret);
+                        AERR(ERR_WRONG);
                 }
                 break;
 #endif /* _NETCDF4 */
@@ -362,7 +362,7 @@ int darray_fill_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
 
                 /* Close the test file. */
                 if ((ret = PIOc_closefile(ncid2)))
-                    ERR(ret);
+                    AERR(ret);
             } /* finish checking file */
         } /* next type */
     } /* next iotype */
@@ -391,19 +391,19 @@ int darray_simple_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
 
         /* Create the test file. */
         if ((ret = PIOc_createfile(iosysid, &ncid, &iotype[iot], filename, PIO_CLOBBER)))
-            ERR(ret);
+            AERR(ret);
 
         /* Define a dimension. */
         if ((ret = PIOc_def_dim(ncid, DIM_NAME, DIM_LEN, &dimid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Define a 1D var. */
         if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_INT, NDIM1, &dimid, &varid)))
-            ERR(ret);
+            AERR(ret);
 
         /* End define mode. */
         if ((ret = PIOc_enddef(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Create the PIO decomposition for this test. */
         int elements_per_pe = 2;
@@ -425,26 +425,26 @@ int darray_simple_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
         /* Initialize the decomposition. */
         if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM1, &gdimlen, elements_per_pe,
                                     compdof, &ioid, PIO_REARR_BOX, NULL, NULL)))
-            ERR(ret);
+            AERR(ret);
 
         /* Set the record number for the unlimited dimension. */
         if ((ret = PIOc_setframe(ncid, varid, 0)))
-            ERR(ret);
+            AERR(ret);
 
         /* Write the data. There are 3 procs with data, each writes 2
          * values. */
         int arraylen = 2;
         int test_data[2] = {my_rank, -my_rank};
         if ((ret = PIOc_write_darray(ncid, varid, ioid, arraylen, test_data, NULL)))
-            ERR(ret);
+            AERR(ret);
 
         /* Close the test file. */
         if ((ret = PIOc_closefile(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Free decomposition. */
         if ((ret = PIOc_freedecomp(iosysid, ioid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Check the file. */
         {
@@ -453,18 +453,18 @@ int darray_simple_test(int iosysid, int my_rank, int num_iotypes, int *iotype,
 
             /* Reopen the file. */
             if ((ret = PIOc_openfile2(iosysid, &ncid2, &iotype[iot], filename, PIO_NOWRITE)))
-                ERR(ret);
+                AERR(ret);
 
             /* Read the data. */
             if ((ret = PIOc_get_var_int(ncid2, 0, data_in)))
-                ERR(ret);
+                AERR(ret);
             if (my_rank && data_in[0] != 1 && data_in[1] != -1 && data_in[2] != 2 &&
                 data_in[3] != -2 && data_in[4] != 3 && data_in[5] != -3)
-                ERR(ret);
+                AERR(ret);
 
             /* Close the test file. */
             if ((ret = PIOc_closefile(ncid2)))
-                ERR(ret);
+                AERR(ret);
         }
     }
 
@@ -479,12 +479,12 @@ int run_darray_tests(int iosysid, int my_rank, int num_iotypes, int *iotype, int
 
     /* Run the simple darray test. */
     if ((ret = darray_simple_test(iosysid, my_rank, num_iotypes, iotype, async)))
-        ERR(ret);
+        return ret;
 
     /* Run the darray fill value tests. */
     if ((ret = darray_fill_test(iosysid, my_rank, num_iotypes, iotype, async)))
-        ERR(ret);
-
+        return ret;
+    
     return PIO_NOERR;
 }
 
@@ -509,7 +509,7 @@ int run_async_tests(MPI_Comm test_comm, int my_rank, int num_iotypes, int *iotyp
     {
         /* Run the tests. */
         if ((ret = run_darray_tests(iosysid, my_rank, num_iotypes, iotype, 1)))
-            ERR(ret);
+            return ret;
 
         /* Finalize PIO system. */
         if ((ret = PIOc_free_iosystem(iosysid)))

--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
                 /* Run the simple darray async test. */
                 if ((ret = run_darray_async_test(iosysid, my_rank, test_comm, comp_comm[0], num_flavors,
                                                  flavor, test_type[t])))
-                    return ret;
+                    AERR(ret);
 
                 /* Finalize PIO system. */
                 if ((ret = PIOc_free_iosystem (iosysid)))

--- a/tests/cunit/test_darray_async_from_comm.c
+++ b/tests/cunit/test_darray_async_from_comm.c
@@ -246,13 +246,13 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm, MPI_Comm
 
     /* Write the decomp file (on appropriate tasks). */
     if ((ret = PIOc_write_nc_decomp(iosysid, decomp_filename, 0, ioid, NULL, NULL, 0)))
-        return ret;
+        PBAIL(ret);
 
     int fortran_order;
     int ioid2;
     if ((ret = PIOc_read_nc_decomp(iosysid, decomp_filename, &ioid2, comp_comm,
                                    PIO_INT, NULL, NULL, &fortran_order)))
-        return ret;
+        PBAIL(ret);
 
     /* Free the decomposition. */
     if ((ret = PIOc_freedecomp(iosysid, ioid2)))
@@ -564,7 +564,7 @@ int main(int argc, char **argv)
                 /* Run the simple darray async test. */
                 if ((ret = run_darray_async_test(iosysid, my_rank, test_comm, comp_comm[0], num_flavors,
                                                  flavor, test_type[t])))
-                    return ret;
+                    AERR(ret);
 
                 /* Finalize PIO system. */
                 if ((ret = PIOc_free_iosystem (iosysid)))

--- a/tests/cunit/test_darray_async_many.c
+++ b/tests/cunit/test_darray_async_many.c
@@ -223,7 +223,6 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
                     PBAIL(ERR_WRONG);
                 break;
             case PIO_UINT:
-		PBAIL(ERR_WRONG);
                 if (((unsigned int *)norec_data_in)[r] != expected_uint[r])
                     PBAIL(ERR_WRONG);
                 break;
@@ -310,7 +309,7 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
 
     /* Close the file. */
     if ((ret = PIOc_closefile(ncid)))
-        ERR(ret);
+        AERR(ret);
 
 exit:
     if (data_in)
@@ -382,47 +381,47 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
     /* Create the PIO decompositions for this test. */
     if ((ret = PIOc_init_decomp(iosysid, PIO_BYTE, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_byte, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_CHAR, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_char, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_SHORT, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_short, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_int, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_FLOAT, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_float, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_DOUBLE, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_double, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
 
 #ifdef _NETCDF4
     if ((ret = PIOc_init_decomp(iosysid, PIO_UBYTE, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_ubyte, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_USHORT, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_ushort, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_UINT, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_uint, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_INT64, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_int64, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_UINT64, NDIM2, &dim_len[2], elements_per_pe,
                                 compdof, &ioid_uint64, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
 #endif
 
     if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM3, &dim_len[1], elements_per_pe_3d,
                                 compdof_3d, &ioid_4d_int, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_init_decomp(iosysid, PIO_FLOAT, NDIM3, &dim_len[1], elements_per_pe_3d,
                                 compdof_3d, &ioid_4d_float, rearr, NULL, NULL)))
-        ERR(ret);
+        AERR(ret);
 
     /* These are the decompositions associated with each type. */
 #ifdef _NETCDF4
@@ -458,12 +457,12 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         sprintf(data_filename, "data_%s_iotype_%d.nc", TEST_NAME, flavor[fmt]);
         if ((ret = PIOc_createfile(iosysid, &ncid, &flavor[fmt], data_filename,
                                    NC_CLOBBER)))
-            ERR(ret);
+            AERR(ret);
 
         /* Define dimensions. */
         for (int d = 0; d < NDIM4; d++)
             if ((ret = PIOc_def_dim(ncid, dim_name[d], dim_len[d], &dimid[d])))
-                ERR(ret);
+                AERR(ret);
 
         /* Define variables. */
         char var_name[PIO_MAX_NAME + 1];
@@ -474,10 +473,10 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
             sprintf(var_name, "var_%d", t);
             sprintf(var_norec_name, "var_norec_%d", t);
             if ((ret = PIOc_def_var(ncid, var_name, my_type[t], NDIM3, dimids_3d, &rec_varid[t])))
-                ERR(ret);
+                AERR(ret);
             if ((ret = PIOc_def_var(ncid, var_norec_name, my_type[t], NDIM2, dimids_2d,
                                     &norec_varid[t])))
-                ERR(ret);
+                AERR(ret);
         }
 
         char var_name_4d[NUM_4D_VARS][PIO_MAX_NAME + 1] = {"var_4d_int", "var_4d_float"};
@@ -488,11 +487,11 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         /* Define some 4D vars for extra fun. */
         for (int v = 0; v < NUM_4D_VARS; v++)
             if ((ret = PIOc_def_var(ncid, var_name_4d[v], var_type_4d[v], NDIM4, dimids_4d, &varid_4d[v])))
-                ERR(ret);
+                AERR(ret);
 
         /* End define mode. */
         if ((ret = PIOc_enddef(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Write a record and non-record var for each type. */
         for (int t = 0; t < num_types; t++)
@@ -504,22 +503,22 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
                 if (!r)
                 {
                     if ((ret = PIOc_setframe(ncid, rec_varid[t], 0)))
-                        ERR(ret);
+                        AERR(ret);
                 }
                 else
                 {
                     if ((ret = PIOc_advanceframe(ncid, rec_varid[t])))
-                        ERR(ret);
+                        AERR(ret);
                 }
 
                 /* Write a record of data. */
                 if ((ret = PIOc_write_darray(ncid, rec_varid[t], var_ioid[t], elements_per_pe,
                                              my_data[t], NULL)))
-                    ERR(ret);
+                    AERR(ret);
 
                 /* Sync the file. */
                 if ((ret = PIOc_sync(ncid)))
-                    ERR(ret);
+                    AERR(ret);
             } /* next record. */
         } /* next type */
 
@@ -527,7 +526,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         for (int t = 0; t < num_types; t++)
         {
             if ((ret = PIOc_write_darray(ncid, norec_varid[t], var_ioid[t], elements_per_pe, my_data[t], NULL)))
-                ERR(ret);
+                AERR(ret);
         }
 
         /* Write the 4D vars. */
@@ -538,23 +537,23 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
                 if (!r)
                 {
                     if ((ret = PIOc_setframe(ncid, varid_4d[v], 0)))
-                        ERR(ret);
+                        AERR(ret);
                 }
                 else
                 {
                     if ((ret = PIOc_advanceframe(ncid, varid_4d[v])))
-                        ERR(ret);
+                        AERR(ret);
                 }
 
                 if ((ret = PIOc_write_darray(ncid, varid_4d[v], var_ioid_4d[v], elements_per_pe_3d,
                                              my_data_4d[v], NULL)))
-                    ERR(ret);
+                    AERR(ret);
             }
         }
 
         /* Close the file. */
         if ((ret = PIOc_closefile(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Check the file for correctness. */
         if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_NETCDF, my_rank,
@@ -565,34 +564,34 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
 
     /* Free the decompositions. */
     if ((ret = PIOc_freedecomp(iosysid, ioid_byte)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_char)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_short)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_int)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_float)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_double)))
-        ERR(ret);
+        AERR(ret);
 #ifdef _NETCDF4
     if ((ret = PIOc_freedecomp(iosysid, ioid_ubyte)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_ushort)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_uint)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_int64)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_uint64)))
-        ERR(ret);
+        AERR(ret);
 #endif /* _NETCDF4 */
 
     if ((ret = PIOc_freedecomp(iosysid, ioid_4d_int)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_freedecomp(iosysid, ioid_4d_float)))
-        ERR(ret);
+        AERR(ret);
     return 0;
 }
 

--- a/tests/cunit/test_darray_async_many.c
+++ b/tests/cunit/test_darray_async_many.c
@@ -223,6 +223,7 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
                     PBAIL(ERR_WRONG);
                 break;
             case PIO_UINT:
+		PBAIL(ERR_WRONG);
                 if (((unsigned int *)norec_data_in)[r] != expected_uint[r])
                     PBAIL(ERR_WRONG);
                 break;
@@ -558,7 +559,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         /* Check the file for correctness. */
         if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_NETCDF, my_rank,
                                      rec_varid, norec_varid, num_types, varid_4d)))
-            ERR(ret);
+            AERR(ret);
 
     } /* next iotype */
 

--- a/tests/cunit/test_darray_async_simple.c
+++ b/tests/cunit/test_darray_async_simple.c
@@ -49,24 +49,24 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank)
 
     /* Reopen the file. */
     if ((ret = PIOc_openfile(iosysid, &ncid, &iotype, data_filename, NC_NOWRITE)))
-        ERR(ret);
+        AERR(ret);
 
     /* Check the metadata. */
     if ((ret = PIOc_inq_varid(ncid, VAR_NAME, &varid)))
-        ERR(ret);
+        AERR(ret);
     if ((ret = PIOc_inq_dimid(ncid, DIM_NAME, &dimid)))
-        ERR(ret);
+        AERR(ret);
 
     /* Check the data. */
     if ((ret = PIOc_get_var(ncid, varid, &data_in)))
-        ERR(ret);
+        AERR(ret);
     for (int r = 1; r < TARGET_NTASKS; r++)
         if (data_in[r - 1] != r * 10.0)
-            ERR(ret);
+            AERR(ret);
 
     /* Close the file. */
     if ((ret = PIOc_closefile(ncid)))
-        ERR(ret);
+        AERR(ret);
 
     return 0;
 }
@@ -107,31 +107,31 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm,
         /* Create sample output file. */
         if ((ret = PIOc_createfile(iosysid, &ncid, &flavor[fmt], data_filename,
                                    NC_CLOBBER)))
-            ERR(ret);
+            AERR(ret);
 
         /* Define dimension. */
         if ((ret = PIOc_def_dim(ncid, DIM_NAME, dim_len, &dimid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Define variable. */
         if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_FLOAT, NDIM1, &dimid, &varid)))
-            ERR(ret);
+            AERR(ret);
 
         /* End define mode. */
         if ((ret = PIOc_enddef(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Write some data. */
         if ((ret = PIOc_write_darray(ncid, varid, ioid, ELEM1, &my_data, NULL)))
-            ERR(ret);
+            AERR(ret);
 
         /* Close the file. */
         if ((ret = PIOc_closefile(ncid)))
-            ERR(ret);
+            AERR(ret);
 
         /* Check the file for correctness. */
         if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_NETCDF, my_rank)))
-            ERR(ret);
+            AERR(ret);
 
     } /* next iotype */
 

--- a/tests/ncint/pio_err_macros.h
+++ b/tests/ncint/pio_err_macros.h
@@ -61,6 +61,8 @@ static int total_err = 0, err = 0;
         return 0;                                               \
     } while (0)
 
-#define ERR_WRONG 99
+/* This is also defined in tests/cunit/pio_tests.h. It will reduce
+ * confusion to use the same value. */    
+#define ERR_WRONG 1112
 
 #endif /* _PIO_ERR_MACROS_H */


### PR DESCRIPTION
Fixes #1792 

Fixed error handling in async tests. Instead of calling MPI_finalize(), call PIOc_finalize() to tell the I/O processes to exit their loop. This causes the test to return as failed, instead of just hanging.