### PR TITLE
fixing cmake workflow

### DIFF
--- a/.github/workflows/cmake_netcdf-4.7.4_hdf5-1.10.7_pnetcdf-12.1_ncint_mpich-3.3_asan.yml
+++ b/.github/workflows/cmake_netcdf-4.7.4_hdf5-1.10.7_pnetcdf-12.1_ncint_mpich-3.3_asan.yml
@@ -132,4 +132,4 @@ jobs:
         cmake -Wno-dev -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH=/home/runner/pnetcdf -DPIO_ENABLE_FORTRAN=On -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off -DNetCDF_Fortran_LIBRARY=/home/runner/netcdf-fortran/lib/libnetcdff.so -DNetCDF_Fortran_INCLUDE_DIR=/home/runner/netcdf-fortran/include ..
         make VERBOSE=1
         make tests VERBOSE=1
-        ctest -VV -I 22,22
+        ctest -VV

--- a/.github/workflows/cmake_netcdf-4.7.4_hdf5-1.10.7_pnetcdf-12.1_ncint_mpich-3.3_asan.yml
+++ b/.github/workflows/cmake_netcdf-4.7.4_hdf5-1.10.7_pnetcdf-12.1_ncint_mpich-3.3_asan.yml
@@ -120,21 +120,6 @@ jobs:
     - name: cmake build
       run: |
         set -x
-        gcc --version
-        echo 'export PATH=/home/runner/mpich/bin:$PATH' > .bashrc
-        source .bashrc
-        export CC=/home/runner/mpich/bin/mpicc
-        export FC=/home/runner/mpich/bin/mpifort
-        export LD_LIBRARY_PATH="/home/runner/netcdf-c/lib:/home/runner/mpich/lib:/home/runner/hdf5/lib:/home/runner/netcdf-fortran/lib:/home/runner/pnetcdf/lib:$LD_LIBRARY_PATH"
-        mkdir build
-        cd build
-        cmake -Wno-dev -DNetCDF_C_LIBRARY=/home/runner/netcdf-c/lib/libnetcdf.so -DNetCDF_C_INCLUDE_DIR=/home/runner/netcdf-c/include -DPnetCDF_PATH='/home/runner/pnetcdf' -DPIO_ENABLE_FORTRAN=Off -DPIO_ENABLE_LOGGING=On -DPIO_ENABLE_TIMING=Off .. || (cat CMakeFiles/CMakeOutput.log && cat CMakeFiles/CMakeError.log)
-        make VERBOSE=1
-        make tests VERBOSE=1
-#        ctest -VV
-    - name: cmake build
-      run: |
-        set -x
         ls -l
         echo 'export PATH=/home/runner/mpich/bin:$PATH' > .bashrc
         source .bashrc


### PR DESCRIPTION
Fixes #1728 

Some changes to the cmake build. It was being run twice, once without fortran, then with fortran. Also, when it was built with fortran, only one test was being run.

Now it builds one, with fortran, and runs all tests.