### PR TITLE
fix inconsistancy in intent

### DIFF
--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -38,7 +38,7 @@ module pionfput_mod
        use iso_c_binding
        integer(C_INT), intent(in), value :: ncid
        integer(C_INT), intent(in), value :: varid
-       {CTYPE} :: op(*)
+       {CTYPE}, intent(in) :: op(*)
      end function PIOc_put_var_{TYPE}
   end interface
   interface


### PR DESCRIPTION
cce 10.0.3 caught an inconsistancy in the declaration of PIOc_put_var_
```
ftn-828 crayftn: ERROR PIOC_PUT_VAR_INT, File = ../../../global/cscratch1/sd/jedwards/foo/bld/cray/mpt/nodebug/nothreads/mct/pio/pio2/src/flib/pionfput_mod.F90, Line = 246, Column = 62 
  Procedure "PIOc_put_var_int" is defined in multiple places.  Argument 3 has INTENT(IN) in one definition but not the other.
```

this fixes the issue.
