### PR TITLE
Refactor subset method

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -133,6 +133,21 @@ if (NOT PnetCDF_C_FOUND AND NOT NetCDF_C_FOUND)
   message (FATAL_ERROR "Must have PnetCDF and/or NetCDF C libraries")
 endif ()
 
+#===== MPI =====
+if (PIO_USE_MPISERIAL)
+  if (MPISERIAL_C_FOUND)
+    target_compile_definitions (pioc
+      PRIVATE _MPISERIAL)
+    target_include_directories (pioc
+      PUBLIC ${MPISERIAL_C_INCLUDE_DIRS})
+    target_link_libraries (pioc
+      PUBLIC ${MPISERIAL_C_LIBRARIES})
+
+    set (WITH_PNETCDF FALSE)
+    set (MPI_C_INCLUDE_PATH ${MPISERIAL_C_INCLUDE_DIRS})
+  endif ()
+endif ()
+
 include(CheckTypeSize)
 check_type_size("size_t" SIZEOF_SIZE_T)
 CHECK_TYPE_SIZE("long long" SIZEOF_LONG_LONG)

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -786,54 +786,54 @@ extern "C" {
 
     /* Init decomposition with 1-based compmap array. */
     int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, int maplen,
-			const PIO_Offset *compmap, int *ioidp, const int *rearr,
-			const PIO_Offset *iostart, const PIO_Offset *iocount);
+                        const PIO_Offset *compmap, int *ioidp, const int *rearr,
+                        const PIO_Offset *iostart, const PIO_Offset *iocount);
     int PIOc_InitDecomp_bc(int iosysid, int basetype, int ndims, const int *gdimlen,
-			   const long int *start, const long int *count, int *ioidp);
+                           const long int *start, const long int *count, int *ioidp);
 
     /* Init decomposition with 0-based compmap array. */
     int PIOc_init_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen, int maplen,
-			 const PIO_Offset *compmap, int *ioidp, int rearranger,
-			 const PIO_Offset *iostart, const PIO_Offset *iocount);
+                         const PIO_Offset *compmap, int *ioidp, int rearranger,
+                         const PIO_Offset *iostart, const PIO_Offset *iocount);
 
     /* Free resources associated with a decomposition. */
     int PIOc_freedecomp(int iosysid, int ioid);
 
     int PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
-		     PIO_Offset **map, MPI_Comm comm);
+                     PIO_Offset **map, MPI_Comm comm);
     int PIOc_readmap_from_f90(const char *file,int *ndims, int **gdims, PIO_Offset *maplen,
-			      PIO_Offset **map, int f90_comm);
+                              PIO_Offset **map, int f90_comm);
     int PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
-		      PIO_Offset *map, MPI_Comm comm);
+                      PIO_Offset *map, MPI_Comm comm);
     int PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
-			       PIO_Offset maplen, const PIO_Offset *map, int f90_comm);
+                               PIO_Offset maplen, const PIO_Offset *map, int f90_comm);
 
     /* Write a decomposition file. */
     int PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm);
 
     /* Write a decomposition file using netCDF. */
     int PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
-			     char *title, char *history, int fortran_order);
+                             char *title, char *history, int fortran_order);
 
     /* Read a netCDF decomposition file. */
     int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioid, MPI_Comm comm,
-			    int pio_type, char *title, char *history, int *fortran_order);
+                            int pio_type, char *title, char *history, int *fortran_order);
 
     /* Initializing IO system for async. */
     int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
-			int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
-			int rearranger, int *iosysidp);
+                        int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
+                        int rearranger, int *iosysidp);
 
     /* Initializing IO system for async - alternative interface. */
     int PIOc_init_async_from_comms(MPI_Comm world, int component_count, MPI_Comm *comp_comm,
-				   MPI_Comm io_comm, int rearranger, int *iosysidp);
+                                   MPI_Comm io_comm, int rearranger, int *iosysidp);
 
     /* How many IO tasks in this iosysid? */
     int PIOc_get_numiotasks(int iosysid, int *numiotasks);
 
     /* Initialize PIO for intracomm mode. */
     int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
-			    int *iosysidp);
+                            int *iosysidp);
 
     /** Shut down an iosystem and free all associated resources. Use
      * PIOc_free_iosystem() instead. */
@@ -862,10 +862,10 @@ extern "C" {
 
     /* Set the options for the rearranger. */
     int PIOc_set_rearr_opts(int iosysid, int comm_type, int fcd,
-			    bool enable_hs_c2i, bool enable_isend_c2i,
-			    int max_pend_req_c2i,
-			    bool enable_hs_i2c, bool enable_isend_i2c,
-			    int max_pend_req_i2c);
+                            bool enable_hs_c2i, bool enable_isend_c2i,
+                            int max_pend_req_c2i,
+                            bool enable_hs_i2c, bool enable_isend_i2c,
+                            int max_pend_req_i2c);
 
     /* Increment record number. */
     int PIOc_advanceframe(int ncid, int varid);
@@ -875,11 +875,11 @@ extern "C" {
 
     /* Write a distributed array. */
     int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *array,
-			  void *fillvalue);
+                          void *fillvalue);
 
     /* Write multiple darrays. */
     int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars, PIO_Offset arraylen,
-				void *array, const int *frame, void **fillvalue, bool flushtodisk);
+                                void *array, const int *frame, void **fillvalue, bool flushtodisk);
 
     /* Read distributed array. */
     int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *array);
@@ -917,9 +917,9 @@ extern "C" {
 
     int PIOc_set_hint(int iosysid, const char *hint, const char *hintval);
     int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems,
-			     float preemption);
+                             float preemption);
     int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset *nelemsp,
-			     float *preemptionp);
+                             float *preemptionp);
 
     /* Dimensions. */
     int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp);
@@ -932,14 +932,14 @@ extern "C" {
     /* Variables. */
     int PIOc_inq_varid(int ncid, const char *name, int *varidp);
     int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp,
-		     int *nattsp);
+                     int *nattsp);
     int PIOc_inq_varname(int ncid, int varid, char *name);
     int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep);
     int PIOc_inq_varndims(int ncid, int varid, int *ndimsp);
     int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp);
     int PIOc_inq_varnatts(int ncid, int varid, int *nattsp);
     int PIOc_def_var(int ncid, const char *name, nc_type xtype,  int ndims,
-		     const int *dimidsp, int *varidp);
+                     const int *dimidsp, int *varidp);
     int PIOc_set_fill(int ncid, int fillmode, int *old_modep);
     int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value);
     int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep);
@@ -947,17 +947,17 @@ extern "C" {
 
     /* These variable settings only apply to netCDF-4 files. */
     int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
-			     int deflate_level);
+                             int deflate_level);
     int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep, int *deflatep,
-			     int *deflate_levelp);
+                             int *deflate_levelp);
     int PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunksizesp);
     int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizesp);
     int PIOc_def_var_endian(int ncid, int varid, int endian);
     int PIOc_inq_var_endian(int ncid, int varid, int *endianp);
     int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset nelems,
-				 float preemption);
+                                 float preemption);
     int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nelemsp,
-				 float *preemptionp);
+                                 float *preemptionp);
 
     /* Attributes - misc. */
     int PIOc_rename_att(int ncid, int varid, const char *name, const char *newname);
@@ -965,7 +965,7 @@ extern "C" {
 
     /* Attributes - inquiry functions. */
     int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
-		     PIO_Offset *lenp);
+                     PIO_Offset *lenp);
     int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp);
     int PIOc_inq_attlen(int ncid, int varid, const char *name, PIO_Offset *lenp);
     int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep);
@@ -975,27 +975,27 @@ extern "C" {
     int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const void *op);
     int PIOc_put_att_text(int ncid, int varid, const char *name, PIO_Offset len, const char *op);
     int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			   const signed char *op);
+                           const signed char *op);
     int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			   const short *op);
+                           const short *op);
     int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			 const int *op);
+                         const int *op);
     int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			  const long *op);
+                          const long *op);
     int PIOc_put_att_float(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			   const float *op);
+                           const float *op);
     int PIOc_put_att_double(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			    const double *op);
+                            const double *op);
     int PIOc_put_att_uchar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			   const unsigned char *op);
+                           const unsigned char *op);
     int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			    const unsigned short *op);
+                            const unsigned short *op);
     int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			  const unsigned int *op);
+                          const unsigned int *op);
     int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-			      const long long *op);
+                              const long long *op);
     int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype,
-			       PIO_Offset len, const unsigned long long *op);
+                               PIO_Offset len, const unsigned long long *op);
 
     /* Attributes - reading. */
     int PIOc_get_att(int ncid, int varid, const char *name, void *ip);
@@ -1067,188 +1067,188 @@ extern "C" {
     int PIOc_put_var1_float(int ncid, int varid, const PIO_Offset *index, const float *op);
     int PIOc_put_var1_double(int ncid, int varid, const PIO_Offset *index, const double *op);
     int PIOc_put_var1_uchar(int ncid, int varid, const PIO_Offset *index,
-			    const unsigned char *op);
+                            const unsigned char *op);
     int PIOc_put_var1_ushort(int ncid, int varid, const PIO_Offset *index,
-			     const unsigned short *op);
+                             const unsigned short *op);
     int PIOc_put_var1_uint(int ncid, int varid, const PIO_Offset *index,
-			   const unsigned int *op);
+                           const unsigned int *op);
     int PIOc_put_var1_longlong(int ncid, int varid, const PIO_Offset *index, const long long *op);
     int PIOc_put_var1_ulonglong(int ncid, int varid, const PIO_Offset *index,
-				const unsigned long long *op);
+                                const unsigned long long *op);
 
     /* Data reads - vara. */
     int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count, void *buf);
     int PIOc_get_vara_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   char *buf);
+                           char *buf);
     int PIOc_get_vara_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    signed char *buf);
+                            signed char *buf);
     int PIOc_get_vara_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    short *buf);
+                            short *buf);
     int PIOc_get_vara_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			  int *buf);
+                          int *buf);
     int PIOc_get_vara_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    float *buf);
+                            float *buf);
     int PIOc_get_vara_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   long *buf);
+                           long *buf);
     int PIOc_get_vara_double(int ncid, int varid, const PIO_Offset *start,
-			     const PIO_Offset *count, double *buf);
+                             const PIO_Offset *count, double *buf);
     int PIOc_get_vara_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    unsigned char *buf);
+                            unsigned char *buf);
     int PIOc_get_vara_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			     unsigned short *buf);
+                             unsigned short *buf);
     int PIOc_get_vara_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   unsigned int *buf);
+                           unsigned int *buf);
     int PIOc_get_vara_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			       long long *buf);
+                               long long *buf);
     int PIOc_get_vara_ulonglong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-				unsigned long long *buf);
+                                unsigned long long *buf);
 
     /* Data writes - vara. */
     int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		      const void *buf);
+                      const void *buf);
     int PIOc_put_vara_text(int ncid, int varid, const PIO_Offset *start,
-			   const PIO_Offset *count, const char *op);
+                           const PIO_Offset *count, const char *op);
     int PIOc_put_vara_schar(int ncid, int varid, const PIO_Offset *start,
-			    const PIO_Offset *count, const signed char *op);
+                            const PIO_Offset *count, const signed char *op);
     int PIOc_put_vara_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const short *op);
+                            const short *op);
     int PIOc_put_vara_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			  const int *op);
+                          const int *op);
     int PIOc_put_vara_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   const long *op);
+                           const long *op);
     int PIOc_put_vara_float(int ncid, int varid, const PIO_Offset *start,
-			    const PIO_Offset *count, const float *op);
+                            const PIO_Offset *count, const float *op);
     int PIOc_put_vara_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			     const double *op);
+                             const double *op);
     int PIOc_put_vara_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const unsigned char *op);
+                            const unsigned char *op);
     int PIOc_put_vara_ushort(int ncid, int varid, const PIO_Offset *start,
-			     const PIO_Offset *count, const unsigned short *op);
+                             const PIO_Offset *count, const unsigned short *op);
     int PIOc_put_vara_uint(int ncid, int varid, const PIO_Offset *start,
-			   const PIO_Offset *count, const unsigned int *op);
+                           const PIO_Offset *count, const unsigned int *op);
     int PIOc_put_vara_longlong(int ncid, int varid, const PIO_Offset *start,
-			       const PIO_Offset *count, const long long *op);
+                               const PIO_Offset *count, const long long *op);
     int PIOc_put_vara_ulonglong(int ncid, int varid, const PIO_Offset *start,
-				const PIO_Offset *count, const unsigned long long *op);
+                                const PIO_Offset *count, const unsigned long long *op);
 
     /* Data reads - vars. */
     int PIOc_get_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		      const PIO_Offset *stride, void *buf);
+                      const PIO_Offset *stride, void *buf);
     int PIOc_get_vars_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   const PIO_Offset *stride, char *buf);
+                           const PIO_Offset *stride, char *buf);
     int PIOc_get_vars_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const PIO_Offset *stride, signed char *buf);
+                            const PIO_Offset *stride, signed char *buf);
     int PIOc_get_vars_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const PIO_Offset *stride, short *buf);
+                            const PIO_Offset *stride, short *buf);
     int PIOc_get_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			  const PIO_Offset *stride, int *buf);
+                          const PIO_Offset *stride, int *buf);
     int PIOc_get_vars_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   const PIO_Offset *stride, long *buf);
+                           const PIO_Offset *stride, long *buf);
     int PIOc_get_vars_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const PIO_Offset *stride, float *buf);
+                            const PIO_Offset *stride, float *buf);
     int PIOc_get_vars_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			     const PIO_Offset *stride, double *buf);
+                             const PIO_Offset *stride, double *buf);
     int PIOc_get_vars_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const PIO_Offset *stride, unsigned char *buf);
+                            const PIO_Offset *stride, unsigned char *buf);
     int PIOc_get_vars_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			     const PIO_Offset *stride, unsigned short *buf);
+                             const PIO_Offset *stride, unsigned short *buf);
     int PIOc_get_vars_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   const PIO_Offset *stride, unsigned int *buf);
+                           const PIO_Offset *stride, unsigned int *buf);
     int PIOc_get_vars_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			       const PIO_Offset *stride, long long *buf);
+                               const PIO_Offset *stride, long long *buf);
     int PIOc_get_vars_ulonglong(int ncid, int varid, const PIO_Offset *start,
-				const PIO_Offset *count, const PIO_Offset *stride,
-				unsigned long long *buf);
+                                const PIO_Offset *count, const PIO_Offset *stride,
+                                unsigned long long *buf);
 
     /* Data writes - vars. */
     int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-		      const PIO_Offset *stride, const void *buf);
+                      const PIO_Offset *stride, const void *buf);
     int PIOc_put_vars_text(int ncid, int varid, const PIO_Offset *start,
-			   const PIO_Offset *count, const PIO_Offset *stride, const char *op);
+                           const PIO_Offset *count, const PIO_Offset *stride, const char *op);
     int PIOc_put_vars_schar(int ncid, int varid, const PIO_Offset *start,
-			    const PIO_Offset *count, const PIO_Offset *stride,
-			    const signed char *op);
+                            const PIO_Offset *count, const PIO_Offset *stride,
+                            const signed char *op);
     int PIOc_put_vars_short(int ncid, int varid, const PIO_Offset *start,
-			    const PIO_Offset *count, const PIO_Offset *stride, const short *op);
+                            const PIO_Offset *count, const PIO_Offset *stride, const short *op);
     int PIOc_put_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			  const PIO_Offset *stride, const int *op);
+                          const PIO_Offset *stride, const int *op);
     int PIOc_put_vars_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const PIO_Offset *stride, const float *op);
+                            const PIO_Offset *stride, const float *op);
     int PIOc_put_vars_double(int ncid, int varid, const PIO_Offset *start,
-			     const PIO_Offset *count, const PIO_Offset *stride, const double *op);
+                             const PIO_Offset *count, const PIO_Offset *stride, const double *op);
     int PIOc_put_vars_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   const PIO_Offset *stride, const long *op);
+                           const PIO_Offset *stride, const long *op);
     int PIOc_put_vars_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			    const PIO_Offset *stride, const unsigned char *op);
+                            const PIO_Offset *stride, const unsigned char *op);
     int PIOc_put_vars_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			     const PIO_Offset *stride, const unsigned short *op);
+                             const PIO_Offset *stride, const unsigned short *op);
     int PIOc_put_vars_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			   const PIO_Offset *stride, const unsigned int *op);
+                           const PIO_Offset *stride, const unsigned int *op);
     int PIOc_put_vars_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-			       const PIO_Offset *stride, const long long *op);
+                               const PIO_Offset *stride, const long long *op);
     int PIOc_put_vars_ulonglong(int ncid, int varid, const PIO_Offset *start,
-				const PIO_Offset *count, const PIO_Offset *stride,
-				const unsigned long long *op);
+                                const PIO_Offset *count, const PIO_Offset *stride,
+                                const unsigned long long *op);
 
     /* Data reads - vard. */
     int PIOc_get_vard(int ncid, int varid, int decompid, const PIO_Offset recnum, void *buf);
     int PIOc_get_vard_text(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			   char *buf);
+                           char *buf);
     int PIOc_get_vard_schar(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			    signed char *buf);
+                            signed char *buf);
     int PIOc_get_vard_short(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			    short *buf);
+                            short *buf);
     int PIOc_get_vard_int(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			  int *buf);
+                          int *buf);
     int PIOc_get_vard_float(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			    float *buf);
+                            float *buf);
     int PIOc_get_vard_double(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			     double *buf);
+                             double *buf);
     int PIOc_get_vard_uchar(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			    unsigned char *buf);
+                            unsigned char *buf);
     int PIOc_get_vard_ushort(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			     unsigned short *buf);
+                             unsigned short *buf);
     int PIOc_get_vard_uint(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			   unsigned int *buf);
+                           unsigned int *buf);
     int PIOc_get_vard_longlong(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			       long long *buf);
+                               long long *buf);
     int PIOc_get_vard_ulonglong(int ncid, int varid, int decompid, const PIO_Offset recnum,
-				unsigned long long *buf);
+                                unsigned long long *buf);
 
     /* Data writes - vard. */
     int PIOc_put_vard(int ncid, int varid, int decompid, const PIO_Offset recnum,
-		      const void *buf);
+                      const void *buf);
     int PIOc_put_vard_text(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			   const char *op);
+                           const char *op);
     int PIOc_put_vard_schar(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			    const signed char *op);
+                            const signed char *op);
     int PIOc_put_vard_short(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			    const short *op);
+                            const short *op);
     int PIOc_put_vard_int(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			  const int *op);
+                          const int *op);
     int PIOc_put_vard_float(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			    const float *op);
+                            const float *op);
     int PIOc_put_vard_double(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			     const double *op);
+                             const double *op);
     int PIOc_put_vard_uchar(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			    const unsigned char *op);
+                            const unsigned char *op);
     int PIOc_put_vard_ushort(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			     const unsigned short *op);
+                             const unsigned short *op);
     int PIOc_put_vard_uint(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			   const unsigned int *op);
+                           const unsigned int *op);
     int PIOc_put_vard_longlong(int ncid, int varid, int decompid, const PIO_Offset recnum,
-			       const long long *op);
+                               const long long *op);
     int PIOc_put_vard_ulonglong(int ncid, int varid, int decompid, const PIO_Offset recnum,
-				const unsigned long long *op);
+                                const unsigned long long *op);
 
     /* These functions are for the netCDF integration layer. */
     int nc_def_iosystem(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
-			 int *iosysidp);
+                         int *iosysidp);
 
     int nc_def_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
-		     int component_count, int *num_procs_per_comp, int **proc_list,
-		     MPI_Comm *io_comm, MPI_Comm *comp_comm, int rearranger,
-		     int *iosysidp);
+                     int component_count, int *num_procs_per_comp, int **proc_list,
+                     MPI_Comm *io_comm, MPI_Comm *comp_comm, int rearranger,
+                     int *iosysidp);
 
     /* Set the default IOsystem ID. */
     int nc_set_iosystem(int iosysid);
@@ -1261,9 +1261,9 @@ extern "C" {
 
     /* Define a decomposition for distributed arrays. */
     int nc_def_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen,
-		      int maplen, const size_t *compmap, int *ioidp,
-		      int rearranger, const size_t *iostart,
-		      const size_t *iocount);
+                      int maplen, const size_t *compmap, int *ioidp,
+                      int rearranger, const size_t *iostart,
+                      const size_t *iocount);
 
     /* Release resources associated with a decomposition. */
     int nc_free_decomp(int ioid);
@@ -1271,53 +1271,53 @@ extern "C" {
     /* Data reads - read a distributed array. */
     int nc_get_vard(int ncid, int varid, int decompid, const size_t recnum, void *buf);
     int nc_get_vard_text(int ncid, int varid, int decompid, const size_t recnum,
-			 char *buf);
+                         char *buf);
     int nc_get_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
-			  signed char *buf);
+                          signed char *buf);
     int nc_get_vard_short(int ncid, int varid, int decompid, const size_t recnum,
-			  short *buf);
+                          short *buf);
     int nc_get_vard_int(int ncid, int varid, int decompid, const size_t recnum,
-			int *buf);
+                        int *buf);
     int nc_get_vard_float(int ncid, int varid, int decompid, const size_t recnum,
-			  float *buf);
+                          float *buf);
     int nc_get_vard_double(int ncid, int varid, int decompid, const size_t recnum,
-			   double *buf);
+                           double *buf);
     int nc_get_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
-			  unsigned char *buf);
+                          unsigned char *buf);
     int nc_get_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
-			   unsigned short *buf);
+                           unsigned short *buf);
     int nc_get_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
-			 unsigned int *buf);
+                         unsigned int *buf);
     int nc_get_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
-			     long long *buf);
+                             long long *buf);
     int nc_get_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
-			      unsigned long long *buf);
+                              unsigned long long *buf);
 
     /* Data writes - Write a distributed array. */
     int nc_put_vard(int ncid, int varid, int decompid, const size_t recnum,
-		    const void *buf);
+                    const void *buf);
     int nc_put_vard_text(int ncid, int varid, int decompid, const size_t recnum,
-			 const char *op);
+                         const char *op);
     int nc_put_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
-			  const signed char *op);
+                          const signed char *op);
     int nc_put_vard_short(int ncid, int varid, int decompid, const size_t recnum,
-			  const short *op);
+                          const short *op);
     int nc_put_vard_int(int ncid, int varid, int decompid, const size_t recnum,
-			const int *op);
+                        const int *op);
     int nc_put_vard_float(int ncid, int varid, int decompid, const size_t recnum,
-			  const float *op);
+                          const float *op);
     int nc_put_vard_double(int ncid, int varid, int decompid, const size_t recnum,
-			   const double *op);
+                           const double *op);
     int nc_put_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
-			  const unsigned char *op);
+                          const unsigned char *op);
     int nc_put_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
-			   const unsigned short *op);
+                           const unsigned short *op);
     int nc_put_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
-			 const unsigned int *op);
+                         const unsigned int *op);
     int nc_put_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
-			     const long long *op);
+                             const long long *op);
     int nc_put_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
-			      const unsigned long long *op);
+                              const unsigned long long *op);
 
 #if defined(__cplusplus)
 }

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -292,7 +292,7 @@ typedef struct io_desc_t
     /** The actual number of IO tasks participating. */
     int num_aiotasks;
 
-    /** The rearranger in use for this variable. */
+    /** The rearranger in use for this decomposition. */
     int rearranger;
 
     /** Maximum number of regions in the decomposition. */
@@ -305,6 +305,10 @@ typedef struct io_desc_t
     /** If the map is not monotonically increasing we will need to
      * sort it. */
     bool needssort;
+
+    /** If the decomp has repeated values it can only be used for reading 
+        since it doesn't make sense to write a single value from more than one location. */
+    bool readonly;
 
     /** The maximum number of bytes of this iodesc before flushing. */
     int maxbytes;

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -327,6 +327,7 @@ typedef struct io_desc_t
      * nodes), each io task contains data from the compmap of one or
      * more compute tasks in the iomap array. */
     PIO_Offset llen;
+    PIO_Offset rllen;
 
     /** Maximum llen participating. */
     int maxiobuflen;
@@ -781,54 +782,54 @@ extern "C" {
 
     /* Init decomposition with 1-based compmap array. */
     int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, int maplen,
-                        const PIO_Offset *compmap, int *ioidp, const int *rearr,
-                        const PIO_Offset *iostart, const PIO_Offset *iocount);
+			const PIO_Offset *compmap, int *ioidp, const int *rearr,
+			const PIO_Offset *iostart, const PIO_Offset *iocount);
     int PIOc_InitDecomp_bc(int iosysid, int basetype, int ndims, const int *gdimlen,
-                           const long int *start, const long int *count, int *ioidp);
+			   const long int *start, const long int *count, int *ioidp);
 
     /* Init decomposition with 0-based compmap array. */
     int PIOc_init_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen, int maplen,
-                         const PIO_Offset *compmap, int *ioidp, int rearranger,
-                         const PIO_Offset *iostart, const PIO_Offset *iocount);
+			 const PIO_Offset *compmap, int *ioidp, int rearranger,
+			 const PIO_Offset *iostart, const PIO_Offset *iocount);
 
     /* Free resources associated with a decomposition. */
     int PIOc_freedecomp(int iosysid, int ioid);
 
     int PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
-                     PIO_Offset **map, MPI_Comm comm);
+		     PIO_Offset **map, MPI_Comm comm);
     int PIOc_readmap_from_f90(const char *file,int *ndims, int **gdims, PIO_Offset *maplen,
-                              PIO_Offset **map, int f90_comm);
+			      PIO_Offset **map, int f90_comm);
     int PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
-                      PIO_Offset *map, MPI_Comm comm);
+		      PIO_Offset *map, MPI_Comm comm);
     int PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
-                               PIO_Offset maplen, const PIO_Offset *map, int f90_comm);
+			       PIO_Offset maplen, const PIO_Offset *map, int f90_comm);
 
     /* Write a decomposition file. */
     int PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm);
 
     /* Write a decomposition file using netCDF. */
     int PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
-                             char *title, char *history, int fortran_order);
+			     char *title, char *history, int fortran_order);
 
     /* Read a netCDF decomposition file. */
     int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioid, MPI_Comm comm,
-                            int pio_type, char *title, char *history, int *fortran_order);
+			    int pio_type, char *title, char *history, int *fortran_order);
 
     /* Initializing IO system for async. */
     int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
-                        int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
-                        int rearranger, int *iosysidp);
+			int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
+			int rearranger, int *iosysidp);
 
     /* Initializing IO system for async - alternative interface. */
     int PIOc_init_async_from_comms(MPI_Comm world, int component_count, MPI_Comm *comp_comm,
-                                   MPI_Comm io_comm, int rearranger, int *iosysidp);
+				   MPI_Comm io_comm, int rearranger, int *iosysidp);
 
     /* How many IO tasks in this iosysid? */
     int PIOc_get_numiotasks(int iosysid, int *numiotasks);
 
     /* Initialize PIO for intracomm mode. */
     int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
-                            int *iosysidp);
+			    int *iosysidp);
 
     /** Shut down an iosystem and free all associated resources. Use
      * PIOc_free_iosystem() instead. */
@@ -857,10 +858,10 @@ extern "C" {
 
     /* Set the options for the rearranger. */
     int PIOc_set_rearr_opts(int iosysid, int comm_type, int fcd,
-                            bool enable_hs_c2i, bool enable_isend_c2i,
-                            int max_pend_req_c2i,
-                            bool enable_hs_i2c, bool enable_isend_i2c,
-                            int max_pend_req_i2c);
+			    bool enable_hs_c2i, bool enable_isend_c2i,
+			    int max_pend_req_c2i,
+			    bool enable_hs_i2c, bool enable_isend_i2c,
+			    int max_pend_req_i2c);
 
     /* Increment record number. */
     int PIOc_advanceframe(int ncid, int varid);
@@ -870,11 +871,11 @@ extern "C" {
 
     /* Write a distributed array. */
     int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *array,
-                          void *fillvalue);
+			  void *fillvalue);
 
     /* Write multiple darrays. */
     int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars, PIO_Offset arraylen,
-                                void *array, const int *frame, void **fillvalue, bool flushtodisk);
+				void *array, const int *frame, void **fillvalue, bool flushtodisk);
 
     /* Read distributed array. */
     int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *array);
@@ -912,9 +913,9 @@ extern "C" {
 
     int PIOc_set_hint(int iosysid, const char *hint, const char *hintval);
     int PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems,
-                             float preemption);
+			     float preemption);
     int PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset *nelemsp,
-                             float *preemptionp);
+			     float *preemptionp);
 
     /* Dimensions. */
     int PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp);
@@ -927,14 +928,14 @@ extern "C" {
     /* Variables. */
     int PIOc_inq_varid(int ncid, const char *name, int *varidp);
     int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp,
-                     int *nattsp);
+		     int *nattsp);
     int PIOc_inq_varname(int ncid, int varid, char *name);
     int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep);
     int PIOc_inq_varndims(int ncid, int varid, int *ndimsp);
     int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp);
     int PIOc_inq_varnatts(int ncid, int varid, int *nattsp);
     int PIOc_def_var(int ncid, const char *name, nc_type xtype,  int ndims,
-                     const int *dimidsp, int *varidp);
+		     const int *dimidsp, int *varidp);
     int PIOc_set_fill(int ncid, int fillmode, int *old_modep);
     int PIOc_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value);
     int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep);
@@ -942,17 +943,17 @@ extern "C" {
 
     /* These variable settings only apply to netCDF-4 files. */
     int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
-                             int deflate_level);
+			     int deflate_level);
     int PIOc_inq_var_deflate(int ncid, int varid, int *shufflep, int *deflatep,
-                             int *deflate_levelp);
+			     int *deflate_levelp);
     int PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunksizesp);
     int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizesp);
     int PIOc_def_var_endian(int ncid, int varid, int endian);
     int PIOc_inq_var_endian(int ncid, int varid, int *endianp);
     int PIOc_set_var_chunk_cache(int ncid, int varid, PIO_Offset size, PIO_Offset nelems,
-                                 float preemption);
+				 float preemption);
     int PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nelemsp,
-                                 float *preemptionp);
+				 float *preemptionp);
 
     /* Attributes - misc. */
     int PIOc_rename_att(int ncid, int varid, const char *name, const char *newname);
@@ -960,7 +961,7 @@ extern "C" {
 
     /* Attributes - inquiry functions. */
     int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
-                     PIO_Offset *lenp);
+		     PIO_Offset *lenp);
     int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp);
     int PIOc_inq_attlen(int ncid, int varid, const char *name, PIO_Offset *lenp);
     int PIOc_inq_atttype(int ncid, int varid, const char *name, nc_type *xtypep);
@@ -970,27 +971,27 @@ extern "C" {
     int PIOc_put_att(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len, const void *op);
     int PIOc_put_att_text(int ncid, int varid, const char *name, PIO_Offset len, const char *op);
     int PIOc_put_att_schar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                           const signed char *op);
+			   const signed char *op);
     int PIOc_put_att_short(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                           const short *op);
+			   const short *op);
     int PIOc_put_att_int(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                         const int *op);
+			 const int *op);
     int PIOc_put_att_long(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                          const long *op);
+			  const long *op);
     int PIOc_put_att_float(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                           const float *op);
+			   const float *op);
     int PIOc_put_att_double(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                            const double *op);
+			    const double *op);
     int PIOc_put_att_uchar(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                           const unsigned char *op);
+			   const unsigned char *op);
     int PIOc_put_att_ushort(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                            const unsigned short *op);
+			    const unsigned short *op);
     int PIOc_put_att_uint(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                          const unsigned int *op);
+			  const unsigned int *op);
     int PIOc_put_att_longlong(int ncid, int varid, const char *name, nc_type xtype, PIO_Offset len,
-                              const long long *op);
+			      const long long *op);
     int PIOc_put_att_ulonglong(int ncid, int varid, const char *name, nc_type xtype,
-                               PIO_Offset len, const unsigned long long *op);
+			       PIO_Offset len, const unsigned long long *op);
 
     /* Attributes - reading. */
     int PIOc_get_att(int ncid, int varid, const char *name, void *ip);
@@ -1062,188 +1063,188 @@ extern "C" {
     int PIOc_put_var1_float(int ncid, int varid, const PIO_Offset *index, const float *op);
     int PIOc_put_var1_double(int ncid, int varid, const PIO_Offset *index, const double *op);
     int PIOc_put_var1_uchar(int ncid, int varid, const PIO_Offset *index,
-                            const unsigned char *op);
+			    const unsigned char *op);
     int PIOc_put_var1_ushort(int ncid, int varid, const PIO_Offset *index,
-                             const unsigned short *op);
+			     const unsigned short *op);
     int PIOc_put_var1_uint(int ncid, int varid, const PIO_Offset *index,
-                           const unsigned int *op);
+			   const unsigned int *op);
     int PIOc_put_var1_longlong(int ncid, int varid, const PIO_Offset *index, const long long *op);
     int PIOc_put_var1_ulonglong(int ncid, int varid, const PIO_Offset *index,
-                                const unsigned long long *op);
+				const unsigned long long *op);
 
     /* Data reads - vara. */
     int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count, void *buf);
     int PIOc_get_vara_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           char *buf);
+			   char *buf);
     int PIOc_get_vara_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            signed char *buf);
+			    signed char *buf);
     int PIOc_get_vara_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            short *buf);
+			    short *buf);
     int PIOc_get_vara_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                          int *buf);
+			  int *buf);
     int PIOc_get_vara_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            float *buf);
+			    float *buf);
     int PIOc_get_vara_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           long *buf);
+			   long *buf);
     int PIOc_get_vara_double(int ncid, int varid, const PIO_Offset *start,
-                             const PIO_Offset *count, double *buf);
+			     const PIO_Offset *count, double *buf);
     int PIOc_get_vara_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            unsigned char *buf);
+			    unsigned char *buf);
     int PIOc_get_vara_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                             unsigned short *buf);
+			     unsigned short *buf);
     int PIOc_get_vara_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           unsigned int *buf);
+			   unsigned int *buf);
     int PIOc_get_vara_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                               long long *buf);
+			       long long *buf);
     int PIOc_get_vara_ulonglong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                                unsigned long long *buf);
+				unsigned long long *buf);
 
     /* Data writes - vara. */
     int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                      const void *buf);
+		      const void *buf);
     int PIOc_put_vara_text(int ncid, int varid, const PIO_Offset *start,
-                           const PIO_Offset *count, const char *op);
+			   const PIO_Offset *count, const char *op);
     int PIOc_put_vara_schar(int ncid, int varid, const PIO_Offset *start,
-                            const PIO_Offset *count, const signed char *op);
+			    const PIO_Offset *count, const signed char *op);
     int PIOc_put_vara_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            const short *op);
+			    const short *op);
     int PIOc_put_vara_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                          const int *op);
+			  const int *op);
     int PIOc_put_vara_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           const long *op);
+			   const long *op);
     int PIOc_put_vara_float(int ncid, int varid, const PIO_Offset *start,
-                            const PIO_Offset *count, const float *op);
+			    const PIO_Offset *count, const float *op);
     int PIOc_put_vara_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                             const double *op);
+			     const double *op);
     int PIOc_put_vara_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            const unsigned char *op);
+			    const unsigned char *op);
     int PIOc_put_vara_ushort(int ncid, int varid, const PIO_Offset *start,
-                             const PIO_Offset *count, const unsigned short *op);
+			     const PIO_Offset *count, const unsigned short *op);
     int PIOc_put_vara_uint(int ncid, int varid, const PIO_Offset *start,
-                           const PIO_Offset *count, const unsigned int *op);
+			   const PIO_Offset *count, const unsigned int *op);
     int PIOc_put_vara_longlong(int ncid, int varid, const PIO_Offset *start,
-                               const PIO_Offset *count, const long long *op);
+			       const PIO_Offset *count, const long long *op);
     int PIOc_put_vara_ulonglong(int ncid, int varid, const PIO_Offset *start,
-                                const PIO_Offset *count, const unsigned long long *op);
+				const PIO_Offset *count, const unsigned long long *op);
 
     /* Data reads - vars. */
     int PIOc_get_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                      const PIO_Offset *stride, void *buf);
+		      const PIO_Offset *stride, void *buf);
     int PIOc_get_vars_text(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           const PIO_Offset *stride, char *buf);
+			   const PIO_Offset *stride, char *buf);
     int PIOc_get_vars_schar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            const PIO_Offset *stride, signed char *buf);
+			    const PIO_Offset *stride, signed char *buf);
     int PIOc_get_vars_short(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            const PIO_Offset *stride, short *buf);
+			    const PIO_Offset *stride, short *buf);
     int PIOc_get_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                          const PIO_Offset *stride, int *buf);
+			  const PIO_Offset *stride, int *buf);
     int PIOc_get_vars_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           const PIO_Offset *stride, long *buf);
+			   const PIO_Offset *stride, long *buf);
     int PIOc_get_vars_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            const PIO_Offset *stride, float *buf);
+			    const PIO_Offset *stride, float *buf);
     int PIOc_get_vars_double(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                             const PIO_Offset *stride, double *buf);
+			     const PIO_Offset *stride, double *buf);
     int PIOc_get_vars_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            const PIO_Offset *stride, unsigned char *buf);
+			    const PIO_Offset *stride, unsigned char *buf);
     int PIOc_get_vars_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                             const PIO_Offset *stride, unsigned short *buf);
+			     const PIO_Offset *stride, unsigned short *buf);
     int PIOc_get_vars_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           const PIO_Offset *stride, unsigned int *buf);
+			   const PIO_Offset *stride, unsigned int *buf);
     int PIOc_get_vars_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                               const PIO_Offset *stride, long long *buf);
+			       const PIO_Offset *stride, long long *buf);
     int PIOc_get_vars_ulonglong(int ncid, int varid, const PIO_Offset *start,
-                                const PIO_Offset *count, const PIO_Offset *stride,
-                                unsigned long long *buf);
+				const PIO_Offset *count, const PIO_Offset *stride,
+				unsigned long long *buf);
 
     /* Data writes - vars. */
     int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                      const PIO_Offset *stride, const void *buf);
+		      const PIO_Offset *stride, const void *buf);
     int PIOc_put_vars_text(int ncid, int varid, const PIO_Offset *start,
-                           const PIO_Offset *count, const PIO_Offset *stride, const char *op);
+			   const PIO_Offset *count, const PIO_Offset *stride, const char *op);
     int PIOc_put_vars_schar(int ncid, int varid, const PIO_Offset *start,
-                            const PIO_Offset *count, const PIO_Offset *stride,
-                            const signed char *op);
+			    const PIO_Offset *count, const PIO_Offset *stride,
+			    const signed char *op);
     int PIOc_put_vars_short(int ncid, int varid, const PIO_Offset *start,
-                            const PIO_Offset *count, const PIO_Offset *stride, const short *op);
+			    const PIO_Offset *count, const PIO_Offset *stride, const short *op);
     int PIOc_put_vars_int(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                          const PIO_Offset *stride, const int *op);
+			  const PIO_Offset *stride, const int *op);
     int PIOc_put_vars_float(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            const PIO_Offset *stride, const float *op);
+			    const PIO_Offset *stride, const float *op);
     int PIOc_put_vars_double(int ncid, int varid, const PIO_Offset *start,
-                             const PIO_Offset *count, const PIO_Offset *stride, const double *op);
+			     const PIO_Offset *count, const PIO_Offset *stride, const double *op);
     int PIOc_put_vars_long(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           const PIO_Offset *stride, const long *op);
+			   const PIO_Offset *stride, const long *op);
     int PIOc_put_vars_uchar(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                            const PIO_Offset *stride, const unsigned char *op);
+			    const PIO_Offset *stride, const unsigned char *op);
     int PIOc_put_vars_ushort(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                             const PIO_Offset *stride, const unsigned short *op);
+			     const PIO_Offset *stride, const unsigned short *op);
     int PIOc_put_vars_uint(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                           const PIO_Offset *stride, const unsigned int *op);
+			   const PIO_Offset *stride, const unsigned int *op);
     int PIOc_put_vars_longlong(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
-                               const PIO_Offset *stride, const long long *op);
+			       const PIO_Offset *stride, const long long *op);
     int PIOc_put_vars_ulonglong(int ncid, int varid, const PIO_Offset *start,
-                                const PIO_Offset *count, const PIO_Offset *stride,
-                                const unsigned long long *op);
+				const PIO_Offset *count, const PIO_Offset *stride,
+				const unsigned long long *op);
 
     /* Data reads - vard. */
     int PIOc_get_vard(int ncid, int varid, int decompid, const PIO_Offset recnum, void *buf);
     int PIOc_get_vard_text(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                           char *buf);
+			   char *buf);
     int PIOc_get_vard_schar(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                            signed char *buf);
+			    signed char *buf);
     int PIOc_get_vard_short(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                            short *buf);
+			    short *buf);
     int PIOc_get_vard_int(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                          int *buf);
+			  int *buf);
     int PIOc_get_vard_float(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                            float *buf);
+			    float *buf);
     int PIOc_get_vard_double(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                             double *buf);
+			     double *buf);
     int PIOc_get_vard_uchar(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                            unsigned char *buf);
+			    unsigned char *buf);
     int PIOc_get_vard_ushort(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                             unsigned short *buf);
+			     unsigned short *buf);
     int PIOc_get_vard_uint(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                           unsigned int *buf);
+			   unsigned int *buf);
     int PIOc_get_vard_longlong(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                               long long *buf);
+			       long long *buf);
     int PIOc_get_vard_ulonglong(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                                unsigned long long *buf);
+				unsigned long long *buf);
 
     /* Data writes - vard. */
     int PIOc_put_vard(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                      const void *buf);
+		      const void *buf);
     int PIOc_put_vard_text(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                           const char *op);
+			   const char *op);
     int PIOc_put_vard_schar(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                            const signed char *op);
+			    const signed char *op);
     int PIOc_put_vard_short(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                            const short *op);
+			    const short *op);
     int PIOc_put_vard_int(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                          const int *op);
+			  const int *op);
     int PIOc_put_vard_float(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                            const float *op);
+			    const float *op);
     int PIOc_put_vard_double(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                             const double *op);
+			     const double *op);
     int PIOc_put_vard_uchar(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                            const unsigned char *op);
+			    const unsigned char *op);
     int PIOc_put_vard_ushort(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                             const unsigned short *op);
+			     const unsigned short *op);
     int PIOc_put_vard_uint(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                           const unsigned int *op);
+			   const unsigned int *op);
     int PIOc_put_vard_longlong(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                               const long long *op);
+			       const long long *op);
     int PIOc_put_vard_ulonglong(int ncid, int varid, int decompid, const PIO_Offset recnum,
-                                const unsigned long long *op);
+				const unsigned long long *op);
 
     /* These functions are for the netCDF integration layer. */
     int nc_def_iosystem(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
-                         int *iosysidp);
+			 int *iosysidp);
 
     int nc_def_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
-                     int component_count, int *num_procs_per_comp, int **proc_list,
-                     MPI_Comm *io_comm, MPI_Comm *comp_comm, int rearranger,
-                     int *iosysidp);
+		     int component_count, int *num_procs_per_comp, int **proc_list,
+		     MPI_Comm *io_comm, MPI_Comm *comp_comm, int rearranger,
+		     int *iosysidp);
 
     /* Set the default IOsystem ID. */
     int nc_set_iosystem(int iosysid);
@@ -1256,9 +1257,9 @@ extern "C" {
 
     /* Define a decomposition for distributed arrays. */
     int nc_def_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen,
-                      int maplen, const size_t *compmap, int *ioidp,
-                      int rearranger, const size_t *iostart,
-                      const size_t *iocount);
+		      int maplen, const size_t *compmap, int *ioidp,
+		      int rearranger, const size_t *iostart,
+		      const size_t *iocount);
 
     /* Release resources associated with a decomposition. */
     int nc_free_decomp(int ioid);
@@ -1266,53 +1267,53 @@ extern "C" {
     /* Data reads - read a distributed array. */
     int nc_get_vard(int ncid, int varid, int decompid, const size_t recnum, void *buf);
     int nc_get_vard_text(int ncid, int varid, int decompid, const size_t recnum,
-                         char *buf);
+			 char *buf);
     int nc_get_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
-                          signed char *buf);
+			  signed char *buf);
     int nc_get_vard_short(int ncid, int varid, int decompid, const size_t recnum,
-                          short *buf);
+			  short *buf);
     int nc_get_vard_int(int ncid, int varid, int decompid, const size_t recnum,
-                        int *buf);
+			int *buf);
     int nc_get_vard_float(int ncid, int varid, int decompid, const size_t recnum,
-                          float *buf);
+			  float *buf);
     int nc_get_vard_double(int ncid, int varid, int decompid, const size_t recnum,
-                           double *buf);
+			   double *buf);
     int nc_get_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
-                          unsigned char *buf);
+			  unsigned char *buf);
     int nc_get_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
-                           unsigned short *buf);
+			   unsigned short *buf);
     int nc_get_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
-                         unsigned int *buf);
+			 unsigned int *buf);
     int nc_get_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
-                             long long *buf);
+			     long long *buf);
     int nc_get_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
-                              unsigned long long *buf);
+			      unsigned long long *buf);
 
     /* Data writes - Write a distributed array. */
     int nc_put_vard(int ncid, int varid, int decompid, const size_t recnum,
-                    const void *buf);
+		    const void *buf);
     int nc_put_vard_text(int ncid, int varid, int decompid, const size_t recnum,
-                         const char *op);
+			 const char *op);
     int nc_put_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
-                          const signed char *op);
+			  const signed char *op);
     int nc_put_vard_short(int ncid, int varid, int decompid, const size_t recnum,
-                          const short *op);
+			  const short *op);
     int nc_put_vard_int(int ncid, int varid, int decompid, const size_t recnum,
-                        const int *op);
+			const int *op);
     int nc_put_vard_float(int ncid, int varid, int decompid, const size_t recnum,
-                          const float *op);
+			  const float *op);
     int nc_put_vard_double(int ncid, int varid, int decompid, const size_t recnum,
-                           const double *op);
+			   const double *op);
     int nc_put_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
-                          const unsigned char *op);
+			  const unsigned char *op);
     int nc_put_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
-                           const unsigned short *op);
+			   const unsigned short *op);
     int nc_put_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
-                         const unsigned int *op);
+			 const unsigned int *op);
     int nc_put_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
-                             const long long *op);
+			     const long long *op);
     int nc_put_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
-                              const unsigned long long *op);
+			      const unsigned long long *op);
 
 #if defined(__cplusplus)
 }

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -331,6 +331,9 @@ typedef struct io_desc_t
      * nodes), each io task contains data from the compmap of one or
      * more compute tasks in the iomap array. */
     PIO_Offset llen;
+
+    /** Actual length of the iobuffer on this task for a case where values
+        are repeated in the compmap - used for darray read only. */
     PIO_Offset rllen;
 
     /** Maximum llen participating. */

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -161,6 +161,9 @@ PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     pioassert(iodesc->rearranger == PIO_REARR_BOX || iodesc->rearranger == PIO_REARR_SUBSET,
               "unknown rearranger", __FILE__, __LINE__);
 
+    pioassert(iodesc->readonly == 0,"Multiple sources in map for a single destination",__FILE__,__LINE__);
+
+
     /* Check the types of all the vars. They must match the type of
      * the decomposition. */
     for (int v = 0; v < nvars; v++)
@@ -669,6 +672,8 @@ PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *arra
     /* Get decomposition information. */
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
         return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__);
+
+    pioassert(iodesc->readonly == 0,"Multiple sources in map for a single destination",__FILE__,__LINE__);
 
     /* Check that the local size of the variable passed in matches the
      * size expected by the io descriptor. Fail if arraylen is too

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -822,7 +822,6 @@ PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *arra
     if (arraylen > 0)
     {
         PLOG((3, "copying %ld bytes of user data %d", arraylen * iodesc->mpitype_size, iodesc->mpitype_size));
-        printf(( "copying %ld bytes of user data %d num_arrays %d bufptr %x array %x\n", arraylen * iodesc->mpitype_size, iodesc->mpitype_size, wmb->num_arrays, bufptr, array));
         memcpy(bufptr, array, arraylen * iodesc->mpitype_size);
     }
 

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -821,8 +821,9 @@ PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *arra
     bufptr = (void *)((char *)wmb->data + arraylen * iodesc->mpitype_size * wmb->num_arrays);
     if (arraylen > 0)
     {
+        PLOG((3, "copying %ld bytes of user data %d", arraylen * iodesc->mpitype_size, iodesc->mpitype_size));
+        printf(( "copying %ld bytes of user data %d num_arrays %d bufptr %x array %x\n", arraylen * iodesc->mpitype_size, iodesc->mpitype_size, wmb->num_arrays, bufptr, array));
         memcpy(bufptr, array, arraylen * iodesc->mpitype_size);
-        PLOG((3, "copied %ld bytes of user data", arraylen * iodesc->mpitype_size));
     }
 
     /* Add the unlimited dimension value of this variable to the frame

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -42,7 +42,7 @@ bpool_free(void *p)
 {
     free(p);
     if(p == CN_bpool){
-        CN_bpool = NULL;
+	CN_bpool = NULL;
     }
 }
 
@@ -60,30 +60,30 @@ bpool_free(void *p)
  */
 int
 get_gdim0(file_desc_t *file,io_desc_t *iodesc, int varid, int fndims,
-          MPI_Offset *gdim0)
+	  MPI_Offset *gdim0)
 {
     int ierr = PIO_NOERR;
 
     *gdim0 = 0;
     if (file->iotype == PIO_IOTYPE_PNETCDF && iodesc->ndims < fndims)
     {
-        int numunlimdims;
+	int numunlimdims;
 
-        /* We need to confirm the file has an unlimited dimension and
-           if it doesn't we need to find the extent of the first
-           variable dimension. */
-        PLOG((3,"look for numunlimdims"));
-        if ((ierr = PIOc_inq_unlimdims(file->pio_ncid, &numunlimdims, NULL)))
-            return check_netcdf(file, ierr, __FILE__, __LINE__);
-        PLOG((3,"numunlimdims = %d", numunlimdims));
-        if (numunlimdims <= 0)
-        {
-            int dimids[fndims];
-            if ((ierr = PIOc_inq_vardimid(file->pio_ncid, varid, dimids)))
-                return check_netcdf(file, ierr, __FILE__, __LINE__);
-            if ((ierr = PIOc_inq_dimlen(file->pio_ncid, dimids[0], gdim0)))
-                return check_netcdf(file, ierr, __FILE__, __LINE__);
-        }
+	/* We need to confirm the file has an unlimited dimension and
+	   if it doesn't we need to find the extent of the first
+	   variable dimension. */
+	PLOG((3,"look for numunlimdims"));
+	if ((ierr = PIOc_inq_unlimdims(file->pio_ncid, &numunlimdims, NULL)))
+	    return check_netcdf(file, ierr, __FILE__, __LINE__);
+	PLOG((3,"numunlimdims = %d", numunlimdims));
+	if (numunlimdims <= 0)
+	{
+	    int dimids[fndims];
+	    if ((ierr = PIOc_inq_vardimid(file->pio_ncid, varid, dimids)))
+		return check_netcdf(file, ierr, __FILE__, __LINE__);
+	    if ((ierr = PIOc_inq_dimlen(file->pio_ncid, dimids[0], gdim0)))
+		return check_netcdf(file, ierr, __FILE__, __LINE__);
+	}
     }
     PLOG((3,"gdim0 = %d",*gdim0));
     return ierr;
@@ -110,9 +110,9 @@ get_gdim0(file_desc_t *file,io_desc_t *iodesc, int varid, int fndims,
  */
 static
 int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdimoffset,
-                         int rrcnt, int ndims, int fndims,
-                         int frame, PIO_Offset **startlist, PIO_Offset **countlist,
-                         MPI_Datatype *filetype)
+			 int rrcnt, int ndims, int fndims,
+			 int frame, PIO_Offset **startlist, PIO_Offset **countlist,
+			 MPI_Datatype *filetype)
 {
 
     int sa_ndims;
@@ -129,126 +129,126 @@ int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdi
     *filetype = MPI_DATATYPE_NULL;
 
     if(rrcnt == 0)
-        return PIO_NOERR;
+	return PIO_NOERR;
 
     for ( int rc=0; rc<rrcnt; rc++)
     {
-        displacements[rc] = 0;
-        blocklengths[rc] = 1;
-        subarray[rc] = MPI_DATATYPE_NULL;
+	displacements[rc] = 0;
+	blocklengths[rc] = 1;
+	subarray[rc] = MPI_DATATYPE_NULL;
     }
     if(fndims > ndims)
     {
-        if ( gdim0 > 0)
-        {
-            gdims[0] = gdim0;
-            sa_ndims = fndims;
-            dim_offset = 0;
-            for (int i=1; i < fndims; i++)
-                gdims[i] = iodesc->dimlen[i-1];
-        }
-        else
-        {
-            sa_ndims = ndims;
-            dim_offset = 1;
-            for (int i=0; i < ndims; i++)
-                gdims[i] = iodesc->dimlen[i];
-        }
+	if ( gdim0 > 0)
+	{
+	    gdims[0] = gdim0;
+	    sa_ndims = fndims;
+	    dim_offset = 0;
+	    for (int i=1; i < fndims; i++)
+		gdims[i] = iodesc->dimlen[i-1];
+	}
+	else
+	{
+	    sa_ndims = ndims;
+	    dim_offset = 1;
+	    for (int i=0; i < ndims; i++)
+		gdims[i] = iodesc->dimlen[i];
+	}
     }
     else
     {
-        sa_ndims = fndims;
-        dim_offset = 0;
-        for (int i=0; i < fndims; i++)
-            gdims[i] = iodesc->dimlen[i];
+	sa_ndims = fndims;
+	dim_offset = 0;
+	for (int i=0; i < fndims; i++)
+	    gdims[i] = iodesc->dimlen[i];
     }
 
     int true_rrcnt=-1; /* true number of contiguous requests */
     MPI_Aint prev_end=-1; /* end offset of rc-1 request */
     for( int rc=0; rc<rrcnt; rc++)
     {
-        int sacount[fndims];
-        int sastart[fndims];
-        for (int i=dim_offset; i< fndims; i++)
-        {
-            sacount[i-dim_offset] = (int) countlist[rc][i];
-            sastart[i-dim_offset] = (int) startlist[rc][i];
-        }
-        if(gdim0 > 0)
-        {
-            unlimdimoffset = gdim0;
-            sastart[0] = max(0, frame);
-            displacements[rc]=0;
-        }
-        else
-            displacements[rc] = unlimdimoffset * max(0, frame);
+	int sacount[fndims];
+	int sastart[fndims];
+	for (int i=dim_offset; i< fndims; i++)
+	{
+	    sacount[i-dim_offset] = (int) countlist[rc][i];
+	    sastart[i-dim_offset] = (int) startlist[rc][i];
+	}
+	if(gdim0 > 0)
+	{
+	    unlimdimoffset = gdim0;
+	    sastart[0] = max(0, frame);
+	    displacements[rc]=0;
+	}
+	else
+	    displacements[rc] = unlimdimoffset * max(0, frame);
 
-        /* Check whether this request is actually contiguous. If contiguous,
-         * we do not need to create an MPI derived datatype.
-         */
-        int blocklen=1, isContig=1, warnContig=0;
-        MPI_Aint disp=0, shape=iodesc->mpitype_size;
-        for (int i=sa_ndims-1; i>=0; i--)
-        {
-            if (isContig) {
-                /* blocklen is the amount of this request, rc */
-                blocklen *= sacount[i];
-                /* disp is the flattened starting array index */
-                disp += sastart[i] * shape;
-                /* shape is the dimension product from sa_ndims-1 to i */
-                shape *= gdims[i];
+	/* Check whether this request is actually contiguous. If contiguous,
+	 * we do not need to create an MPI derived datatype.
+	 */
+	int blocklen=1, isContig=1, warnContig=0;
+	MPI_Aint disp=0, shape=iodesc->mpitype_size;
+	for (int i=sa_ndims-1; i>=0; i--)
+	{
+	    if (isContig) {
+		/* blocklen is the amount of this request, rc */
+		blocklen *= sacount[i];
+		/* disp is the flattened starting array index */
+		disp += sastart[i] * shape;
+		/* shape is the dimension product from sa_ndims-1 to i */
+		shape *= gdims[i];
 
-                if (warnContig == 0) {
-                    if (sacount[i] < gdims[i])
-                        /* first i detected to access partial dimension. If this
-                         * one is contiguous, the remaining sacount[i-1 ... 0]
-                         * must all == 1 */
-                        warnContig = 1; /* possible non-contiguos */
-                }
-                else if (sacount[i] != 1) {
-                    isContig = 0;
-                    break; /* loop i */
-                }
-            }
-        }
-        /* if this is a record variable, add the gap of record size */
-        disp += _unlimdimoffset * max(0, frame);
+		if (warnContig == 0) {
+		    if (sacount[i] < gdims[i])
+			/* first i detected to access partial dimension. If this
+			 * one is contiguous, the remaining sacount[i-1 ... 0]
+			 * must all == 1 */
+			warnContig = 1; /* possible non-contiguos */
+		}
+		else if (sacount[i] != 1) {
+		    isContig = 0;
+		    break; /* loop i */
+		}
+	    }
+	}
+	/* if this is a record variable, add the gap of record size */
+	disp += _unlimdimoffset * max(0, frame);
 
 #if PIO_ENABLE_LOGGING
-        for (int i=0; i< sa_ndims; i++)
-            PLOG((3, "vard: sastart[%d]=%d sacount[%d]=%d gdims[%d]=%d %ld %ld displacement = %ld un %d",
-                  i,sastart[i], i,sacount[i], i, gdims[i], startlist[rc][i], countlist[rc][i], displacements[rc], unlimdimoffset));
+	for (int i=0; i< sa_ndims; i++)
+	    PLOG((3, "vard: sastart[%d]=%d sacount[%d]=%d gdims[%d]=%d %ld %ld displacement = %ld un %d",
+		  i,sastart[i], i,sacount[i], i, gdims[i], startlist[rc][i], countlist[rc][i], displacements[rc], unlimdimoffset));
 #endif
-        if (isContig) { /* this request rc is contiguous, no need to create a new MPI datatype */
-            if (prev_end == disp) {
-                /* this request rc can be coalesced into the previous
-                 * displacements and blocklengths.
-                 */
-                blocklengths[true_rrcnt] += blocklen;
-                prev_end += blocklen;
-            }
-            else {
-                /* this request cannot be coalesced with the previous one */
-                true_rrcnt++;
-                subarray[true_rrcnt] = iodesc->mpitype;
-                displacements[true_rrcnt] = disp;
-                blocklengths[true_rrcnt] = blocklen;
-                prev_end = disp + blocklen;
-            }
-        }
-        else { /* request rc is not contiguous, must create a new MPI datatype */
-            true_rrcnt++;
-            if((mpierr = MPI_Type_create_subarray(sa_ndims, gdims,
-                                                  sacount, sastart,MPI_ORDER_C
-                                                  ,iodesc->mpitype, subarray + true_rrcnt)))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if (isContig) { /* this request rc is contiguous, no need to create a new MPI datatype */
+	    if (prev_end == disp) {
+		/* this request rc can be coalesced into the previous
+		 * displacements and blocklengths.
+		 */
+		blocklengths[true_rrcnt] += blocklen;
+		prev_end += blocklen;
+	    }
+	    else {
+		/* this request cannot be coalesced with the previous one */
+		true_rrcnt++;
+		subarray[true_rrcnt] = iodesc->mpitype;
+		displacements[true_rrcnt] = disp;
+		blocklengths[true_rrcnt] = blocklen;
+		prev_end = disp + blocklen;
+	    }
+	}
+	else { /* request rc is not contiguous, must create a new MPI datatype */
+	    true_rrcnt++;
+	    if((mpierr = MPI_Type_create_subarray(sa_ndims, gdims,
+						  sacount, sastart,MPI_ORDER_C
+						  ,iodesc->mpitype, subarray + true_rrcnt)))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-            if((mpierr = MPI_Type_commit(subarray + true_rrcnt)))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        }
+	    if((mpierr = MPI_Type_commit(subarray + true_rrcnt)))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	}
 
 #if PIO_ENABLE_LOGGING
-        PLOG((3,"vard: blocklengths[%d]=%d displacement[%d]=%ld unlimdimoffset=%ld",rc,blocklengths[rc], rc, displacements[rc], unlimdimoffset));
+	PLOG((3,"vard: blocklengths[%d]=%d displacement[%d]=%ld unlimdimoffset=%ld",rc,blocklengths[rc], rc, displacements[rc], unlimdimoffset));
 #endif
 
     }
@@ -256,15 +256,15 @@ int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdi
 
     /* concatenate all MPI datatypes into filetype */
     if((mpierr = MPI_Type_create_struct(true_rrcnt, blocklengths, displacements, subarray, filetype)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     if((mpierr = MPI_Type_commit(filetype)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     for( int rc=0; rc<true_rrcnt; rc++)
-        if (subarray[rc] != MPI_DATATYPE_NULL && subarray[rc] != iodesc->mpitype &&
-            (mpierr = MPI_Type_free(subarray + rc)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if (subarray[rc] != MPI_DATATYPE_NULL && subarray[rc] != iodesc->mpitype &&
+	    (mpierr = MPI_Type_free(subarray + rc)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -290,56 +290,56 @@ int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdi
  */
 int
 find_start_count(int ndims, int fndims, var_desc_t *vdesc,
-                 io_region *region, const int *frame, size_t *start,
-                 size_t *count)
+		 io_region *region, const int *frame, size_t *start,
+		 size_t *count)
 {
     /* Init start/count arrays to zero. */
     for (int i = 0; i < fndims; i++)
     {
-        start[i] = 0;
-        count[i] = 0;
+	start[i] = 0;
+	count[i] = 0;
     }
 
     if (region)
     {
-        if (vdesc->record >= 0)
-        {
-            /* This is a record based multidimensional
-             * array. Figure out start/count for all but the
-             * record dimension (dimid 0). */
-            for (int i = fndims - ndims; i < fndims; i++)
-            {
-                start[i] = region->start[i - (fndims - ndims)];
-                count[i] = region->count[i - (fndims - ndims)];
-            }
+	if (vdesc->record >= 0)
+	{
+	    /* This is a record based multidimensional
+	     * array. Figure out start/count for all but the
+	     * record dimension (dimid 0). */
+	    for (int i = fndims - ndims; i < fndims; i++)
+	    {
+		start[i] = region->start[i - (fndims - ndims)];
+		count[i] = region->count[i - (fndims - ndims)];
+	    }
 
-            /* Now figure out start/count for record dimension. */
-            if (fndims > 1 && ndims < fndims && count[1] > 0)
-            {
-                count[0] = 1;
-                start[0] = frame[0];
-            }
-            else if (fndims == ndims)
-            {
-                /* In some cases the unlimited dim is not treated as
-                   the pio record dim */
-                start[0] += vdesc->record;
-            }
-        }
-        else
-        {
-            /* This is a non record variable. */
-            for (int i = 0; i < ndims; i++)
-            {
-                start[i] = region->start[i];
-                count[i] = region->count[i];
-            }
-        }
+	    /* Now figure out start/count for record dimension. */
+	    if (fndims > 1 && ndims < fndims && count[1] > 0)
+	    {
+		count[0] = 1;
+		start[0] = frame[0];
+	    }
+	    else if (fndims == ndims)
+	    {
+		/* In some cases the unlimited dim is not treated as
+		   the pio record dim */
+		start[0] += vdesc->record;
+	    }
+	}
+	else
+	{
+	    /* This is a non record variable. */
+	    for (int i = 0; i < ndims; i++)
+	    {
+		start[i] = region->start[i];
+		count[i] = region->count[i];
+	    }
+	}
 
 #if PIO_ENABLE_LOGGING
-        /* Log arrays for debug purposes. */
-        for (int i = 0; i < ndims; i++)
-            PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
+	/* Log arrays for debug purposes. */
+	for (int i = 0; i < ndims; i++)
+	    PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
@@ -367,7 +367,7 @@ find_start_count(int ndims, int fndims, var_desc_t *vdesc,
  */
 int
 write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *varids,
-                       io_desc_t *iodesc, int fill, const int *frame)
+		       io_desc_t *iodesc, int fill, const int *frame)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;    /* Pointer to var info struct. */
@@ -382,16 +382,16 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
 #endif
     /* Check inputs. */
     pioassert(file && file->iosystem && varids && varids[0] >= 0 && varids[0] <= PIO_MAX_VARS &&
-              iodesc, "invalid input", __FILE__, __LINE__);
+	      iodesc, "invalid input", __FILE__, __LINE__);
 
     PLOG((1, "write_darray_multi_par nvars = %d iodesc->ndims = %d iodesc->mpitype = %d "
-          "iodesc->maxregions = %d iodesc->llen = %d", nvars, iodesc->ndims,
-          iodesc->mpitype, iodesc->maxregions, iodesc->llen));
+	  "iodesc->maxregions = %d iodesc->llen = %d", nvars, iodesc->ndims,
+	  iodesc->mpitype, iodesc->maxregions, iodesc->llen));
 
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ierr = pio_start_timer("PIO:write_darray_multi_par")))
-        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Get pointer to iosystem. */
@@ -399,7 +399,7 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
 
     /* Point to var description scruct for first var. */
     if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
-        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Set these differently for data and fill writing. */
     int num_regions = fill ? iodesc->maxfillregions: iodesc->maxregions;
@@ -410,8 +410,8 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
 #if USE_VARD_WRITE
     if (!ios->async || !ios->ioproc)
     {
-        if ((ierr = get_gdim0(file, iodesc, varids[0], fndims, &gdim0)))
-            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	if ((ierr = get_gdim0(file, iodesc, varids[0], fndims, &gdim0)))
+	    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     }
 #endif
@@ -419,270 +419,270 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
     /* If this is an IO task write the data. */
     if (ios->ioproc)
     {
-        void *bufptr;
-        size_t start[fndims];
-        size_t count[fndims];
-        int ndims = iodesc->ndims;
+	void *bufptr;
+	size_t start[fndims];
+	size_t count[fndims];
+	int ndims = iodesc->ndims;
 #ifdef _PNETCDF
-        int rrcnt = 0; /* Number of subarray requests (pnetcdf only). */
-        PIO_Offset *startlist[num_regions]; /* Array of start arrays for ncmpi_iput_varn(). */
-        PIO_Offset *countlist[num_regions]; /* Array of count  arrays for ncmpi_iput_varn(). */
+	int rrcnt = 0; /* Number of subarray requests (pnetcdf only). */
+	PIO_Offset *startlist[num_regions]; /* Array of start arrays for ncmpi_iput_varn(). */
+	PIO_Offset *countlist[num_regions]; /* Array of count  arrays for ncmpi_iput_varn(). */
 #endif /* _PNETCDF */
 
-        /* Process each region of data to be written. */
-        for (int regioncnt = 0; regioncnt < num_regions; regioncnt++)
-        {
-            /* Fill the start/count arrays. */
-            if ((ierr = find_start_count(iodesc->ndims, fndims, vdesc, region, frame,
-                                         start, count)))
-                return pio_err(ios, file, ierr, __FILE__, __LINE__);
+	/* Process each region of data to be written. */
+	for (int regioncnt = 0; regioncnt < num_regions; regioncnt++)
+	{
+	    /* Fill the start/count arrays. */
+	    if ((ierr = find_start_count(iodesc->ndims, fndims, vdesc, region, frame,
+					 start, count)))
+		return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
-            /* IO tasks will run the netCDF/pnetcdf functions to write the data. */
-            switch (file->iotype)
-            {
+	    /* IO tasks will run the netCDF/pnetcdf functions to write the data. */
+	    switch (file->iotype)
+	    {
 #ifdef _NETCDF4
-            case PIO_IOTYPE_NETCDF4P:
-                /* For each variable to be written. */
-                for (int nv = 0; nv < nvars; nv++)
-                {
-                    /* Set the start of the record dimension. (Hasn't
-                     * this already been set above ???) */
-                    if (vdesc->record >= 0 && ndims < fndims)
-                        start[0] = frame[nv];
+	    case PIO_IOTYPE_NETCDF4P:
+		/* For each variable to be written. */
+		for (int nv = 0; nv < nvars; nv++)
+		{
+		    /* Set the start of the record dimension. (Hasn't
+		     * this already been set above ???) */
+		    if (vdesc->record >= 0 && ndims < fndims)
+			start[0] = frame[nv];
 
-                    /* If there is data for this region, get a pointer to it. */
-                    if (region)
-                        bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * (nv * llen + region->loffset));
+		    /* If there is data for this region, get a pointer to it. */
+		    if (region)
+			bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * (nv * llen + region->loffset));
 
-                    /* Ensure collective access. */
-                    ierr = nc_var_par_access(file->fh, varids[nv], NC_COLLECTIVE);
+		    /* Ensure collective access. */
+		    ierr = nc_var_par_access(file->fh, varids[nv], NC_COLLECTIVE);
 
-                    /* Write the data for this variable. */
-                    if (!ierr)
-                        ierr = nc_put_vara(file->fh, varids[nv], (size_t *)start, (size_t *)count, bufptr);
-                }
-                break;
+		    /* Write the data for this variable. */
+		    if (!ierr)
+			ierr = nc_put_vara(file->fh, varids[nv], (size_t *)start, (size_t *)count, bufptr);
+		}
+		break;
 #endif
 #ifdef _PNETCDF
-            case PIO_IOTYPE_PNETCDF:
-                /* Get the total number of data elements we are
-                 * writing for this region. */
-                dsize = 1;
-                for (int i = 0; i < fndims; i++)
-                    dsize *= count[i];
-                PLOG((3, "dsize = %d", dsize));
+	    case PIO_IOTYPE_PNETCDF:
+		/* Get the total number of data elements we are
+		 * writing for this region. */
+		dsize = 1;
+		for (int i = 0; i < fndims; i++)
+		    dsize *= count[i];
+		PLOG((3, "dsize = %d", dsize));
 
-                /* For pnetcdf's ncmpi_iput_varn() function, we need
-                 * to provide arrays of arrays for start/count. */
-                if (dsize > 0)
-                {
-                    /* Allocate storage for start/count arrays for
-                     * this region. */
-                    if (!(startlist[rrcnt] = calloc(fndims, sizeof(PIO_Offset))))
-                        return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-                    if (!(countlist[rrcnt] = calloc(fndims, sizeof(PIO_Offset))))
-                        return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+		/* For pnetcdf's ncmpi_iput_varn() function, we need
+		 * to provide arrays of arrays for start/count. */
+		if (dsize > 0)
+		{
+		    /* Allocate storage for start/count arrays for
+		     * this region. */
+		    if (!(startlist[rrcnt] = calloc(fndims, sizeof(PIO_Offset))))
+			return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+		    if (!(countlist[rrcnt] = calloc(fndims, sizeof(PIO_Offset))))
+			return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
-                    /* Copy the start/count arrays for this region. */
-                    for (int i = 0; i < fndims; i++)
-                    {
-                        startlist[rrcnt][i] = start[i];
-                        countlist[rrcnt][i] = count[i];
-                        PLOG((3, "startlist[%d][%d] = %d countlist[%d][%d] = %d", rrcnt, i,
-                              startlist[rrcnt][i], rrcnt, i, countlist[rrcnt][i]));
-                    }
-                    rrcnt++;
-                }
+		    /* Copy the start/count arrays for this region. */
+		    for (int i = 0; i < fndims; i++)
+		    {
+			startlist[rrcnt][i] = start[i];
+			countlist[rrcnt][i] = count[i];
+			PLOG((3, "startlist[%d][%d] = %d countlist[%d][%d] = %d", rrcnt, i,
+			      startlist[rrcnt][i], rrcnt, i, countlist[rrcnt][i]));
+		    }
+		    rrcnt++;
+		}
 
-                /* Do this when we reach the last region. */
-                if (regioncnt == num_regions - 1)
-                {
+		/* Do this when we reach the last region. */
+		if (regioncnt == num_regions - 1)
+		{
 #ifdef USE_VARD_WRITE
-                    MPI_Aint   var0_offset, var_offsets[nvars];
-                    MPI_Offset vari_offset, vard_llen=0;
-                    MPI_Datatype vartypes[nvars];
-                    MPI_Datatype filetype = MPI_DATATYPE_NULL;
-                    int blocklens[nvars];
-                    int fvartype, var0_id;
-                    int numReqs=0;
-                    void *vard_bufptr;
-                    int doFlush[nvars]; /* whether to flush or not */
+		    MPI_Aint   var0_offset, var_offsets[nvars];
+		    MPI_Offset vari_offset, vard_llen=0;
+		    MPI_Datatype vartypes[nvars];
+		    MPI_Datatype filetype = MPI_DATATYPE_NULL;
+		    int blocklens[nvars];
+		    int fvartype, var0_id;
+		    int numReqs=0;
+		    void *vard_bufptr;
+		    int doFlush[nvars]; /* whether to flush or not */
 
-                    /* construct doFlush[], so later when looping through nvars,
-                     * it tells whether to flush or not.
-                     */
-                    for (int nv = 0; nv < nvars; nv++) {
-                        /* Get the var info. */
-                        if ((ierr = get_var_desc(varids[nv], &file->varlist, &vdesc)))
-                            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-                        if (nv == 0) { /* first variable */
-                            fvartype = vdesc->pio_type; /* first var's var type */
-                            continue;
-                        }
-                        if (fvartype != vdesc->pio_type) {
-                            /* nv's external datatype is different from nv-1 */
-                            doFlush[nv-1] = 1;
-                            fvartype = vdesc->pio_type;
-                        }
-                        else /* same as nv-1, no flush */
-                            doFlush[nv-1] = 0;
-                    }
-                    doFlush[nvars-1] = 1; /* flush when reach the last variable */
+		    /* construct doFlush[], so later when looping through nvars,
+		     * it tells whether to flush or not.
+		     */
+		    for (int nv = 0; nv < nvars; nv++) {
+			/* Get the var info. */
+			if ((ierr = get_var_desc(varids[nv], &file->varlist, &vdesc)))
+			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+			if (nv == 0) { /* first variable */
+			    fvartype = vdesc->pio_type; /* first var's var type */
+			    continue;
+			}
+			if (fvartype != vdesc->pio_type) {
+			    /* nv's external datatype is different from nv-1 */
+			    doFlush[nv-1] = 1;
+			    fvartype = vdesc->pio_type;
+			}
+			else /* same as nv-1, no flush */
+			    doFlush[nv-1] = 0;
+		    }
+		    doFlush[nvars-1] = 1; /* flush when reach the last variable */
 #endif
-                    /* For each variable to be written. */
-                    for (int nv = 0; nv < nvars; nv++)
-                    {
+		    /* For each variable to be written. */
+		    for (int nv = 0; nv < nvars; nv++)
+		    {
 #if USE_VARD_WRITE
-                        /* PnetCDF 1.10.0 and later support type conversion in
-                         * vard APIs. However, it requires all variables
-                         * accessed by the filetype are of the same NC data
-                         * type.
-                         */
+			/* PnetCDF 1.10.0 and later support type conversion in
+			 * vard APIs. However, it requires all variables
+			 * accessed by the filetype are of the same NC data
+			 * type.
+			 */
 
-                        /* obtain file offset of variable nv */
-                        if ((ierr = ncmpi_inq_varoffset(file->fh, varids[nv], &vari_offset)))
-                            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+			/* obtain file offset of variable nv */
+			if ((ierr = ncmpi_inq_varoffset(file->fh, varids[nv], &vari_offset)))
+			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
-                        if (numReqs == 0) { /* 1st variable of same datatype */
-                            var0_offset = vari_offset;
-                            var0_id = varids[nv];
-                        }
-                        /* calculate the offset relative to the first var */
-                        var_offsets[numReqs] = vari_offset - var0_offset;
-                        blocklens[nv] = 1; /* 1 for each vartypes[nv] */
+			if (numReqs == 0) { /* 1st variable of same datatype */
+			    var0_offset = vari_offset;
+			    var0_id = varids[nv];
+			}
+			/* calculate the offset relative to the first var */
+			var_offsets[numReqs] = vari_offset - var0_offset;
+			blocklens[nv] = 1; /* 1 for each vartypes[nv] */
 
-                        /* If this is the first variable or the frame has changed between variables (this should be rare) */
-                        if(nv==0 || (nv > 0 && frame != NULL && frame[nv] != frame[nv-1])){
-                            int thisframe;
-                            PIO_Offset unlimdimoffset;
-                            if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
-                            {
-                                if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
-                                    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-                                PLOG((3, "num_regions = %d unlimdimoffset %ld", num_regions, unlimdimoffset));
-                            }else
-                                unlimdimoffset = gdim0;
-                            if (frame)
-                                thisframe = frame[nv];
-                            else
-                                thisframe = 0;
+			/* If this is the first variable or the frame has changed between variables (this should be rare) */
+			if(nv==0 || (nv > 0 && frame != NULL && frame[nv] != frame[nv-1])){
+			    int thisframe;
+			    PIO_Offset unlimdimoffset;
+			    if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
+			    {
+				if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
+				    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+				PLOG((3, "num_regions = %d unlimdimoffset %ld", num_regions, unlimdimoffset));
+			    }else
+				unlimdimoffset = gdim0;
+			    if (frame)
+				thisframe = frame[nv];
+			    else
+				thisframe = 0;
 
-                            ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
-                                                        rrcnt, ndims, fndims,
-                                                        thisframe, startlist, countlist,
-                                                        &vartypes[numReqs]);
-                        }
-                        else /* reuse the previous variable's datatype */
-                            vartypes[numReqs] = vartypes[numReqs-1];
+			    ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
+							rrcnt, ndims, fndims,
+							thisframe, startlist, countlist,
+							&vartypes[numReqs]);
+			}
+			else /* reuse the previous variable's datatype */
+			    vartypes[numReqs] = vartypes[numReqs-1];
 #else
-                        /* Get the var info. */
-                        if ((ierr = get_var_desc(varids[nv], &file->varlist, &vdesc)))
-                            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+			/* Get the var info. */
+			if ((ierr = get_var_desc(varids[nv], &file->varlist, &vdesc)))
+			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
-                        if (vdesc->record >= 0 && ndims < fndims)
-                            for (int rc = 0; rc < rrcnt; rc++)
-                                startlist[rc][0] = frame[nv];
+			if (vdesc->record >= 0 && ndims < fndims)
+			    for (int rc = 0; rc < rrcnt; rc++)
+				startlist[rc][0] = frame[nv];
 #endif
-                        /* Get a pointer to the data. */
-                        bufptr = (void *)((char *)iobuf + nv * iodesc->mpitype_size * llen);
+			/* Get a pointer to the data. */
+			bufptr = (void *)((char *)iobuf + nv * iodesc->mpitype_size * llen);
 
 #if USE_VARD_WRITE
-                        if (numReqs == 0) { /* first var of the same type */
-                            vard_bufptr = bufptr; /* preserve variable ID */
-                            vard_llen = llen;     /* reset I/O request size */
-                        }
-                        numReqs++;
+			if (numReqs == 0) { /* first var of the same type */
+			    vard_bufptr = bufptr; /* preserve variable ID */
+			    vard_llen = llen;     /* reset I/O request size */
+			}
+			numReqs++;
 
-                        if (doFlush[nv]) { /* flush the data now */
-                            int mpierr;
-                            /* concatenate vartypes[0...numReqs-1] */
-                            if (numReqs > 1) {
-                                /* check and remove NULL vartype */
-                                int i, j=0;
-                                for (i=0; i<numReqs; i++) {
-                                    if (vartypes[i] != MPI_DATATYPE_NULL) {
-                                        if (j < i) vartypes[j] = vartypes[i];
-                                        j++;
-                                    }
-                                }
-                                if (j > 0) { /* at least one vartypes[] is not NULL */
-                                    /* concatenate non-NULL vartypes */
-                                    if((mpierr = MPI_Type_create_struct(j, blocklens, var_offsets, vartypes, &filetype)))
-                                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+			if (doFlush[nv]) { /* flush the data now */
+			    int mpierr;
+			    /* concatenate vartypes[0...numReqs-1] */
+			    if (numReqs > 1) {
+				/* check and remove NULL vartype */
+				int i, j=0;
+				for (i=0; i<numReqs; i++) {
+				    if (vartypes[i] != MPI_DATATYPE_NULL) {
+					if (j < i) vartypes[j] = vartypes[i];
+					j++;
+				    }
+				}
+				if (j > 0) { /* at least one vartypes[] is not NULL */
+				    /* concatenate non-NULL vartypes */
+				    if((mpierr = MPI_Type_create_struct(j, blocklens, var_offsets, vartypes, &filetype)))
+					return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-                                    if((mpierr = MPI_Type_commit(&filetype)))
-                                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+				    if((mpierr = MPI_Type_commit(&filetype)))
+					return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-                                    /* free vartypes */
-                                    for (i=j-1; i>0; i--) {
-                                        if (vartypes[i] == vartypes[i-1]) continue;
-                                        if((mpierr = MPI_Type_free(&vartypes[i])))
-                                            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-                                    }
-                                    if((mpierr = MPI_Type_free(&vartypes[0])))
-                                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-                                }
-                                else /* all vartypes[] are NULL */
-                                    filetype = MPI_DATATYPE_NULL;
-                            }
-                            else /* there is only one variable to flush */
-                                filetype = vartypes[0];
+				    /* free vartypes */
+				    for (i=j-1; i>0; i--) {
+					if (vartypes[i] == vartypes[i-1]) continue;
+					if((mpierr = MPI_Type_free(&vartypes[i])))
+					    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+				    }
+				    if((mpierr = MPI_Type_free(&vartypes[0])))
+					return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+				}
+				else /* all vartypes[] are NULL */
+				    filetype = MPI_DATATYPE_NULL;
+			    }
+			    else /* there is only one variable to flush */
+				filetype = vartypes[0];
 
-                            PLOG((3, "vard: call ncmpi_put_vard llen = %d %d", llen, iodesc->mpitype_size ));
-                            ierr = ncmpi_put_vard_all(file->fh, var0_id, filetype, vard_bufptr, vard_llen, iodesc->mpitype);
-                            PLOG((3, "vard: return ncmpi_put_vard ierr = %d", ierr));
-                            if(filetype != MPI_DATATYPE_NULL)
-                            {
-                                if((mpierr = MPI_Type_free(&filetype)))
-                                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-                            }
-                            vard_llen = 0; /* reset request size to 0 */
-                            numReqs = 0;
-                        }
-                        else /* don't flush yet, accumulate the request size */
-                            vard_llen += llen;
+			    PLOG((3, "vard: call ncmpi_put_vard llen = %d %d", llen, iodesc->mpitype_size ));
+			    ierr = ncmpi_put_vard_all(file->fh, var0_id, filetype, vard_bufptr, vard_llen, iodesc->mpitype);
+			    PLOG((3, "vard: return ncmpi_put_vard ierr = %d", ierr));
+			    if(filetype != MPI_DATATYPE_NULL)
+			    {
+				if((mpierr = MPI_Type_free(&filetype)))
+				    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+			    }
+			    vard_llen = 0; /* reset request size to 0 */
+			    numReqs = 0;
+			}
+			else /* don't flush yet, accumulate the request size */
+			    vard_llen += llen;
 #else
-                        if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
-                        {
-                            if (!(vdesc->request = realloc(vdesc->request, sizeof(int) *
-                                                           (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
-                                return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+			if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
+			{
+			    if (!(vdesc->request = realloc(vdesc->request, sizeof(int) *
+							   (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
+				return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
-                            for (int i = vdesc->nreqs; i < vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK; i++)
-                                vdesc->request[i] = NC_REQ_NULL;
-                        }
+			    for (int i = vdesc->nreqs; i < vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK; i++)
+				vdesc->request[i] = NC_REQ_NULL;
+			}
 
-                        /* Write, in non-blocking fashion, a list of subarrays. */
-                        PLOG((3, "about to call ncmpi_iput_varn() varids[%d] = %d rrcnt = %d, llen = %d",
-                              nv, varids[nv], rrcnt, llen));
-                        ierr = ncmpi_iput_varn(file->fh, varids[nv], rrcnt, startlist, countlist,
-                                               bufptr, llen, iodesc->mpitype, &vdesc->request[vdesc->nreqs]);
+			/* Write, in non-blocking fashion, a list of subarrays. */
+			PLOG((3, "about to call ncmpi_iput_varn() varids[%d] = %d rrcnt = %d, llen = %d",
+			      nv, varids[nv], rrcnt, llen));
+			ierr = ncmpi_iput_varn(file->fh, varids[nv], rrcnt, startlist, countlist,
+					       bufptr, llen, iodesc->mpitype, &vdesc->request[vdesc->nreqs]);
 
-                        /* keeps wait calls in sync */
-                        if (vdesc->request[vdesc->nreqs] == NC_REQ_NULL)
-                            vdesc->request[vdesc->nreqs] = PIO_REQ_NULL;
+			/* keeps wait calls in sync */
+			if (vdesc->request[vdesc->nreqs] == NC_REQ_NULL)
+			    vdesc->request[vdesc->nreqs] = PIO_REQ_NULL;
 
-                        vdesc->nreqs++;
+			vdesc->nreqs++;
 #endif
-                    }
+		    }
 
-                    /* Free resources. */
-                    for (int i = 0; i < rrcnt; i++)
-                    {
-                        free(startlist[i]);
-                        free(countlist[i]);
-                    }
-                }
-                break;
+		    /* Free resources. */
+		    for (int i = 0; i < rrcnt; i++)
+		    {
+			free(startlist[i]);
+			free(countlist[i]);
+		    }
+		}
+		break;
 #endif
-            default:
-                return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
-            }
+	    default:
+		return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
+	    }
 
-            /* Go to next region. */
-            if (region)
-                region = region->next;
-        } /* next regioncnt */
+	    /* Go to next region. */
+	    if (region)
+		region = region->next;
+	} /* next regioncnt */
     } /* endif (ios->ioproc) */
 
     /* Check the return code from the netCDF/pnetcdf call. */
@@ -690,7 +690,7 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
 
 #ifdef TIMING
     if ((ierr = pio_stop_timer("PIO:write_darray_multi_par")))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return ierr;
@@ -721,56 +721,56 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
  **/
 int
 find_all_start_count(io_region *region, int maxregions, int fndims,
-                     int iodesc_ndims, var_desc_t *vdesc, size_t *tmp_start,
-                     size_t *tmp_count)
+		     int iodesc_ndims, var_desc_t *vdesc, size_t *tmp_start,
+		     size_t *tmp_count)
 {
     /* Check inputs. */
     pioassert(maxregions >= 0 && fndims > 0 && iodesc_ndims >= 0 && vdesc &&
-              tmp_start && tmp_count, "invalid input", __FILE__, __LINE__);
+	      tmp_start && tmp_count, "invalid input", __FILE__, __LINE__);
 
     /* Find the start/count arrays for each region in the list. */
     for (int r = 0; r < maxregions; r++)
     {
-        /* Initialize the start/count arrays for this region to 0. */
-        for (int d = 0; d < fndims; d++)
-        {
-            tmp_start[d + r * fndims] = 0;
-            tmp_count[d + r * fndims] = 0;
-        }
+	/* Initialize the start/count arrays for this region to 0. */
+	for (int d = 0; d < fndims; d++)
+	{
+	    tmp_start[d + r * fndims] = 0;
+	    tmp_count[d + r * fndims] = 0;
+	}
 
-        if (region)
-        {
-            if (vdesc->record >= 0)
-            {
-                /* This is a record based multidimensional
-                 * array. Copy start/count for non-record
-                 * dimensions. */
-                for (int i = fndims - iodesc_ndims; i < fndims; i++)
-                {
-                    tmp_start[i + r * fndims] = region->start[i - (fndims - iodesc_ndims)];
-                    tmp_count[i + r * fndims] = region->count[i - (fndims - iodesc_ndims)];
-                    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
-                          tmp_start[i + r * fndims], i + r * fndims,
-                          tmp_count[i + r * fndims]));
-                }
-            }
-            else
-            {
-                /* This is not a record based multidimensional array. */
-                for (int i = 0; i < iodesc_ndims; i++)
-                {
-                    tmp_start[i + r * fndims] = region->start[i];
-                    tmp_count[i + r * fndims] = region->count[i];
-                    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
-                          tmp_start[i + r * fndims], i + r * fndims,
-                          tmp_count[i + r * fndims]));
-                }
-            }
+	if (region)
+	{
+	    if (vdesc->record >= 0)
+	    {
+		/* This is a record based multidimensional
+		 * array. Copy start/count for non-record
+		 * dimensions. */
+		for (int i = fndims - iodesc_ndims; i < fndims; i++)
+		{
+		    tmp_start[i + r * fndims] = region->start[i - (fndims - iodesc_ndims)];
+		    tmp_count[i + r * fndims] = region->count[i - (fndims - iodesc_ndims)];
+		    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
+			  tmp_start[i + r * fndims], i + r * fndims,
+			  tmp_count[i + r * fndims]));
+		}
+	    }
+	    else
+	    {
+		/* This is not a record based multidimensional array. */
+		for (int i = 0; i < iodesc_ndims; i++)
+		{
+		    tmp_start[i + r * fndims] = region->start[i];
+		    tmp_count[i + r * fndims] = region->count[i];
+		    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
+			  tmp_start[i + r * fndims], i + r * fndims,
+			  tmp_count[i + r * fndims]));
+		}
+	    }
 
-            /* Move to next region. */
-            region = region->next;
+	    /* Move to next region. */
+	    region = region->next;
 
-        } /* endif region */
+	} /* endif region */
     } /* next r */
 
     return PIO_NOERR;
@@ -789,8 +789,8 @@ find_all_start_count(io_region *region, int maxregions, int fndims,
  */
 int
 send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset llen,
-                     int maxregions, int nvars, int fndims, size_t *tmp_start,
-                     size_t *tmp_count, void *iobuf)
+		     int maxregions, int nvars, int fndims, size_t *tmp_start,
+		     size_t *tmp_count, void *iobuf)
 {
     MPI_Status status;     /* Recv status for MPI. */
     int mpierr;  /* Return code from MPI function codes. */
@@ -798,35 +798,35 @@ send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset llen,
 
     /* Check inputs. */
     pioassert(ios && ios->ioproc && ios->io_rank > 0 && maxregions >= 0,
-              "invalid inputs", __FILE__, __LINE__);
+	      "invalid inputs", __FILE__, __LINE__);
 
     /* Do a handshake. */
     if ((mpierr = MPI_Recv(&ierr, 1, MPI_INT, 0, 0, ios->io_comm, &status)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Send local length of iobuffer for each field (all
      * fields are the same length). */
     if ((mpierr = MPI_Send((void *)&llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     PLOG((3, "sent llen = %d", llen));
 
     /* Send the number of data regions, the start/count for
      * all regions, and the data buffer with all the data. */
     if (llen > 0)
     {
-        if ((mpierr = MPI_Send((void *)&maxregions, 1, MPI_INT, 0, ios->io_rank + ios->num_iotasks,
-                               ios->io_comm)))
-            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Send(tmp_start, maxregions * fndims, MPI_OFFSET, 0,
-                               ios->io_rank + 2 * ios->num_iotasks, ios->io_comm)))
-            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Send(tmp_count, maxregions * fndims, MPI_OFFSET, 0,
-                               ios->io_rank + 3 * ios->num_iotasks, ios->io_comm)))
-            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Send(iobuf, nvars * llen, iodesc->mpitype, 0,
-                               ios->io_rank + 4 * ios->num_iotasks, ios->io_comm)))
-            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        PLOG((3, "sent data for maxregions = %d", maxregions));
+	if ((mpierr = MPI_Send((void *)&maxregions, 1, MPI_INT, 0, ios->io_rank + ios->num_iotasks,
+			       ios->io_comm)))
+	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Send(tmp_start, maxregions * fndims, MPI_OFFSET, 0,
+			       ios->io_rank + 2 * ios->num_iotasks, ios->io_comm)))
+	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Send(tmp_count, maxregions * fndims, MPI_OFFSET, 0,
+			       ios->io_rank + 3 * ios->num_iotasks, ios->io_comm)))
+	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Send(iobuf, nvars * llen, iodesc->mpitype, 0,
+			       ios->io_rank + 4 * ios->num_iotasks, ios->io_comm)))
+	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	PLOG((3, "sent data for maxregions = %d", maxregions));
     }
 
     return PIO_NOERR;
@@ -869,8 +869,8 @@ send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset llen,
  */
 int
 recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
-                    io_desc_t *iodesc, PIO_Offset llen, int maxregions, int nvars,
-                    int fndims, size_t *tmp_start, size_t *tmp_count, void *iobuf)
+		    io_desc_t *iodesc, PIO_Offset llen, int maxregions, int nvars,
+		    int fndims, size_t *tmp_start, size_t *tmp_count, void *iobuf)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     size_t rlen;    /* Length of IO buffer on this task. */
@@ -885,10 +885,10 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
 
     /* Check inputs. */
     pioassert(file && varids && iodesc && tmp_start && tmp_count, "invalid input",
-              __FILE__, __LINE__);
+	      __FILE__, __LINE__);
 
     PLOG((2, "recv_and_write_data llen = %d maxregions = %d nvars = %d fndims = %d",
-          llen, maxregions, nvars, fndims));
+	  llen, maxregions, nvars, fndims));
 
     /* Get pointer to IO system. */
     ios = file->iosystem;
@@ -897,112 +897,112 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
      * for IO. */
     for (int rtask = 0; rtask < ios->num_iotasks; rtask++)
     {
-        /* From the remote tasks, we send information about
-         * the data regions. and also the data. */
-        if (rtask)
-        {
-            /* handshake - tell the sending task I'm ready */
-            if ((mpierr = MPI_Send(&ierr, 1, MPI_INT, rtask, 0, ios->io_comm)))
-                return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	/* From the remote tasks, we send information about
+	 * the data regions. and also the data. */
+	if (rtask)
+	{
+	    /* handshake - tell the sending task I'm ready */
+	    if ((mpierr = MPI_Send(&ierr, 1, MPI_INT, rtask, 0, ios->io_comm)))
+		return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-            /* Get length of iobuffer for each field on this
-             * task (all fields are the same length). */
-            if ((mpierr = MPI_Recv(&rlen, 1, MPI_OFFSET, rtask, rtask, ios->io_comm,
-                                   &status)))
-                return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-            PLOG((3, "received rlen = %d", rlen));
+	    /* Get length of iobuffer for each field on this
+	     * task (all fields are the same length). */
+	    if ((mpierr = MPI_Recv(&rlen, 1, MPI_OFFSET, rtask, rtask, ios->io_comm,
+				   &status)))
+		return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	    PLOG((3, "received rlen = %d", rlen));
 
-            /* Get the number of regions, the start/count
-             * values for all regions, and the data buffer. */
-            if (rlen > 0)
-            {
-                if ((mpierr = MPI_Recv(&rregions, 1, MPI_INT, rtask, rtask + ios->num_iotasks,
-                                       ios->io_comm, &status)))
-                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-                if ((mpierr = MPI_Recv(tmp_start, rregions * fndims, MPI_OFFSET, rtask,
-                                       rtask + 2 * ios->num_iotasks, ios->io_comm, &status)))
-                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-                if ((mpierr = MPI_Recv(tmp_count, rregions * fndims, MPI_OFFSET, rtask,
-                                       rtask + 3 * ios->num_iotasks, ios->io_comm, &status)))
-                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-                if ((mpierr = MPI_Recv(iobuf, nvars * rlen, iodesc->mpitype, rtask,
-                                       rtask + 4 * ios->num_iotasks, ios->io_comm, &status)))
-                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-                PLOG((3, "received data rregions = %d fndims = %d", rregions, fndims));
-            }
-        }
-        else /* task 0 */
-        {
-            rlen = llen;
-            rregions = maxregions;
-        }
-        PLOG((3, "rtask = %d rlen = %d rregions = %d", rtask, rlen, rregions));
+	    /* Get the number of regions, the start/count
+	     * values for all regions, and the data buffer. */
+	    if (rlen > 0)
+	    {
+		if ((mpierr = MPI_Recv(&rregions, 1, MPI_INT, rtask, rtask + ios->num_iotasks,
+				       ios->io_comm, &status)))
+		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+		if ((mpierr = MPI_Recv(tmp_start, rregions * fndims, MPI_OFFSET, rtask,
+				       rtask + 2 * ios->num_iotasks, ios->io_comm, &status)))
+		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+		if ((mpierr = MPI_Recv(tmp_count, rregions * fndims, MPI_OFFSET, rtask,
+				       rtask + 3 * ios->num_iotasks, ios->io_comm, &status)))
+		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+		if ((mpierr = MPI_Recv(iobuf, nvars * rlen, iodesc->mpitype, rtask,
+				       rtask + 4 * ios->num_iotasks, ios->io_comm, &status)))
+		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+		PLOG((3, "received data rregions = %d fndims = %d", rregions, fndims));
+	    }
+	}
+	else /* task 0 */
+	{
+	    rlen = llen;
+	    rregions = maxregions;
+	}
+	PLOG((3, "rtask = %d rlen = %d rregions = %d", rtask, rlen, rregions));
 
-        /* If there is data from this task, write it. */
-        if (rlen > 0)
-        {
-            loffset = 0;
-            for (int regioncnt = 0; regioncnt < rregions; regioncnt++)
-            {
-                PLOG((3, "writing data for region with regioncnt = %d", regioncnt));
+	/* If there is data from this task, write it. */
+	if (rlen > 0)
+	{
+	    loffset = 0;
+	    for (int regioncnt = 0; regioncnt < rregions; regioncnt++)
+	    {
+		PLOG((3, "writing data for region with regioncnt = %d", regioncnt));
 
-                /* Get the start/count arrays for this region. */
-                for (int i = 0; i < fndims; i++)
-                {
-                    start[i] = tmp_start[i + regioncnt * fndims];
-                    count[i] = tmp_count[i + regioncnt * fndims];
-                    PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
-                }
+		/* Get the start/count arrays for this region. */
+		for (int i = 0; i < fndims; i++)
+		{
+		    start[i] = tmp_start[i + regioncnt * fndims];
+		    count[i] = tmp_count[i + regioncnt * fndims];
+		    PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
+		}
 
-                /* Process each variable in the buffer. */
-                for (int nv = 0; nv < nvars; nv++)
-                {
-                    PLOG((3, "writing buffer var %d", nv));
-                    if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
-                        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+		/* Process each variable in the buffer. */
+		for (int nv = 0; nv < nvars; nv++)
+		{
+		    PLOG((3, "writing buffer var %d", nv));
+		    if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
+			return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
-                    /* Get a pointer to the correct part of the buffer. */
-                    bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * (nv * rlen + loffset));
+		    /* Get a pointer to the correct part of the buffer. */
+		    bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * (nv * rlen + loffset));
 
-                    /* If this var has an unlimited dim, set
-                     * the start on that dim to the frame
-                     * value for this variable. */
-                    if (vdesc->record >= 0)
-                    {
-                        if (fndims > 1 && iodesc->ndims < fndims && count[1] > 0)
-                        {
-                            count[0] = 1;
-                            start[0] = frame[nv];
-                        }
-                        else if (fndims == iodesc->ndims)
-                        {
-                            start[0] += vdesc->record;
-                        }
-                    }
+		    /* If this var has an unlimited dim, set
+		     * the start on that dim to the frame
+		     * value for this variable. */
+		    if (vdesc->record >= 0)
+		    {
+			if (fndims > 1 && iodesc->ndims < fndims && count[1] > 0)
+			{
+			    count[0] = 1;
+			    start[0] = frame[nv];
+			}
+			else if (fndims == iodesc->ndims)
+			{
+			    start[0] += vdesc->record;
+			}
+		    }
 
 #ifdef LOGGING
-                    for (int i = 1; i < fndims; i++)
-                        PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
+		    for (int i = 1; i < fndims; i++)
+			PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
 #endif /* LOGGING */
 
-                    /* Call the netCDF functions to write the data. */
-                    if ((ierr = nc_put_vara(file->fh, varids[nv], start, count, bufptr)))
-                        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+		    /* Call the netCDF functions to write the data. */
+		    if ((ierr = nc_put_vara(file->fh, varids[nv], start, count, bufptr)))
+			return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
 
-                } /* next var */
+		} /* next var */
 
-                /* Calculate the total size. */
-                size_t tsize = 1;
-                for (int i = 0; i < fndims; i++)
-                    tsize *= count[i];
+		/* Calculate the total size. */
+		size_t tsize = 1;
+		for (int i = 0; i < fndims; i++)
+		    tsize *= count[i];
 
-                /* Keep track of where we are in the buffer. */
-                loffset += tsize;
+		/* Keep track of where we are in the buffer. */
+		loffset += tsize;
 
-                PLOG((3, " at bottom of loop regioncnt = %d tsize = %d loffset = %d", regioncnt,
-                      tsize, loffset));
-            } /* next regioncnt */
-        } /* endif (rlen > 0) */
+		PLOG((3, " at bottom of loop regioncnt = %d tsize = %d loffset = %d", regioncnt,
+		      tsize, loffset));
+	    } /* next regioncnt */
+	} /* endif (rlen > 0) */
     } /* next rtask */
 
     return PIO_NOERR;
@@ -1030,7 +1030,7 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
  */
 int
 write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *varids,
-                          io_desc_t *iodesc, int fill, const int *frame)
+			  io_desc_t *iodesc, int fill, const int *frame)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;     /* Contains info about the variable. */
@@ -1038,17 +1038,17 @@ write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *v
 
     /* Check inputs. */
     pioassert(file && file->iosystem && varids && varids[0] >= 0 &&
-              varids[0] <= PIO_MAX_VARS && iodesc, "invalid input", __FILE__, __LINE__);
+	      varids[0] <= PIO_MAX_VARS && iodesc, "invalid input", __FILE__, __LINE__);
 
     PLOG((1, "write_darray_multi_serial nvars = %d fndims = %d iodesc->ndims = %d "
-          "iodesc->mpitype = %d", nvars, fndims, iodesc->ndims, iodesc->mpitype));
+	  "iodesc->mpitype = %d", nvars, fndims, iodesc->ndims, iodesc->mpitype));
 
     /* Get the iosystem info. */
     ios = file->iosystem;
 
     /* Get the var info. */
     if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
-        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Set these differently for data and fill writing. iobuf may be
      * null if array size < number of nodes. */
@@ -1060,45 +1060,45 @@ write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *v
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ierr = pio_start_timer("PIO:write_darray_multi_serial")))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Only IO tasks participate in this code. */
     if (ios->ioproc)
     {
-        size_t tmp_start[fndims * num_regions]; /* A start array for each region. */
-        size_t tmp_count[fndims * num_regions]; /* A count array for each region. */
+	size_t tmp_start[fndims * num_regions]; /* A start array for each region. */
+	size_t tmp_count[fndims * num_regions]; /* A count array for each region. */
 
-        PLOG((3, "num_regions = %d", num_regions));
+	PLOG((3, "num_regions = %d", num_regions));
 
-        /* Fill the tmp_start and tmp_count arrays, which contain the
-         * start and count arrays for all regions. */
-        if ((ierr = find_all_start_count(region, num_regions, fndims, iodesc->ndims, vdesc,
-                                         tmp_start, tmp_count)))
-            return pio_err(ios, file, ierr, __FILE__, __LINE__);
+	/* Fill the tmp_start and tmp_count arrays, which contain the
+	 * start and count arrays for all regions. */
+	if ((ierr = find_all_start_count(region, num_regions, fndims, iodesc->ndims, vdesc,
+					 tmp_start, tmp_count)))
+	    return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
-        /* Tasks other than 0 will send their data to task 0. */
-        if (ios->io_rank > 0)
-        {
-            /* Send the tmp_start and tmp_count arrays from this IO task
-             * to task 0. */
-            if ((ierr = send_all_start_count(ios, iodesc, llen, num_regions, nvars, fndims,
-                                             tmp_start, tmp_count, iobuf)))
-                return pio_err(ios, file, ierr, __FILE__, __LINE__);
-        }
-        else
-        {
-            /* Task 0 will receive data from all other IO tasks. */
+	/* Tasks other than 0 will send their data to task 0. */
+	if (ios->io_rank > 0)
+	{
+	    /* Send the tmp_start and tmp_count arrays from this IO task
+	     * to task 0. */
+	    if ((ierr = send_all_start_count(ios, iodesc, llen, num_regions, nvars, fndims,
+					     tmp_start, tmp_count, iobuf)))
+		return pio_err(ios, file, ierr, __FILE__, __LINE__);
+	}
+	else
+	{
+	    /* Task 0 will receive data from all other IO tasks. */
 
-            if ((ierr = recv_and_write_data(file, varids, frame, iodesc, llen, num_regions, nvars, fndims,
-                                            tmp_start, tmp_count, iobuf)))
-                return pio_err(ios, file, ierr, __FILE__, __LINE__);
-        }
+	    if ((ierr = recv_and_write_data(file, varids, frame, iodesc, llen, num_regions, nvars, fndims,
+					    tmp_start, tmp_count, iobuf)))
+		return pio_err(ios, file, ierr, __FILE__, __LINE__);
+	}
     }
 
 #ifdef TIMING
     if ((ierr = pio_stop_timer("PIO:write_darray_multi_serial")))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return PIO_NOERR;
@@ -1137,7 +1137,7 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
 
     /* Check inputs. */
     pioassert(file && file->iosystem && iodesc && vid <= PIO_MAX_VARS, "invalid input",
-              __FILE__, __LINE__);
+	      __FILE__, __LINE__);
 
     /* Get the IO system info. */
     ios = file->iosystem;
@@ -1146,12 +1146,12 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ierr = pio_start_timer("PIO:read_darray_nc")))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Get the variable info. */
     if ((ierr = get_var_desc(vid, &file->varlist, &vdesc)))
-        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Get the number of dimensions in the decomposition. */
     ndims = iodesc->ndims;
@@ -1163,216 +1163,218 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
     /* ??? */
 #if USE_VARD_READ
     if(!ios->async || !ios->ioproc)
-        ierr = get_gdim0(file, iodesc, vid, fndims, &gdim0);
+	ierr = get_gdim0(file, iodesc, vid, fndims, &gdim0);
 #endif
 
     /* IO procs will read the data. */
     if (ios->ioproc)
     {
-        io_region *region;
-        size_t start[fndims];
-        size_t count[fndims];
-        void *bufptr;
+	io_region *region;
+	size_t start[fndims];
+	size_t count[fndims];
+	void *bufptr;
 #ifdef _PNETCDF
-        size_t tmp_bufsize = 1;
-        int rrlen = 0;
-        PIO_Offset *startlist[iodesc->maxregions];
-        PIO_Offset *countlist[iodesc->maxregions];
+	size_t tmp_bufsize = 1;
+	int rrlen = 0;
+	PIO_Offset *startlist[iodesc->maxregions];
+	PIO_Offset *countlist[iodesc->maxregions];
 #endif
-	
-        /* buffer is incremented by byte and loffset is in terms of
-           the iodessc->mpitype so we need to multiply by the size of
-           the mpitype. */
-        region = iodesc->firstregion;
 
-        /* There are different numbers of dims in the decomposition
-         * and the file. */
-        if (fndims > ndims)
-        {
-            /* If the user did not call setframe, use a default frame
-             * of 0. This is required for backward compatibility. */
-            if (vdesc->record < 0)
-                vdesc->record = 0;
-        }
+	/* buffer is incremented by byte and loffset is in terms of
+	   the iodessc->mpitype so we need to multiply by the size of
+	   the mpitype. */
+	region = iodesc->firstregion;
 
-        /* For each regions, read the data. */
-        for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
-        {
-            if (region == NULL || iodesc->llen == 0)
-            {
-                /* No data for this region. */
-                for (int i = 0; i < fndims; i++)
-                {
-                    start[i] = 0;
-                    count[i] = 0;
-                }
-                bufptr = NULL;
-            }
-            else
-            {
-                /* Get a pointer where we should put the data we read. */
-                if (regioncnt == 0 || region == NULL)
-                    bufptr = iobuf;
-                else
-                    bufptr=(void *)((char *)iobuf + iodesc->mpitype_size * region->loffset);
+	/* There are different numbers of dims in the decomposition
+	 * and the file. */
+	if (fndims > ndims)
+	{
+	    /* If the user did not call setframe, use a default frame
+	     * of 0. This is required for backward compatibility. */
+	    if (vdesc->record < 0)
+		vdesc->record = 0;
+	}
 
-                PLOG((2, "iodesc->llen - region->loffset %d, iodesc->llen %d, region->loffset  %d vdesc->record %d",
-                      iodesc->llen - region->loffset, iodesc->llen, region->loffset, vdesc->record));
+	/* For each regions, read the data. */
+	for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
+	{
+	    if (region == NULL || iodesc->llen == 0)
+	    {
+		/* No data for this region. */
+		for (int i = 0; i < fndims; i++)
+		{
+		    start[i] = 0;
+		    count[i] = 0;
+		}
+		bufptr = NULL;
+	    }
+	    else
+	    {
+		/* Get a pointer where we should put the data we read. */
+		if (regioncnt == 0 || region == NULL)
+		    bufptr = iobuf;
+		else
+		    bufptr=(void *)((char *)iobuf + iodesc->mpitype_size * region->loffset);
 
-                /* Get the start/count arrays. */
-                if (vdesc->record >= 0 && fndims > 1)
-                {
-                    /* This is a record var. The unlimited dimension
-                     * (0) is handled specially. */
-                    start[0] = vdesc->record;
-                    for (int i = 1; i < fndims; i++)
-                    {
-                        start[i] = region->start[i-1];
-                        count[i] = region->count[i-1];
-                    }
+		PLOG((2, "iodesc->llen - region->loffset %d, iodesc->llen %d, region->loffset  %d vdesc->record %d",
+		      iodesc->llen - region->loffset, iodesc->llen, region->loffset, vdesc->record));
 
-                    /* Read one record. */
-                    if (count[1] > 0)
-                        count[0] = 1;
-                }
-                else
-                {
-                    /* Non-time dependent array */
-                    for (int i = 0; i < fndims; i++)
-                    {
-                        start[i] = region->start[i];
-                        count[i] = region->count[i];
-                    }
-                }
-            }
+		/* Get the start/count arrays. */
+		if (vdesc->record >= 0 && fndims > 1)
+		{
+		    /* This is a record var. The unlimited dimension
+		     * (0) is handled specially. */
+		    start[0] = vdesc->record;
+		    for (int i = 1; i < fndims; i++)
+		    {
+			start[i] = region->start[i-1];
+			count[i] = region->count[i-1];
+		    }
+
+		    /* Read one record. */
+		    if (count[1] > 0)
+			count[0] = 1;
+		}
+		else
+		{
+		    /* Non-time dependent array */
+		    for (int i = 0; i < fndims; i++)
+		    {
+			start[i] = region->start[i];
+			count[i] = region->count[i];
+		    }
+		}
+	    }
 
 #ifdef PIO_ENABLE_LOGGING
-            for (int i = 1; i < ndims; i++)
-                PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
+	    for (int i = 1; i < ndims; i++)
+		PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
 #endif /* LOGGING */
-            /* Do the read. */
-            switch (file->iotype)
-            {
+	    /* Do the read. */
+	    switch (file->iotype)
+	    {
 #ifdef _NETCDF4
-            case PIO_IOTYPE_NETCDF4P:
-                /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
-                switch (iodesc->piotype)
-                {
-                case PIO_BYTE:
-                    ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
-                    break;
-                case PIO_CHAR:
-                    ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
-                    break;
-                case PIO_SHORT:
-                    ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
-                    break;
-                case PIO_INT:
-                    ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
-                    break;
-                case PIO_FLOAT:
-                    ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
-                    break;
-                case PIO_DOUBLE:
-                    ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
-                    break;
-                case PIO_UBYTE:
-                    ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
-                    break;
-                case PIO_USHORT:
-                    ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
-                    break;
-                case PIO_UINT:
-                    ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
-                    break;
-                case PIO_INT64:
-                    ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
-                    break;
-                case PIO_UINT64:
-                    ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
-                    break;
-                case PIO_STRING:
-                    ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
-                    break;
-                default:
-                    return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
-                }
-                break;
+	    case PIO_IOTYPE_NETCDF4P:
+		/* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
+		switch (iodesc->piotype)
+		{
+		case PIO_BYTE:
+		    ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
+		    break;
+		case PIO_CHAR:
+		    ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
+		    break;
+		case PIO_SHORT:
+		    ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
+		    break;
+		case PIO_INT:
+		    ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
+		    break;
+		case PIO_FLOAT:
+		    ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
+		    break;
+		case PIO_DOUBLE:
+		    ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
+		    break;
+		case PIO_UBYTE:
+		    ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
+		    break;
+		case PIO_USHORT:
+		    ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
+		    break;
+		case PIO_UINT:
+		    ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
+		    break;
+		case PIO_INT64:
+		    ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
+		    break;
+		case PIO_UINT64:
+		    ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
+		    break;
+		case PIO_STRING:
+		    ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
+		    break;
+		default:
+		    return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
+		}
+		break;
 #endif
 #ifdef _PNETCDF
-            case PIO_IOTYPE_PNETCDF:
-            {
-                tmp_bufsize = 1;
-                for (int j = 0; j < fndims; j++)
-                    tmp_bufsize *= count[j];
+	    case PIO_IOTYPE_PNETCDF:
+	    {
+		tmp_bufsize = 1;
+		for (int j = 0; j < fndims; j++)
+		    tmp_bufsize *= count[j];
 
-                if (tmp_bufsize > 0)
-                {
-                    startlist[rrlen] = malloc(fndims * sizeof(PIO_Offset));
-                    countlist[rrlen] = malloc(fndims * sizeof(PIO_Offset));
+		if (tmp_bufsize > 0)
+		{
+		    startlist[rrlen] = malloc(fndims * sizeof(PIO_Offset));
+		    countlist[rrlen] = malloc(fndims * sizeof(PIO_Offset));
 
-                    for (int j = 0; j < fndims; j++)
-                    {
-                        startlist[rrlen][j] = start[j];
-                        countlist[rrlen][j] = count[j];
-                    }
-                    rrlen++;
-                }
+		    for (int j = 0; j < fndims; j++)
+		    {
+			startlist[rrlen][j] = start[j];
+			countlist[rrlen][j] = count[j];
+		    }
+		    rrlen++;
+		}
 
-                /* Is this is the last region to process? */
-                if (regioncnt == iodesc->maxregions - 1)
-                {
+		/* Is this is the last region to process? */
+		if (regioncnt == iodesc->maxregions - 1)
+		{
 #if USE_VARD_READ
-                    MPI_Datatype filetype;
-                    PIO_Offset unlimdimoffset;
-                    int mpierr;
-                    if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
-                    {
-                        if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
-                            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-                    }
-                    else
-                        unlimdimoffset = gdim0;
+		    MPI_Datatype filetype;
+		    PIO_Offset unlimdimoffset;
+		    int mpierr;
+		    if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
+		    {
+			if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
+			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+		    }
+		    else
+			unlimdimoffset = gdim0;
 
-                    ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
-                                                rrlen, ndims, fndims,
-                                                vdesc->record, startlist, countlist, &filetype);
-                    ierr = ncmpi_get_vard_all(file->fh, vid, filetype, iobuf, iodesc->llen, iodesc->mpitype);
-                    if(filetype != MPI_DATATYPE_NULL && (mpierr = MPI_Type_free(&filetype)))
-                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		    ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
+						rrlen, ndims, fndims,
+						vdesc->record, startlist, countlist, &filetype);
+		    ierr = ncmpi_get_vard_all(file->fh, vid, filetype, iobuf, iodesc->llen, iodesc->mpitype);
+		    if(filetype != MPI_DATATYPE_NULL && (mpierr = MPI_Type_free(&filetype)))
+			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
 #else
-                    /* Read a list of subarrays. */
-                    ierr = ncmpi_get_varn_all(file->fh, vid, rrlen, startlist,
-                                              countlist, iobuf, iodesc->llen, iodesc->mpitype);
+		    printf("rllen %d mpitype %d\n",iodesc->rllen, iodesc->mpitype);
+		    /* Read a list of subarrays. */
+		    ierr = ncmpi_get_varn_all(file->fh, vid, rrlen, startlist,
+					      countlist, iobuf, iodesc->rllen, iodesc->mpitype);
 #endif
-                    /* Release the start and count arrays. */
-                    for (int i = 0; i < rrlen; i++)
-                    {
-                        free(startlist[i]);
-                        free(countlist[i]);
-                    }
-                }
-            }
-            break;
+		    /* Release the start and count arrays. */
+		    for (int i = 0; i < rrlen; i++)
+		    {
+			PLOG((3,"startlist %d %d countlist %d %d",startlist[i][0],startlist[i][1],countlist[i][0],countlist[i][1]));
+			free(startlist[i]);
+			free(countlist[i]);
+		    }
+		}
+	    }
+	    break;
 #endif
-            default:
-                return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
-            }
+	    default:
+		return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
+	    }
 
-            /* Check return code. */
-            if (ierr)
-                return check_netcdf(file, ierr, __FILE__,__LINE__);
+	    /* Check return code. */
+	    if (ierr)
+		return check_netcdf(file, ierr, __FILE__,__LINE__);
 
-            /* Move to next region. */
-            if (region)
-                region = region->next;
-        } /* next regioncnt */
+	    /* Move to next region. */
+	    if (region)
+		region = region->next;
+	} /* next regioncnt */
     }
 
 #ifdef TIMING
     if ((ierr = pio_stop_timer("PIO:read_darray_nc")))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return PIO_NOERR;
@@ -1400,7 +1402,7 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
  */
 int
 pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
-                          void *iobuf)
+			  void *iobuf)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;    /* Information about the variable. */
@@ -1412,7 +1414,7 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
 
     /* Check inputs. */
     pioassert(file && file->iosystem && iodesc && vid >= 0 && vid <= PIO_MAX_VARS,
-              "invalid input", __FILE__, __LINE__);
+	      "invalid input", __FILE__, __LINE__);
 
     PLOG((2, "pio_read_darray_nc_serial vid = %d", vid));
     ios = file->iosystem;
@@ -1420,12 +1422,12 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ierr = pio_start_timer("PIO:read_darray_nc_serial")))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Get var info for this var. */
     if ((ierr = get_var_desc(vid, &file->varlist, &vdesc)))
-        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Get the number of dims in our decomposition. */
     ndims = iodesc->ndims;
@@ -1436,251 +1438,251 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
     /* If setframe was not called, use a default value of 0. This is
      * required for backward compatibility. */
     if (fndims == ndims + 1 && vdesc->record < 0)
-        vdesc->record = 0;
+	vdesc->record = 0;
     PLOG((3, "fndims %d ndims %d vdesc->record %d vdesc->ndims %d", fndims,
-          ndims, vdesc->record, vdesc->ndims));
+	  ndims, vdesc->record, vdesc->ndims));
 
     /* Confirm that we are being called with the correct ndims. */
     pioassert((fndims == ndims && vdesc->record < 0) ||
-              (fndims == ndims + 1 && vdesc->record >= 0),
-              "unexpected record", __FILE__, __LINE__);
+	      (fndims == ndims + 1 && vdesc->record >= 0),
+	      "unexpected record", __FILE__, __LINE__);
 
     if (ios->ioproc)
     {
-        io_region *region;
-        size_t start[fndims];
-        size_t count[fndims];
-        size_t tmp_start[fndims * iodesc->maxregions];
-        size_t tmp_count[fndims * iodesc->maxregions];
-        size_t tmp_bufsize;
-        void *bufptr;
+	io_region *region;
+	size_t start[fndims];
+	size_t count[fndims];
+	size_t tmp_start[fndims * iodesc->maxregions];
+	size_t tmp_count[fndims * iodesc->maxregions];
+	size_t tmp_bufsize;
+	void *bufptr;
 
-        /* buffer is incremented by byte and loffset is in terms of
-           the iodessc->mpitype so we need to multiply by the size of
-           the mpitype. */
-        region = iodesc->firstregion;
+	/* buffer is incremented by byte and loffset is in terms of
+	   the iodessc->mpitype so we need to multiply by the size of
+	   the mpitype. */
+	region = iodesc->firstregion;
 
-        /* If setframe was not set before this call, assume a value of
-         * 0. This is required for backward compatibility. */
-        if (fndims > ndims)
-            if (vdesc->record < 0)
-                vdesc->record = 0;
+	/* If setframe was not set before this call, assume a value of
+	 * 0. This is required for backward compatibility. */
+	if (fndims > ndims)
+	    if (vdesc->record < 0)
+		vdesc->record = 0;
 
-        /* Put together start/count arrays for all regions. */
-        for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
-        {
-            if (!region || iodesc->llen == 0)
-            {
-                /* Nothing to write for this region. */
-                for (int i = 0; i < fndims; i++)
-                {
-                    tmp_start[i + regioncnt * fndims] = 0;
-                    tmp_count[i + regioncnt * fndims] = 0;
-                }
-                bufptr = NULL;
-            }
-            else
-            {
-                if (vdesc->record >= 0 && fndims > 1)
-                {
-                    /* This is a record var. Find start for record dims. */
-                    tmp_start[regioncnt * fndims] = vdesc->record;
+	/* Put together start/count arrays for all regions. */
+	for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
+	{
+	    if (!region || iodesc->llen == 0)
+	    {
+		/* Nothing to write for this region. */
+		for (int i = 0; i < fndims; i++)
+		{
+		    tmp_start[i + regioncnt * fndims] = 0;
+		    tmp_count[i + regioncnt * fndims] = 0;
+		}
+		bufptr = NULL;
+	    }
+	    else
+	    {
+		if (vdesc->record >= 0 && fndims > 1)
+		{
+		    /* This is a record var. Find start for record dims. */
+		    tmp_start[regioncnt * fndims] = vdesc->record;
 
-                    /* Find start/count for all non-record dims. */
-                    for (int i = 1; i < fndims; i++)
-                    {
-                        tmp_start[i + regioncnt * fndims] = region->start[i - 1];
-                        tmp_count[i + regioncnt * fndims] = region->count[i - 1];
-                    }
+		    /* Find start/count for all non-record dims. */
+		    for (int i = 1; i < fndims; i++)
+		    {
+			tmp_start[i + regioncnt * fndims] = region->start[i - 1];
+			tmp_count[i + regioncnt * fndims] = region->count[i - 1];
+		    }
 
-                    /* Set count for record dimension. */
-                    if (tmp_count[1 + regioncnt * fndims] > 0)
-                        tmp_count[regioncnt * fndims] = 1;
-                }
-                else
-                {
-                    /* Non-time dependent array */
-                    for (int i = 0; i < fndims; i++)
-                    {
-                        tmp_start[i + regioncnt * fndims] = region->start[i];
-                        tmp_count[i + regioncnt * fndims] = region->count[i];
-                    }
-                }
-            }
+		    /* Set count for record dimension. */
+		    if (tmp_count[1 + regioncnt * fndims] > 0)
+			tmp_count[regioncnt * fndims] = 1;
+		}
+		else
+		{
+		    /* Non-time dependent array */
+		    for (int i = 0; i < fndims; i++)
+		    {
+			tmp_start[i + regioncnt * fndims] = region->start[i];
+			tmp_count[i + regioncnt * fndims] = region->count[i];
+		    }
+		}
+	    }
 
 #if PIO_ENABLE_LOGGING
-            /* Log arrays for debug purposes. */
-            PLOG((3, "region = %d", region));
-            for (int i = 0; i < fndims; i++)
-                PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + regioncnt * fndims, tmp_start[i + regioncnt * fndims],
-                      i + regioncnt * fndims, tmp_count[i + regioncnt * fndims]));
+	    /* Log arrays for debug purposes. */
+	    PLOG((3, "region = %d", region));
+	    for (int i = 0; i < fndims; i++)
+		PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + regioncnt * fndims, tmp_start[i + regioncnt * fndims],
+		      i + regioncnt * fndims, tmp_count[i + regioncnt * fndims]));
 #endif /* PIO_ENABLE_LOGGING */
 
-            /* Move to next region. */
-            if (region)
-                region = region->next;
-        } /* next regioncnt */
+	    /* Move to next region. */
+	    if (region)
+		region = region->next;
+	} /* next regioncnt */
 
-        /* IO tasks other than 0 send their starts/counts and data to
-         * IO task 0. */
-        if (ios->io_rank > 0)
-        {
-            if ((mpierr = MPI_Send(&iodesc->llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm)))
-                return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-            PLOG((3, "sent iodesc->llen = %d", iodesc->llen));
+	/* IO tasks other than 0 send their starts/counts and data to
+	 * IO task 0. */
+	if (ios->io_rank > 0)
+	{
+	    if ((mpierr = MPI_Send(&iodesc->llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm)))
+		return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	    PLOG((3, "sent iodesc->llen = %d", iodesc->llen));
 
-            if (iodesc->llen > 0)
-            {
-                if ((mpierr = MPI_Send(&(iodesc->maxregions), 1, MPI_INT, 0,
-                                       ios->num_iotasks + ios->io_rank, ios->io_comm)))
-                    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                if ((mpierr = MPI_Send(tmp_count, iodesc->maxregions * fndims, MPI_OFFSET, 0,
-                                       2 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
-                    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                if ((mpierr = MPI_Send(tmp_start, iodesc->maxregions * fndims, MPI_OFFSET, 0,
-                                       3 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
-                    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                PLOG((3, "sent iodesc->maxregions = %d tmp_count and tmp_start arrays", iodesc->maxregions));
+	    if (iodesc->llen > 0)
+	    {
+		if ((mpierr = MPI_Send(&(iodesc->maxregions), 1, MPI_INT, 0,
+				       ios->num_iotasks + ios->io_rank, ios->io_comm)))
+		    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+		if ((mpierr = MPI_Send(tmp_count, iodesc->maxregions * fndims, MPI_OFFSET, 0,
+				       2 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
+		    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+		if ((mpierr = MPI_Send(tmp_start, iodesc->maxregions * fndims, MPI_OFFSET, 0,
+				       3 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
+		    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+		PLOG((3, "sent iodesc->maxregions = %d tmp_count and tmp_start arrays", iodesc->maxregions));
 
-                if ((mpierr = MPI_Recv(iobuf, iodesc->llen, iodesc->mpitype, 0,
-                                       4 * ios->num_iotasks + ios->io_rank, ios->io_comm, &status)))
-                    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                PLOG((3, "received %d elements of data", iodesc->llen));
-            }
-        }
-        else if (ios->io_rank == 0)
-        {
-            /* This is IO task 0. Get starts/counts and data from
-             * other IO tasks. */
-            int maxregions = 0;
-            size_t loffset, regionsize;
-            size_t this_start[fndims * iodesc->maxregions];
-            size_t this_count[fndims * iodesc->maxregions];
+		if ((mpierr = MPI_Recv(iobuf, iodesc->llen, iodesc->mpitype, 0,
+				       4 * ios->num_iotasks + ios->io_rank, ios->io_comm, &status)))
+		    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+		PLOG((3, "received %d elements of data", iodesc->llen));
+	    }
+	}
+	else if (ios->io_rank == 0)
+	{
+	    /* This is IO task 0. Get starts/counts and data from
+	     * other IO tasks. */
+	    int maxregions = 0;
+	    size_t loffset, regionsize;
+	    size_t this_start[fndims * iodesc->maxregions];
+	    size_t this_count[fndims * iodesc->maxregions];
 
-            for (int rtask = 1; rtask <= ios->num_iotasks; rtask++)
-            {
-                if (rtask < ios->num_iotasks)
-                {
-                    if ((mpierr = MPI_Recv(&tmp_bufsize, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status)))
-                        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                    PLOG((3, "received tmp_bufsize = %d", tmp_bufsize));
+	    for (int rtask = 1; rtask <= ios->num_iotasks; rtask++)
+	    {
+		if (rtask < ios->num_iotasks)
+		{
+		    if ((mpierr = MPI_Recv(&tmp_bufsize, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status)))
+			return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+		    PLOG((3, "received tmp_bufsize = %d", tmp_bufsize));
 
-                    if (tmp_bufsize > 0)
-                    {
-                        if ((mpierr = MPI_Recv(&maxregions, 1, MPI_INT, rtask, ios->num_iotasks + rtask,
-                                               ios->io_comm, &status)))
-                            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                        if ((mpierr = MPI_Recv(this_count, maxregions * fndims, MPI_OFFSET, rtask,
-                                               2 * ios->num_iotasks + rtask, ios->io_comm, &status)))
-                            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                        if ((mpierr = MPI_Recv(this_start, maxregions * fndims, MPI_OFFSET, rtask,
-                                               3 * ios->num_iotasks + rtask, ios->io_comm, &status)))
-                            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                        PLOG((3, "received maxregions = %d this_count, this_start arrays ", maxregions));
-                    }
-                }
-                else
-                {
-                    maxregions = iodesc->maxregions;
-                    tmp_bufsize = iodesc->llen;
-                }
-                PLOG((3, "maxregions = %d tmp_bufsize = %d", maxregions, tmp_bufsize));
+		    if (tmp_bufsize > 0)
+		    {
+			if ((mpierr = MPI_Recv(&maxregions, 1, MPI_INT, rtask, ios->num_iotasks + rtask,
+					       ios->io_comm, &status)))
+			    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+			if ((mpierr = MPI_Recv(this_count, maxregions * fndims, MPI_OFFSET, rtask,
+					       2 * ios->num_iotasks + rtask, ios->io_comm, &status)))
+			    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+			if ((mpierr = MPI_Recv(this_start, maxregions * fndims, MPI_OFFSET, rtask,
+					       3 * ios->num_iotasks + rtask, ios->io_comm, &status)))
+			    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+			PLOG((3, "received maxregions = %d this_count, this_start arrays ", maxregions));
+		    }
+		}
+		else
+		{
+		    maxregions = iodesc->maxregions;
+		    tmp_bufsize = iodesc->llen;
+		}
+		PLOG((3, "maxregions = %d tmp_bufsize = %d", maxregions, tmp_bufsize));
 
-                /* Now get each region of data. */
-                loffset = 0;
-                for (int regioncnt = 0; regioncnt < maxregions; regioncnt++)
-                {
-                    /* Get pointer where data should go. */
-                    bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * loffset);
-                    regionsize = 1;
+		/* Now get each region of data. */
+		loffset = 0;
+		for (int regioncnt = 0; regioncnt < maxregions; regioncnt++)
+		{
+		    /* Get pointer where data should go. */
+		    bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * loffset);
+		    regionsize = 1;
 
-                    /* ??? */
-                    if (rtask < ios->num_iotasks)
-                    {
-                        for (int m = 0; m < fndims; m++)
-                        {
-                            start[m] = this_start[m + regioncnt * fndims];
-                            count[m] = this_count[m + regioncnt * fndims];
-                            regionsize *= count[m];
-                        }
-                    }
-                    else
-                    {
-                        for (int m = 0; m < fndims; m++)
-                        {
-                            start[m] = tmp_start[m + regioncnt * fndims];
-                            count[m] = tmp_count[m + regioncnt * fndims];
-                            regionsize *= count[m];
-                        }
-                    }
-                    loffset += regionsize;
+		    /* ??? */
+		    if (rtask < ios->num_iotasks)
+		    {
+			for (int m = 0; m < fndims; m++)
+			{
+			    start[m] = this_start[m + regioncnt * fndims];
+			    count[m] = this_count[m + regioncnt * fndims];
+			    regionsize *= count[m];
+			}
+		    }
+		    else
+		    {
+			for (int m = 0; m < fndims; m++)
+			{
+			    start[m] = tmp_start[m + regioncnt * fndims];
+			    count[m] = tmp_count[m + regioncnt * fndims];
+			    regionsize *= count[m];
+			}
+		    }
+		    loffset += regionsize;
 
-                    /* Read the data. */
-                    /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
-                    switch (iodesc->piotype)
-                    {
-                    case PIO_BYTE:
-                        ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
-                        break;
-                    case PIO_CHAR:
-                        ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
-                        break;
-                    case PIO_SHORT:
-                        ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
-                        break;
-                    case PIO_INT:
-                        ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
-                        break;
-                    case PIO_FLOAT:
-                        ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
-                        break;
-                    case PIO_DOUBLE:
-                        ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
-                        break;
+		    /* Read the data. */
+		    /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
+		    switch (iodesc->piotype)
+		    {
+		    case PIO_BYTE:
+			ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
+			break;
+		    case PIO_CHAR:
+			ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
+			break;
+		    case PIO_SHORT:
+			ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
+			break;
+		    case PIO_INT:
+			ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
+			break;
+		    case PIO_FLOAT:
+			ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
+			break;
+		    case PIO_DOUBLE:
+			ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
+			break;
 #ifdef _NETCDF4
-                    case PIO_UBYTE:
-                        ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
-                        break;
-                    case PIO_USHORT:
-                        ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
-                        break;
-                    case PIO_UINT:
-                        ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
-                        break;
-                    case PIO_INT64:
-                        ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
-                        break;
-                    case PIO_UINT64:
-                        ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
-                        break;
-                    case PIO_STRING:
-                        ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
-                        break;
+		    case PIO_UBYTE:
+			ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
+			break;
+		    case PIO_USHORT:
+			ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
+			break;
+		    case PIO_UINT:
+			ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
+			break;
+		    case PIO_INT64:
+			ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
+			break;
+		    case PIO_UINT64:
+			ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
+			break;
+		    case PIO_STRING:
+			ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
+			break;
 #endif /* _NETCDF4 */
-                    default:
-                        return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
-                    }
+		    default:
+			return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
+		    }
 
-                    /* Check error code of netCDF call. */
-                    if (ierr)
-                        return check_netcdf(file, ierr, __FILE__, __LINE__);
-                }
+		    /* Check error code of netCDF call. */
+		    if (ierr)
+			return check_netcdf(file, ierr, __FILE__, __LINE__);
+		}
 
-                /* The decomposition may not use all of the active io
-                 * tasks. rtask here is the io task rank and
-                 * ios->num_iotasks is the number of iotasks actually
-                 * used in this decomposition. */
-                if (rtask < ios->num_iotasks && tmp_bufsize > 0)
-                    if ((mpierr = MPI_Send(iobuf, tmp_bufsize, iodesc->mpitype, rtask,
-                                           4 * ios->num_iotasks + rtask, ios->io_comm)))
-                        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-            }
-        }
+		/* The decomposition may not use all of the active io
+		 * tasks. rtask here is the io task rank and
+		 * ios->num_iotasks is the number of iotasks actually
+		 * used in this decomposition. */
+		if (rtask < ios->num_iotasks && tmp_bufsize > 0)
+		    if ((mpierr = MPI_Send(iobuf, tmp_bufsize, iodesc->mpitype, rtask,
+					   4 * ios->num_iotasks + rtask, ios->io_comm)))
+			return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	    }
+	}
     }
 
 #ifdef TIMING
     if ((ierr = pio_stop_timer("PIO:read_darray_nc_serial")))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     PLOG((2, "pio_read_darray_nc_serial complete ierr %d", ierr));
@@ -1714,100 +1716,100 @@ flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     PLOG((1, "flush_output_buffer"));
     /* Find out the buffer usage. */
     if ((ierr = ncmpi_inq_buffer_usage(file->fh, &usage)))
-        /* allow the buffer to be undefined */
-        if (ierr != NC_ENULLABUF)
-            return pio_err(NULL, file, PIO_EBADID, __FILE__, __LINE__);
+	/* allow the buffer to be undefined */
+	if (ierr != NC_ENULLABUF)
+	    return pio_err(NULL, file, PIO_EBADID, __FILE__, __LINE__);
 
     /* If we are not forcing a flush, spread the usage to all IO
      * tasks. */
     if (!force && file->iosystem->ioproc)
     {
-        usage += addsize;
-        if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &usage, 1,  MPI_OFFSET,  MPI_MAX,
-                                    file->iosystem->io_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	usage += addsize;
+	if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &usage, 1,  MPI_OFFSET,  MPI_MAX,
+				    file->iosystem->io_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* Keep track of the maximum usage. */
     if (usage > maxusage)
-        maxusage = usage;
+	maxusage = usage;
 
     PLOG((2, "flush_output_buffer usage=%ld force=%d",usage, force));
     /* If the user forces it, or the buffer has exceeded the size
      * limit, then flush to disk. */
     if (force || (usage >= pio_buffer_size_limit))
     {
-        int rcnt;
-        int  maxreq;
-        int reqcnt;
-        maxreq = 0;
-        reqcnt = 0;
-        rcnt = 0;
+	int rcnt;
+	int  maxreq;
+	int reqcnt;
+	maxreq = 0;
+	reqcnt = 0;
+	rcnt = 0;
 
-        for (int i = 0; i < file->nvars; i++)
-        {
-            if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
-                return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-            reqcnt += vdesc->nreqs;
-            if (vdesc->nreqs > 0)
-                maxreq = i;
-        }
-        int request[reqcnt];
-        int status[reqcnt];
+	for (int i = 0; i < file->nvars; i++)
+	{
+	    if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
+		return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	    reqcnt += vdesc->nreqs;
+	    if (vdesc->nreqs > 0)
+		maxreq = i;
+	}
+	int request[reqcnt];
+	int status[reqcnt];
 
-        if (file->varlist)
-        {
-            for (int i = 0; i <= maxreq; i++)
-            {
-                if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
-                    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	if (file->varlist)
+	{
+	    for (int i = 0; i <= maxreq; i++)
+	    {
+		if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
+		    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 #ifdef MPIO_ONESIDED
-                /*onesided optimization requires that all of the requests in a wait_all call represent
-                  a contiguous block of data in the file */
-                if (rcnt > 0 && (prev_record != vdesc->record || vdesc->nreqs == 0))
-                {
-                    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-                    rcnt = 0;
-                }
-                prev_record = vdesc->record;
+		/*onesided optimization requires that all of the requests in a wait_all call represent
+		  a contiguous block of data in the file */
+		if (rcnt > 0 && (prev_record != vdesc->record || vdesc->nreqs == 0))
+		{
+		    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+		    rcnt = 0;
+		}
+		prev_record = vdesc->record;
 #endif
-                for (reqcnt = 0; reqcnt < vdesc->nreqs; reqcnt++)
-                    request[rcnt++] = max(vdesc->request[reqcnt], NC_REQ_NULL);
-                PLOG((3,"flush_output_buffer rcnt=%d",rcnt));
+		for (reqcnt = 0; reqcnt < vdesc->nreqs; reqcnt++)
+		    request[rcnt++] = max(vdesc->request[reqcnt], NC_REQ_NULL);
+		PLOG((3,"flush_output_buffer rcnt=%d",rcnt));
 
-                if (vdesc->request != NULL)
-                    free(vdesc->request);
-                vdesc->request = NULL;
-                vdesc->nreqs = 0;
+		if (vdesc->request != NULL)
+		    free(vdesc->request);
+		vdesc->request = NULL;
+		vdesc->nreqs = 0;
 
 #ifdef FLUSH_EVERY_VAR
-                ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-                rcnt = 0;
+		ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+		rcnt = 0;
 #endif
-            }
-        }
+	    }
+	}
 
-        if (rcnt > 0)
-            ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+	if (rcnt > 0)
+	    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
 
-        /* Release resources. */
-        if (file->iobuf)
-        {
-            PLOG((3,"freeing variable buffer in flush_output_buffer"));
-            free(file->iobuf);
-            file->iobuf = NULL;
-        }
+	/* Release resources. */
+	if (file->iobuf)
+	{
+	    PLOG((3,"freeing variable buffer in flush_output_buffer"));
+	    free(file->iobuf);
+	    file->iobuf = NULL;
+	}
 
-        for (int v = 0; v < file->nvars; v++)
-        {
-            if ((ierr = get_var_desc(v, &file->varlist, &vdesc)))
-                return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-            if (vdesc->fillbuf)
-            {
-                free(vdesc->fillbuf);
-                vdesc->fillbuf = NULL;
-            }
-        }
+	for (int v = 0; v < file->nvars; v++)
+	{
+	    if ((ierr = get_var_desc(v, &file->varlist, &vdesc)))
+		return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	    if (vdesc->fillbuf)
+	    {
+		free(vdesc->fillbuf);
+		vdesc->fillbuf = NULL;
+	    }
+	}
     }
 
 #endif /* _PNETCDF */
@@ -1835,41 +1837,41 @@ flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
 
     /* Get the file info (to get error handler). */
     if ((ret = pio_get_file(ncid, &file)))
-        return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
 
     PLOG((1, "flush_buffer ncid = %d flushtodisk = %d", ncid, flushtodisk));
 
     /* If there are any variables in this buffer... */
     if (wmb->num_arrays > 0)
     {
-        /* Write any data in the buffer. */
-        ret = PIOc_write_darray_multi(ncid, wmb->vid,  wmb->ioid, wmb->num_arrays,
-                                      wmb->arraylen, wmb->data, wmb->frame,
-                                      wmb->fillvalue, flushtodisk);
-        PLOG((2, "return from PIOc_write_darray_multi ret = %d", ret));
+	/* Write any data in the buffer. */
+	ret = PIOc_write_darray_multi(ncid, wmb->vid,  wmb->ioid, wmb->num_arrays,
+				      wmb->arraylen, wmb->data, wmb->frame,
+				      wmb->fillvalue, flushtodisk);
+	PLOG((2, "return from PIOc_write_darray_multi ret = %d", ret));
 
-        wmb->num_arrays = 0;
+	wmb->num_arrays = 0;
 
-        /* Release the list of variable IDs. */
-        free(wmb->vid);
-        wmb->vid = NULL;
+	/* Release the list of variable IDs. */
+	free(wmb->vid);
+	wmb->vid = NULL;
 
-        /* Release the data memory. */
-        free(wmb->data);
-        wmb->data = NULL;
+	/* Release the data memory. */
+	free(wmb->data);
+	wmb->data = NULL;
 
-        /* If there is a fill value, release it. */
-        if (wmb->fillvalue)
-            free(wmb->fillvalue);
-        wmb->fillvalue = NULL;
+	/* If there is a fill value, release it. */
+	if (wmb->fillvalue)
+	    free(wmb->fillvalue);
+	wmb->fillvalue = NULL;
 
-        /* Release the record number. */
-        if (wmb->frame)
-            free(wmb->frame);
-        wmb->frame = NULL;
+	/* Release the record number. */
+	if (wmb->frame)
+	    free(wmb->frame);
+	wmb->frame = NULL;
 
-        if (ret)
-            return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	if (ret)
+	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
     }
 
     return PIO_NOERR;
@@ -1889,242 +1891,242 @@ flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
  */
 int
 pio_sorted_copy(const void *array, void *sortedarray, io_desc_t *iodesc,
-                int nvars, int direction)
+		int nvars, int direction)
 {
     int maplen = iodesc->maplen;
 
     if (direction == 0){
-        switch (iodesc->piotype)
-        {
-        case PIO_BYTE:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((signed char *)sortedarray)[m+maplen*v] = ((signed char *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_CHAR:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((char *)sortedarray)[m+maplen*v] = ((char *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_SHORT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((short *)sortedarray)[m+maplen*v] = ((short *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
+	switch (iodesc->piotype)
+	{
+	case PIO_BYTE:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((signed char *)sortedarray)[m+maplen*v] = ((signed char *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_CHAR:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((char *)sortedarray)[m+maplen*v] = ((char *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_SHORT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((short *)sortedarray)[m+maplen*v] = ((short *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
 
-            break;
-        case PIO_INT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((int *)sortedarray)[m+maplen*v] = ((int *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_FLOAT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((float *)sortedarray)[m+maplen*v] = ((float *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_DOUBLE:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((double *)sortedarray)[m+maplen*v] = ((double *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_UBYTE:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((unsigned char *)sortedarray)[m+maplen*v] = ((unsigned char *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_USHORT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((unsigned short *)sortedarray)[m+maplen*v] = ((unsigned short *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_UINT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((unsigned int *)sortedarray)[m+maplen*v] = ((unsigned int *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_INT64:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((long long *)sortedarray)[m+maplen*v] = ((long long *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_UINT64:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((unsigned long long *)sortedarray)[m+maplen*v] = ((unsigned long long *)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        case PIO_STRING:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((char **)sortedarray)[m+maplen*v] = ((char **)array)[iodesc->remap[m]+maplen*v];
-                }
-            }
-            break;
-        default:
-            return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
-        }
+	    break;
+	case PIO_INT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((int *)sortedarray)[m+maplen*v] = ((int *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_FLOAT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((float *)sortedarray)[m+maplen*v] = ((float *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_DOUBLE:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((double *)sortedarray)[m+maplen*v] = ((double *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UBYTE:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned char *)sortedarray)[m+maplen*v] = ((unsigned char *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_USHORT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned short *)sortedarray)[m+maplen*v] = ((unsigned short *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UINT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned int *)sortedarray)[m+maplen*v] = ((unsigned int *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_INT64:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((long long *)sortedarray)[m+maplen*v] = ((long long *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UINT64:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned long long *)sortedarray)[m+maplen*v] = ((unsigned long long *)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_STRING:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((char **)sortedarray)[m+maplen*v] = ((char **)array)[iodesc->remap[m]+maplen*v];
+		}
+	    }
+	    break;
+	default:
+	    return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
+	}
     }
     else
     {
-        switch (iodesc->piotype)
-        {
-        case PIO_BYTE:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((signed char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((signed char *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_CHAR:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((char *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_SHORT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((short *)sortedarray)[iodesc->remap[m]+maplen*v] = ((short *)array)[m+maplen*v];
-                }
-            }
+	switch (iodesc->piotype)
+	{
+	case PIO_BYTE:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((signed char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((signed char *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_CHAR:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((char *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_SHORT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((short *)sortedarray)[iodesc->remap[m]+maplen*v] = ((short *)array)[m+maplen*v];
+		}
+	    }
 
-            break;
-        case PIO_INT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((int *)sortedarray)[iodesc->remap[m]+maplen*v] = ((int *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_FLOAT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((float *)sortedarray)[iodesc->remap[m]+maplen*v] = ((float *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_DOUBLE:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((double *)sortedarray)[iodesc->remap[m]+maplen*v] = ((double *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_UBYTE:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((unsigned char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned char *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_USHORT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((unsigned short *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned short *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_UINT:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((unsigned int *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned int *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_INT64:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((long long *)sortedarray)[iodesc->remap[m]+maplen*v] = ((long long *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_UINT64:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((unsigned long long *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned long long *)array)[m+maplen*v];
-                }
-            }
-            break;
-        case PIO_STRING:
-            for (int v=0; v < nvars; v++)
-            {
-                for (int m=0; m < maplen; m++)
-                {
-                    ((char **)sortedarray)[iodesc->remap[m]+maplen*v] = ((char **)array)[m+maplen*v];
-                }
-            }
-            break;
-        default:
-            return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
-        }
+	    break;
+	case PIO_INT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((int *)sortedarray)[iodesc->remap[m]+maplen*v] = ((int *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_FLOAT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((float *)sortedarray)[iodesc->remap[m]+maplen*v] = ((float *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_DOUBLE:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((double *)sortedarray)[iodesc->remap[m]+maplen*v] = ((double *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UBYTE:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned char *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_USHORT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned short *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned short *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UINT:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned int *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned int *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_INT64:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((long long *)sortedarray)[iodesc->remap[m]+maplen*v] = ((long long *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_UINT64:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((unsigned long long *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned long long *)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	case PIO_STRING:
+	    for (int v=0; v < nvars; v++)
+	    {
+		for (int m=0; m < maplen; m++)
+		{
+		    ((char **)sortedarray)[iodesc->remap[m]+maplen*v] = ((char **)array)[m+maplen*v];
+		}
+	    }
+	    break;
+	default:
+	    return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
+	}
     }
     return PIO_NOERR;
 }
@@ -2150,26 +2152,26 @@ compute_maxaggregate_bytes(iosystem_desc_t *ios, io_desc_t *iodesc)
     pioassert(iodesc, "invalid input", __FILE__, __LINE__);
 
     PLOG((2, "compute_maxaggregate_bytes iodesc->maxiobuflen = %d iodesc->ndof = %d",
-          iodesc->maxiobuflen, iodesc->ndof));
+	  iodesc->maxiobuflen, iodesc->ndof));
 
     /* Determine the max bytes that can be held on IO task. */
     if (ios->ioproc && iodesc->maxiobuflen > 0)
-        maxbytesoniotask = pio_buffer_size_limit / iodesc->maxiobuflen;
+	maxbytesoniotask = pio_buffer_size_limit / iodesc->maxiobuflen;
 
     /* Determine the max bytes that can be held on computation task. */
     if (ios->comp_rank >= 0 && iodesc->ndof > 0)
-        maxbytesoncomputetask = pio_cnbuffer_limit / iodesc->ndof;
+	maxbytesoncomputetask = pio_cnbuffer_limit / iodesc->ndof;
 
     /* Take the min of the max IO and max comp bytes. */
     maxbytes = min(maxbytesoniotask, maxbytesoncomputetask);
     PLOG((2, "compute_maxaggregate_bytes maxbytesoniotask = %d maxbytesoncomputetask = %d",
-          maxbytesoniotask, maxbytesoncomputetask));
+	  maxbytesoniotask, maxbytesoncomputetask));
 
     /* Get the min value of this on all tasks. */
     PLOG((3, "before allreaduce maxbytes = %d", maxbytes));
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxbytes, 1, MPI_INT, MPI_MIN,
-                                ios->union_comm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+				ios->union_comm)))
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     PLOG((3, "after allreaduce maxbytes = %d", maxbytes));
 
     /* Remember the result. */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -636,7 +636,6 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
                                 if((mpierr = MPI_Type_free(&filetype)))
                                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
                             }
-fg
                             vard_llen = 0; /* reset request size to 0 */
                             numReqs = 0;
                         }

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -42,7 +42,7 @@ bpool_free(void *p)
 {
     free(p);
     if(p == CN_bpool){
-	CN_bpool = NULL;
+        CN_bpool = NULL;
     }
 }
 
@@ -60,30 +60,30 @@ bpool_free(void *p)
  */
 int
 get_gdim0(file_desc_t *file,io_desc_t *iodesc, int varid, int fndims,
-	  MPI_Offset *gdim0)
+          MPI_Offset *gdim0)
 {
     int ierr = PIO_NOERR;
 
     *gdim0 = 0;
     if (file->iotype == PIO_IOTYPE_PNETCDF && iodesc->ndims < fndims)
     {
-	int numunlimdims;
+        int numunlimdims;
 
-	/* We need to confirm the file has an unlimited dimension and
-	   if it doesn't we need to find the extent of the first
-	   variable dimension. */
-	PLOG((3,"look for numunlimdims"));
-	if ((ierr = PIOc_inq_unlimdims(file->pio_ncid, &numunlimdims, NULL)))
-	    return check_netcdf(file, ierr, __FILE__, __LINE__);
-	PLOG((3,"numunlimdims = %d", numunlimdims));
-	if (numunlimdims <= 0)
-	{
-	    int dimids[fndims];
-	    if ((ierr = PIOc_inq_vardimid(file->pio_ncid, varid, dimids)))
-		return check_netcdf(file, ierr, __FILE__, __LINE__);
-	    if ((ierr = PIOc_inq_dimlen(file->pio_ncid, dimids[0], gdim0)))
-		return check_netcdf(file, ierr, __FILE__, __LINE__);
-	}
+        /* We need to confirm the file has an unlimited dimension and
+           if it doesn't we need to find the extent of the first
+           variable dimension. */
+        PLOG((3,"look for numunlimdims"));
+        if ((ierr = PIOc_inq_unlimdims(file->pio_ncid, &numunlimdims, NULL)))
+            return check_netcdf(file, ierr, __FILE__, __LINE__);
+        PLOG((3,"numunlimdims = %d", numunlimdims));
+        if (numunlimdims <= 0)
+        {
+            int dimids[fndims];
+            if ((ierr = PIOc_inq_vardimid(file->pio_ncid, varid, dimids)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+            if ((ierr = PIOc_inq_dimlen(file->pio_ncid, dimids[0], gdim0)))
+                return check_netcdf(file, ierr, __FILE__, __LINE__);
+        }
     }
     PLOG((3,"gdim0 = %d",*gdim0));
     return ierr;
@@ -110,9 +110,9 @@ get_gdim0(file_desc_t *file,io_desc_t *iodesc, int varid, int fndims,
  */
 static
 int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdimoffset,
-			 int rrcnt, int ndims, int fndims,
-			 int frame, PIO_Offset **startlist, PIO_Offset **countlist,
-			 MPI_Datatype *filetype)
+                         int rrcnt, int ndims, int fndims,
+                         int frame, PIO_Offset **startlist, PIO_Offset **countlist,
+                         MPI_Datatype *filetype)
 {
 
     int sa_ndims;
@@ -129,126 +129,126 @@ int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdi
     *filetype = MPI_DATATYPE_NULL;
 
     if(rrcnt == 0)
-	return PIO_NOERR;
+        return PIO_NOERR;
 
     for ( int rc=0; rc<rrcnt; rc++)
     {
-	displacements[rc] = 0;
-	blocklengths[rc] = 1;
-	subarray[rc] = MPI_DATATYPE_NULL;
+        displacements[rc] = 0;
+        blocklengths[rc] = 1;
+        subarray[rc] = MPI_DATATYPE_NULL;
     }
     if(fndims > ndims)
     {
-	if ( gdim0 > 0)
-	{
-	    gdims[0] = gdim0;
-	    sa_ndims = fndims;
-	    dim_offset = 0;
-	    for (int i=1; i < fndims; i++)
-		gdims[i] = iodesc->dimlen[i-1];
-	}
-	else
-	{
-	    sa_ndims = ndims;
-	    dim_offset = 1;
-	    for (int i=0; i < ndims; i++)
-		gdims[i] = iodesc->dimlen[i];
-	}
+        if ( gdim0 > 0)
+        {
+            gdims[0] = gdim0;
+            sa_ndims = fndims;
+            dim_offset = 0;
+            for (int i=1; i < fndims; i++)
+                gdims[i] = iodesc->dimlen[i-1];
+        }
+        else
+        {
+            sa_ndims = ndims;
+            dim_offset = 1;
+            for (int i=0; i < ndims; i++)
+                gdims[i] = iodesc->dimlen[i];
+        }
     }
     else
     {
-	sa_ndims = fndims;
-	dim_offset = 0;
-	for (int i=0; i < fndims; i++)
-	    gdims[i] = iodesc->dimlen[i];
+        sa_ndims = fndims;
+        dim_offset = 0;
+        for (int i=0; i < fndims; i++)
+            gdims[i] = iodesc->dimlen[i];
     }
 
     int true_rrcnt=-1; /* true number of contiguous requests */
     MPI_Aint prev_end=-1; /* end offset of rc-1 request */
     for( int rc=0; rc<rrcnt; rc++)
     {
-	int sacount[fndims];
-	int sastart[fndims];
-	for (int i=dim_offset; i< fndims; i++)
-	{
-	    sacount[i-dim_offset] = (int) countlist[rc][i];
-	    sastart[i-dim_offset] = (int) startlist[rc][i];
-	}
-	if(gdim0 > 0)
-	{
-	    unlimdimoffset = gdim0;
-	    sastart[0] = max(0, frame);
-	    displacements[rc]=0;
-	}
-	else
-	    displacements[rc] = unlimdimoffset * max(0, frame);
+        int sacount[fndims];
+        int sastart[fndims];
+        for (int i=dim_offset; i< fndims; i++)
+        {
+            sacount[i-dim_offset] = (int) countlist[rc][i];
+            sastart[i-dim_offset] = (int) startlist[rc][i];
+        }
+        if(gdim0 > 0)
+        {
+            unlimdimoffset = gdim0;
+            sastart[0] = max(0, frame);
+            displacements[rc]=0;
+        }
+        else
+            displacements[rc] = unlimdimoffset * max(0, frame);
 
-	/* Check whether this request is actually contiguous. If contiguous,
-	 * we do not need to create an MPI derived datatype.
-	 */
-	int blocklen=1, isContig=1, warnContig=0;
-	MPI_Aint disp=0, shape=iodesc->mpitype_size;
-	for (int i=sa_ndims-1; i>=0; i--)
-	{
-	    if (isContig) {
-		/* blocklen is the amount of this request, rc */
-		blocklen *= sacount[i];
-		/* disp is the flattened starting array index */
-		disp += sastart[i] * shape;
-		/* shape is the dimension product from sa_ndims-1 to i */
-		shape *= gdims[i];
+        /* Check whether this request is actually contiguous. If contiguous,
+         * we do not need to create an MPI derived datatype.
+         */
+        int blocklen=1, isContig=1, warnContig=0;
+        MPI_Aint disp=0, shape=iodesc->mpitype_size;
+        for (int i=sa_ndims-1; i>=0; i--)
+        {
+            if (isContig) {
+                /* blocklen is the amount of this request, rc */
+                blocklen *= sacount[i];
+                /* disp is the flattened starting array index */
+                disp += sastart[i] * shape;
+                /* shape is the dimension product from sa_ndims-1 to i */
+                shape *= gdims[i];
 
-		if (warnContig == 0) {
-		    if (sacount[i] < gdims[i])
-			/* first i detected to access partial dimension. If this
-			 * one is contiguous, the remaining sacount[i-1 ... 0]
-			 * must all == 1 */
-			warnContig = 1; /* possible non-contiguos */
-		}
-		else if (sacount[i] != 1) {
-		    isContig = 0;
-		    break; /* loop i */
-		}
-	    }
-	}
-	/* if this is a record variable, add the gap of record size */
-	disp += _unlimdimoffset * max(0, frame);
+                if (warnContig == 0) {
+                    if (sacount[i] < gdims[i])
+                        /* first i detected to access partial dimension. If this
+                         * one is contiguous, the remaining sacount[i-1 ... 0]
+                         * must all == 1 */
+                        warnContig = 1; /* possible non-contiguos */
+                }
+                else if (sacount[i] != 1) {
+                    isContig = 0;
+                    break; /* loop i */
+                }
+            }
+        }
+        /* if this is a record variable, add the gap of record size */
+        disp += _unlimdimoffset * max(0, frame);
 
 #if PIO_ENABLE_LOGGING
-	for (int i=0; i< sa_ndims; i++)
-	    PLOG((3, "vard: sastart[%d]=%d sacount[%d]=%d gdims[%d]=%d %ld %ld displacement = %ld un %d",
-		  i,sastart[i], i,sacount[i], i, gdims[i], startlist[rc][i], countlist[rc][i], displacements[rc], unlimdimoffset));
+        for (int i=0; i< sa_ndims; i++)
+            PLOG((3, "vard: sastart[%d]=%d sacount[%d]=%d gdims[%d]=%d %ld %ld displacement = %ld un %d",
+                  i,sastart[i], i,sacount[i], i, gdims[i], startlist[rc][i], countlist[rc][i], displacements[rc], unlimdimoffset));
 #endif
-	if (isContig) { /* this request rc is contiguous, no need to create a new MPI datatype */
-	    if (prev_end == disp) {
-		/* this request rc can be coalesced into the previous
-		 * displacements and blocklengths.
-		 */
-		blocklengths[true_rrcnt] += blocklen;
-		prev_end += blocklen;
-	    }
-	    else {
-		/* this request cannot be coalesced with the previous one */
-		true_rrcnt++;
-		subarray[true_rrcnt] = iodesc->mpitype;
-		displacements[true_rrcnt] = disp;
-		blocklengths[true_rrcnt] = blocklen;
-		prev_end = disp + blocklen;
-	    }
-	}
-	else { /* request rc is not contiguous, must create a new MPI datatype */
-	    true_rrcnt++;
-	    if((mpierr = MPI_Type_create_subarray(sa_ndims, gdims,
-						  sacount, sastart,MPI_ORDER_C
-						  ,iodesc->mpitype, subarray + true_rrcnt)))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if (isContig) { /* this request rc is contiguous, no need to create a new MPI datatype */
+            if (prev_end == disp) {
+                /* this request rc can be coalesced into the previous
+                 * displacements and blocklengths.
+                 */
+                blocklengths[true_rrcnt] += blocklen;
+                prev_end += blocklen;
+            }
+            else {
+                /* this request cannot be coalesced with the previous one */
+                true_rrcnt++;
+                subarray[true_rrcnt] = iodesc->mpitype;
+                displacements[true_rrcnt] = disp;
+                blocklengths[true_rrcnt] = blocklen;
+                prev_end = disp + blocklen;
+            }
+        }
+        else { /* request rc is not contiguous, must create a new MPI datatype */
+            true_rrcnt++;
+            if((mpierr = MPI_Type_create_subarray(sa_ndims, gdims,
+                                                  sacount, sastart,MPI_ORDER_C
+                                                  ,iodesc->mpitype, subarray + true_rrcnt)))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-	    if((mpierr = MPI_Type_commit(subarray + true_rrcnt)))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	}
+            if((mpierr = MPI_Type_commit(subarray + true_rrcnt)))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        }
 
 #if PIO_ENABLE_LOGGING
-	PLOG((3,"vard: blocklengths[%d]=%d displacement[%d]=%ld unlimdimoffset=%ld",rc,blocklengths[rc], rc, displacements[rc], unlimdimoffset));
+        PLOG((3,"vard: blocklengths[%d]=%d displacement[%d]=%ld unlimdimoffset=%ld",rc,blocklengths[rc], rc, displacements[rc], unlimdimoffset));
 #endif
 
     }
@@ -256,15 +256,15 @@ int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdi
 
     /* concatenate all MPI datatypes into filetype */
     if((mpierr = MPI_Type_create_struct(true_rrcnt, blocklengths, displacements, subarray, filetype)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     if((mpierr = MPI_Type_commit(filetype)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     for( int rc=0; rc<true_rrcnt; rc++)
-	if (subarray[rc] != MPI_DATATYPE_NULL && subarray[rc] != iodesc->mpitype &&
-	    (mpierr = MPI_Type_free(subarray + rc)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if (subarray[rc] != MPI_DATATYPE_NULL && subarray[rc] != iodesc->mpitype &&
+            (mpierr = MPI_Type_free(subarray + rc)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -290,56 +290,56 @@ int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdi
  */
 int
 find_start_count(int ndims, int fndims, var_desc_t *vdesc,
-		 io_region *region, const int *frame, size_t *start,
-		 size_t *count)
+                 io_region *region, const int *frame, size_t *start,
+                 size_t *count)
 {
     /* Init start/count arrays to zero. */
     for (int i = 0; i < fndims; i++)
     {
-	start[i] = 0;
-	count[i] = 0;
+        start[i] = 0;
+        count[i] = 0;
     }
 
     if (region)
     {
-	if (vdesc->record >= 0)
-	{
-	    /* This is a record based multidimensional
-	     * array. Figure out start/count for all but the
-	     * record dimension (dimid 0). */
-	    for (int i = fndims - ndims; i < fndims; i++)
-	    {
-		start[i] = region->start[i - (fndims - ndims)];
-		count[i] = region->count[i - (fndims - ndims)];
-	    }
+        if (vdesc->record >= 0)
+        {
+            /* This is a record based multidimensional
+             * array. Figure out start/count for all but the
+             * record dimension (dimid 0). */
+            for (int i = fndims - ndims; i < fndims; i++)
+            {
+                start[i] = region->start[i - (fndims - ndims)];
+                count[i] = region->count[i - (fndims - ndims)];
+            }
 
-	    /* Now figure out start/count for record dimension. */
-	    if (fndims > 1 && ndims < fndims && count[1] > 0)
-	    {
-		count[0] = 1;
-		start[0] = frame[0];
-	    }
-	    else if (fndims == ndims)
-	    {
-		/* In some cases the unlimited dim is not treated as
-		   the pio record dim */
-		start[0] += vdesc->record;
-	    }
-	}
-	else
-	{
-	    /* This is a non record variable. */
-	    for (int i = 0; i < ndims; i++)
-	    {
-		start[i] = region->start[i];
-		count[i] = region->count[i];
-	    }
-	}
+            /* Now figure out start/count for record dimension. */
+            if (fndims > 1 && ndims < fndims && count[1] > 0)
+            {
+                count[0] = 1;
+                start[0] = frame[0];
+            }
+            else if (fndims == ndims)
+            {
+                /* In some cases the unlimited dim is not treated as
+                   the pio record dim */
+                start[0] += vdesc->record;
+            }
+        }
+        else
+        {
+            /* This is a non record variable. */
+            for (int i = 0; i < ndims; i++)
+            {
+                start[i] = region->start[i];
+                count[i] = region->count[i];
+            }
+        }
 
 #if PIO_ENABLE_LOGGING
-	/* Log arrays for debug purposes. */
-	for (int i = 0; i < ndims; i++)
-	    PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
+        /* Log arrays for debug purposes. */
+        for (int i = 0; i < ndims; i++)
+            PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
@@ -367,7 +367,7 @@ find_start_count(int ndims, int fndims, var_desc_t *vdesc,
  */
 int
 write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *varids,
-		       io_desc_t *iodesc, int fill, const int *frame)
+                       io_desc_t *iodesc, int fill, const int *frame)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;    /* Pointer to var info struct. */
@@ -382,16 +382,16 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
 #endif
     /* Check inputs. */
     pioassert(file && file->iosystem && varids && varids[0] >= 0 && varids[0] <= PIO_MAX_VARS &&
-	      iodesc, "invalid input", __FILE__, __LINE__);
+              iodesc, "invalid input", __FILE__, __LINE__);
 
     PLOG((1, "write_darray_multi_par nvars = %d iodesc->ndims = %d iodesc->mpitype = %d "
-	  "iodesc->maxregions = %d iodesc->llen = %d", nvars, iodesc->ndims,
-	  iodesc->mpitype, iodesc->maxregions, iodesc->llen));
+          "iodesc->maxregions = %d iodesc->llen = %d", nvars, iodesc->ndims,
+          iodesc->mpitype, iodesc->maxregions, iodesc->llen));
 
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ierr = pio_start_timer("PIO:write_darray_multi_par")))
-	return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Get pointer to iosystem. */
@@ -399,7 +399,7 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
 
     /* Point to var description scruct for first var. */
     if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
-	return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Set these differently for data and fill writing. */
     int num_regions = fill ? iodesc->maxfillregions: iodesc->maxregions;
@@ -410,8 +410,8 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
 #if USE_VARD_WRITE
     if (!ios->async || !ios->ioproc)
     {
-	if ((ierr = get_gdim0(file, iodesc, varids[0], fndims, &gdim0)))
-	    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+        if ((ierr = get_gdim0(file, iodesc, varids[0], fndims, &gdim0)))
+            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     }
 #endif
@@ -419,271 +419,271 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
     /* If this is an IO task write the data. */
     if (ios->ioproc)
     {
-	void *bufptr;
-	size_t start[fndims];
-	size_t count[fndims];
-	int ndims = iodesc->ndims;
+        void *bufptr;
+        size_t start[fndims];
+        size_t count[fndims];
+        int ndims = iodesc->ndims;
 #ifdef _PNETCDF
-	int rrcnt = 0; /* Number of subarray requests (pnetcdf only). */
-	PIO_Offset *startlist[num_regions]; /* Array of start arrays for ncmpi_iput_varn(). */
-	PIO_Offset *countlist[num_regions]; /* Array of count  arrays for ncmpi_iput_varn(). */
+        int rrcnt = 0; /* Number of subarray requests (pnetcdf only). */
+        PIO_Offset *startlist[num_regions]; /* Array of start arrays for ncmpi_iput_varn(). */
+        PIO_Offset *countlist[num_regions]; /* Array of count  arrays for ncmpi_iput_varn(). */
 #endif /* _PNETCDF */
 
-	/* Process each region of data to be written. */
-	for (int regioncnt = 0; regioncnt < num_regions; regioncnt++)
-	{
-	    /* Fill the start/count arrays. */
-	    if ((ierr = find_start_count(iodesc->ndims, fndims, vdesc, region, frame,
-					 start, count)))
-		return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        /* Process each region of data to be written. */
+        for (int regioncnt = 0; regioncnt < num_regions; regioncnt++)
+        {
+            /* Fill the start/count arrays. */
+            if ((ierr = find_start_count(iodesc->ndims, fndims, vdesc, region, frame,
+                                         start, count)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
-	    /* IO tasks will run the netCDF/pnetcdf functions to write the data. */
-	    switch (file->iotype)
-	    {
+            /* IO tasks will run the netCDF/pnetcdf functions to write the data. */
+            switch (file->iotype)
+            {
 #ifdef _NETCDF4
-	    case PIO_IOTYPE_NETCDF4P:
-		/* For each variable to be written. */
-		for (int nv = 0; nv < nvars; nv++)
-		{
-		    /* Set the start of the record dimension. (Hasn't
-		     * this already been set above ???) */
-		    if (vdesc->record >= 0 && ndims < fndims)
-			start[0] = frame[nv];
+            case PIO_IOTYPE_NETCDF4P:
+                /* For each variable to be written. */
+                for (int nv = 0; nv < nvars; nv++)
+                {
+                    /* Set the start of the record dimension. (Hasn't
+                     * this already been set above ???) */
+                    if (vdesc->record >= 0 && ndims < fndims)
+                        start[0] = frame[nv];
 
-		    /* If there is data for this region, get a pointer to it. */
-		    if (region)
-			bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * (nv * llen + region->loffset));
+                    /* If there is data for this region, get a pointer to it. */
+                    if (region)
+                        bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * (nv * llen + region->loffset));
 
-		    /* Ensure collective access. */
-		    ierr = nc_var_par_access(file->fh, varids[nv], NC_COLLECTIVE);
+                    /* Ensure collective access. */
+                    ierr = nc_var_par_access(file->fh, varids[nv], NC_COLLECTIVE);
 
-		    /* Write the data for this variable. */
-		    if (!ierr)
-			ierr = nc_put_vara(file->fh, varids[nv], (size_t *)start, (size_t *)count, bufptr);
-		}
-		break;
+                    /* Write the data for this variable. */
+                    if (!ierr)
+                        ierr = nc_put_vara(file->fh, varids[nv], (size_t *)start, (size_t *)count, bufptr);
+                }
+                break;
 #endif
 #ifdef _PNETCDF
-	    case PIO_IOTYPE_PNETCDF:
-		/* Get the total number of data elements we are
-		 * writing for this region. */
-		dsize = 1;
-		for (int i = 0; i < fndims; i++)
-		    dsize *= count[i];
-		PLOG((3, "dsize = %d", dsize));
+            case PIO_IOTYPE_PNETCDF:
+                /* Get the total number of data elements we are
+                 * writing for this region. */
+                dsize = 1;
+                for (int i = 0; i < fndims; i++)
+                    dsize *= count[i];
+                PLOG((3, "dsize = %d", dsize));
 
-		/* For pnetcdf's ncmpi_iput_varn() function, we need
-		 * to provide arrays of arrays for start/count. */
-		if (dsize > 0)
-		{
-		    /* Allocate storage for start/count arrays for
-		     * this region. */
-		    if (!(startlist[rrcnt] = calloc(fndims, sizeof(PIO_Offset))))
-			return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-		    if (!(countlist[rrcnt] = calloc(fndims, sizeof(PIO_Offset))))
-			return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+                /* For pnetcdf's ncmpi_iput_varn() function, we need
+                 * to provide arrays of arrays for start/count. */
+                if (dsize > 0)
+                {
+                    /* Allocate storage for start/count arrays for
+                     * this region. */
+                    if (!(startlist[rrcnt] = calloc(fndims, sizeof(PIO_Offset))))
+                        return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+                    if (!(countlist[rrcnt] = calloc(fndims, sizeof(PIO_Offset))))
+                        return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
-		    /* Copy the start/count arrays for this region. */
-		    for (int i = 0; i < fndims; i++)
-		    {
-			startlist[rrcnt][i] = start[i];
-			countlist[rrcnt][i] = count[i];
-			PLOG((3, "startlist[%d][%d] = %d countlist[%d][%d] = %d", rrcnt, i,
-			      startlist[rrcnt][i], rrcnt, i, countlist[rrcnt][i]));
-		    }
-		    rrcnt++;
-		}
+                    /* Copy the start/count arrays for this region. */
+                    for (int i = 0; i < fndims; i++)
+                    {
+                        startlist[rrcnt][i] = start[i];
+                        countlist[rrcnt][i] = count[i];
+                        PLOG((3, "startlist[%d][%d] = %d countlist[%d][%d] = %d", rrcnt, i,
+                              startlist[rrcnt][i], rrcnt, i, countlist[rrcnt][i]));
+                    }
+                    rrcnt++;
+                }
 
-		/* Do this when we reach the last region. */
-		if (regioncnt == num_regions - 1)
-		{
+                /* Do this when we reach the last region. */
+                if (regioncnt == num_regions - 1)
+                {
 #ifdef USE_VARD_WRITE
-		    MPI_Aint   var0_offset, var_offsets[nvars];
-		    MPI_Offset vari_offset, vard_llen=0;
-		    MPI_Datatype vartypes[nvars];
-		    MPI_Datatype filetype = MPI_DATATYPE_NULL;
-		    int blocklens[nvars];
-		    int fvartype, var0_id;
-		    int numReqs=0;
-		    void *vard_bufptr;
-		    int doFlush[nvars]; /* whether to flush or not */
+                    MPI_Aint   var0_offset, var_offsets[nvars];
+                    MPI_Offset vari_offset, vard_llen=0;
+                    MPI_Datatype vartypes[nvars];
+                    MPI_Datatype filetype = MPI_DATATYPE_NULL;
+                    int blocklens[nvars];
+                    int fvartype, var0_id;
+                    int numReqs=0;
+                    void *vard_bufptr;
+                    int doFlush[nvars]; /* whether to flush or not */
 
-		    /* construct doFlush[], so later when looping through nvars,
-		     * it tells whether to flush or not.
-		     */
-		    for (int nv = 0; nv < nvars; nv++) {
-			/* Get the var info. */
-			if ((ierr = get_var_desc(varids[nv], &file->varlist, &vdesc)))
-			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-			if (nv == 0) { /* first variable */
-			    fvartype = vdesc->pio_type; /* first var's var type */
-			    continue;
-			}
-			if (fvartype != vdesc->pio_type) {
-			    /* nv's external datatype is different from nv-1 */
-			    doFlush[nv-1] = 1;
-			    fvartype = vdesc->pio_type;
-			}
-			else /* same as nv-1, no flush */
-			    doFlush[nv-1] = 0;
-		    }
-		    doFlush[nvars-1] = 1; /* flush when reach the last variable */
+                    /* construct doFlush[], so later when looping through nvars,
+                     * it tells whether to flush or not.
+                     */
+                    for (int nv = 0; nv < nvars; nv++) {
+                        /* Get the var info. */
+                        if ((ierr = get_var_desc(varids[nv], &file->varlist, &vdesc)))
+                            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+                        if (nv == 0) { /* first variable */
+                            fvartype = vdesc->pio_type; /* first var's var type */
+                            continue;
+                        }
+                        if (fvartype != vdesc->pio_type) {
+                            /* nv's external datatype is different from nv-1 */
+                            doFlush[nv-1] = 1;
+                            fvartype = vdesc->pio_type;
+                        }
+                        else /* same as nv-1, no flush */
+                            doFlush[nv-1] = 0;
+                    }
+                    doFlush[nvars-1] = 1; /* flush when reach the last variable */
 #endif
-		    /* For each variable to be written. */
-		    for (int nv = 0; nv < nvars; nv++)
-		    {
+                    /* For each variable to be written. */
+                    for (int nv = 0; nv < nvars; nv++)
+                    {
 #if USE_VARD_WRITE
-			/* PnetCDF 1.10.0 and later support type conversion in
-			 * vard APIs. However, it requires all variables
-			 * accessed by the filetype are of the same NC data
-			 * type.
-			 */
+                        /* PnetCDF 1.10.0 and later support type conversion in
+                         * vard APIs. However, it requires all variables
+                         * accessed by the filetype are of the same NC data
+                         * type.
+                         */
 
-			/* obtain file offset of variable nv */
-			if ((ierr = ncmpi_inq_varoffset(file->fh, varids[nv], &vari_offset)))
-			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+                        /* obtain file offset of variable nv */
+                        if ((ierr = ncmpi_inq_varoffset(file->fh, varids[nv], &vari_offset)))
+                            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
-			if (numReqs == 0) { /* 1st variable of same datatype */
-			    var0_offset = vari_offset;
-			    var0_id = varids[nv];
-			}
-			/* calculate the offset relative to the first var */
-			var_offsets[numReqs] = vari_offset - var0_offset;
-			blocklens[nv] = 1; /* 1 for each vartypes[nv] */
+                        if (numReqs == 0) { /* 1st variable of same datatype */
+                            var0_offset = vari_offset;
+                            var0_id = varids[nv];
+                        }
+                        /* calculate the offset relative to the first var */
+                        var_offsets[numReqs] = vari_offset - var0_offset;
+                        blocklens[nv] = 1; /* 1 for each vartypes[nv] */
 
-			/* If this is the first variable or the frame has changed between variables (this should be rare) */
-			if(nv==0 || (nv > 0 && frame != NULL && frame[nv] != frame[nv-1])){
-			    int thisframe;
-			    PIO_Offset unlimdimoffset;
-			    if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
-			    {
-				if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
-				    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-				PLOG((3, "num_regions = %d unlimdimoffset %ld", num_regions, unlimdimoffset));
-			    }else
-				unlimdimoffset = gdim0;
-			    if (frame)
-				thisframe = frame[nv];
-			    else
-				thisframe = 0;
+                        /* If this is the first variable or the frame has changed between variables (this should be rare) */
+                        if(nv==0 || (nv > 0 && frame != NULL && frame[nv] != frame[nv-1])){
+                            int thisframe;
+                            PIO_Offset unlimdimoffset;
+                            if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
+                            {
+                                if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
+                                    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+                                PLOG((3, "num_regions = %d unlimdimoffset %ld", num_regions, unlimdimoffset));
+                            }else
+                                unlimdimoffset = gdim0;
+                            if (frame)
+                                thisframe = frame[nv];
+                            else
+                                thisframe = 0;
 
-			    ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
-							rrcnt, ndims, fndims,
-							thisframe, startlist, countlist,
-							&vartypes[numReqs]);
-			}
-			else /* reuse the previous variable's datatype */
-			    vartypes[numReqs] = vartypes[numReqs-1];
+                            ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
+                                                        rrcnt, ndims, fndims,
+                                                        thisframe, startlist, countlist,
+                                                        &vartypes[numReqs]);
+                        }
+                        else /* reuse the previous variable's datatype */
+                            vartypes[numReqs] = vartypes[numReqs-1];
 #else
-			/* Get the var info. */
-			if ((ierr = get_var_desc(varids[nv], &file->varlist, &vdesc)))
-			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+                        /* Get the var info. */
+                        if ((ierr = get_var_desc(varids[nv], &file->varlist, &vdesc)))
+                            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
-			if (vdesc->record >= 0 && ndims < fndims)
-			    for (int rc = 0; rc < rrcnt; rc++)
-				startlist[rc][0] = frame[nv];
+                        if (vdesc->record >= 0 && ndims < fndims)
+                            for (int rc = 0; rc < rrcnt; rc++)
+                                startlist[rc][0] = frame[nv];
 #endif
-			/* Get a pointer to the data. */
-			bufptr = (void *)((char *)iobuf + nv * iodesc->mpitype_size * llen);
+                        /* Get a pointer to the data. */
+                        bufptr = (void *)((char *)iobuf + nv * iodesc->mpitype_size * llen);
 
 #if USE_VARD_WRITE
-			if (numReqs == 0) { /* first var of the same type */
-			    vard_bufptr = bufptr; /* preserve variable ID */
-			    vard_llen = llen;     /* reset I/O request size */
-			}
-			numReqs++;
+                        if (numReqs == 0) { /* first var of the same type */
+                            vard_bufptr = bufptr; /* preserve variable ID */
+                            vard_llen = llen;     /* reset I/O request size */
+                        }
+                        numReqs++;
 
-			if (doFlush[nv]) { /* flush the data now */
-			    int mpierr;
-			    /* concatenate vartypes[0...numReqs-1] */
-			    if (numReqs > 1) {
-				/* check and remove NULL vartype */
-				int i, j=0;
-				for (i=0; i<numReqs; i++) {
-				    if (vartypes[i] != MPI_DATATYPE_NULL) {
-					if (j < i) vartypes[j] = vartypes[i];
-					j++;
-				    }
-				}
-				if (j > 0) { /* at least one vartypes[] is not NULL */
-				    /* concatenate non-NULL vartypes */
-				    if((mpierr = MPI_Type_create_struct(j, blocklens, var_offsets, vartypes, &filetype)))
-					return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                        if (doFlush[nv]) { /* flush the data now */
+                            int mpierr;
+                            /* concatenate vartypes[0...numReqs-1] */
+                            if (numReqs > 1) {
+                                /* check and remove NULL vartype */
+                                int i, j=0;
+                                for (i=0; i<numReqs; i++) {
+                                    if (vartypes[i] != MPI_DATATYPE_NULL) {
+                                        if (j < i) vartypes[j] = vartypes[i];
+                                        j++;
+                                    }
+                                }
+                                if (j > 0) { /* at least one vartypes[] is not NULL */
+                                    /* concatenate non-NULL vartypes */
+                                    if((mpierr = MPI_Type_create_struct(j, blocklens, var_offsets, vartypes, &filetype)))
+                                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-				    if((mpierr = MPI_Type_commit(&filetype)))
-					return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                                    if((mpierr = MPI_Type_commit(&filetype)))
+                                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-				    /* free vartypes */
-				    for (i=j-1; i>0; i--) {
-					if (vartypes[i] == vartypes[i-1]) continue;
-					if((mpierr = MPI_Type_free(&vartypes[i])))
-					    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-				    }
-				    if((mpierr = MPI_Type_free(&vartypes[0])))
-					return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-				}
-				else /* all vartypes[] are NULL */
-				    filetype = MPI_DATATYPE_NULL;
-			    }
-			    else /* there is only one variable to flush */
-				filetype = vartypes[0];
+                                    /* free vartypes */
+                                    for (i=j-1; i>0; i--) {
+                                        if (vartypes[i] == vartypes[i-1]) continue;
+                                        if((mpierr = MPI_Type_free(&vartypes[i])))
+                                            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                                    }
+                                    if((mpierr = MPI_Type_free(&vartypes[0])))
+                                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                                }
+                                else /* all vartypes[] are NULL */
+                                    filetype = MPI_DATATYPE_NULL;
+                            }
+                            else /* there is only one variable to flush */
+                                filetype = vartypes[0];
 
-			    PLOG((3, "vard: call ncmpi_put_vard llen = %d %d", llen, iodesc->mpitype_size ));
-			    ierr = ncmpi_put_vard_all(file->fh, var0_id, filetype, vard_bufptr, vard_llen, iodesc->mpitype);
-			    PLOG((3, "vard: return ncmpi_put_vard ierr = %d", ierr));
-			    if(filetype != MPI_DATATYPE_NULL)
-			    {
-				if((mpierr = MPI_Type_free(&filetype)))
-				    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-			    }
+                            PLOG((3, "vard: call ncmpi_put_vard llen = %d %d", llen, iodesc->mpitype_size ));
+                            ierr = ncmpi_put_vard_all(file->fh, var0_id, filetype, vard_bufptr, vard_llen, iodesc->mpitype);
+                            PLOG((3, "vard: return ncmpi_put_vard ierr = %d", ierr));
+                            if(filetype != MPI_DATATYPE_NULL)
+                            {
+                                if((mpierr = MPI_Type_free(&filetype)))
+                                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                            }
 fg
-			    vard_llen = 0; /* reset request size to 0 */
-			    numReqs = 0;
-			}
-			else /* don't flush yet, accumulate the request size */
-			    vard_llen += llen;
+                            vard_llen = 0; /* reset request size to 0 */
+                            numReqs = 0;
+                        }
+                        else /* don't flush yet, accumulate the request size */
+                            vard_llen += llen;
 #else
-			if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
-			{
-			    if (!(vdesc->request = realloc(vdesc->request, sizeof(int) *
-							   (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
-				return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+                        if (vdesc->nreqs % PIO_REQUEST_ALLOC_CHUNK == 0)
+                        {
+                            if (!(vdesc->request = realloc(vdesc->request, sizeof(int) *
+                                                           (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
+                                return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
-			    for (int i = vdesc->nreqs; i < vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK; i++)
-				vdesc->request[i] = NC_REQ_NULL;
-			}
+                            for (int i = vdesc->nreqs; i < vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK; i++)
+                                vdesc->request[i] = NC_REQ_NULL;
+                        }
 
-			/* Write, in non-blocking fashion, a list of subarrays. */
-			PLOG((3, "about to call ncmpi_iput_varn() varids[%d] = %d rrcnt = %d, llen = %d",
-			      nv, varids[nv], rrcnt, llen));
-			ierr = ncmpi_iput_varn(file->fh, varids[nv], rrcnt, startlist, countlist,
-					       bufptr, llen, iodesc->mpitype, &vdesc->request[vdesc->nreqs]);
+                        /* Write, in non-blocking fashion, a list of subarrays. */
+                        PLOG((3, "about to call ncmpi_iput_varn() varids[%d] = %d rrcnt = %d, llen = %d",
+                              nv, varids[nv], rrcnt, llen));
+                        ierr = ncmpi_iput_varn(file->fh, varids[nv], rrcnt, startlist, countlist,
+                                               bufptr, llen, iodesc->mpitype, &vdesc->request[vdesc->nreqs]);
 
-			/* keeps wait calls in sync */
-			if (vdesc->request[vdesc->nreqs] == NC_REQ_NULL)
-			    vdesc->request[vdesc->nreqs] = PIO_REQ_NULL;
+                        /* keeps wait calls in sync */
+                        if (vdesc->request[vdesc->nreqs] == NC_REQ_NULL)
+                            vdesc->request[vdesc->nreqs] = PIO_REQ_NULL;
 
-			vdesc->nreqs++;
+                        vdesc->nreqs++;
 #endif
-		    }
+                    }
 
-		    /* Free resources. */
-		    for (int i = 0; i < rrcnt; i++)
-		    {
-			free(startlist[i]);
-			free(countlist[i]);
-		    }
-		}
-		break;
+                    /* Free resources. */
+                    for (int i = 0; i < rrcnt; i++)
+                    {
+                        free(startlist[i]);
+                        free(countlist[i]);
+                    }
+                }
+                break;
 #endif
-	    default:
-		return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
-	    }
+            default:
+                return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
+            }
 
-	    /* Go to next region. */
-	    if (region)
-		region = region->next;
-	} /* next regioncnt */
+            /* Go to next region. */
+            if (region)
+                region = region->next;
+        } /* next regioncnt */
     } /* endif (ios->ioproc) */
 
     /* Check the return code from the netCDF/pnetcdf call. */
@@ -691,7 +691,7 @@ fg
 
 #ifdef TIMING
     if ((ierr = pio_stop_timer("PIO:write_darray_multi_par")))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return ierr;
@@ -722,56 +722,56 @@ fg
  **/
 int
 find_all_start_count(io_region *region, int maxregions, int fndims,
-		     int iodesc_ndims, var_desc_t *vdesc, size_t *tmp_start,
-		     size_t *tmp_count)
+                     int iodesc_ndims, var_desc_t *vdesc, size_t *tmp_start,
+                     size_t *tmp_count)
 {
     /* Check inputs. */
     pioassert(maxregions >= 0 && fndims > 0 && iodesc_ndims >= 0 && vdesc &&
-	      tmp_start && tmp_count, "invalid input", __FILE__, __LINE__);
+              tmp_start && tmp_count, "invalid input", __FILE__, __LINE__);
 
     /* Find the start/count arrays for each region in the list. */
     for (int r = 0; r < maxregions; r++)
     {
-	/* Initialize the start/count arrays for this region to 0. */
-	for (int d = 0; d < fndims; d++)
-	{
-	    tmp_start[d + r * fndims] = 0;
-	    tmp_count[d + r * fndims] = 0;
-	}
+        /* Initialize the start/count arrays for this region to 0. */
+        for (int d = 0; d < fndims; d++)
+        {
+            tmp_start[d + r * fndims] = 0;
+            tmp_count[d + r * fndims] = 0;
+        }
 
-	if (region)
-	{
-	    if (vdesc->record >= 0)
-	    {
-		/* This is a record based multidimensional
-		 * array. Copy start/count for non-record
-		 * dimensions. */
-		for (int i = fndims - iodesc_ndims; i < fndims; i++)
-		{
-		    tmp_start[i + r * fndims] = region->start[i - (fndims - iodesc_ndims)];
-		    tmp_count[i + r * fndims] = region->count[i - (fndims - iodesc_ndims)];
-		    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
-			  tmp_start[i + r * fndims], i + r * fndims,
-			  tmp_count[i + r * fndims]));
-		}
-	    }
-	    else
-	    {
-		/* This is not a record based multidimensional array. */
-		for (int i = 0; i < iodesc_ndims; i++)
-		{
-		    tmp_start[i + r * fndims] = region->start[i];
-		    tmp_count[i + r * fndims] = region->count[i];
-		    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
-			  tmp_start[i + r * fndims], i + r * fndims,
-			  tmp_count[i + r * fndims]));
-		}
-	    }
+        if (region)
+        {
+            if (vdesc->record >= 0)
+            {
+                /* This is a record based multidimensional
+                 * array. Copy start/count for non-record
+                 * dimensions. */
+                for (int i = fndims - iodesc_ndims; i < fndims; i++)
+                {
+                    tmp_start[i + r * fndims] = region->start[i - (fndims - iodesc_ndims)];
+                    tmp_count[i + r * fndims] = region->count[i - (fndims - iodesc_ndims)];
+                    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
+                          tmp_start[i + r * fndims], i + r * fndims,
+                          tmp_count[i + r * fndims]));
+                }
+            }
+            else
+            {
+                /* This is not a record based multidimensional array. */
+                for (int i = 0; i < iodesc_ndims; i++)
+                {
+                    tmp_start[i + r * fndims] = region->start[i];
+                    tmp_count[i + r * fndims] = region->count[i];
+                    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
+                          tmp_start[i + r * fndims], i + r * fndims,
+                          tmp_count[i + r * fndims]));
+                }
+            }
 
-	    /* Move to next region. */
-	    region = region->next;
+            /* Move to next region. */
+            region = region->next;
 
-	} /* endif region */
+        } /* endif region */
     } /* next r */
 
     return PIO_NOERR;
@@ -790,8 +790,8 @@ find_all_start_count(io_region *region, int maxregions, int fndims,
  */
 int
 send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset llen,
-		     int maxregions, int nvars, int fndims, size_t *tmp_start,
-		     size_t *tmp_count, void *iobuf)
+                     int maxregions, int nvars, int fndims, size_t *tmp_start,
+                     size_t *tmp_count, void *iobuf)
 {
     MPI_Status status;     /* Recv status for MPI. */
     int mpierr;  /* Return code from MPI function codes. */
@@ -799,35 +799,35 @@ send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset llen,
 
     /* Check inputs. */
     pioassert(ios && ios->ioproc && ios->io_rank > 0 && maxregions >= 0,
-	      "invalid inputs", __FILE__, __LINE__);
+              "invalid inputs", __FILE__, __LINE__);
 
     /* Do a handshake. */
     if ((mpierr = MPI_Recv(&ierr, 1, MPI_INT, 0, 0, ios->io_comm, &status)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Send local length of iobuffer for each field (all
      * fields are the same length). */
     if ((mpierr = MPI_Send((void *)&llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     PLOG((3, "sent llen = %d", llen));
 
     /* Send the number of data regions, the start/count for
      * all regions, and the data buffer with all the data. */
     if (llen > 0)
     {
-	if ((mpierr = MPI_Send((void *)&maxregions, 1, MPI_INT, 0, ios->io_rank + ios->num_iotasks,
-			       ios->io_comm)))
-	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Send(tmp_start, maxregions * fndims, MPI_OFFSET, 0,
-			       ios->io_rank + 2 * ios->num_iotasks, ios->io_comm)))
-	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Send(tmp_count, maxregions * fndims, MPI_OFFSET, 0,
-			       ios->io_rank + 3 * ios->num_iotasks, ios->io_comm)))
-	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Send(iobuf, nvars * llen, iodesc->mpitype, 0,
-			       ios->io_rank + 4 * ios->num_iotasks, ios->io_comm)))
-	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-	PLOG((3, "sent data for maxregions = %d", maxregions));
+        if ((mpierr = MPI_Send((void *)&maxregions, 1, MPI_INT, 0, ios->io_rank + ios->num_iotasks,
+                               ios->io_comm)))
+            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Send(tmp_start, maxregions * fndims, MPI_OFFSET, 0,
+                               ios->io_rank + 2 * ios->num_iotasks, ios->io_comm)))
+            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Send(tmp_count, maxregions * fndims, MPI_OFFSET, 0,
+                               ios->io_rank + 3 * ios->num_iotasks, ios->io_comm)))
+            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Send(iobuf, nvars * llen, iodesc->mpitype, 0,
+                               ios->io_rank + 4 * ios->num_iotasks, ios->io_comm)))
+            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        PLOG((3, "sent data for maxregions = %d", maxregions));
     }
 
     return PIO_NOERR;
@@ -870,8 +870,8 @@ send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset llen,
  */
 int
 recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
-		    io_desc_t *iodesc, PIO_Offset llen, int maxregions, int nvars,
-		    int fndims, size_t *tmp_start, size_t *tmp_count, void *iobuf)
+                    io_desc_t *iodesc, PIO_Offset llen, int maxregions, int nvars,
+                    int fndims, size_t *tmp_start, size_t *tmp_count, void *iobuf)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     size_t rlen;    /* Length of IO buffer on this task. */
@@ -886,10 +886,10 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
 
     /* Check inputs. */
     pioassert(file && varids && iodesc && tmp_start && tmp_count, "invalid input",
-	      __FILE__, __LINE__);
+              __FILE__, __LINE__);
 
     PLOG((2, "recv_and_write_data llen = %d maxregions = %d nvars = %d fndims = %d",
-	  llen, maxregions, nvars, fndims));
+          llen, maxregions, nvars, fndims));
 
     /* Get pointer to IO system. */
     ios = file->iosystem;
@@ -898,112 +898,112 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
      * for IO. */
     for (int rtask = 0; rtask < ios->num_iotasks; rtask++)
     {
-	/* From the remote tasks, we send information about
-	 * the data regions. and also the data. */
-	if (rtask)
-	{
-	    /* handshake - tell the sending task I'm ready */
-	    if ((mpierr = MPI_Send(&ierr, 1, MPI_INT, rtask, 0, ios->io_comm)))
-		return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        /* From the remote tasks, we send information about
+         * the data regions. and also the data. */
+        if (rtask)
+        {
+            /* handshake - tell the sending task I'm ready */
+            if ((mpierr = MPI_Send(&ierr, 1, MPI_INT, rtask, 0, ios->io_comm)))
+                return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-	    /* Get length of iobuffer for each field on this
-	     * task (all fields are the same length). */
-	    if ((mpierr = MPI_Recv(&rlen, 1, MPI_OFFSET, rtask, rtask, ios->io_comm,
-				   &status)))
-		return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-	    PLOG((3, "received rlen = %d", rlen));
+            /* Get length of iobuffer for each field on this
+             * task (all fields are the same length). */
+            if ((mpierr = MPI_Recv(&rlen, 1, MPI_OFFSET, rtask, rtask, ios->io_comm,
+                                   &status)))
+                return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+            PLOG((3, "received rlen = %d", rlen));
 
-	    /* Get the number of regions, the start/count
-	     * values for all regions, and the data buffer. */
-	    if (rlen > 0)
-	    {
-		if ((mpierr = MPI_Recv(&rregions, 1, MPI_INT, rtask, rtask + ios->num_iotasks,
-				       ios->io_comm, &status)))
-		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-		if ((mpierr = MPI_Recv(tmp_start, rregions * fndims, MPI_OFFSET, rtask,
-				       rtask + 2 * ios->num_iotasks, ios->io_comm, &status)))
-		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-		if ((mpierr = MPI_Recv(tmp_count, rregions * fndims, MPI_OFFSET, rtask,
-				       rtask + 3 * ios->num_iotasks, ios->io_comm, &status)))
-		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-		if ((mpierr = MPI_Recv(iobuf, nvars * rlen, iodesc->mpitype, rtask,
-				       rtask + 4 * ios->num_iotasks, ios->io_comm, &status)))
-		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-		PLOG((3, "received data rregions = %d fndims = %d", rregions, fndims));
-	    }
-	}
-	else /* task 0 */
-	{
-	    rlen = llen;
-	    rregions = maxregions;
-	}
-	PLOG((3, "rtask = %d rlen = %d rregions = %d", rtask, rlen, rregions));
+            /* Get the number of regions, the start/count
+             * values for all regions, and the data buffer. */
+            if (rlen > 0)
+            {
+                if ((mpierr = MPI_Recv(&rregions, 1, MPI_INT, rtask, rtask + ios->num_iotasks,
+                                       ios->io_comm, &status)))
+                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                if ((mpierr = MPI_Recv(tmp_start, rregions * fndims, MPI_OFFSET, rtask,
+                                       rtask + 2 * ios->num_iotasks, ios->io_comm, &status)))
+                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                if ((mpierr = MPI_Recv(tmp_count, rregions * fndims, MPI_OFFSET, rtask,
+                                       rtask + 3 * ios->num_iotasks, ios->io_comm, &status)))
+                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                if ((mpierr = MPI_Recv(iobuf, nvars * rlen, iodesc->mpitype, rtask,
+                                       rtask + 4 * ios->num_iotasks, ios->io_comm, &status)))
+                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                PLOG((3, "received data rregions = %d fndims = %d", rregions, fndims));
+            }
+        }
+        else /* task 0 */
+        {
+            rlen = llen;
+            rregions = maxregions;
+        }
+        PLOG((3, "rtask = %d rlen = %d rregions = %d", rtask, rlen, rregions));
 
-	/* If there is data from this task, write it. */
-	if (rlen > 0)
-	{
-	    loffset = 0;
-	    for (int regioncnt = 0; regioncnt < rregions; regioncnt++)
-	    {
-		PLOG((3, "writing data for region with regioncnt = %d", regioncnt));
+        /* If there is data from this task, write it. */
+        if (rlen > 0)
+        {
+            loffset = 0;
+            for (int regioncnt = 0; regioncnt < rregions; regioncnt++)
+            {
+                PLOG((3, "writing data for region with regioncnt = %d", regioncnt));
 
-		/* Get the start/count arrays for this region. */
-		for (int i = 0; i < fndims; i++)
-		{
-		    start[i] = tmp_start[i + regioncnt * fndims];
-		    count[i] = tmp_count[i + regioncnt * fndims];
-		    PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
-		}
+                /* Get the start/count arrays for this region. */
+                for (int i = 0; i < fndims; i++)
+                {
+                    start[i] = tmp_start[i + regioncnt * fndims];
+                    count[i] = tmp_count[i + regioncnt * fndims];
+                    PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
+                }
 
-		/* Process each variable in the buffer. */
-		for (int nv = 0; nv < nvars; nv++)
-		{
-		    PLOG((3, "writing buffer var %d", nv));
-		    if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
-			return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+                /* Process each variable in the buffer. */
+                for (int nv = 0; nv < nvars; nv++)
+                {
+                    PLOG((3, "writing buffer var %d", nv));
+                    if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
+                        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
-		    /* Get a pointer to the correct part of the buffer. */
-		    bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * (nv * rlen + loffset));
+                    /* Get a pointer to the correct part of the buffer. */
+                    bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * (nv * rlen + loffset));
 
-		    /* If this var has an unlimited dim, set
-		     * the start on that dim to the frame
-		     * value for this variable. */
-		    if (vdesc->record >= 0)
-		    {
-			if (fndims > 1 && iodesc->ndims < fndims && count[1] > 0)
-			{
-			    count[0] = 1;
-			    start[0] = frame[nv];
-			}
-			else if (fndims == iodesc->ndims)
-			{
-			    start[0] += vdesc->record;
-			}
-		    }
+                    /* If this var has an unlimited dim, set
+                     * the start on that dim to the frame
+                     * value for this variable. */
+                    if (vdesc->record >= 0)
+                    {
+                        if (fndims > 1 && iodesc->ndims < fndims && count[1] > 0)
+                        {
+                            count[0] = 1;
+                            start[0] = frame[nv];
+                        }
+                        else if (fndims == iodesc->ndims)
+                        {
+                            start[0] += vdesc->record;
+                        }
+                    }
 
 #ifdef LOGGING
-		    for (int i = 1; i < fndims; i++)
-			PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
+                    for (int i = 1; i < fndims; i++)
+                        PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
 #endif /* LOGGING */
 
-		    /* Call the netCDF functions to write the data. */
-		    if ((ierr = nc_put_vara(file->fh, varids[nv], start, count, bufptr)))
-			return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+                    /* Call the netCDF functions to write the data. */
+                    if ((ierr = nc_put_vara(file->fh, varids[nv], start, count, bufptr)))
+                        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
 
-		} /* next var */
+                } /* next var */
 
-		/* Calculate the total size. */
-		size_t tsize = 1;
-		for (int i = 0; i < fndims; i++)
-		    tsize *= count[i];
+                /* Calculate the total size. */
+                size_t tsize = 1;
+                for (int i = 0; i < fndims; i++)
+                    tsize *= count[i];
 
-		/* Keep track of where we are in the buffer. */
-		loffset += tsize;
+                /* Keep track of where we are in the buffer. */
+                loffset += tsize;
 
-		PLOG((3, " at bottom of loop regioncnt = %d tsize = %d loffset = %d", regioncnt,
-		      tsize, loffset));
-	    } /* next regioncnt */
-	} /* endif (rlen > 0) */
+                PLOG((3, " at bottom of loop regioncnt = %d tsize = %d loffset = %d", regioncnt,
+                      tsize, loffset));
+            } /* next regioncnt */
+        } /* endif (rlen > 0) */
     } /* next rtask */
 
     return PIO_NOERR;
@@ -1031,7 +1031,7 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
  */
 int
 write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *varids,
-			  io_desc_t *iodesc, int fill, const int *frame)
+                          io_desc_t *iodesc, int fill, const int *frame)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;     /* Contains info about the variable. */
@@ -1039,17 +1039,17 @@ write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *v
 
     /* Check inputs. */
     pioassert(file && file->iosystem && varids && varids[0] >= 0 &&
-	      varids[0] <= PIO_MAX_VARS && iodesc, "invalid input", __FILE__, __LINE__);
+              varids[0] <= PIO_MAX_VARS && iodesc, "invalid input", __FILE__, __LINE__);
 
     PLOG((1, "write_darray_multi_serial nvars = %d fndims = %d iodesc->ndims = %d "
-	  "iodesc->mpitype = %d", nvars, fndims, iodesc->ndims, iodesc->mpitype));
+          "iodesc->mpitype = %d", nvars, fndims, iodesc->ndims, iodesc->mpitype));
 
     /* Get the iosystem info. */
     ios = file->iosystem;
 
     /* Get the var info. */
     if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
-	return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Set these differently for data and fill writing. iobuf may be
      * null if array size < number of nodes. */
@@ -1061,45 +1061,45 @@ write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *v
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ierr = pio_start_timer("PIO:write_darray_multi_serial")))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Only IO tasks participate in this code. */
     if (ios->ioproc)
     {
-	size_t tmp_start[fndims * num_regions]; /* A start array for each region. */
-	size_t tmp_count[fndims * num_regions]; /* A count array for each region. */
+        size_t tmp_start[fndims * num_regions]; /* A start array for each region. */
+        size_t tmp_count[fndims * num_regions]; /* A count array for each region. */
 
-	PLOG((3, "num_regions = %d", num_regions));
+        PLOG((3, "num_regions = %d", num_regions));
 
-	/* Fill the tmp_start and tmp_count arrays, which contain the
-	 * start and count arrays for all regions. */
-	if ((ierr = find_all_start_count(region, num_regions, fndims, iodesc->ndims, vdesc,
-					 tmp_start, tmp_count)))
-	    return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        /* Fill the tmp_start and tmp_count arrays, which contain the
+         * start and count arrays for all regions. */
+        if ((ierr = find_all_start_count(region, num_regions, fndims, iodesc->ndims, vdesc,
+                                         tmp_start, tmp_count)))
+            return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
-	/* Tasks other than 0 will send their data to task 0. */
-	if (ios->io_rank > 0)
-	{
-	    /* Send the tmp_start and tmp_count arrays from this IO task
-	     * to task 0. */
-	    if ((ierr = send_all_start_count(ios, iodesc, llen, num_regions, nvars, fndims,
-					     tmp_start, tmp_count, iobuf)))
-		return pio_err(ios, file, ierr, __FILE__, __LINE__);
-	}
-	else
-	{
-	    /* Task 0 will receive data from all other IO tasks. */
+        /* Tasks other than 0 will send their data to task 0. */
+        if (ios->io_rank > 0)
+        {
+            /* Send the tmp_start and tmp_count arrays from this IO task
+             * to task 0. */
+            if ((ierr = send_all_start_count(ios, iodesc, llen, num_regions, nvars, fndims,
+                                             tmp_start, tmp_count, iobuf)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        }
+        else
+        {
+            /* Task 0 will receive data from all other IO tasks. */
 
-	    if ((ierr = recv_and_write_data(file, varids, frame, iodesc, llen, num_regions, nvars, fndims,
-					    tmp_start, tmp_count, iobuf)))
-		return pio_err(ios, file, ierr, __FILE__, __LINE__);
-	}
+            if ((ierr = recv_and_write_data(file, varids, frame, iodesc, llen, num_regions, nvars, fndims,
+                                            tmp_start, tmp_count, iobuf)))
+                return pio_err(ios, file, ierr, __FILE__, __LINE__);
+        }
     }
 
 #ifdef TIMING
     if ((ierr = pio_stop_timer("PIO:write_darray_multi_serial")))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return PIO_NOERR;
@@ -1138,7 +1138,7 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
 
     /* Check inputs. */
     pioassert(file && file->iosystem && iodesc && vid <= PIO_MAX_VARS, "invalid input",
-	      __FILE__, __LINE__);
+              __FILE__, __LINE__);
 
     /* Get the IO system info. */
     ios = file->iosystem;
@@ -1147,12 +1147,12 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ierr = pio_start_timer("PIO:read_darray_nc")))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Get the variable info. */
     if ((ierr = get_var_desc(vid, &file->varlist, &vdesc)))
-	return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Get the number of dimensions in the decomposition. */
     ndims = iodesc->ndims;
@@ -1164,218 +1164,218 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
     /* ??? */
 #if USE_VARD_READ
     if(!ios->async || !ios->ioproc)
-	ierr = get_gdim0(file, iodesc, vid, fndims, &gdim0);
+        ierr = get_gdim0(file, iodesc, vid, fndims, &gdim0);
 #endif
 
     /* IO procs will read the data. */
     if (ios->ioproc)
     {
-	io_region *region;
-	size_t start[fndims];
-	size_t count[fndims];
-	void *bufptr;
+        io_region *region;
+        size_t start[fndims];
+        size_t count[fndims];
+        void *bufptr;
 #ifdef _PNETCDF
-	size_t tmp_bufsize = 1;
-	int rrlen = 0;
-	PIO_Offset *startlist[iodesc->maxregions];
-	PIO_Offset *countlist[iodesc->maxregions];
+        size_t tmp_bufsize = 1;
+        int rrlen = 0;
+        PIO_Offset *startlist[iodesc->maxregions];
+        PIO_Offset *countlist[iodesc->maxregions];
 #endif
 
-	/* buffer is incremented by byte and loffset is in terms of
-	   the iodessc->mpitype so we need to multiply by the size of
-	   the mpitype. */
-	region = iodesc->firstregion;
+        /* buffer is incremented by byte and loffset is in terms of
+           the iodessc->mpitype so we need to multiply by the size of
+           the mpitype. */
+        region = iodesc->firstregion;
 
-	/* There are different numbers of dims in the decomposition
-	 * and the file. */
-	if (fndims > ndims)
-	{
-	    /* If the user did not call setframe, use a default frame
-	     * of 0. This is required for backward compatibility. */
-	    if (vdesc->record < 0)
-		vdesc->record = 0;
-	}
+        /* There are different numbers of dims in the decomposition
+         * and the file. */
+        if (fndims > ndims)
+        {
+            /* If the user did not call setframe, use a default frame
+             * of 0. This is required for backward compatibility. */
+            if (vdesc->record < 0)
+                vdesc->record = 0;
+        }
 
-	/* For each regions, read the data. */
-	for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
-	{
-	    if (region == NULL || iodesc->llen == 0)
-	    {
-		/* No data for this region. */
-		for (int i = 0; i < fndims; i++)
-		{
-		    start[i] = 0;
-		    count[i] = 0;
-		}
-		bufptr = NULL;
-	    }
-	    else
-	    {
-		/* Get a pointer where we should put the data we read. */
-		if (regioncnt == 0 || region == NULL)
-		    bufptr = iobuf;
-		else
-		    bufptr=(void *)((char *)iobuf + iodesc->mpitype_size * region->loffset);
+        /* For each regions, read the data. */
+        for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
+        {
+            if (region == NULL || iodesc->llen == 0)
+            {
+                /* No data for this region. */
+                for (int i = 0; i < fndims; i++)
+                {
+                    start[i] = 0;
+                    count[i] = 0;
+                }
+                bufptr = NULL;
+            }
+            else
+            {
+                /* Get a pointer where we should put the data we read. */
+                if (regioncnt == 0 || region == NULL)
+                    bufptr = iobuf;
+                else
+                    bufptr=(void *)((char *)iobuf + iodesc->mpitype_size * region->loffset);
 
-		PLOG((2, "iodesc->llen - region->loffset %d, iodesc->llen %d, region->loffset  %d vdesc->record %d",
-		      iodesc->llen - region->loffset, iodesc->llen, region->loffset, vdesc->record));
+                PLOG((2, "iodesc->llen - region->loffset %d, iodesc->llen %d, region->loffset  %d vdesc->record %d",
+                      iodesc->llen - region->loffset, iodesc->llen, region->loffset, vdesc->record));
 
-		/* Get the start/count arrays. */
-		if (vdesc->record >= 0 && fndims > 1)
-		{
-		    /* This is a record var. The unlimited dimension
-		     * (0) is handled specially. */
-		    start[0] = vdesc->record;
-		    for (int i = 1; i < fndims; i++)
-		    {
-			start[i] = region->start[i-1];
-			count[i] = region->count[i-1];
-		    }
+                /* Get the start/count arrays. */
+                if (vdesc->record >= 0 && fndims > 1)
+                {
+                    /* This is a record var. The unlimited dimension
+                     * (0) is handled specially. */
+                    start[0] = vdesc->record;
+                    for (int i = 1; i < fndims; i++)
+                    {
+                        start[i] = region->start[i-1];
+                        count[i] = region->count[i-1];
+                    }
 
-		    /* Read one record. */
-		    if (count[1] > 0)
-			count[0] = 1;
-		}
-		else
-		{
-		    /* Non-time dependent array */
-		    for (int i = 0; i < fndims; i++)
-		    {
-			start[i] = region->start[i];
-			count[i] = region->count[i];
-		    }
-		}
-	    }
+                    /* Read one record. */
+                    if (count[1] > 0)
+                        count[0] = 1;
+                }
+                else
+                {
+                    /* Non-time dependent array */
+                    for (int i = 0; i < fndims; i++)
+                    {
+                        start[i] = region->start[i];
+                        count[i] = region->count[i];
+                    }
+                }
+            }
 
 #ifdef PIO_ENABLE_LOGGING
-	    for (int i = 1; i < ndims; i++)
-		PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
+            for (int i = 1; i < ndims; i++)
+                PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
 #endif /* LOGGING */
-	    /* Do the read. */
-	    switch (file->iotype)
-	    {
+            /* Do the read. */
+            switch (file->iotype)
+            {
 #ifdef _NETCDF4
-	    case PIO_IOTYPE_NETCDF4P:
-		/* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
-		switch (iodesc->piotype)
-		{
-		case PIO_BYTE:
-		    ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
-		    break;
-		case PIO_CHAR:
-		    ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
-		    break;
-		case PIO_SHORT:
-		    ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
-		    break;
-		case PIO_INT:
-		    ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
-		    break;
-		case PIO_FLOAT:
-		    ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
-		    break;
-		case PIO_DOUBLE:
-		    ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
-		    break;
-		case PIO_UBYTE:
-		    ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
-		    break;
-		case PIO_USHORT:
-		    ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
-		    break;
-		case PIO_UINT:
-		    ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
-		    break;
-		case PIO_INT64:
-		    ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
-		    break;
-		case PIO_UINT64:
-		    ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
-		    break;
-		case PIO_STRING:
-		    ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
-		    break;
-		default:
-		    return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
-		}
-		break;
+            case PIO_IOTYPE_NETCDF4P:
+                /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
+                switch (iodesc->piotype)
+                {
+                case PIO_BYTE:
+                    ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
+                    break;
+                case PIO_CHAR:
+                    ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
+                    break;
+                case PIO_SHORT:
+                    ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
+                    break;
+                case PIO_INT:
+                    ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
+                    break;
+                case PIO_FLOAT:
+                    ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
+                    break;
+                case PIO_DOUBLE:
+                    ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
+                    break;
+                case PIO_UBYTE:
+                    ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
+                    break;
+                case PIO_USHORT:
+                    ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
+                    break;
+                case PIO_UINT:
+                    ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
+                    break;
+                case PIO_INT64:
+                    ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
+                    break;
+                case PIO_UINT64:
+                    ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
+                    break;
+                case PIO_STRING:
+                    ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
+                    break;
+                default:
+                    return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
+                }
+                break;
 #endif
 #ifdef _PNETCDF
-	    case PIO_IOTYPE_PNETCDF:
-	    {
-		tmp_bufsize = 1;
-		for (int j = 0; j < fndims; j++)
-		    tmp_bufsize *= count[j];
+            case PIO_IOTYPE_PNETCDF:
+            {
+                tmp_bufsize = 1;
+                for (int j = 0; j < fndims; j++)
+                    tmp_bufsize *= count[j];
 
-		if (tmp_bufsize > 0)
-		{
-		    startlist[rrlen] = malloc(fndims * sizeof(PIO_Offset));
-		    countlist[rrlen] = malloc(fndims * sizeof(PIO_Offset));
+                if (tmp_bufsize > 0)
+                {
+                    startlist[rrlen] = malloc(fndims * sizeof(PIO_Offset));
+                    countlist[rrlen] = malloc(fndims * sizeof(PIO_Offset));
 
-		    for (int j = 0; j < fndims; j++)
-		    {
-			startlist[rrlen][j] = start[j];
-			countlist[rrlen][j] = count[j];
-		    }
-		    rrlen++;
-		}
+                    for (int j = 0; j < fndims; j++)
+                    {
+                        startlist[rrlen][j] = start[j];
+                        countlist[rrlen][j] = count[j];
+                    }
+                    rrlen++;
+                }
 
-		/* Is this is the last region to process? */
-		if (regioncnt == iodesc->maxregions - 1)
-		{
+                /* Is this is the last region to process? */
+                if (regioncnt == iodesc->maxregions - 1)
+                {
 #if USE_VARD_READ
-		    MPI_Datatype filetype;
-		    PIO_Offset unlimdimoffset;
-		    int mpierr;
-		    if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
-		    {
-			if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
-			    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-		    }
-		    else
-			unlimdimoffset = gdim0;
+                    MPI_Datatype filetype;
+                    PIO_Offset unlimdimoffset;
+                    int mpierr;
+                    if (gdim0 == 0) /* if there is an unlimited dimension get the offset between records of a variable */
+                    {
+                        if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
+                            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+                    }
+                    else
+                        unlimdimoffset = gdim0;
 
-		    ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
-						rrlen, ndims, fndims,
-						vdesc->record, startlist, countlist, &filetype);
-		    ierr = ncmpi_get_vard_all(file->fh, vid, filetype, iobuf, iodesc->llen, iodesc->mpitype);
-		    if(filetype != MPI_DATATYPE_NULL && (mpierr = MPI_Type_free(&filetype)))
-			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                    ierr = get_vard_mpidatatype(iodesc, gdim0, unlimdimoffset,
+                                                rrlen, ndims, fndims,
+                                                vdesc->record, startlist, countlist, &filetype);
+                    ierr = ncmpi_get_vard_all(file->fh, vid, filetype, iobuf, iodesc->llen, iodesc->mpitype);
+                    if(filetype != MPI_DATATYPE_NULL && (mpierr = MPI_Type_free(&filetype)))
+                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
 #else
-		    printf("rllen %d mpitype %d\n",iodesc->rllen, iodesc->mpitype);
-		    /* Read a list of subarrays. */
-		    ierr = ncmpi_get_varn_all(file->fh, vid, rrlen, startlist,
-					      countlist, iobuf, iodesc->rllen, iodesc->mpitype);
+                    printf("rllen %d mpitype %d\n",iodesc->rllen, iodesc->mpitype);
+                    /* Read a list of subarrays. */
+                    ierr = ncmpi_get_varn_all(file->fh, vid, rrlen, startlist,
+                                              countlist, iobuf, iodesc->rllen, iodesc->mpitype);
 #endif
-		    /* Release the start and count arrays. */
-		    for (int i = 0; i < rrlen; i++)
-		    {
-			PLOG((3,"startlist %d %d countlist %d %d",startlist[i][0],startlist[i][1],countlist[i][0],countlist[i][1]));
-			free(startlist[i]);
-			free(countlist[i]);
-		    }
-		}
-	    }
-	    break;
+                    /* Release the start and count arrays. */
+                    for (int i = 0; i < rrlen; i++)
+                    {
+                        PLOG((3,"startlist %d %d countlist %d %d",startlist[i][0],startlist[i][1],countlist[i][0],countlist[i][1]));
+                        free(startlist[i]);
+                        free(countlist[i]);
+                    }
+                }
+            }
+            break;
 #endif
-	    default:
-		return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
-	    }
+            default:
+                return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
+            }
 
-	    /* Check return code. */
-	    if (ierr)
-		return check_netcdf(file, ierr, __FILE__,__LINE__);
+            /* Check return code. */
+            if (ierr)
+                return check_netcdf(file, ierr, __FILE__,__LINE__);
 
-	    /* Move to next region. */
-	    if (region)
-		region = region->next;
-	} /* next regioncnt */
+            /* Move to next region. */
+            if (region)
+                region = region->next;
+        } /* next regioncnt */
     }
 
 #ifdef TIMING
     if ((ierr = pio_stop_timer("PIO:read_darray_nc")))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return PIO_NOERR;
@@ -1403,7 +1403,7 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
  */
 int
 pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
-			  void *iobuf)
+                          void *iobuf)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     var_desc_t *vdesc;    /* Information about the variable. */
@@ -1415,7 +1415,7 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
 
     /* Check inputs. */
     pioassert(file && file->iosystem && iodesc && vid >= 0 && vid <= PIO_MAX_VARS,
-	      "invalid input", __FILE__, __LINE__);
+              "invalid input", __FILE__, __LINE__);
 
     PLOG((2, "pio_read_darray_nc_serial vid = %d", vid));
     ios = file->iosystem;
@@ -1423,12 +1423,12 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ierr = pio_start_timer("PIO:read_darray_nc_serial")))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Get var info for this var. */
     if ((ierr = get_var_desc(vid, &file->varlist, &vdesc)))
-	return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+        return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
     /* Get the number of dims in our decomposition. */
     ndims = iodesc->ndims;
@@ -1439,251 +1439,251 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
     /* If setframe was not called, use a default value of 0. This is
      * required for backward compatibility. */
     if (fndims == ndims + 1 && vdesc->record < 0)
-	vdesc->record = 0;
+        vdesc->record = 0;
     PLOG((3, "fndims %d ndims %d vdesc->record %d vdesc->ndims %d", fndims,
-	  ndims, vdesc->record, vdesc->ndims));
+          ndims, vdesc->record, vdesc->ndims));
 
     /* Confirm that we are being called with the correct ndims. */
     pioassert((fndims == ndims && vdesc->record < 0) ||
-	      (fndims == ndims + 1 && vdesc->record >= 0),
-	      "unexpected record", __FILE__, __LINE__);
+              (fndims == ndims + 1 && vdesc->record >= 0),
+              "unexpected record", __FILE__, __LINE__);
 
     if (ios->ioproc)
     {
-	io_region *region;
-	size_t start[fndims];
-	size_t count[fndims];
-	size_t tmp_start[fndims * iodesc->maxregions];
-	size_t tmp_count[fndims * iodesc->maxregions];
-	size_t tmp_bufsize;
-	void *bufptr;
+        io_region *region;
+        size_t start[fndims];
+        size_t count[fndims];
+        size_t tmp_start[fndims * iodesc->maxregions];
+        size_t tmp_count[fndims * iodesc->maxregions];
+        size_t tmp_bufsize;
+        void *bufptr;
 
-	/* buffer is incremented by byte and loffset is in terms of
-	   the iodessc->mpitype so we need to multiply by the size of
-	   the mpitype. */
-	region = iodesc->firstregion;
+        /* buffer is incremented by byte and loffset is in terms of
+           the iodessc->mpitype so we need to multiply by the size of
+           the mpitype. */
+        region = iodesc->firstregion;
 
-	/* If setframe was not set before this call, assume a value of
-	 * 0. This is required for backward compatibility. */
-	if (fndims > ndims)
-	    if (vdesc->record < 0)
-		vdesc->record = 0;
+        /* If setframe was not set before this call, assume a value of
+         * 0. This is required for backward compatibility. */
+        if (fndims > ndims)
+            if (vdesc->record < 0)
+                vdesc->record = 0;
 
-	/* Put together start/count arrays for all regions. */
-	for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
-	{
-	    if (!region || iodesc->llen == 0)
-	    {
-		/* Nothing to write for this region. */
-		for (int i = 0; i < fndims; i++)
-		{
-		    tmp_start[i + regioncnt * fndims] = 0;
-		    tmp_count[i + regioncnt * fndims] = 0;
-		}
-		bufptr = NULL;
-	    }
-	    else
-	    {
-		if (vdesc->record >= 0 && fndims > 1)
-		{
-		    /* This is a record var. Find start for record dims. */
-		    tmp_start[regioncnt * fndims] = vdesc->record;
+        /* Put together start/count arrays for all regions. */
+        for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
+        {
+            if (!region || iodesc->llen == 0)
+            {
+                /* Nothing to write for this region. */
+                for (int i = 0; i < fndims; i++)
+                {
+                    tmp_start[i + regioncnt * fndims] = 0;
+                    tmp_count[i + regioncnt * fndims] = 0;
+                }
+                bufptr = NULL;
+            }
+            else
+            {
+                if (vdesc->record >= 0 && fndims > 1)
+                {
+                    /* This is a record var. Find start for record dims. */
+                    tmp_start[regioncnt * fndims] = vdesc->record;
 
-		    /* Find start/count for all non-record dims. */
-		    for (int i = 1; i < fndims; i++)
-		    {
-			tmp_start[i + regioncnt * fndims] = region->start[i - 1];
-			tmp_count[i + regioncnt * fndims] = region->count[i - 1];
-		    }
+                    /* Find start/count for all non-record dims. */
+                    for (int i = 1; i < fndims; i++)
+                    {
+                        tmp_start[i + regioncnt * fndims] = region->start[i - 1];
+                        tmp_count[i + regioncnt * fndims] = region->count[i - 1];
+                    }
 
-		    /* Set count for record dimension. */
-		    if (tmp_count[1 + regioncnt * fndims] > 0)
-			tmp_count[regioncnt * fndims] = 1;
-		}
-		else
-		{
-		    /* Non-time dependent array */
-		    for (int i = 0; i < fndims; i++)
-		    {
-			tmp_start[i + regioncnt * fndims] = region->start[i];
-			tmp_count[i + regioncnt * fndims] = region->count[i];
-		    }
-		}
-	    }
+                    /* Set count for record dimension. */
+                    if (tmp_count[1 + regioncnt * fndims] > 0)
+                        tmp_count[regioncnt * fndims] = 1;
+                }
+                else
+                {
+                    /* Non-time dependent array */
+                    for (int i = 0; i < fndims; i++)
+                    {
+                        tmp_start[i + regioncnt * fndims] = region->start[i];
+                        tmp_count[i + regioncnt * fndims] = region->count[i];
+                    }
+                }
+            }
 
 #if PIO_ENABLE_LOGGING
-	    /* Log arrays for debug purposes. */
-	    PLOG((3, "region = %d", region));
-	    for (int i = 0; i < fndims; i++)
-		PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + regioncnt * fndims, tmp_start[i + regioncnt * fndims],
-		      i + regioncnt * fndims, tmp_count[i + regioncnt * fndims]));
+            /* Log arrays for debug purposes. */
+            PLOG((3, "region = %d", region));
+            for (int i = 0; i < fndims; i++)
+                PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + regioncnt * fndims, tmp_start[i + regioncnt * fndims],
+                      i + regioncnt * fndims, tmp_count[i + regioncnt * fndims]));
 #endif /* PIO_ENABLE_LOGGING */
 
-	    /* Move to next region. */
-	    if (region)
-		region = region->next;
-	} /* next regioncnt */
+            /* Move to next region. */
+            if (region)
+                region = region->next;
+        } /* next regioncnt */
 
-	/* IO tasks other than 0 send their starts/counts and data to
-	 * IO task 0. */
-	if (ios->io_rank > 0)
-	{
-	    if ((mpierr = MPI_Send(&iodesc->llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm)))
-		return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-	    PLOG((3, "sent iodesc->llen = %d", iodesc->llen));
+        /* IO tasks other than 0 send their starts/counts and data to
+         * IO task 0. */
+        if (ios->io_rank > 0)
+        {
+            if ((mpierr = MPI_Send(&iodesc->llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm)))
+                return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            PLOG((3, "sent iodesc->llen = %d", iodesc->llen));
 
-	    if (iodesc->llen > 0)
-	    {
-		if ((mpierr = MPI_Send(&(iodesc->maxregions), 1, MPI_INT, 0,
-				       ios->num_iotasks + ios->io_rank, ios->io_comm)))
-		    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-		if ((mpierr = MPI_Send(tmp_count, iodesc->maxregions * fndims, MPI_OFFSET, 0,
-				       2 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
-		    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-		if ((mpierr = MPI_Send(tmp_start, iodesc->maxregions * fndims, MPI_OFFSET, 0,
-				       3 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
-		    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-		PLOG((3, "sent iodesc->maxregions = %d tmp_count and tmp_start arrays", iodesc->maxregions));
+            if (iodesc->llen > 0)
+            {
+                if ((mpierr = MPI_Send(&(iodesc->maxregions), 1, MPI_INT, 0,
+                                       ios->num_iotasks + ios->io_rank, ios->io_comm)))
+                    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+                if ((mpierr = MPI_Send(tmp_count, iodesc->maxregions * fndims, MPI_OFFSET, 0,
+                                       2 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
+                    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+                if ((mpierr = MPI_Send(tmp_start, iodesc->maxregions * fndims, MPI_OFFSET, 0,
+                                       3 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
+                    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+                PLOG((3, "sent iodesc->maxregions = %d tmp_count and tmp_start arrays", iodesc->maxregions));
 
-		if ((mpierr = MPI_Recv(iobuf, iodesc->llen, iodesc->mpitype, 0,
-				       4 * ios->num_iotasks + ios->io_rank, ios->io_comm, &status)))
-		    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-		PLOG((3, "received %d elements of data", iodesc->llen));
-	    }
-	}
-	else if (ios->io_rank == 0)
-	{
-	    /* This is IO task 0. Get starts/counts and data from
-	     * other IO tasks. */
-	    int maxregions = 0;
-	    size_t loffset, regionsize;
-	    size_t this_start[fndims * iodesc->maxregions];
-	    size_t this_count[fndims * iodesc->maxregions];
+                if ((mpierr = MPI_Recv(iobuf, iodesc->llen, iodesc->mpitype, 0,
+                                       4 * ios->num_iotasks + ios->io_rank, ios->io_comm, &status)))
+                    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+                PLOG((3, "received %d elements of data", iodesc->llen));
+            }
+        }
+        else if (ios->io_rank == 0)
+        {
+            /* This is IO task 0. Get starts/counts and data from
+             * other IO tasks. */
+            int maxregions = 0;
+            size_t loffset, regionsize;
+            size_t this_start[fndims * iodesc->maxregions];
+            size_t this_count[fndims * iodesc->maxregions];
 
-	    for (int rtask = 1; rtask <= ios->num_iotasks; rtask++)
-	    {
-		if (rtask < ios->num_iotasks)
-		{
-		    if ((mpierr = MPI_Recv(&tmp_bufsize, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status)))
-			return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-		    PLOG((3, "received tmp_bufsize = %d", tmp_bufsize));
+            for (int rtask = 1; rtask <= ios->num_iotasks; rtask++)
+            {
+                if (rtask < ios->num_iotasks)
+                {
+                    if ((mpierr = MPI_Recv(&tmp_bufsize, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status)))
+                        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+                    PLOG((3, "received tmp_bufsize = %d", tmp_bufsize));
 
-		    if (tmp_bufsize > 0)
-		    {
-			if ((mpierr = MPI_Recv(&maxregions, 1, MPI_INT, rtask, ios->num_iotasks + rtask,
-					       ios->io_comm, &status)))
-			    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-			if ((mpierr = MPI_Recv(this_count, maxregions * fndims, MPI_OFFSET, rtask,
-					       2 * ios->num_iotasks + rtask, ios->io_comm, &status)))
-			    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-			if ((mpierr = MPI_Recv(this_start, maxregions * fndims, MPI_OFFSET, rtask,
-					       3 * ios->num_iotasks + rtask, ios->io_comm, &status)))
-			    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-			PLOG((3, "received maxregions = %d this_count, this_start arrays ", maxregions));
-		    }
-		}
-		else
-		{
-		    maxregions = iodesc->maxregions;
-		    tmp_bufsize = iodesc->llen;
-		}
-		PLOG((3, "maxregions = %d tmp_bufsize = %d", maxregions, tmp_bufsize));
+                    if (tmp_bufsize > 0)
+                    {
+                        if ((mpierr = MPI_Recv(&maxregions, 1, MPI_INT, rtask, ios->num_iotasks + rtask,
+                                               ios->io_comm, &status)))
+                            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+                        if ((mpierr = MPI_Recv(this_count, maxregions * fndims, MPI_OFFSET, rtask,
+                                               2 * ios->num_iotasks + rtask, ios->io_comm, &status)))
+                            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+                        if ((mpierr = MPI_Recv(this_start, maxregions * fndims, MPI_OFFSET, rtask,
+                                               3 * ios->num_iotasks + rtask, ios->io_comm, &status)))
+                            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+                        PLOG((3, "received maxregions = %d this_count, this_start arrays ", maxregions));
+                    }
+                }
+                else
+                {
+                    maxregions = iodesc->maxregions;
+                    tmp_bufsize = iodesc->llen;
+                }
+                PLOG((3, "maxregions = %d tmp_bufsize = %d", maxregions, tmp_bufsize));
 
-		/* Now get each region of data. */
-		loffset = 0;
-		for (int regioncnt = 0; regioncnt < maxregions; regioncnt++)
-		{
-		    /* Get pointer where data should go. */
-		    bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * loffset);
-		    regionsize = 1;
+                /* Now get each region of data. */
+                loffset = 0;
+                for (int regioncnt = 0; regioncnt < maxregions; regioncnt++)
+                {
+                    /* Get pointer where data should go. */
+                    bufptr = (void *)((char *)iobuf + iodesc->mpitype_size * loffset);
+                    regionsize = 1;
 
-		    /* ??? */
-		    if (rtask < ios->num_iotasks)
-		    {
-			for (int m = 0; m < fndims; m++)
-			{
-			    start[m] = this_start[m + regioncnt * fndims];
-			    count[m] = this_count[m + regioncnt * fndims];
-			    regionsize *= count[m];
-			}
-		    }
-		    else
-		    {
-			for (int m = 0; m < fndims; m++)
-			{
-			    start[m] = tmp_start[m + regioncnt * fndims];
-			    count[m] = tmp_count[m + regioncnt * fndims];
-			    regionsize *= count[m];
-			}
-		    }
-		    loffset += regionsize;
+                    /* ??? */
+                    if (rtask < ios->num_iotasks)
+                    {
+                        for (int m = 0; m < fndims; m++)
+                        {
+                            start[m] = this_start[m + regioncnt * fndims];
+                            count[m] = this_count[m + regioncnt * fndims];
+                            regionsize *= count[m];
+                        }
+                    }
+                    else
+                    {
+                        for (int m = 0; m < fndims; m++)
+                        {
+                            start[m] = tmp_start[m + regioncnt * fndims];
+                            count[m] = tmp_count[m + regioncnt * fndims];
+                            regionsize *= count[m];
+                        }
+                    }
+                    loffset += regionsize;
 
-		    /* Read the data. */
-		    /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
-		    switch (iodesc->piotype)
-		    {
-		    case PIO_BYTE:
-			ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
-			break;
-		    case PIO_CHAR:
-			ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
-			break;
-		    case PIO_SHORT:
-			ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
-			break;
-		    case PIO_INT:
-			ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
-			break;
-		    case PIO_FLOAT:
-			ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
-			break;
-		    case PIO_DOUBLE:
-			ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
-			break;
+                    /* Read the data. */
+                    /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
+                    switch (iodesc->piotype)
+                    {
+                    case PIO_BYTE:
+                        ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
+                        break;
+                    case PIO_CHAR:
+                        ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
+                        break;
+                    case PIO_SHORT:
+                        ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
+                        break;
+                    case PIO_INT:
+                        ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
+                        break;
+                    case PIO_FLOAT:
+                        ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
+                        break;
+                    case PIO_DOUBLE:
+                        ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
+                        break;
 #ifdef _NETCDF4
-		    case PIO_UBYTE:
-			ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
-			break;
-		    case PIO_USHORT:
-			ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
-			break;
-		    case PIO_UINT:
-			ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
-			break;
-		    case PIO_INT64:
-			ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
-			break;
-		    case PIO_UINT64:
-			ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
-			break;
-		    case PIO_STRING:
-			ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
-			break;
+                    case PIO_UBYTE:
+                        ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
+                        break;
+                    case PIO_USHORT:
+                        ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
+                        break;
+                    case PIO_UINT:
+                        ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
+                        break;
+                    case PIO_INT64:
+                        ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
+                        break;
+                    case PIO_UINT64:
+                        ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
+                        break;
+                    case PIO_STRING:
+                        ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
+                        break;
 #endif /* _NETCDF4 */
-		    default:
-			return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
-		    }
+                    default:
+                        return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
+                    }
 
-		    /* Check error code of netCDF call. */
-		    if (ierr)
-			return check_netcdf(file, ierr, __FILE__, __LINE__);
-		}
+                    /* Check error code of netCDF call. */
+                    if (ierr)
+                        return check_netcdf(file, ierr, __FILE__, __LINE__);
+                }
 
-		/* The decomposition may not use all of the active io
-		 * tasks. rtask here is the io task rank and
-		 * ios->num_iotasks is the number of iotasks actually
-		 * used in this decomposition. */
-		if (rtask < ios->num_iotasks && tmp_bufsize > 0)
-		    if ((mpierr = MPI_Send(iobuf, tmp_bufsize, iodesc->mpitype, rtask,
-					   4 * ios->num_iotasks + rtask, ios->io_comm)))
-			return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-	    }
-	}
+                /* The decomposition may not use all of the active io
+                 * tasks. rtask here is the io task rank and
+                 * ios->num_iotasks is the number of iotasks actually
+                 * used in this decomposition. */
+                if (rtask < ios->num_iotasks && tmp_bufsize > 0)
+                    if ((mpierr = MPI_Send(iobuf, tmp_bufsize, iodesc->mpitype, rtask,
+                                           4 * ios->num_iotasks + rtask, ios->io_comm)))
+                        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            }
+        }
     }
 
 #ifdef TIMING
     if ((ierr = pio_stop_timer("PIO:read_darray_nc_serial")))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 #endif /* TIMING */
 
     PLOG((2, "pio_read_darray_nc_serial complete ierr %d", ierr));
@@ -1717,100 +1717,100 @@ flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     PLOG((1, "flush_output_buffer"));
     /* Find out the buffer usage. */
     if ((ierr = ncmpi_inq_buffer_usage(file->fh, &usage)))
-	/* allow the buffer to be undefined */
-	if (ierr != NC_ENULLABUF)
-	    return pio_err(NULL, file, PIO_EBADID, __FILE__, __LINE__);
+        /* allow the buffer to be undefined */
+        if (ierr != NC_ENULLABUF)
+            return pio_err(NULL, file, PIO_EBADID, __FILE__, __LINE__);
 
     /* If we are not forcing a flush, spread the usage to all IO
      * tasks. */
     if (!force && file->iosystem->ioproc)
     {
-	usage += addsize;
-	if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &usage, 1,  MPI_OFFSET,  MPI_MAX,
-				    file->iosystem->io_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        usage += addsize;
+        if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &usage, 1,  MPI_OFFSET,  MPI_MAX,
+                                    file->iosystem->io_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* Keep track of the maximum usage. */
     if (usage > maxusage)
-	maxusage = usage;
+        maxusage = usage;
 
     PLOG((2, "flush_output_buffer usage=%ld force=%d",usage, force));
     /* If the user forces it, or the buffer has exceeded the size
      * limit, then flush to disk. */
     if (force || (usage >= pio_buffer_size_limit))
     {
-	int rcnt;
-	int  maxreq;
-	int reqcnt;
-	maxreq = 0;
-	reqcnt = 0;
-	rcnt = 0;
+        int rcnt;
+        int  maxreq;
+        int reqcnt;
+        maxreq = 0;
+        reqcnt = 0;
+        rcnt = 0;
 
-	for (int i = 0; i < file->nvars; i++)
-	{
-	    if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
-		return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-	    reqcnt += vdesc->nreqs;
-	    if (vdesc->nreqs > 0)
-		maxreq = i;
-	}
-	int request[reqcnt];
-	int status[reqcnt];
+        for (int i = 0; i < file->nvars; i++)
+        {
+            if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
+                return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+            reqcnt += vdesc->nreqs;
+            if (vdesc->nreqs > 0)
+                maxreq = i;
+        }
+        int request[reqcnt];
+        int status[reqcnt];
 
-	if (file->varlist)
-	{
-	    for (int i = 0; i <= maxreq; i++)
-	    {
-		if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
-		    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+        if (file->varlist)
+        {
+            for (int i = 0; i <= maxreq; i++)
+            {
+                if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
+                    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 #ifdef MPIO_ONESIDED
-		/*onesided optimization requires that all of the requests in a wait_all call represent
-		  a contiguous block of data in the file */
-		if (rcnt > 0 && (prev_record != vdesc->record || vdesc->nreqs == 0))
-		{
-		    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-		    rcnt = 0;
-		}
-		prev_record = vdesc->record;
+                /*onesided optimization requires that all of the requests in a wait_all call represent
+                  a contiguous block of data in the file */
+                if (rcnt > 0 && (prev_record != vdesc->record || vdesc->nreqs == 0))
+                {
+                    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+                    rcnt = 0;
+                }
+                prev_record = vdesc->record;
 #endif
-		for (reqcnt = 0; reqcnt < vdesc->nreqs; reqcnt++)
-		    request[rcnt++] = max(vdesc->request[reqcnt], NC_REQ_NULL);
-		PLOG((3,"flush_output_buffer rcnt=%d",rcnt));
+                for (reqcnt = 0; reqcnt < vdesc->nreqs; reqcnt++)
+                    request[rcnt++] = max(vdesc->request[reqcnt], NC_REQ_NULL);
+                PLOG((3,"flush_output_buffer rcnt=%d",rcnt));
 
-		if (vdesc->request != NULL)
-		    free(vdesc->request);
-		vdesc->request = NULL;
-		vdesc->nreqs = 0;
+                if (vdesc->request != NULL)
+                    free(vdesc->request);
+                vdesc->request = NULL;
+                vdesc->nreqs = 0;
 
 #ifdef FLUSH_EVERY_VAR
-		ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-		rcnt = 0;
+                ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+                rcnt = 0;
 #endif
-	    }
-	}
+            }
+        }
 
-	if (rcnt > 0)
-	    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+        if (rcnt > 0)
+            ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
 
-	/* Release resources. */
-	if (file->iobuf)
-	{
-	    PLOG((3,"freeing variable buffer in flush_output_buffer"));
-	    free(file->iobuf);
-	    file->iobuf = NULL;
-	}
+        /* Release resources. */
+        if (file->iobuf)
+        {
+            PLOG((3,"freeing variable buffer in flush_output_buffer"));
+            free(file->iobuf);
+            file->iobuf = NULL;
+        }
 
-	for (int v = 0; v < file->nvars; v++)
-	{
-	    if ((ierr = get_var_desc(v, &file->varlist, &vdesc)))
-		return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-	    if (vdesc->fillbuf)
-	    {
-		free(vdesc->fillbuf);
-		vdesc->fillbuf = NULL;
-	    }
-	}
+        for (int v = 0; v < file->nvars; v++)
+        {
+            if ((ierr = get_var_desc(v, &file->varlist, &vdesc)))
+                return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+            if (vdesc->fillbuf)
+            {
+                free(vdesc->fillbuf);
+                vdesc->fillbuf = NULL;
+            }
+        }
     }
 
 #endif /* _PNETCDF */
@@ -1838,41 +1838,41 @@ flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
 
     /* Get the file info (to get error handler). */
     if ((ret = pio_get_file(ncid, &file)))
-	return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
 
     PLOG((1, "flush_buffer ncid = %d flushtodisk = %d", ncid, flushtodisk));
 
     /* If there are any variables in this buffer... */
     if (wmb->num_arrays > 0)
     {
-	/* Write any data in the buffer. */
-	ret = PIOc_write_darray_multi(ncid, wmb->vid,  wmb->ioid, wmb->num_arrays,
-				      wmb->arraylen, wmb->data, wmb->frame,
-				      wmb->fillvalue, flushtodisk);
-	PLOG((2, "return from PIOc_write_darray_multi ret = %d", ret));
+        /* Write any data in the buffer. */
+        ret = PIOc_write_darray_multi(ncid, wmb->vid,  wmb->ioid, wmb->num_arrays,
+                                      wmb->arraylen, wmb->data, wmb->frame,
+                                      wmb->fillvalue, flushtodisk);
+        PLOG((2, "return from PIOc_write_darray_multi ret = %d", ret));
 
-	wmb->num_arrays = 0;
+        wmb->num_arrays = 0;
 
-	/* Release the list of variable IDs. */
-	free(wmb->vid);
-	wmb->vid = NULL;
+        /* Release the list of variable IDs. */
+        free(wmb->vid);
+        wmb->vid = NULL;
 
-	/* Release the data memory. */
-	free(wmb->data);
-	wmb->data = NULL;
+        /* Release the data memory. */
+        free(wmb->data);
+        wmb->data = NULL;
 
-	/* If there is a fill value, release it. */
-	if (wmb->fillvalue)
-	    free(wmb->fillvalue);
-	wmb->fillvalue = NULL;
+        /* If there is a fill value, release it. */
+        if (wmb->fillvalue)
+            free(wmb->fillvalue);
+        wmb->fillvalue = NULL;
 
-	/* Release the record number. */
-	if (wmb->frame)
-	    free(wmb->frame);
-	wmb->frame = NULL;
+        /* Release the record number. */
+        if (wmb->frame)
+            free(wmb->frame);
+        wmb->frame = NULL;
 
-	if (ret)
-	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+        if (ret)
+            return pio_err(NULL, file, ret, __FILE__, __LINE__);
     }
 
     return PIO_NOERR;
@@ -1892,242 +1892,242 @@ flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
  */
 int
 pio_sorted_copy(const void *array, void *sortedarray, io_desc_t *iodesc,
-		int nvars, int direction)
+                int nvars, int direction)
 {
     int maplen = iodesc->maplen;
 
     if (direction == 0){
-	switch (iodesc->piotype)
-	{
-	case PIO_BYTE:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((signed char *)sortedarray)[m+maplen*v] = ((signed char *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_CHAR:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((char *)sortedarray)[m+maplen*v] = ((char *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_SHORT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((short *)sortedarray)[m+maplen*v] = ((short *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
+        switch (iodesc->piotype)
+        {
+        case PIO_BYTE:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((signed char *)sortedarray)[m+maplen*v] = ((signed char *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_CHAR:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((char *)sortedarray)[m+maplen*v] = ((char *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_SHORT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((short *)sortedarray)[m+maplen*v] = ((short *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
 
-	    break;
-	case PIO_INT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((int *)sortedarray)[m+maplen*v] = ((int *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_FLOAT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((float *)sortedarray)[m+maplen*v] = ((float *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_DOUBLE:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((double *)sortedarray)[m+maplen*v] = ((double *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_UBYTE:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((unsigned char *)sortedarray)[m+maplen*v] = ((unsigned char *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_USHORT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((unsigned short *)sortedarray)[m+maplen*v] = ((unsigned short *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_UINT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((unsigned int *)sortedarray)[m+maplen*v] = ((unsigned int *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_INT64:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((long long *)sortedarray)[m+maplen*v] = ((long long *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_UINT64:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((unsigned long long *)sortedarray)[m+maplen*v] = ((unsigned long long *)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_STRING:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((char **)sortedarray)[m+maplen*v] = ((char **)array)[iodesc->remap[m]+maplen*v];
-		}
-	    }
-	    break;
-	default:
-	    return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
-	}
+            break;
+        case PIO_INT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((int *)sortedarray)[m+maplen*v] = ((int *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_FLOAT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((float *)sortedarray)[m+maplen*v] = ((float *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_DOUBLE:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((double *)sortedarray)[m+maplen*v] = ((double *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_UBYTE:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((unsigned char *)sortedarray)[m+maplen*v] = ((unsigned char *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_USHORT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((unsigned short *)sortedarray)[m+maplen*v] = ((unsigned short *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_UINT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((unsigned int *)sortedarray)[m+maplen*v] = ((unsigned int *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_INT64:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((long long *)sortedarray)[m+maplen*v] = ((long long *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_UINT64:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((unsigned long long *)sortedarray)[m+maplen*v] = ((unsigned long long *)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        case PIO_STRING:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((char **)sortedarray)[m+maplen*v] = ((char **)array)[iodesc->remap[m]+maplen*v];
+                }
+            }
+            break;
+        default:
+            return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
+        }
     }
     else
     {
-	switch (iodesc->piotype)
-	{
-	case PIO_BYTE:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((signed char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((signed char *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_CHAR:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((char *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_SHORT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((short *)sortedarray)[iodesc->remap[m]+maplen*v] = ((short *)array)[m+maplen*v];
-		}
-	    }
+        switch (iodesc->piotype)
+        {
+        case PIO_BYTE:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((signed char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((signed char *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_CHAR:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((char *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_SHORT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((short *)sortedarray)[iodesc->remap[m]+maplen*v] = ((short *)array)[m+maplen*v];
+                }
+            }
 
-	    break;
-	case PIO_INT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((int *)sortedarray)[iodesc->remap[m]+maplen*v] = ((int *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_FLOAT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((float *)sortedarray)[iodesc->remap[m]+maplen*v] = ((float *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_DOUBLE:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((double *)sortedarray)[iodesc->remap[m]+maplen*v] = ((double *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_UBYTE:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((unsigned char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned char *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_USHORT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((unsigned short *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned short *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_UINT:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((unsigned int *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned int *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_INT64:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((long long *)sortedarray)[iodesc->remap[m]+maplen*v] = ((long long *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_UINT64:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((unsigned long long *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned long long *)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	case PIO_STRING:
-	    for (int v=0; v < nvars; v++)
-	    {
-		for (int m=0; m < maplen; m++)
-		{
-		    ((char **)sortedarray)[iodesc->remap[m]+maplen*v] = ((char **)array)[m+maplen*v];
-		}
-	    }
-	    break;
-	default:
-	    return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
-	}
+            break;
+        case PIO_INT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((int *)sortedarray)[iodesc->remap[m]+maplen*v] = ((int *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_FLOAT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((float *)sortedarray)[iodesc->remap[m]+maplen*v] = ((float *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_DOUBLE:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((double *)sortedarray)[iodesc->remap[m]+maplen*v] = ((double *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_UBYTE:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((unsigned char *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned char *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_USHORT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((unsigned short *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned short *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_UINT:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((unsigned int *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned int *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_INT64:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((long long *)sortedarray)[iodesc->remap[m]+maplen*v] = ((long long *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_UINT64:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((unsigned long long *)sortedarray)[iodesc->remap[m]+maplen*v] = ((unsigned long long *)array)[m+maplen*v];
+                }
+            }
+            break;
+        case PIO_STRING:
+            for (int v=0; v < nvars; v++)
+            {
+                for (int m=0; m < maplen; m++)
+                {
+                    ((char **)sortedarray)[iodesc->remap[m]+maplen*v] = ((char **)array)[m+maplen*v];
+                }
+            }
+            break;
+        default:
+            return pio_err(NULL, NULL, PIO_EBADTYPE, __FILE__, __LINE__);
+        }
     }
     return PIO_NOERR;
 }
@@ -2153,26 +2153,26 @@ compute_maxaggregate_bytes(iosystem_desc_t *ios, io_desc_t *iodesc)
     pioassert(iodesc, "invalid input", __FILE__, __LINE__);
 
     PLOG((2, "compute_maxaggregate_bytes iodesc->maxiobuflen = %d iodesc->ndof = %d",
-	  iodesc->maxiobuflen, iodesc->ndof));
+          iodesc->maxiobuflen, iodesc->ndof));
 
     /* Determine the max bytes that can be held on IO task. */
     if (ios->ioproc && iodesc->maxiobuflen > 0)
-	maxbytesoniotask = pio_buffer_size_limit / iodesc->maxiobuflen;
+        maxbytesoniotask = pio_buffer_size_limit / iodesc->maxiobuflen;
 
     /* Determine the max bytes that can be held on computation task. */
     if (ios->comp_rank >= 0 && iodesc->ndof > 0)
-	maxbytesoncomputetask = pio_cnbuffer_limit / iodesc->ndof;
+        maxbytesoncomputetask = pio_cnbuffer_limit / iodesc->ndof;
 
     /* Take the min of the max IO and max comp bytes. */
     maxbytes = min(maxbytesoniotask, maxbytesoncomputetask);
     PLOG((2, "compute_maxaggregate_bytes maxbytesoniotask = %d maxbytesoncomputetask = %d",
-	  maxbytesoniotask, maxbytesoncomputetask));
+          maxbytesoniotask, maxbytesoncomputetask));
 
     /* Get the min value of this on all tasks. */
     PLOG((3, "before allreaduce maxbytes = %d", maxbytes));
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxbytes, 1, MPI_INT, MPI_MIN,
-				ios->union_comm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                                ios->union_comm)))
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     PLOG((3, "after allreaduce maxbytes = %d", maxbytes));
 
     /* Remember the result. */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1342,7 +1342,7 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
                         return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
 #else
-                    printf("rllen %d mpitype %d\n",iodesc->rllen, iodesc->mpitype);
+                    //printf("rllen %d mpitype %d\n",iodesc->rllen, iodesc->mpitype);
                     /* Read a list of subarrays. */
                     ierr = ncmpi_get_varn_all(file->fh, vid, rrlen, startlist,
                                               countlist, iobuf, iodesc->rllen, iodesc->mpitype);

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -636,6 +636,7 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
 				if((mpierr = MPI_Type_free(&filetype)))
 				    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 			    }
+fg
 			    vard_llen = 0; /* reset request size to 0 */
 			    numReqs = 0;
 			}

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -417,6 +417,9 @@ extern "C" {
     /* Stop a timer. */
     int pio_stop_timer(const char *name);
 
+    bool check_compmap(iosystem_desc_t *ios, io_desc_t *iodesc,const PIO_Offset *compmap);
+
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -1251,12 +1251,12 @@ PIOc_inq_att_eh(int ncid, int varid, const char *name, int eh,
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);
-        PLOG((2, "PIOc_inq_att netcdf call %s returned %d", name,ierr));
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+    PLOG((2, "PIOc_inq_att netcdf call %s returned %d eh %d", name,ierr,eh));
     if (eh && ierr)
         return check_netcdf(file, ierr, __FILE__, __LINE__);
 

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -110,7 +110,6 @@ expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
 	    if (test_idx >= maplen || map[test_idx] != map[j] + i * region_stride)
 	    {
 		expansion_done = 1;
-		printf("test_idx %d maplen %d map[test_idx] %d i %d stride %d\n",test_idx, maplen, map[test_idx],i, region_stride);
 		break;
 	    }
 	}
@@ -191,9 +190,6 @@ find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
     for (int dim = 0; dim < ndims; dim++)
 	*regionlen *= count[dim];
 
-    printf("regionlen = %d\n",*regionlen);
-//    int ierr;
-//    MPI_Abort(MPI_COMM_WORLD, ierr);
     return PIO_NOERR;
 }
 
@@ -463,11 +459,9 @@ define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
 	  "iodesc->nrecvs %d", ios->ioproc, iodesc->rtype ? "not " : "",
 	  iodesc->nrecvs));
 
-    if(ios->comp_rank==1) PIOc_set_log_level(3);
     /* Set up the to transfer data to and from the IO tasks. */
     if (ios->ioproc)
     {
-        PIOc_set_log_level(3);
 	/* If the types for the IO tasks have not been created, then
 	 * create them. */
 	if (!iodesc->rtype)
@@ -525,7 +519,6 @@ define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
 	    if ((ret = create_mpi_datatypes(iodesc->mpitype, ntypes, iodesc->sindex,
 					    iodesc->scount, NULL, iodesc->stype)))
 		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-            PIOc_set_log_level(0);
 
 	}
     }
@@ -1355,7 +1348,7 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
 
     /* Set the iomaplen in the sc_info msg */
     sc_info_msg_send[0] = iodesc->llen;
-
+    iodesc->rllen = iodesc->llen;
     /* start/count array to be sent: 1st half for start, 2nd half for count */
     for (int j = 0; j < ndims; j++)
     {
@@ -2105,8 +2098,8 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
      * compmap. */
     for (i = 0; i < iodesc->ndof; i++)
     {
-	pioassert(compmap[i]>=-1 && compmap[i]<=totalgridsize, "Compmap value out of bounds",
-	    __FILE__,__LINE__);
+//	pioassert(compmap[i]>=-1 && compmap[i]<=totalgridsize, "Compmap value out of bounds",
+//	    __FILE__,__LINE__);
 	if (compmap[i] > 0)
 	    (iodesc->scount[0])++;
     }
@@ -2268,12 +2261,6 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
         iodesc->rllen = rllen+1;
     
     }
-
-    if(ios->ioproc)
-        for(int i=0;i<iodesc->llen;i++)
-            printf("srcindex[%d]=%d\n",i,srcindex[i]);
-
-
 
     /* Handle fill values if needed. */
     PLOG((2, "ios->ioproc %d iodesc->needsfill %d iodesc->rllen %d", ios->ioproc, iodesc->needsfill, iodesc->rllen));

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -30,25 +30,25 @@
  */
 inline void
 idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
-                PIO_Offset *dim_list)
+		PIO_Offset *dim_list)
 {
     /* Check inputs. */
     pioassert(ndims >= 0 && gdimlen && idx >= -1 && dim_list, "invalid input",
-              __FILE__, __LINE__);
+	      __FILE__, __LINE__);
     PLOG((2, "idx_to_dim_list ndims = %d idx = %d", ndims, idx));
 
     /* Easiest to start from the right and move left. */
     for (int i = ndims - 1; i >= 0; --i)
     {
-        PIO_Offset next_idx;
+	PIO_Offset next_idx;
 
-        /* This way of doing div/mod is slightly faster than using "/"
-         * and "%". */
-        next_idx = idx / gdimlen[i];
-        dim_list[i] = idx - (next_idx * gdimlen[i]);
-        PLOG((3, "next_idx = %d idx = %d gdimlen[%d] = %d dim_list[%d] = %d",
-              next_idx, idx, i, gdimlen[i], i, dim_list[i]));
-        idx = next_idx;
+	/* This way of doing div/mod is slightly faster than using "/"
+	 * and "%". */
+	next_idx = idx / gdimlen[i];
+	dim_list[i] = idx - (next_idx * gdimlen[i]);
+	PLOG((3, "next_idx = %d idx = %d gdimlen[%d] = %d dim_list[%d] = %d",
+	      next_idx, idx, i, gdimlen[i], i, dim_list[i]));
+	idx = next_idx;
     }
 }
 
@@ -77,52 +77,54 @@ idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
  */
 void
 expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
-              int region_size, int region_stride, const int *max_size,
-              PIO_Offset *count)
+	      int region_size, int region_stride, const int *max_size,
+	      PIO_Offset *count)
 {
     /* Flag used to signal that we can no longer expand the region
        along dimension dim. */
     int expansion_done = 0;
-
+    printf("%d %d %d %d\n",map[0],map[1],map[2],map[3]);
     /* Check inputs. */
     pioassert(dim >= 0 && gdimlen && maplen >= 0 && map && region_size >= 0 &&
-              maplen >= region_size && region_stride >= 0 && max_size && count,
-              "invalid input", __FILE__, __LINE__);
+	      maplen >= region_size && region_stride >= 0 && max_size && count,
+	      "invalid input", __FILE__, __LINE__);
 
     /* Expand no greater than max_size along this dimension. */
     for (int i = 1; i <= max_size[dim]; ++i)
     {
-        /* Count so far is at least i. */
-        count[dim] = i;
+	/* Count so far is at least i. */
+	count[dim] = i;
 
-        /* Now see if we can expand to i+1 by checking that the next
-           region_size elements are ahead by exactly region_stride.
-           Assuming monotonicity in the map, we could skip this for the
-           innermost dimension, but it's necessary past that because the
-           region does not necessarily comprise contiguous values. */
-        for (int j = 0; j < region_size; j++)
-        {
-            int test_idx; /* Index we are testing. */
+	/* Now see if we can expand to i+1 by checking that the next
+	   region_size elements are ahead by exactly region_stride.
+	   Assuming monotonicity in the map, we could skip this for the
+	   innermost dimension, but it's necessary past that because the
+	   region does not necessarily comprise contiguous values. */
+	for (int j = 0; j < region_size; j++)
+	{
+	    int test_idx; /* Index we are testing. */
 
-            test_idx = j + i * region_size;
+	    test_idx = j + i * region_size;
 
-            /* If we have exhausted the map, or the map no longer matches,
-               we are done, break out of both loops. */
-            if (test_idx >= maplen || map[test_idx] != map[j] + i * region_stride)
-            {
-                expansion_done = 1;
-                break;
-            }
-        }
-        if (expansion_done)
-            break;
+	    /* If we have exhausted the map, or the map no longer matches,
+	       we are done, break out of both loops. */
+	    if (test_idx >= maplen || map[test_idx] != map[j] + i * region_stride)
+	    {
+		expansion_done = 1;
+		printf("test_idx %d maplen %d map[test_idx] %d i %d stride %d\n",test_idx, maplen, map[test_idx],i, region_stride);
+		break;
+	    }
+	}
+	if (expansion_done)
+	    break;
+
     }
 
     /* Move on to next outermost dimension if there are more left,
      * else return. */
     if (dim > 0)
-        expand_region(dim - 1, gdimlen, maplen, map, region_size * count[dim],
-                      region_stride * gdimlen[dim], max_size, count);
+	expand_region(dim - 1, gdimlen, maplen, map, region_size * count[dim],
+		      region_stride * gdimlen[dim], max_size, count);
 }
 
 /**
@@ -156,11 +158,11 @@ expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
  */
 int
 find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
-            PIO_Offset *start, PIO_Offset *count, PIO_Offset *regionlen)
+	    PIO_Offset *start, PIO_Offset *count, PIO_Offset *regionlen)
 {
     /* Check inputs. */
     pioassert(ndims > 0 && gdimlen && maplen > 0 && map && start && count &&
-              regionlen, "invalid input", __FILE__, __LINE__);
+	      regionlen, "invalid input", __FILE__, __LINE__);
     PLOG((2, "find_region ndims = %d maplen = %d", ndims, maplen));
 
     *regionlen = 1;
@@ -175,8 +177,8 @@ find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
      * expand_region call below. */
     for (int dim = 0; dim < ndims; ++dim)
     {
-        max_size[dim] = gdimlen[dim] - start[dim];
-        PLOG((3, "max_size[%d] = %d", max_size[dim]));
+	max_size[dim] = gdimlen[dim] - start[dim];
+	PLOG((3, "max_size[%d] = %d", max_size[dim]));
     }
 
     /* For each dimension, figure out how far we can expand in that dimension
@@ -188,8 +190,11 @@ find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
 
     /* Calculate the number of data elements in this region. */
     for (int dim = 0; dim < ndims; dim++)
-        *regionlen *= count[dim];
+	*regionlen *= count[dim];
 
+    printf("regionlen = %d\n",*regionlen);
+//    int ierr;
+//    MPI_Abort(MPI_COMM_WORLD, ierr);
     return PIO_NOERR;
 }
 
@@ -213,8 +218,8 @@ coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO_Offset *count)
 
     for (int i = ndims - 1; i >= 0; i--)
     {
-        lindex += lcoord[i] * stride;
-        stride = stride * count[i];
+	lindex += lcoord[i] * stride;
+	stride = stride * count[i];
     }
     return lindex;
 }
@@ -242,19 +247,19 @@ compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
      *  combined size of all regions */
     for (io_region *region = iodesc->firstregion; region; region = region->next)
     {
-        if (region->count[0] > 0)
-        {
-            PIO_Offset iosize = 1;
-            for (int i = 0; i < iodesc->ndims; i++)
-                iosize *= region->count[i];
-            totiosize += iosize;
-        }
+	if (region->count[0] > 0)
+	{
+	    PIO_Offset iosize = 1;
+	    for (int i = 0; i < iodesc->ndims; i++)
+		iosize *= region->count[i];
+	    totiosize += iosize;
+	}
     }
     PLOG((2, "compute_maxIObuffersize got totiosize = %lld", totiosize));
 
     /* Share the max io buffer size with all io tasks. */
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &totiosize, 1, MPI_OFFSET, MPI_MAX, io_comm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     pioassert(totiosize > 0, "totiosize <= 0", __FILE__, __LINE__);
     PLOG((2, "after allreduce compute_maxIObuffersize got totiosize = %lld", totiosize));
 
@@ -283,8 +288,8 @@ compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
  */
 int
 create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
-                     const PIO_Offset *mindex, const int *mcount, int *mfrom,
-                     MPI_Datatype *mtype)
+		     const PIO_Offset *mindex, const int *mcount, int *mfrom,
+		     MPI_Datatype *mtype)
 {
     int blocksize;
     int numinds = 0;
@@ -298,22 +303,22 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
     PIO_Offset bsizeT[msgcnt];
 
     PLOG((1, "create_mpi_datatypes mpitype = %d msgcnt = %d", mpitype,
-          msgcnt));
+	  msgcnt));
     PLOG((2, "MPI_BYTE = %d MPI_CHAR = %d MPI_SHORT = %d MPI_INT = %d "
-          "MPI_FLOAT = %d MPI_DOUBLE = %d", MPI_BYTE, MPI_CHAR, MPI_SHORT,
-          MPI_INT, MPI_FLOAT, MPI_DOUBLE));
+	  "MPI_FLOAT = %d MPI_DOUBLE = %d", MPI_BYTE, MPI_CHAR, MPI_SHORT,
+	  MPI_INT, MPI_FLOAT, MPI_DOUBLE));
 
     /* How many indicies in the array? */
     for (int j = 0; j < msgcnt; j++)
-        numinds += mcount[j];
+	numinds += mcount[j];
     PLOG((2, "numinds = %d", numinds));
 
     if (mindex)
     {
-        if (!(lindex = malloc(numinds * sizeof(PIO_Offset))))
-            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        memcpy(lindex, mindex, (size_t)(numinds * sizeof(PIO_Offset)));
-        PLOG((3, "allocated lindex, copied mindex"));
+	if (!(lindex = malloc(numinds * sizeof(PIO_Offset))))
+	    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	memcpy(lindex, mindex, (size_t)(numinds * sizeof(PIO_Offset)));
+	PLOG((3, "allocated lindex, copied mindex"));
     }
 
     bsizeT[0] = 0;
@@ -325,24 +330,24 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
      * rearrangers. (If mfrom is NULL, this is the box rearranger.) */
     if (mfrom == NULL)
     {
-        PLOG((3, "mfrom is NULL"));
-        for (int i = 0; i < msgcnt; i++)
-        {
-            if (mcount[i] > 0)
-            {
-                /* Look for the largest block of data for io which
-                 * can be expressed in terms of start and
-                 * count. */
-                bsizeT[ii] = GCDblocksize(mcount[i], lindex + pos);
-                ii++;
-                pos += mcount[i];
-            }
-        }
-        blocksize = (int)lgcd_array(ii, bsizeT);
+	PLOG((3, "mfrom is NULL"));
+	for (int i = 0; i < msgcnt; i++)
+	{
+	    if (mcount[i] > 0)
+	    {
+		/* Look for the largest block of data for io which
+		 * can be expressed in terms of start and
+		 * count. */
+		bsizeT[ii] = GCDblocksize(mcount[i], lindex + pos);
+		ii++;
+		pos += mcount[i];
+	    }
+	}
+	blocksize = (int)lgcd_array(ii, bsizeT);
     }
     else
     {
-        blocksize = 1;
+	blocksize = 1;
     }
     PLOG((3, "blocksize = %d", blocksize));
 
@@ -350,67 +355,67 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
     pos = 0;
     for (int i = 0; i < msgcnt; i++)
     {
-        if (mcount[i] > 0)
-        {
-            int len = mcount[i] / blocksize;
-            int *displace;
+	if (mcount[i] > 0)
+	{
+	    int len = mcount[i] / blocksize;
+	    int *displace;
 
-            if (!(displace = malloc(sizeof(int) * len)))
-                EXIT1(PIO_ENOMEM);
+	    if (!(displace = malloc(sizeof(int) * len)))
+		EXIT1(PIO_ENOMEM);
 
-            PLOG((3, "blocksize = %d i = %d mcount[%d] = %d len = %d", blocksize, i, i,
-                  mcount[i], len));
-            if (blocksize == 1)
-            {
-                if (!mfrom)
-                {
-                    /* Box rearranger. */
-                    for (int j = 0; j < len; j++)
-                        displace[j] = (int)(lindex[pos + j]);
-                }
-                else
-                {
-                    /* Subset rearranger. */
-                    int k = 0;
-                    for (int j = 0; j < numinds; j++)
-                        if (mfrom[j] == i)
-                            displace[k++] = (int)(lindex[j]);
-                }
+	    PLOG((2, "blocksize = %d i = %d mcount[%d] = %d len = %d", blocksize, i, i,
+		  mcount[i], len));
+	    if (blocksize == 1)
+	    {
+		if (!mfrom)
+		{
+		    /* Box rearranger. */
+		    for (int j = 0; j < len; j++)
+			displace[j] = (int)(lindex[pos + j]);
+		}
+		else
+		{
+		    /* Subset rearranger. */
+		    int k = 0;
+		    for (int j = 0; j < numinds; j++)
+			if (mfrom[j] == i)
+			    displace[k++] = (int)(lindex[j]);
+		}
 
-            }
-            else
-            {
-                for (int j = 0; j < mcount[i]; j++)
-                    (lindex + pos)[j]++;
+	    }
+	    else
+	    {
+		for (int j = 0; j < mcount[i]; j++)
+		    (lindex + pos)[j]++;
 
-                for (int j = 0; j < len; j++)
-                    displace[j] = ((lindex + pos)[j * blocksize] - 1);
-            }
+		for (int j = 0; j < len; j++)
+		    displace[j] = ((lindex + pos)[j * blocksize] - 1);
+	    }
 
 #if PIO_ENABLE_LOGGING
-            for (int j = 0; j < len; j++)
-                PLOG((3, "displace[%d] = %d", j, displace[j]));
+	    for (int j = 0; j < 8; j++)
+		PLOG((2, "displace[%d] = %d mfrom[%d] %d", j, displace[j], j, mfrom[j]));
 #endif /* PIO_ENABLE_LOGGING */
 
-            PLOG((3, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "
-                  "mpitype = %d", len, blocksize, mpitype));
-            /* Create an indexed datatype with constant-sized blocks. */
-            mpierr = MPI_Type_create_indexed_block(len, blocksize, displace,
-                                                   mpitype, &mtype[i]);
+	    PLOG((2, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "
+		  "mpitype = %d", len, blocksize, mpitype));
+	    /* Create an indexed datatype with constant-sized blocks. */
+	    mpierr = MPI_Type_create_indexed_block(len, blocksize, displace,
+						   mpitype, &mtype[i]);
 
-            free(displace);
-            if (mpierr)
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    free(displace);
+	    if (mpierr)
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-            if (mtype[i] == PIO_DATATYPE_NULL)
-                return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	    if (mtype[i] == PIO_DATATYPE_NULL)
+		return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-            /* Commit the MPI data type. */
-            PLOG((3, "about to commit type"));
-            if ((mpierr = MPI_Type_commit(&mtype[i])))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            pos += mcount[i];
-        }
+	    /* Commit the MPI data type. */
+	    PLOG((3, "about to commit type"));
+	    if ((mpierr = MPI_Type_commit(&mtype[i])))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    pos += mcount[i];
+	}
     }
 
     PLOG((3, "done with create_mpi_datatypes()"));
@@ -418,7 +423,7 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
 exit:
     /* Free resources. */
     if (lindex)
-        free(lindex);
+	free(lindex);
 
     return ret;
 }
@@ -451,37 +456,37 @@ define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);
     PLOG((3, "define_iodesc_datatypes ios->ioproc = %d iodesc->rtype is %sNULL, "
-          "iodesc->nrecvs %d", ios->ioproc, iodesc->rtype ? "not " : "",
-          iodesc->nrecvs));
+	  "iodesc->nrecvs %d", ios->ioproc, iodesc->rtype ? "not " : "",
+	  iodesc->nrecvs));
 
     /* Set up the to transfer data to and from the IO tasks. */
     if (ios->ioproc)
     {
-        /* If the types for the IO tasks have not been created, then
-         * create them. */
-        if (!iodesc->rtype)
-        {
-            if (iodesc->nrecvs > 0)
-            {
-                /* Allocate memory for array of MPI types for the IO tasks. */
-                if (!(iodesc->rtype = malloc(iodesc->nrecvs * sizeof(MPI_Datatype))))
-                    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-                PLOG((2, "allocated memory for IO task MPI types iodesc->nrecvs = %d "
-                      "iodesc->rearranger = %d", iodesc->nrecvs, iodesc->rearranger));
+	/* If the types for the IO tasks have not been created, then
+	 * create them. */
+	if (!iodesc->rtype)
+	{
+	    if (iodesc->nrecvs > 0)
+	    {
+		/* Allocate memory for array of MPI types for the IO tasks. */
+		if (!(iodesc->rtype = malloc(iodesc->nrecvs * sizeof(MPI_Datatype))))
+		    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+		PLOG((2, "allocated memory for IO task MPI types iodesc->nrecvs = %d "
+		      "iodesc->rearranger = %d", iodesc->nrecvs, iodesc->rearranger));
 
-                /* Initialize data types to NULL. */
-                for (int i = 0; i < iodesc->nrecvs; i++)
-                    iodesc->rtype[i] = PIO_DATATYPE_NULL;
+		/* Initialize data types to NULL. */
+		for (int i = 0; i < iodesc->nrecvs; i++)
+		    iodesc->rtype[i] = PIO_DATATYPE_NULL;
 
-                /* The different rearrangers get different values for mfrom. */
-                int *mfrom = iodesc->rearranger == PIO_REARR_SUBSET ? iodesc->rfrom : NULL;
+		/* The different rearrangers get different values for mfrom. */
+		int *mfrom = iodesc->rearranger == PIO_REARR_SUBSET ? iodesc->rfrom : NULL;
 
-                /* Create the MPI datatypes. */
-                if ((ret = create_mpi_datatypes(iodesc->mpitype, iodesc->nrecvs, iodesc->rindex,
-                                                iodesc->rcount, mfrom, iodesc->rtype)))
-                    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-            }
-        }
+		/* Create the MPI datatypes. */
+		if ((ret = create_mpi_datatypes(iodesc->mpitype, iodesc->nrecvs, iodesc->rindex,
+						iodesc->rcount, mfrom, iodesc->rtype)))
+		    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	    }
+	}
     }
 
     /* Define the datatypes for the computation components if they
@@ -489,32 +494,32 @@ define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
      * operation.) */
     if (ios->compproc)
     {
-        if (!iodesc->stype)
-        {
-            int ntypes;
+	if (!iodesc->stype)
+	{
+	    int ntypes;
 
-            /* Subset rearranger gets one type; box rearranger gets one
-             * type per IO task. */
-            ntypes = iodesc->rearranger == PIO_REARR_SUBSET ? 1 : ios->num_iotasks;
+	    /* Subset rearranger gets one type; box rearranger gets one
+	     * type per IO task. */
+	    ntypes = iodesc->rearranger == PIO_REARR_SUBSET ? 1 : ios->num_iotasks;
 
-            /* Allocate memory for array of MPI types for the computation tasks. */
-            if (!(iodesc->stype = malloc(ntypes * sizeof(MPI_Datatype))))
-                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-            PLOG((3, "allocated memory for computation MPI types ntypes = %d", ntypes));
+	    /* Allocate memory for array of MPI types for the computation tasks. */
+	    if (!(iodesc->stype = malloc(ntypes * sizeof(MPI_Datatype))))
+		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	    PLOG((3, "allocated memory for computation MPI types ntypes = %d", ntypes));
 
-            /* Initialize send types to NULL. */
-            for (int i = 0; i < ntypes; i++)
-                iodesc->stype[i] = PIO_DATATYPE_NULL;
+	    /* Initialize send types to NULL. */
+	    for (int i = 0; i < ntypes; i++)
+		iodesc->stype[i] = PIO_DATATYPE_NULL;
 
-            /* Remember how many types we created for the send side. */
-            iodesc->num_stypes = ntypes;
+	    /* Remember how many types we created for the send side. */
+	    iodesc->num_stypes = ntypes;
 
-            /* Create the MPI data types. */
-            PLOG((3, "about to call create_mpi_datatypes for computation MPI types"));
-            if ((ret = create_mpi_datatypes(iodesc->mpitype, ntypes, iodesc->sindex,
-                                            iodesc->scount, NULL, iodesc->stype)))
-                return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-        }
+	    /* Create the MPI data types. */
+	    PLOG((3, "about to call create_mpi_datatypes for computation MPI types"));
+	    if ((ret = create_mpi_datatypes(iodesc->mpitype, ntypes, iodesc->sindex,
+					    iodesc->scount, NULL, iodesc->stype)))
+		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	}
     }
 
     PLOG((3, "done with define_iodesc_datatypes()"));
@@ -555,7 +560,7 @@ define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
  */
 int
 compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
-               const int *dest_ioproc, const PIO_Offset *dest_ioindex)
+	       const int *dest_ioproc, const PIO_Offset *dest_ioindex)
 {
     int *recv_buf = NULL;
     int nrecvs = 0;
@@ -563,11 +568,11 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
 
     /* Check inputs. */
     pioassert(ios && iodesc && (iodesc->ndof == 0 ||
-                                (iodesc->ndof > 0 && dest_ioproc && dest_ioindex)) &&
-              iodesc->rearranger == PIO_REARR_BOX && ios->num_uniontasks > 0,
-              "invalid input", __FILE__, __LINE__);
+				(iodesc->ndof > 0 && dest_ioproc && dest_ioindex)) &&
+	      iodesc->rearranger == PIO_REARR_BOX && ios->num_uniontasks > 0,
+	      "invalid input", __FILE__, __LINE__);
     PLOG((1, "compute_counts ios->num_uniontasks = %d ios->compproc %d ios->ioproc %d",
-          ios->num_uniontasks, ios->compproc, ios->ioproc));
+	  ios->num_uniontasks, ios->compproc, ios->ioproc));
 
     /* Arrays for swapm all to all gather calls. */
     MPI_Datatype sr_types[ios->num_uniontasks];
@@ -580,29 +585,29 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     PIO_Offset *s2rindex = NULL;
     if (iodesc->ndof > 0)
     {
-        if (!(s2rindex = malloc(sizeof(PIO_Offset) * iodesc->ndof)))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(s2rindex = malloc(sizeof(PIO_Offset) * iodesc->ndof)))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     }
     /* Allocate memory for the array of counts and init to zero. */
     if (!(iodesc->scount = calloc(ios->num_iotasks, sizeof(int))))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* iodesc->scount is the number of data elements sent to each IO
      * task from the current compute task. dest_ioindex[i] may be
      * -1. */
     if (ios->compproc)
-        for (int i = 0; i < iodesc->ndof; i++)
-            if (dest_ioindex[i] >= 0)
-                (iodesc->scount[dest_ioproc[i]])++;
+	for (int i = 0; i < iodesc->ndof; i++)
+	    if (dest_ioindex[i] >= 0)
+		(iodesc->scount[dest_ioproc[i]])++;
 
     /* Initialize arrays used in swapm call. */
     for (int i = 0; i < ios->num_uniontasks; i++)
     {
-        send_counts[i] = 0;
-        send_displs[i] = 0;
-        recv_counts[i] = 0;
-        recv_displs[i] = 0;
-        sr_types[i] = MPI_INT;
+	send_counts[i] = 0;
+	send_displs[i] = 0;
+	recv_counts[i] = 0;
+	recv_displs[i] = 0;
+	sr_types[i] = MPI_INT;
     }
 
     /* Setup for the swapm call. iodesc->scount is the amount of data
@@ -615,13 +620,13 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
      * rank of that task. */
     if (ios->compproc)
     {
-        for (int i = 0; i < ios->num_iotasks; i++)
-        {
-            send_counts[ios->ioranks[i]] = 1;
-            send_displs[ios->ioranks[i]] = i * sizeof(int);
-            PLOG((3, "send_counts[%d] = %d send_displs[%d] = %d", ios->ioranks[i],
-                  send_counts[ios->ioranks[i]], ios->ioranks[i], send_displs[ios->ioranks[i]]));
-        }
+	for (int i = 0; i < ios->num_iotasks; i++)
+	{
+	    send_counts[ios->ioranks[i]] = 1;
+	    send_displs[ios->ioranks[i]] = i * sizeof(int);
+	    PLOG((3, "send_counts[%d] = %d send_displs[%d] = %d", ios->ioranks[i],
+		  send_counts[ios->ioranks[i]], ios->ioranks[i], send_displs[ios->ioranks[i]]));
+	}
     }
 
     /* IO tasks need to know how many data elements they will receive
@@ -629,63 +634,63 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
      * swapm call. */
     if (ios->ioproc)
     {
-        /* Allocate memory to hold array of the scounts from all
-         * computation tasks. */
-        if (!(recv_buf = calloc(ios->num_comptasks, sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	/* Allocate memory to hold array of the scounts from all
+	 * computation tasks. */
+	if (!(recv_buf = calloc(ios->num_comptasks, sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        /* Initialize arrays that keep track of counts and
-         * displacements for the all-to-all gather. */
-        for (int i = 0; i < ios->num_comptasks; i++)
-        {
-            recv_counts[ios->compranks[i]] = 1;
-            recv_displs[ios->compranks[i]] = i * sizeof(int);
-            PLOG((3, "recv_counts[%d] = %d recv_displs[%d] = %d", ios->compranks[i],
-                  recv_counts[ios->compranks[i]], ios->compranks[i],
-                  recv_displs[ios->compranks[i]]));
-        }
+	/* Initialize arrays that keep track of counts and
+	 * displacements for the all-to-all gather. */
+	for (int i = 0; i < ios->num_comptasks; i++)
+	{
+	    recv_counts[ios->compranks[i]] = 1;
+	    recv_displs[ios->compranks[i]] = i * sizeof(int);
+	    PLOG((3, "recv_counts[%d] = %d recv_displs[%d] = %d", ios->compranks[i],
+		  recv_counts[ios->compranks[i]], ios->compranks[i],
+		  recv_displs[ios->compranks[i]]));
+	}
     }
 
     PLOG((2, "about to share scount from each compute task to all IO tasks."));
     /* Share the iodesc->scount from each compute task to all IO
      * tasks. The scounts will end up in array recv_buf. */
     if ((ierr = pio_swapm(iodesc->scount, send_counts, send_displs, sr_types,
-                          recv_buf, recv_counts, recv_displs, sr_types, ios->union_comm,
-                          &iodesc->rearr_opts.comp2io)))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+			  recv_buf, recv_counts, recv_displs, sr_types, ios->union_comm,
+			  &iodesc->rearr_opts.comp2io)))
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 
     /* On IO tasks, set up data receives. */
     if (ios->ioproc)
     {
-        /* Count the number of non-zero scounts from the compute
-         * tasks. */
-        for (int i = 0; i < ios->num_comptasks; i++)
-        {
-            if (recv_buf[i] != 0)
-                nrecvs++;
-            PLOG((3, "recv_buf[%d] = %d", i, recv_buf[i]));
-        }
+	/* Count the number of non-zero scounts from the compute
+	 * tasks. */
+	for (int i = 0; i < ios->num_comptasks; i++)
+	{
+	    if (recv_buf[i] != 0)
+		nrecvs++;
+	    PLOG((3, "recv_buf[%d] = %d", i, recv_buf[i]));
+	}
 
-        /* Get memory to hold the count of data receives. */
-        if (!(iodesc->rcount = calloc(max(1, nrecvs), sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	/* Get memory to hold the count of data receives. */
+	if (!(iodesc->rcount = calloc(max(1, nrecvs), sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        /* Get memory to hold the list of task data was from. */
-        if (!(iodesc->rfrom = calloc(max(1, nrecvs), sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        PLOG((3, "allocared rfrom max(1, nrecvs) = %d", max(1, nrecvs)));
+	/* Get memory to hold the list of task data was from. */
+	if (!(iodesc->rfrom = calloc(max(1, nrecvs), sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	PLOG((3, "allocared rfrom max(1, nrecvs) = %d", max(1, nrecvs)));
 
-        nrecvs = 0;
-        for (int i = 0; i < ios->num_comptasks; i++)
-        {
-            if (recv_buf[i] != 0)
-            {
-                iodesc->rcount[nrecvs] = recv_buf[i];
-                iodesc->rfrom[nrecvs] = ios->compranks[i];
-                nrecvs++;
-            }
-        }
-        free(recv_buf);
+	nrecvs = 0;
+	for (int i = 0; i < ios->num_comptasks; i++)
+	{
+	    if (recv_buf[i] != 0)
+	    {
+		iodesc->rcount[nrecvs] = recv_buf[i];
+		iodesc->rfrom[nrecvs] = ios->compranks[i];
+		nrecvs++;
+	    }
+	}
+	free(recv_buf);
     }
 
     /* ??? */
@@ -695,8 +700,8 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     /* Allocate an array for indicies on the computation tasks (the
      * send side when writing). */
     if (iodesc->sindex == NULL && iodesc->ndof > 0)
-        if (!(iodesc->sindex = malloc(iodesc->ndof * sizeof(PIO_Offset))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(iodesc->sindex = malloc(iodesc->ndof * sizeof(PIO_Offset))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     PLOG((2, "iodesc->ndof = %d ios->num_iotasks = %d", iodesc->ndof, ios->num_iotasks));
 
     int tempcount[ios->num_iotasks];
@@ -707,99 +712,99 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     tempcount[0] = 0;
     for (int i = 1; i < ios->num_iotasks; i++)
     {
-        spos[i] = spos[i - 1] + iodesc->scount[i - 1];
-        tempcount[i] = 0;
-        PLOG((3, "spos[%d] = %d tempcount[%d] = %d", i, spos[i], i, tempcount[i]));
+	spos[i] = spos[i - 1] + iodesc->scount[i - 1];
+	tempcount[i] = 0;
+	PLOG((3, "spos[%d] = %d tempcount[%d] = %d", i, spos[i], i, tempcount[i]));
     }
 
     /* ??? */
     for (int i = 0; i < iodesc->ndof; i++)
     {
-        int iorank;
-        int ioindex;
+	int iorank;
+	int ioindex;
 
-        PLOG((3, "dest_ioproc[%d] = %d dest_ioindex[%d] = %d", i, dest_ioproc[i], i,
-              dest_ioindex[i]));
-        iorank = dest_ioproc[i];
-        ioindex = dest_ioindex[i];
-        if (iorank > -1)
-        {
-            /* this should be moved to create_box */
-            iodesc->sindex[spos[iorank] + tempcount[iorank]] = i;
+	PLOG((3, "dest_ioproc[%d] = %d dest_ioindex[%d] = %d", i, dest_ioproc[i], i,
+	      dest_ioindex[i]));
+	iorank = dest_ioproc[i];
+	ioindex = dest_ioindex[i];
+	if (iorank > -1)
+	{
+	    /* this should be moved to create_box */
+	    iodesc->sindex[spos[iorank] + tempcount[iorank]] = i;
 
-            s2rindex[spos[iorank] + tempcount[iorank]] = ioindex;
-            (tempcount[iorank])++;
-            PLOG((3, "iorank = %d ioindex = %d tempcount[iorank] = %d", iorank, ioindex,
-                  tempcount[iorank]));
-        }
+	    s2rindex[spos[iorank] + tempcount[iorank]] = ioindex;
+	    (tempcount[iorank])++;
+	    PLOG((3, "iorank = %d ioindex = %d tempcount[iorank] = %d", iorank, ioindex,
+		  tempcount[iorank]));
+	}
     }
 
     /* Initialize arrays to zeros. */
     for (int i = 0; i < ios->num_uniontasks; i++)
     {
-        send_counts[i] = 0;
-        send_displs[i] = 0;
-        recv_counts[i] = 0;
-        recv_displs[i] = 0;
+	send_counts[i] = 0;
+	send_displs[i] = 0;
+	recv_counts[i] = 0;
+	recv_displs[i] = 0;
     }
 
     /* ??? */
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-        /* Subset rearranger needs one type, box rearranger needs one for
-         * each IO task. */
-        send_counts[ios->ioranks[i]] = iodesc->scount[i];
-        if (send_counts[ios->ioranks[i]] > 0)
-            send_displs[ios->ioranks[i]] = spos[i] * SIZEOF_MPI_OFFSET;
-        PLOG((3, "ios->ioranks[i] = %d iodesc->scount[%d] = %d spos[%d] = %d",
-              ios->ioranks[i], i, iodesc->scount[i], i, spos[i]));
+	/* Subset rearranger needs one type, box rearranger needs one for
+	 * each IO task. */
+	send_counts[ios->ioranks[i]] = iodesc->scount[i];
+	if (send_counts[ios->ioranks[i]] > 0)
+	    send_displs[ios->ioranks[i]] = spos[i] * SIZEOF_MPI_OFFSET;
+	PLOG((3, "ios->ioranks[i] = %d iodesc->scount[%d] = %d spos[%d] = %d",
+	      ios->ioranks[i], i, iodesc->scount[i], i, spos[i]));
     }
 
     /* Only do this on IO tasks. */
     if (ios->ioproc)
     {
-        int totalrecv = 0;
-        for (int i = 0; i < nrecvs; i++)
-        {
-            recv_counts[iodesc->rfrom[i]] = iodesc->rcount[i];
-            totalrecv += iodesc->rcount[i];
-        }
+	int totalrecv = 0;
+	for (int i = 0; i < nrecvs; i++)
+	{
+	    recv_counts[iodesc->rfrom[i]] = iodesc->rcount[i];
+	    totalrecv += iodesc->rcount[i];
+	}
 
-        recv_displs[0] = 0;
-        for (int i = 1; i < nrecvs; i++)
-        {
-            recv_displs[iodesc->rfrom[i]] = recv_displs[iodesc->rfrom[i - 1]] +
-                iodesc->rcount[i - 1] * SIZEOF_MPI_OFFSET;
-            PLOG((3, "iodesc->rfrom[%d] = %d recv_displs[iodesc->rfrom[i]] = %d", i,
-                  iodesc->rfrom[i], recv_displs[iodesc->rfrom[i]]));
-        }
+	recv_displs[0] = 0;
+	for (int i = 1; i < nrecvs; i++)
+	{
+	    recv_displs[iodesc->rfrom[i]] = recv_displs[iodesc->rfrom[i - 1]] +
+		iodesc->rcount[i - 1] * SIZEOF_MPI_OFFSET;
+	    PLOG((3, "iodesc->rfrom[%d] = %d recv_displs[iodesc->rfrom[i]] = %d", i,
+		  iodesc->rfrom[i], recv_displs[iodesc->rfrom[i]]));
+	}
 
-        /* rindex is an array of the indices of the data to be sent from
-           this io task to each compute task. */
-        PLOG((3, "totalrecv = %d", totalrecv));
-        if (totalrecv > 0)
-        {
-            totalrecv = iodesc->llen;  /* can reduce memory usage here */
-            if (!(iodesc->rindex = calloc(totalrecv, sizeof(PIO_Offset))))
-                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-            PLOG((3, "allocated totalrecv elements in rindex array"));
-        }
+	/* rindex is an array of the indices of the data to be sent from
+	   this io task to each compute task. */
+	PLOG((3, "totalrecv = %d", totalrecv));
+	if (totalrecv > 0)
+	{
+	    totalrecv = iodesc->llen;  /* can reduce memory usage here */
+	    if (!(iodesc->rindex = calloc(totalrecv, sizeof(PIO_Offset))))
+		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	    PLOG((3, "allocated totalrecv elements in rindex array"));
+	}
     }
 
     /* For the swapm call below, init the types to MPI_OFFSET. */
     for (int i = 0; i < ios->num_uniontasks; i++)
-        sr_types[i] = MPI_OFFSET;
+	sr_types[i] = MPI_OFFSET;
 
     /* Here we are sending the mapping from the index on the compute
      * task to the index on the io task. */
     /* s2rindex is the list of indeces on each compute task */
     PLOG((3, "sending mapping"));
     if ((ierr = pio_swapm(s2rindex, send_counts, send_displs, sr_types, iodesc->rindex,
-                          recv_counts, recv_displs, sr_types, ios->union_comm,
-                          &iodesc->rearr_opts.comp2io)))
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+			  recv_counts, recv_displs, sr_types, ios->union_comm,
+			  &iodesc->rearr_opts.comp2io)))
+	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     if(s2rindex)
-        free(s2rindex);
+	free(s2rindex);
 
     return PIO_NOERR;
 }
@@ -818,7 +823,7 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
  */
 int
 rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
-                  void *rbuf, int nvars)
+		  void *rbuf, int nvars)
 {
     int ntasks;       /* Number of tasks in communicator. */
     int niotasks;     /* Number of IO tasks. */
@@ -829,30 +834,30 @@ rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ret = pio_start_timer("PIO:rearrange_comp2io")))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Caller must provide these. */
     pioassert(ios && iodesc && nvars > 0, "invalid input", __FILE__, __LINE__);
 
     PLOG((1, "rearrange_comp2io nvars = %d iodesc->rearranger = %d", nvars,
-          iodesc->rearranger));
+	  iodesc->rearranger));
 
     /* Different rearraangers use different communicators. */
     if (iodesc->rearranger == PIO_REARR_BOX)
     {
-        mycomm = ios->union_comm;
-        niotasks = ios->num_iotasks;
+	mycomm = ios->union_comm;
+	niotasks = ios->num_iotasks;
     }
     else
     {
-        mycomm = iodesc->subset_comm;
-        niotasks = 1;
+	mycomm = iodesc->subset_comm;
+	niotasks = 1;
     }
 
     /* Get the number of tasks. */
     if ((mpierr = MPI_Comm_size(mycomm, &ntasks)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     /* These are parameters to pio_swapm to send data from compute to
      * IO tasks. */
@@ -866,127 +871,127 @@ rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     /* Initialize pio_swapm parameter arrays. */
     for (int i = 0; i < ntasks; i++)
     {
-        sendcounts[i] = 0;
-        recvcounts[i] = 0;
-        sdispls[i] = 0;
-        rdispls[i] = 0;
-        recvtypes[i] = PIO_DATATYPE_NULL;
-        sendtypes[i] =  PIO_DATATYPE_NULL;
+	sendcounts[i] = 0;
+	recvcounts[i] = 0;
+	sdispls[i] = 0;
+	rdispls[i] = 0;
+	recvtypes[i] = PIO_DATATYPE_NULL;
+	sendtypes[i] =  PIO_DATATYPE_NULL;
     }
     PLOG((3, "ntasks = %d iodesc->mpitype_size = %d niotasks = %d", ntasks,
-          iodesc->mpitype_size, niotasks));
+	  iodesc->mpitype_size, niotasks));
 
     /* If it has not already been done, define the MPI data types that
      * will be used for this io_desc_t. */
     if ((ret = define_iodesc_datatypes(ios, iodesc)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* If this io proc, we need to exchange data with compute
      * tasks. Create a MPI DataType for that exchange. */
     PLOG((2, "ios->ioproc %d iodesc->nrecvs = %d", ios->ioproc, iodesc->nrecvs));
     if (ios->ioproc && iodesc->nrecvs > 0)
     {
-        for (int i = 0; i < iodesc->nrecvs; i++)
-        {
-            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
-            {
-                PLOG((3, "iodesc->rtype[%d] = %d iodesc->rearranger = %d", i, iodesc->rtype[i],
-                      iodesc->rearranger));
-                if (iodesc->rearranger == PIO_REARR_SUBSET)
-                {
-                    PLOG((3, "exchanging data for subset rearranger"));
-                    recvcounts[i] = 1;
+	for (int i = 0; i < iodesc->nrecvs; i++)
+	{
+	    if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
+	    {
+		PLOG((3, "iodesc->rtype[%d] = %d iodesc->rearranger = %d", i, iodesc->rtype[i],
+		      iodesc->rearranger));
+		if (iodesc->rearranger == PIO_REARR_SUBSET)
+		{
+		    PLOG((3, "exchanging data for subset rearranger"));
+		    recvcounts[i] = 1;
 
-                    /*  Create an MPI derived data type from equally
-                     *  spaced blocks of the same size. The block size
-                     *  is 1, the stride here is the length of the
-                     *  collected array (llen). */
-                    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
-                                                          iodesc->rtype[i], &recvtypes[i])))
-                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		    /*  Create an MPI derived data type from equally
+		     *  spaced blocks of the same size. The block size
+		     *  is 1, the stride here is the length of the
+		     *  collected array (llen). */
+		    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
+							  iodesc->rtype[i], &recvtypes[i])))
+			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-                    pioassert(recvtypes[i] != PIO_DATATYPE_NULL, "bad mpi type", __FILE__, __LINE__);
+		    pioassert(recvtypes[i] != PIO_DATATYPE_NULL, "bad mpi type", __FILE__, __LINE__);
 
-                    if ((mpierr = MPI_Type_commit(&recvtypes[i])))
-                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-                }
-                else
-                {
-                    recvcounts[iodesc->rfrom[i]] = 1;
-                    PLOG((3, "exchanging data for box rearranger i = %d iodesc->rfrom[i] = %d "
-                          "recvcounts[iodesc->rfrom[i]] = %d", i, iodesc->rfrom[i],
-                          recvcounts[iodesc->rfrom[i]]));
+		    if ((mpierr = MPI_Type_commit(&recvtypes[i])))
+			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		}
+		else
+		{
+		    recvcounts[iodesc->rfrom[i]] = 1;
+		    PLOG((3, "exchanging data for box rearranger i = %d iodesc->rfrom[i] = %d "
+			  "recvcounts[iodesc->rfrom[i]] = %d", i, iodesc->rfrom[i],
+			  recvcounts[iodesc->rfrom[i]]));
 
-                    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
-                                                          iodesc->rtype[i], &recvtypes[iodesc->rfrom[i]])))
-                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
+							  iodesc->rtype[i], &recvtypes[iodesc->rfrom[i]])))
+			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-                    pioassert(recvtypes[iodesc->rfrom[i]] != PIO_DATATYPE_NULL,  "bad mpi type",
-                              __FILE__, __LINE__);
+		    pioassert(recvtypes[iodesc->rfrom[i]] != PIO_DATATYPE_NULL,  "bad mpi type",
+			      __FILE__, __LINE__);
 
-                    if ((mpierr = MPI_Type_commit(&recvtypes[iodesc->rfrom[i]])))
-                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		    if ((mpierr = MPI_Type_commit(&recvtypes[iodesc->rfrom[i]])))
+			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-                    rdispls[iodesc->rfrom[i]] = 0;
-                }
-            }
-        }
+		    rdispls[iodesc->rfrom[i]] = 0;
+		}
+	    }
+	}
     }
 
     /* On compute tasks loop over iotasks and create a data type for
      * each exchange.  */
     if(!ios->async || ios->compproc)
     {
-        for (int i = 0; i < niotasks; i++)
-        {
-            int io_comprank = ios->ioranks[i];
-            PLOG((3, "ios->ioranks[%d] = %d", i, ios->ioranks[i]));
-            if (iodesc->rearranger == PIO_REARR_SUBSET)
-                io_comprank = 0;
+	for (int i = 0; i < niotasks; i++)
+	{
+	    int io_comprank = ios->ioranks[i];
+	    PLOG((3, "ios->ioranks[%d] = %d", i, ios->ioranks[i]));
+	    if (iodesc->rearranger == PIO_REARR_SUBSET)
+		io_comprank = 0;
 
-            PLOG((3, "i = %d iodesc->scount[i] = %d", i, iodesc->scount[i]));
-            if (iodesc->scount[i] > 0 && sbuf)
-            {
-                PLOG((3, "io task %d creating sendtypes[%d]", i, io_comprank));
-                sendcounts[io_comprank] = 1;
-                if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->ndof * iodesc->mpitype_size,
-                                                      iodesc->stype[i], &sendtypes[io_comprank])))
-                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-                pioassert(sendtypes[io_comprank] != PIO_DATATYPE_NULL,  "bad mpi type", __FILE__, __LINE__);
+	    PLOG((3, "i = %d iodesc->scount[i] = %d", i, iodesc->scount[i]));
+	    if (iodesc->scount[i] > 0 && sbuf)
+	    {
+		PLOG((3, "io task %d creating sendtypes[%d]", i, io_comprank));
+		sendcounts[io_comprank] = 1;
+		if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->ndof * iodesc->mpitype_size,
+						      iodesc->stype[i], &sendtypes[io_comprank])))
+		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		pioassert(sendtypes[io_comprank] != PIO_DATATYPE_NULL,  "bad mpi type", __FILE__, __LINE__);
 
-                if ((mpierr = MPI_Type_commit(&sendtypes[io_comprank])))
-                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            }
-            else
-            {
-                sendcounts[io_comprank] = 0;
-            }
-        }
+		if ((mpierr = MPI_Type_commit(&sendtypes[io_comprank])))
+		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    }
+	    else
+	    {
+		sendcounts[io_comprank] = 0;
+	    }
+	}
     }
 
     /* Data in sbuf on the compute nodes is sent to rbuf on the ionodes */
     PLOG((2, "about to call pio_swapm for sbuf"));
     if ((ret = pio_swapm(sbuf, sendcounts, sdispls, sendtypes,
-                         rbuf, recvcounts, rdispls, recvtypes, mycomm,
-                         &iodesc->rearr_opts.comp2io)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+			 rbuf, recvcounts, rdispls, recvtypes, mycomm,
+			 &iodesc->rearr_opts.comp2io)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Free the MPI types. */
     for (int i = 0; i < ntasks; i++)
     {
-        PLOG((3, "freeing MPI types for task %d", i));
-        if (sendtypes[i] != PIO_DATATYPE_NULL)
-            if ((mpierr = MPI_Type_free(&sendtypes[i])))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	PLOG((3, "freeing MPI types for task %d", i));
+	if (sendtypes[i] != PIO_DATATYPE_NULL)
+	    if ((mpierr = MPI_Type_free(&sendtypes[i])))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-        if (recvtypes[i] != PIO_DATATYPE_NULL)
-            if ((mpierr = MPI_Type_free(&recvtypes[i])))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if (recvtypes[i] != PIO_DATATYPE_NULL)
+	    if ((mpierr = MPI_Type_free(&recvtypes[i])))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     }
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:rearrange_comp2io")))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return PIO_NOERR;
@@ -1005,7 +1010,7 @@ rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  */
 int
 rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
-                  void *rbuf)
+		  void *rbuf)
 {
     MPI_Comm mycomm;
     int ntasks;
@@ -1020,31 +1025,31 @@ rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ret = pio_start_timer("PIO:rearrange_io2comp")))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Different rearrangers use different communicators and number of
      * IO tasks. */
     if (iodesc->rearranger == PIO_REARR_BOX)
     {
-        mycomm = ios->union_comm;
-        niotasks = ios->num_iotasks;
+	mycomm = ios->union_comm;
+	niotasks = ios->num_iotasks;
     }
     else
     {
-        mycomm = iodesc->subset_comm;
-        niotasks = 1;
+	mycomm = iodesc->subset_comm;
+	niotasks = 1;
     }
 
     /* Get the size of this communicator. */
     if ((mpierr = MPI_Comm_size(mycomm, &ntasks)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     PLOG((3, "niotasks %d ntasks %d", niotasks, ntasks));
 
     /* Define the MPI data types that will be used for this
      * io_desc_t. */
     if ((ret = define_iodesc_datatypes(ios, iodesc)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Allocate arrays needed by the pio_swapm() function. */
     int sendcounts[ntasks];
@@ -1057,37 +1062,37 @@ rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     /* Initialize arrays. */
     for (int i = 0; i < ntasks; i++)
     {
-        sendcounts[i] = 0;
-        recvcounts[i] = 0;
-        sdispls[i] = 0;
-        rdispls[i] = 0;
-        sendtypes[i] = PIO_DATATYPE_NULL;
-        recvtypes[i] = PIO_DATATYPE_NULL;
+	sendcounts[i] = 0;
+	recvcounts[i] = 0;
+	sdispls[i] = 0;
+	rdispls[i] = 0;
+	sendtypes[i] = PIO_DATATYPE_NULL;
+	recvtypes[i] = PIO_DATATYPE_NULL;
     }
 
     /* In IO tasks set up sendcounts/sendtypes for pio_swapm() call
      * below. */
     if (ios->ioproc)
     {
-        for (int i = 0; i < iodesc->nrecvs; i++)
-        {
-            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
-            {
-                if (iodesc->rearranger == PIO_REARR_SUBSET)
-                {
-                    if (sbuf)
-                    {
-                        sendcounts[i] = 1;
-                        sendtypes[i] = iodesc->rtype[i];
-                    }
-                }
-                else
-                {
-                    sendcounts[iodesc->rfrom[i]] = 1;
-                    sendtypes[iodesc->rfrom[i]] = iodesc->rtype[i];
-                }
-            }
-        }
+	for (int i = 0; i < iodesc->nrecvs; i++)
+	{
+	    if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
+	    {
+		if (iodesc->rearranger == PIO_REARR_SUBSET)
+		{
+		    if (sbuf)
+		    {
+			sendcounts[i] = 1;
+			sendtypes[i] = iodesc->rtype[i];
+		    }
+		}
+		else
+		{
+		    sendcounts[iodesc->rfrom[i]] = 1;
+		    sendtypes[iodesc->rfrom[i]] = iodesc->rtype[i];
+		}
+	    }
+	}
     }
 
     /* In the box rearranger each comp task may communicate with
@@ -1096,27 +1101,32 @@ rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
      * task. */
     for (int i = 0; i < niotasks; i++)
     {
-        int io_comprank = ios->ioranks[i];
+	int io_comprank = ios->ioranks[i];
 
-        if (iodesc->rearranger == PIO_REARR_SUBSET)
-            io_comprank = 0;
+	if (iodesc->rearranger == PIO_REARR_SUBSET)
+	    io_comprank = 0;
 
-        if (iodesc->scount[i] > 0 && iodesc->stype[i] != PIO_DATATYPE_NULL)
-        {
-            recvcounts[io_comprank] = 1;
-            recvtypes[io_comprank] = iodesc->stype[i];
-        }
+	if (iodesc->scount[i] > 0 && iodesc->stype[i] != PIO_DATATYPE_NULL)
+	{
+	    recvcounts[io_comprank] = 1;
+	    recvtypes[io_comprank] = iodesc->stype[i];
+	}
     }
 
     /* Data in sbuf on the ionodes is sent to rbuf on the compute
      * nodes. */
+    if(ios->ioproc){
+	printf("%f %f %f %f\n",((double *) sbuf)[0],((double *) sbuf)[1],((double *) sbuf)[2],((double *) sbuf)[3]);
+	printf("%d %d %d %d\n",sendcounts[0],sendcounts[1],sendcounts[2],sendcounts[3]);
+    }
+
     if ((ret = pio_swapm(sbuf, sendcounts, sdispls, sendtypes, rbuf, recvcounts,
-                         rdispls, recvtypes, mycomm, &iodesc->rearr_opts.io2comp)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+			 rdispls, recvtypes, mycomm, &iodesc->rearr_opts.io2comp)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:rearrange_io2comp")))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif
 
     return PIO_NOERR;
@@ -1139,7 +1149,7 @@ rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  */
 int
 determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
-               const PIO_Offset *compmap)
+	       const PIO_Offset *compmap)
 {
     PIO_Offset totalllen = 0;
     PIO_Offset totalgridsize = 1;
@@ -1147,26 +1157,26 @@ determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
 
     /* Check inputs. */
     pioassert(ios && iodesc && gdimlen && compmap, "invalid input",
-              __FILE__, __LINE__);
+	      __FILE__, __LINE__);
 
     /* Determine size of data space. */
     for (int i = 0; i < iodesc->ndims; i++)
-        totalgridsize *= gdimlen[i];
+	totalgridsize *= gdimlen[i];
 
     /* Determine how many values we have locally. */
     if (iodesc->rearranger == PIO_REARR_SUBSET)
-        totalllen = iodesc->llen;
+	totalllen = iodesc->llen;
     else
-        for (int i = 0; i < iodesc->ndof; i++)
-            if (compmap[i] > 0)
-                totalllen++;
+	for (int i = 0; i < iodesc->ndof; i++)
+	    if (compmap[i] > 0)
+		totalllen++;
 
     /* Add results accross communicator. */
     PLOG((2, "determine_fill before allreduce totalllen = %d totalgridsize = %d",
-          totalllen, totalgridsize));
+	  totalllen, totalgridsize));
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &totalllen, 1, PIO_OFFSET, MPI_SUM,
-                                ios->union_comm)))
-        check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+				ios->union_comm)))
+	check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     PLOG((2, "after allreduce totalllen = %d", totalllen));
 
     /* If the total size of the data provided to be written is < the
@@ -1174,7 +1184,7 @@ determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
     iodesc->needsfill = totalllen < totalgridsize;
 
     /*  TURN OFF FILL for timing test
-        iodesc->needsfill=false; */
+	iodesc->needsfill=false; */
 
     return PIO_NOERR;
 }
@@ -1221,15 +1231,15 @@ determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
  */
 int
 box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap,
-                     const int *gdimlen, int ndims, io_desc_t *iodesc)
+		     const int *gdimlen, int ndims, io_desc_t *iodesc)
 {
     int ret;
 
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims > 0 && iodesc,
-              "invalid input", __FILE__, __LINE__);
+	      "invalid input", __FILE__, __LINE__);
     PLOG((1, "box_rearrange_create maplen = %d ndims = %d ios->num_comptasks = %d "
-          "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
+	  "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
 
     /* Allocate arrays needed for this function. */
     int *dest_ioproc = NULL; /* Destination IO task for each data element on compute task. */
@@ -1252,7 +1262,7 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ret = pio_start_timer("PIO:box_rearrange_create")))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* This is the box rearranger. */
@@ -1263,26 +1273,26 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
 
     if (maplen > 0)
     {
-        if (!(dest_ioproc = malloc(maplen * sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(dest_ioproc = malloc(maplen * sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        if (!(gcoord_map = malloc(maplen * sizeof(PIO_Offset*))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(gcoord_map = malloc(maplen * sizeof(PIO_Offset*))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        for (int i = 0; i < maplen; i++)
-        {
-            if (!(gcoord_map[i] = calloc(ndims, sizeof(PIO_Offset))))
-                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        }
+	for (int i = 0; i < maplen; i++)
+	{
+	    if (!(gcoord_map[i] = calloc(ndims, sizeof(PIO_Offset))))
+		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	}
     }
 
     /* Initialize the sc_info send and recv messages */
     for(int i=0; i<sc_info_msg_sz; i++)
     {
-        sc_info_msg_send[i] = 0;
+	sc_info_msg_send[i] = 0;
     }
 
     /* The sc_info_msg_recv[i * sc_msg_info_sz] contains the sc_info from
@@ -1291,24 +1301,24 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
      */
     for(int i=0; i<ios->num_iotasks * sc_info_msg_sz; i++)
     {
-        sc_info_msg_recv[i] = 0;
+	sc_info_msg_recv[i] = 0;
     }
 
     /* Initialize array values. */
     for (int i = 0; i < maplen; i++)
     {
-        dest_ioproc[i] = -1;
-        dest_ioindex[i] = -1;
+	dest_ioproc[i] = -1;
+	dest_ioindex[i] = -1;
     }
 
     /* Initialize arrays used in swapm. */
     for (int i = 0; i < ios->num_uniontasks; i++)
     {
-        sendcounts[i] = 0;
-        sdispls[i] = 0;
-        recvcounts[i] = 0;
-        rdispls[i] = 0;
-        dtypes[i] = MPI_OFFSET;
+	sendcounts[i] = 0;
+	sdispls[i] = 0;
+	recvcounts[i] = 0;
+	rdispls[i] = 0;
+	dtypes[i] = MPI_OFFSET;
     }
 
     /* For IO tasks, determine llen, the length of the data array on
@@ -1316,28 +1326,28 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
      * set up arrays for the allgather which will give every IO task a
      * complete list of llens for each IO task. */
     PLOG((3, "ios->ioproc = %d ios->num_uniontasks = %d", ios->ioproc,
-          ios->num_uniontasks));
+	  ios->num_uniontasks));
     pioassert(iodesc->llen == 0, "error", __FILE__, __LINE__);
     if (ios->ioproc)
     {
-        /* Determine llen, the length of the data array on this IO
-         * node, by multipliying the counts in the
-         * iodesc->firstregion. */
-        iodesc->llen = 1;
-        for (int i = 0; i < ndims; i++)
-        {
-            iodesc->llen *= iodesc->firstregion->count[i];
-            PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
-                  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
-        }
-        PLOG((2, "iodesc->llen = %d", iodesc->llen));
+	/* Determine llen, the length of the data array on this IO
+	 * node, by multipliying the counts in the
+	 * iodesc->firstregion. */
+	iodesc->llen = 1;
+	for (int i = 0; i < ndims; i++)
+	{
+	    iodesc->llen *= iodesc->firstregion->count[i];
+	    PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
+		  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
+	}
+	PLOG((2, "iodesc->llen = %d", iodesc->llen));
     }
 
     /* Determine whether fill values will be needed. */
     if ((ret = determine_fill(ios, iodesc, gdimlen, compmap)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((2, "a iodesc->needsfill = %d ios->num_iotasks = %d", iodesc->needsfill,
-          ios->num_iotasks));
+	  ios->num_iotasks));
 
     /* Set the iomaplen in the sc_info msg */
     sc_info_msg_send[0] = iodesc->llen;
@@ -1345,149 +1355,149 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
     /* start/count array to be sent: 1st half for start, 2nd half for count */
     for (int j = 0; j < ndims; j++)
     {
-        /* The first data in sc_info_msg_send[] is the iomaplen */
-        sc_info_msg_send[j + 1] = iodesc->firstregion->start[j];
-        sc_info_msg_send[ndims + j + 1] = iodesc->firstregion->count[j];
+	/* The first data in sc_info_msg_send[] is the iomaplen */
+	sc_info_msg_send[j + 1] = iodesc->firstregion->start[j];
+	sc_info_msg_send[ndims + j + 1] = iodesc->firstregion->count[j];
     }
 
     /* Set the recvcounts/recv displs for the sc_info msg from each io task */
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-        /* From each iotask all procs (compute and I/O procs) receive an
-         * sc_info message containing [iomaplen, start_for_all_dims,
-         * count_for_all_dims] and the size of this message is
-         * [sizeof(MPI_OFFSET) + ndims * sizeof(MPI_OFFSET) + ndims *
-         * sizeof(MPI_OFFSET)]
-         * Note: The displacements are in bytes
-         */
-        recvcounts[ios->ioranks[i]] = sc_info_msg_sz;
-        rdispls[ios->ioranks[i]] = i * sc_info_msg_sz * SIZEOF_MPI_OFFSET;
+	/* From each iotask all procs (compute and I/O procs) receive an
+	 * sc_info message containing [iomaplen, start_for_all_dims,
+	 * count_for_all_dims] and the size of this message is
+	 * [sizeof(MPI_OFFSET) + ndims * sizeof(MPI_OFFSET) + ndims *
+	 * sizeof(MPI_OFFSET)]
+	 * Note: The displacements are in bytes
+	 */
+	recvcounts[ios->ioranks[i]] = sc_info_msg_sz;
+	rdispls[ios->ioranks[i]] = i * sc_info_msg_sz * SIZEOF_MPI_OFFSET;
     }
 
     /* Set the sendcounts/send displs for the sc_info msg sent from each
      * I/O task
      */
     for(int i=0; i<ios->num_uniontasks; i++){
-        sendcounts[i] = 0;
-        sdispls[i] = 0;
+	sendcounts[i] = 0;
+	sdispls[i] = 0;
     }
     if(ios->ioproc){
-        /* Only I/O procs send sc_info messages */
-        for (int i = 0; i < ios->num_comptasks; i++)
-        {
-            sendcounts[ios->compranks[i]] = sc_info_msg_sz;
-            sdispls[ios->compranks[i]] = 0;
-        }
-        for (int i = 0; i < ios->num_iotasks; i++)
-        {
-            sendcounts[ios->ioranks[i]] = sc_info_msg_sz;
-            sdispls[ios->ioranks[i]] = 0;
-        }
+	/* Only I/O procs send sc_info messages */
+	for (int i = 0; i < ios->num_comptasks; i++)
+	{
+	    sendcounts[ios->compranks[i]] = sc_info_msg_sz;
+	    sdispls[ios->compranks[i]] = 0;
+	}
+	for (int i = 0; i < ios->num_iotasks; i++)
+	{
+	    sendcounts[ios->ioranks[i]] = sc_info_msg_sz;
+	    sdispls[ios->ioranks[i]] = 0;
+	}
     }
 
     /* Send sc_info msg from iotasks (all iotasks) to all procs(compute and I/O procs)*/
     PLOG((3, "about to call pio_swapm with start/count from iotask ndims = %d",
-          ndims));
+	  ndims));
     if ((ret = pio_swapm(sc_info_msg_send, sendcounts, sdispls, dtypes, sc_info_msg_recv,
-                         recvcounts, rdispls, dtypes, ios->union_comm,
-                         &iodesc->rearr_opts.io2comp)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+			 recvcounts, rdispls, dtypes, ios->union_comm,
+			 &iodesc->rearr_opts.io2comp)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
 #if PIO_ENABLE_LOGGING
     /* First entry in the sc_info msg for each iorank is the iomaplen */
     for (int i = 0; i < ios->num_iotasks; i++)
-        PLOG((3, "iomaplen[%d] = %d", i, sc_info_msg_recv[i * sc_info_msg_sz]));
+	PLOG((3, "iomaplen[%d] = %d", i, sc_info_msg_recv[i * sc_info_msg_sz]));
 #endif /* PIO_ENABLE_LOGGING */
 
     /* Convert a 1-D index into a global coordinate value for each data element */
     for (int k = 0; k < maplen; k++)
     {
-        /* The compmap array is 1 based but calculations are 0 based */
-        PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
-        idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
+	/* The compmap array is 1 based but calculations are 0 based */
+	PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
+	idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
 #if PIO_ENABLE_LOGGING
-        for (int d = 0; d < ndims; d++)
-            PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
+	for (int d = 0; d < ndims; d++)
+	    PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-        /* First entry in the sc_info msg is the iomaplen */
-        iomaplen[i] = sc_info_msg_recv[i * sc_info_msg_sz];
-        if(iomaplen[i] > 0)
-        {
-            /* The rest of the entries in the sc_info msg are the start and
-             * count arrays
-             */
-            PIO_Offset *start = &(sc_info_msg_recv[i * sc_info_msg_sz + 1]);
-            PIO_Offset *count = &(sc_info_msg_recv[i * sc_info_msg_sz + 1 + ndims]);
+	/* First entry in the sc_info msg is the iomaplen */
+	iomaplen[i] = sc_info_msg_recv[i * sc_info_msg_sz];
+	if(iomaplen[i] > 0)
+	{
+	    /* The rest of the entries in the sc_info msg are the start and
+	     * count arrays
+	     */
+	    PIO_Offset *start = &(sc_info_msg_recv[i * sc_info_msg_sz + 1]);
+	    PIO_Offset *count = &(sc_info_msg_recv[i * sc_info_msg_sz + 1 + ndims]);
 
 #if PIO_ENABLE_LOGGING
-            for (int d = 0; d < ndims; d++)
-                PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
+	    for (int d = 0; d < ndims; d++)
+		PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
 #endif /* PIO_ENABLE_LOGGING */
 
-            /* Moved this outside of loop over maplen, for performance. */
-            PIO_Offset lcoord[ndims];
+	    /* Moved this outside of loop over maplen, for performance. */
+	    PIO_Offset lcoord[ndims];
 
-            /* For each element of the data array on the compute task,
-             * find the IO task to send the data element to, and its
-             * offset into the global data array. */
-            for (int k = 0; k < maplen; k++)
-            {
-                /* An IO task has already been found for this element */
-                if (dest_ioproc[k] >= 0)
-                    continue;
+	    /* For each element of the data array on the compute task,
+	     * find the IO task to send the data element to, and its
+	     * offset into the global data array. */
+	    for (int k = 0; k < maplen; k++)
+	    {
+		/* An IO task has already been found for this element */
+		if (dest_ioproc[k] >= 0)
+		    continue;
 
-                bool found = true;
+		bool found = true;
 
-                /* Find a destination for each entry in the compmap. */
-                for (int j = 0; j < ndims; j++)
-                {
-                    if (gcoord_map[k][j] >= start[j] && gcoord_map[k][j] < start[j] + count[j])
-                    {
-                        lcoord[j] = gcoord_map[k][j] - start[j];
-                    }
-                    else
-                    {
-                        found = false;
-                        break;
-                    }
-                }
+		/* Find a destination for each entry in the compmap. */
+		for (int j = 0; j < ndims; j++)
+		{
+		    if (gcoord_map[k][j] >= start[j] && gcoord_map[k][j] < start[j] + count[j])
+		    {
+			lcoord[j] = gcoord_map[k][j] - start[j];
+		    }
+		    else
+		    {
+			found = false;
+			break;
+		    }
+		}
 
-                /* Did we find a destination IO task for this element
-                 * of the computation task data array? If so, remember
-                 * the destination IO task, and determine the index
-                 * for that element in the IO task data. */
-                if (found)
-                {
-                    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
-                    dest_ioproc[k] = i;
-                    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
-                          k, dest_ioproc[k]));
-                }
-            }
-        }
+		/* Did we find a destination IO task for this element
+		 * of the computation task data array? If so, remember
+		 * the destination IO task, and determine the index
+		 * for that element in the IO task data. */
+		if (found)
+		{
+		    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
+		    dest_ioproc[k] = i;
+		    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
+			  k, dest_ioproc[k]));
+		}
+	    }
+	}
     }
 
     for (int i = 0; i < maplen; i++)
-        free(gcoord_map[i]);
+	free(gcoord_map[i]);
     free(gcoord_map);
     gcoord_map = NULL;
 
     /* Check that a destination is found for each compmap entry. */
     for (int k = 0; k < maplen; k++)
-        if (dest_ioproc[k] < 0 && compmap[k] > 0)
-        {
-            PLOG((1, "Error: Found dest_ioproc[%d] = %d and compmap[%d] = %lld", k, dest_ioproc[k], k, compmap[k]));
-            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
-        }
+	if (dest_ioproc[k] < 0 && compmap[k] > 0)
+	{
+	    PLOG((1, "Error: Found dest_ioproc[%d] = %d and compmap[%d] = %lld", k, dest_ioproc[k], k, compmap[k]));
+	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	}
 
     /* Completes the mapping for the box rearranger. */
     PLOG((2, "calling compute_counts maplen = %d", maplen));
     if ((ret = compute_counts(ios, iodesc, dest_ioproc, dest_ioindex)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     free(dest_ioproc);
     free(dest_ioindex);
@@ -1497,20 +1507,20 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
     /* Compute the max io buffer size needed for an iodesc. */
     if (ios->ioproc)
     {
-        if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
-            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-        PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
+	if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
+	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
     }
 
     /* Using maxiobuflen compute the maximum number of bytes that the
      * io task buffer can handle. */
     if ((ret = compute_maxaggregate_bytes(ios, iodesc)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:box_rearrange_create")))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif
 
     return PIO_NOERR;
@@ -1534,23 +1544,23 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
  */
 int
 box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
-                                const PIO_Offset *compmap,
-                                const int *gdimlen, int ndims,
-                                io_desc_t *iodesc)
+				const PIO_Offset *compmap,
+				const int *gdimlen, int ndims,
+				io_desc_t *iodesc)
 {
     int ret;
 
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ret = pio_start_timer("PIO:box_rearrange_create_with_holes")))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims > 0 && iodesc,
-              "invalid input", __FILE__, __LINE__);
+	      "invalid input", __FILE__, __LINE__);
     PLOG((1, "box_rearrange_create maplen = %d ndims = %d ios->num_comptasks = %d "
-          "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
+	  "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
 
     /* Allocate arrays needed for this function. */
     int *dest_ioproc = NULL; /* Destination IO task for each data element on compute task. */
@@ -1571,37 +1581,37 @@ box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
 
     if (maplen > 0)
     {
-        if (!(dest_ioproc = malloc(maplen * sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(dest_ioproc = malloc(maplen * sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        if (!(gcoord_map = malloc(maplen * sizeof(PIO_Offset*))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(gcoord_map = malloc(maplen * sizeof(PIO_Offset*))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        for (int i = 0; i < maplen; i++)
-        {
-            if (!(gcoord_map[i] = calloc(ndims, sizeof(PIO_Offset))))
-                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        }
+	for (int i = 0; i < maplen; i++)
+	{
+	    if (!(gcoord_map[i] = calloc(ndims, sizeof(PIO_Offset))))
+		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	}
     }
 
     /* Initialize array values. */
     for (int i = 0; i < maplen; i++)
     {
-        dest_ioproc[i] = -1;
-        dest_ioindex[i] = -1;
+	dest_ioproc[i] = -1;
+	dest_ioindex[i] = -1;
     }
 
     /* Initialize arrays used in swapm. */
     for (int i = 0; i < ios->num_uniontasks; i++)
     {
-        sendcounts[i] = 0;
-        sdispls[i] = 0;
-        recvcounts[i] = 0;
-        rdispls[i] = 0;
-        dtypes[i] = MPI_OFFSET;
+	sendcounts[i] = 0;
+	sdispls[i] = 0;
+	recvcounts[i] = 0;
+	rdispls[i] = 0;
+	dtypes[i] = MPI_OFFSET;
     }
 
     /* For IO tasks, determine llen, the length of the data array on
@@ -1609,177 +1619,177 @@ box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
      * set up arrays for the allgather which will give every IO task a
      * complete list of llens for each IO task. */
     PLOG((3, "ios->ioproc = %d ios->num_uniontasks = %d", ios->ioproc,
-          ios->num_uniontasks));
+	  ios->num_uniontasks));
     pioassert(iodesc->llen == 0, "error", __FILE__, __LINE__);
     if (ios->ioproc)
     {
-        /* Set up send counts for sending llen in all to all
-         * gather. We are sending to all tasks, IO and computation. */
-        for (int i = 0; i < ios->num_comptasks; i++)
-            sendcounts[ios->compranks[i]] = 1;
-        for (int i = 0; i < ios->num_iotasks; i++)
-            sendcounts[ios->ioranks[i]] = 1;
+	/* Set up send counts for sending llen in all to all
+	 * gather. We are sending to all tasks, IO and computation. */
+	for (int i = 0; i < ios->num_comptasks; i++)
+	    sendcounts[ios->compranks[i]] = 1;
+	for (int i = 0; i < ios->num_iotasks; i++)
+	    sendcounts[ios->ioranks[i]] = 1;
 
-        /* Determine llen, the lenght of the data array on this IO
-         * node, by multipliying the counts in the
-         * iodesc->firstregion. */
-        iodesc->llen = 1;
-        for (int i = 0; i < ndims; i++)
-        {
-            iodesc->llen *= iodesc->firstregion->count[i];
-            PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
-                  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
-        }
-        PLOG((2, "iodesc->llen = %d", iodesc->llen));
+	/* Determine llen, the lenght of the data array on this IO
+	 * node, by multipliying the counts in the
+	 * iodesc->firstregion. */
+	iodesc->llen = 1;
+	for (int i = 0; i < ndims; i++)
+	{
+	    iodesc->llen *= iodesc->firstregion->count[i];
+	    PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
+		  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
+	}
+	PLOG((2, "iodesc->llen = %d", iodesc->llen));
     }
 
     /* Determine whether fill values will be needed. */
     if ((ret = determine_fill(ios, iodesc, gdimlen, compmap)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((2, "b iodesc->needsfill = %d ios->num_iotasks = %d", iodesc->needsfill,
-          ios->num_iotasks));
+	  ios->num_iotasks));
 
     /* Set up receive counts and displacements to for an AllToAll
      * gather of llen. */
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-        recvcounts[ios->ioranks[i]] = 1;
-        rdispls[ios->ioranks[i]] = i * SIZEOF_MPI_OFFSET;
-        PLOG((3, "i = %d ios->ioranks[%d] = %d recvcounts[%d] = %d rdispls[%d] = %d",
-              i, i, ios->ioranks[i], ios->ioranks[i], recvcounts[ios->ioranks[i]],
-              ios->ioranks[i], rdispls[ios->ioranks[i]]));
+	recvcounts[ios->ioranks[i]] = 1;
+	rdispls[ios->ioranks[i]] = i * SIZEOF_MPI_OFFSET;
+	PLOG((3, "i = %d ios->ioranks[%d] = %d recvcounts[%d] = %d rdispls[%d] = %d",
+	      i, i, ios->ioranks[i], ios->ioranks[i], recvcounts[ios->ioranks[i]],
+	      ios->ioranks[i], rdispls[ios->ioranks[i]]));
     }
 
     /* All-gather the llen to all tasks into array iomaplen. */
     PLOG((3, "calling pio_swapm to allgather llen into array iomaplen, ndims = %d dtypes[0] = %d",
-          ndims, dtypes));
+	  ndims, dtypes));
     if ((ret = pio_swapm(&iodesc->llen, sendcounts, sdispls, dtypes, iomaplen, recvcounts,
-                         rdispls, dtypes, ios->union_comm, &iodesc->rearr_opts.io2comp)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+			 rdispls, dtypes, ios->union_comm, &iodesc->rearr_opts.io2comp)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "iodesc->llen = %d", iodesc->llen));
 #if PIO_ENABLE_LOGGING
     for (int i = 0; i < ios->num_iotasks; i++)
-        PLOG((3, "iomaplen[%d] = %d", i, iomaplen[i]));
+	PLOG((3, "iomaplen[%d] = %d", i, iomaplen[i]));
 #endif /* PIO_ENABLE_LOGGING */
 
     /* Convert a 1-D index into a global coordinate value for each data element */
     for (int k = 0; k < maplen; k++)
     {
-        /* The compmap array is 1 based but calculations are 0 based */
-        PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
-        idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
+	/* The compmap array is 1 based but calculations are 0 based */
+	PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
+	idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
 #if PIO_ENABLE_LOGGING
-        for (int d = 0; d < ndims; d++)
-            PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
+	for (int d = 0; d < ndims; d++)
+	    PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
     /* For each IO task send starts/counts to all compute tasks. */
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-        /* The ipmaplen contains the llen (number of data elements)
-         * for this IO task. */
-        PLOG((2, "iomaplen[%d] = %d", i, iomaplen[i]));
+	/* The ipmaplen contains the llen (number of data elements)
+	 * for this IO task. */
+	PLOG((2, "iomaplen[%d] = %d", i, iomaplen[i]));
 
-        /* If there is data for this IO task, send start/count to all
-         * compute tasks. */
-        if (iomaplen[i] > 0)
-        {
-            PIO_Offset start_count_send[ndims * 2];
-            PIO_Offset start_count_recv[ndims * 2];
+	/* If there is data for this IO task, send start/count to all
+	 * compute tasks. */
+	if (iomaplen[i] > 0)
+	{
+	    PIO_Offset start_count_send[ndims * 2];
+	    PIO_Offset start_count_recv[ndims * 2];
 
-            /* start/count array to be sent: 1st half for start, 2nd half for count */
-            for (int j = 0; j < ndims; j++)
-            {
-                start_count_send[j] = iodesc->firstregion->start[j];
-                start_count_send[ndims + j] = iodesc->firstregion->count[j];
-            }
+	    /* start/count array to be sent: 1st half for start, 2nd half for count */
+	    for (int j = 0; j < ndims; j++)
+	    {
+		start_count_send[j] = iodesc->firstregion->start[j];
+		start_count_send[ndims + j] = iodesc->firstregion->count[j];
+	    }
 
-            /* Set up send/recv parameters for all to all gather of
-             * counts and starts. */
-            for (int j = 0; j < ios->num_uniontasks; j++)
-            {
-                sendcounts[j] = 0;
-                sdispls[j] = 0;
-                rdispls[j] = 0;
-                recvcounts[j] = 0;
-                if (ios->union_rank == ios->ioranks[i])
-                    sendcounts[j] = ndims * 2;
-            }
-            recvcounts[ios->ioranks[i]] = ndims * 2;
+	    /* Set up send/recv parameters for all to all gather of
+	     * counts and starts. */
+	    for (int j = 0; j < ios->num_uniontasks; j++)
+	    {
+		sendcounts[j] = 0;
+		sdispls[j] = 0;
+		rdispls[j] = 0;
+		recvcounts[j] = 0;
+		if (ios->union_rank == ios->ioranks[i])
+		    sendcounts[j] = ndims * 2;
+	    }
+	    recvcounts[ios->ioranks[i]] = ndims * 2;
 
-            /* The start/count array from iotask i is sent to all compute tasks. */
-            PLOG((3, "about to call pio_swapm with start/count from iotask %d ndims = %d",
-                  i, ndims));
-            if ((ret = pio_swapm(start_count_send, sendcounts, sdispls, dtypes, start_count_recv,
-                                 recvcounts, rdispls, dtypes, ios->union_comm,
-                                 &iodesc->rearr_opts.io2comp)))
-                return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	    /* The start/count array from iotask i is sent to all compute tasks. */
+	    PLOG((3, "about to call pio_swapm with start/count from iotask %d ndims = %d",
+		  i, ndims));
+	    if ((ret = pio_swapm(start_count_send, sendcounts, sdispls, dtypes, start_count_recv,
+				 recvcounts, rdispls, dtypes, ios->union_comm,
+				 &iodesc->rearr_opts.io2comp)))
+		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
-            /* start/count array received: 1st half for start, 2nd half for count */
-            PIO_Offset *start = start_count_recv;
-            PIO_Offset *count = start_count_recv + ndims;
+	    /* start/count array received: 1st half for start, 2nd half for count */
+	    PIO_Offset *start = start_count_recv;
+	    PIO_Offset *count = start_count_recv + ndims;
 
 #if PIO_ENABLE_LOGGING
-            for (int d = 0; d < ndims; d++)
-                PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
+	    for (int d = 0; d < ndims; d++)
+		PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
 #endif /* PIO_ENABLE_LOGGING */
 
-            /* For each element of the data array on the compute task,
-             * find the IO task to send the data element to, and its
-             * offset into the global data array. */
-            for (int k = 0; k < maplen; k++)
-            {
-                /* An IO task has already been found for this element */
-                if (dest_ioproc[k] >= 0)
-                    continue;
+	    /* For each element of the data array on the compute task,
+	     * find the IO task to send the data element to, and its
+	     * offset into the global data array. */
+	    for (int k = 0; k < maplen; k++)
+	    {
+		/* An IO task has already been found for this element */
+		if (dest_ioproc[k] >= 0)
+		    continue;
 
-                PIO_Offset lcoord[ndims];
-                bool found = true;
+		PIO_Offset lcoord[ndims];
+		bool found = true;
 
-                /* Find a destination for each entry in the compmap. */
-                for (int j = 0; j < ndims; j++)
-                {
-                    if (gcoord_map[k][j] >= start[j] && gcoord_map[k][j] < start[j] + count[j])
-                    {
-                        lcoord[j] = gcoord_map[k][j] - start[j];
-                    }
-                    else
-                    {
-                        found = false;
-                        break;
-                    }
-                }
+		/* Find a destination for each entry in the compmap. */
+		for (int j = 0; j < ndims; j++)
+		{
+		    if (gcoord_map[k][j] >= start[j] && gcoord_map[k][j] < start[j] + count[j])
+		    {
+			lcoord[j] = gcoord_map[k][j] - start[j];
+		    }
+		    else
+		    {
+			found = false;
+			break;
+		    }
+		}
 
-                /* Did we find a destination IO task for this element
-                 * of the computation task data array? If so, remember
-                 * the destination IO task, and determine the index
-                 * for that element in the IO task data. */
-                if (found)
-                {
-                    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
-                    dest_ioproc[k] = i;
-                    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
-                          k, dest_ioproc[k]));
-                }
-            }
-        }
+		/* Did we find a destination IO task for this element
+		 * of the computation task data array? If so, remember
+		 * the destination IO task, and determine the index
+		 * for that element in the IO task data. */
+		if (found)
+		{
+		    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
+		    dest_ioproc[k] = i;
+		    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
+			  k, dest_ioproc[k]));
+		}
+	    }
+	}
     }
 
     for (int i = 0; i < maplen; i++)
-        free(gcoord_map[i]);
+	free(gcoord_map[i]);
     free(gcoord_map);
     gcoord_map = NULL;
 
     /* Check that a destination is found for each compmap entry. */
     for (int k = 0; k < maplen; k++)
-        if (dest_ioproc[k] < 0 && compmap[k] > 0)
-            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	if (dest_ioproc[k] < 0 && compmap[k] > 0)
+	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* Completes the mapping for the box rearranger. */
     PLOG((2, "calling compute_counts maplen = %d", maplen));
     if ((ret = compute_counts(ios, iodesc, dest_ioproc, dest_ioindex)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     free(dest_ioproc);
     free(dest_ioindex);
@@ -1789,20 +1799,20 @@ box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
     /* Compute the max io buffer size needed for an iodesc. */
     if (ios->ioproc)
     {
-        if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
-            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-        PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
+	if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
+	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
     }
 
     /* Using maxiobuflen compute the maximum number of bytes that the
      * io task buffer can handle. */
     if ((ret = compute_maxaggregate_bytes(ios, iodesc)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:box_rearrange_create_with_holes")))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return PIO_NOERR;
@@ -1823,7 +1833,7 @@ compare_offsets(const void *a, const void *b)
     mapsort *x = (mapsort *)a;
     mapsort *y = (mapsort *)b;
     if (!x || !y)
-        return 0;
+	return 0;
     return (int)(x->iomap - y->iomap);
 }
 
@@ -1848,7 +1858,7 @@ compare_offsets(const void *a, const void *b)
  */
 int
 get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
-            int *maxregions, io_region *firstregion)
+	    int *maxregions, io_region *firstregion)
 {
     int nmaplen = 0;
     PIO_Offset regionlen;
@@ -1857,18 +1867,18 @@ get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
 
     /* Check inputs. */
     pioassert(ndims >= 0 && gdimlen && maplen >= 0 && maxregions && firstregion,
-              "invalid input", __FILE__, __LINE__);
+	      "invalid input", __FILE__, __LINE__);
     PLOG((1, "get_regions ndims = %d maplen = %d", ndims, maplen));
 
     region = firstregion;
     if (map)
     {
-        while (map[nmaplen++] <= 0)
-        {
-            PLOG((3, "map[%d] = %d", nmaplen, map[nmaplen]));
-            ;
-        }
-        nmaplen--;
+	while (map[nmaplen++] <= 0)
+	{
+	    PLOG((3, "map[%d] = %d", nmaplen, map[nmaplen]));
+	    ;
+	}
+	nmaplen--;
     }
     region->loffset = nmaplen;
     PLOG((2, "region->loffset = %d", region->loffset));
@@ -1877,41 +1887,41 @@ get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
 
     while (nmaplen < maplen)
     {
-        /* Here we find the largest region from the current offset
-           into the iomap. regionlen is the size of that region and we
-           step to that point in the map array until we reach the
-           end. */
-        for (int i = 0; i < ndims; i++)
-            region->count[i] = 1;
+	/* Here we find the largest region from the current offset
+	   into the iomap. regionlen is the size of that region and we
+	   step to that point in the map array until we reach the
+	   end. */
+	for (int i = 0; i < ndims; i++)
+	    region->count[i] = 1;
 
-        /* Set start/count to describe first region in map. */
-        if ((ret = find_region(ndims, gdimlen, maplen-nmaplen,
-                               &map[nmaplen], region->start, region->count, &regionlen)))
-            return ret;
-        pioassert(region->start[0] >= 0, "failed to find region", __FILE__, __LINE__);
+	/* Set start/count to describe first region in map. */
+	if ((ret = find_region(ndims, gdimlen, maplen-nmaplen,
+			       &map[nmaplen], region->start, region->count, &regionlen)))
+	    return ret;
+	pioassert(region->start[0] >= 0, "failed to find region", __FILE__, __LINE__);
 
-        nmaplen = nmaplen + regionlen;
-        PLOG((2, "regionlen = %d nmaplen = %d", regionlen, nmaplen));
+	nmaplen = nmaplen + regionlen;
+	PLOG((2, "regionlen = %d nmaplen = %d", regionlen, nmaplen));
 
-        /* If we need to, allocate the next region. */
-        if (region->next == NULL && nmaplen < maplen)
-        {
-            PLOG((2, "allocating next region"));
-            if ((ret = alloc_region2(NULL, ndims, &region->next)))
-                return ret;
+	/* If we need to, allocate the next region. */
+	if (region->next == NULL && nmaplen < maplen)
+	{
+	    PLOG((2, "allocating next region"));
+	    if ((ret = alloc_region2(NULL, ndims, &region->next)))
+		return ret;
 
-            /* The offset into the local array buffer is the sum of
-             * the sizes of all of the previous regions (loffset) */
-            region = region->next;
-            region->loffset = nmaplen;
+	    /* The offset into the local array buffer is the sum of
+	     * the sizes of all of the previous regions (loffset) */
+	    region = region->next;
+	    region->loffset = nmaplen;
 
-            /* The calls to the io library are collective and so we
-               must have the same number of regions on each io task
-               maxregions will be the total number of regions on this
-               task. */
-            (*maxregions)++;
-            PLOG((2, "*maxregions = %d", *maxregions));
-        }
+	    /* The calls to the io library are collective and so we
+	       must have the same number of regions on each io task
+	       maxregions will be the total number of regions on this
+	       task. */
+	    (*maxregions)++;
+	    PLOG((2, "*maxregions = %d", *maxregions));
+	}
     }
 
     return PIO_NOERR;
@@ -1944,26 +1954,26 @@ default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);
     PLOG((1, "default_subset_partition ios->ioproc = %d ios->io_rank = %d "
-          "ios->comp_rank = %d", ios->ioproc, ios->io_rank, ios->comp_rank));
+	  "ios->comp_rank = %d", ios->ioproc, ios->io_rank, ios->comp_rank));
 
     /* Create a new comm for each subset group with the io task in
        rank 0 and only 1 io task per group */
     if (ios->ioproc)
     {
-        key = 0;
-        color= ios->io_rank;
+	key = 0;
+	color= ios->io_rank;
     }
     else
     {
-        int taskratio = max(1,ios->num_comptasks / ios->num_iotasks);
-        key = max(1, ios->comp_rank % taskratio + 1);
-        color = min(ios->num_iotasks - 1, ios->comp_rank / taskratio);
+	int taskratio = max(1,ios->num_comptasks / ios->num_iotasks);
+	key = max(1, ios->comp_rank % taskratio + 1);
+	color = min(ios->num_iotasks - 1, ios->comp_rank / taskratio);
     }
     PLOG((3, "key = %d color = %d", key, color));
 
     /* Create new communicators. */
     if ((mpierr = MPI_Comm_split(ios->union_comm, color, key, &iodesc->subset_comm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -2019,7 +2029,7 @@ default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
  */
 int
 subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
-                        const int *gdimlen, int ndims, io_desc_t *iodesc)
+			const int *gdimlen, int ndims, io_desc_t *iodesc)
 {
     int i, j;
     PIO_Offset *iomap = NULL;
@@ -2035,7 +2045,7 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
 
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims >= 0 && iodesc,
-              "invalid input", __FILE__, __LINE__);
+	      "invalid input", __FILE__, __LINE__);
 
     PLOG((2, "subset_rearrange_create maplen = %d ndims = %d", maplen, ndims));
 
@@ -2043,76 +2053,76 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
      * of that subset_comm */
     /* TODO: introduce a mechanism for users to define partitions */
     if ((ret = default_subset_partition(ios, iodesc)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     iodesc->rearranger = PIO_REARR_SUBSET;
 
     /* Get size of this subset communicator and rank of this task in it. */
     if ((mpierr = MPI_Comm_rank(iodesc->subset_comm, &rank)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_size(iodesc->subset_comm, &ntasks)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Check rank for correctness. */
     if (ios->ioproc)
-        pioassert(rank == 0, "Bad io rank in subset create", __FILE__, __LINE__);
+	pioassert(rank == 0, "Bad io rank in subset create", __FILE__, __LINE__);
     else
-        pioassert(rank > 0 && rank < ntasks, "Bad comp rank in subset create",
-                  __FILE__, __LINE__);
+	pioassert(rank > 0 && rank < ntasks, "Bad comp rank in subset create",
+		  __FILE__, __LINE__);
 
     /* Remember the maplen for this computation task. */
     iodesc->ndof = maplen;
 
     if (ios->ioproc)
     {
-        /* Allocate space to hold count of data to be received in pio_swapm(). */
-        if (!(iodesc->rcount = malloc(ntasks * sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	/* Allocate space to hold count of data to be received in pio_swapm(). */
+	if (!(iodesc->rcount = malloc(ntasks * sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        rcnt = 1;
+	rcnt = 1;
 
-        if(ios->async)
-            iodesc->ndof = 0;
+	if(ios->async)
+	    iodesc->ndof = 0;
 
     }
 
     /* Allocate space to hold count of data to be sent in pio_swapm(). */
     if (!(iodesc->scount = malloc(sizeof(int))))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     iodesc->scount[0] = 0;
 
     /* Find the total size of the global data array. */
     totalgridsize = 1;
     for (i = 0; i < ndims; i++)
-        totalgridsize *= gdimlen[i];
+	totalgridsize *= gdimlen[i];
 
     /* Determine scount[0], the number of data elements in the
      * computation task that are to be written, by looking at
      * compmap. */
     for (i = 0; i < iodesc->ndof; i++)
     {
-        pioassert(compmap[i]>=-1 && compmap[i]<=totalgridsize, "Compmap value out of bounds",
-            __FILE__,__LINE__); 
-        if (compmap[i] > 0)
-            (iodesc->scount[0])++;
+	pioassert(compmap[i]>=-1 && compmap[i]<=totalgridsize, "Compmap value out of bounds",
+	    __FILE__,__LINE__);
+	if (compmap[i] > 0)
+	    (iodesc->scount[0])++;
     }
 
     /* Allocate an array for indicies on the computation tasks (the
      * send side when writing). */
     if (iodesc->scount[0] > 0)
-        if (!(iodesc->sindex = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(iodesc->sindex = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     j = 0;
     for (i = 0; i < iodesc->ndof; i++)
-        if (compmap[i] > 0)
-            iodesc->sindex[j++] = i;
+	if (compmap[i] > 0)
+	    iodesc->sindex[j++] = i;
 
     /* Pass the reduced maplen (without holes) from each compute task
      * to its associated IO task. */
     if ((mpierr = MPI_Gather(iodesc->scount, 1, MPI_INT, iodesc->rcount, rcnt,
-                             MPI_INT, 0, iodesc->subset_comm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+			     MPI_INT, 0, iodesc->subset_comm)))
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
 
     iodesc->llen = 0;
@@ -2123,310 +2133,319 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
     /* On IO tasks determine llen. */
     if (ios->ioproc)
     {
-        for (i = 0; i < ntasks; i++)
-        {
-            iodesc->llen += iodesc->rcount[i];
-            rdispls[i] = 0;
-            recvcounts[i] = iodesc->rcount[i];
-            if (i > 0)
-                rdispls[i] = rdispls[i - 1] + iodesc->rcount[i - 1];
-        }
+	for (i = 0; i < ntasks; i++)
+	{
+	    iodesc->llen += iodesc->rcount[i];
+	    rdispls[i] = 0;
+	    recvcounts[i] = iodesc->rcount[i];
+	    if (i > 0)
+		rdispls[i] = rdispls[i - 1] + iodesc->rcount[i - 1];
+	}
 
-        if (iodesc->llen > 0)
-        {
-            if (!(srcindex = calloc(iodesc->llen, sizeof(PIO_Offset))))
-                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        }
+	if (iodesc->llen > 0)
+	{
+	    if (!(srcindex = calloc(iodesc->llen, sizeof(PIO_Offset))))
+		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	}
     }
     else
     {
-        for (i = 0; i < ntasks; i++)
-        {
-            recvcounts[i] = 0;
-            rdispls[i] = 0;
-        }
+	for (i = 0; i < ntasks; i++)
+	{
+	    recvcounts[i] = 0;
+	    rdispls[i] = 0;
+	}
     }
 
     /* Determine whether fill values will be needed. */
     if ((ret = determine_fill(ios, iodesc, gdimlen, compmap)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Pass the sindex from each compute task to its associated IO task. */
     if ((mpierr = MPI_Gatherv(iodesc->sindex, iodesc->scount[0], PIO_OFFSET,
-                              srcindex, recvcounts, rdispls, PIO_OFFSET, 0,
-                              iodesc->subset_comm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+			      srcindex, recvcounts, rdispls, PIO_OFFSET, 0,
+			      iodesc->subset_comm)))
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     /* On IO tasks which need it, allocate memory for the map and the
      * iomap. */
     if (ios->ioproc && iodesc->llen > 0)
     {
-        if (!(map = calloc(iodesc->llen, sizeof(mapsort))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(map = calloc(iodesc->llen, sizeof(mapsort))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        if (!(iomap = calloc(iodesc->llen, sizeof(PIO_Offset))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(iomap = calloc(iodesc->llen, sizeof(PIO_Offset))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     }
 
     /* Now pass the compmap, skipping the holes. */
     PIO_Offset *shrtmap;
     if (maplen > iodesc->scount[0] && iodesc->scount[0] > 0)
     {
-        if (!(shrtmap = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(shrtmap = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-        j = 0;
-        for (int i = 0; i < maplen; i++)
-            if (compmap[i] > 0)
-                shrtmap[j++] = compmap[i];
+	j = 0;
+	for (int i = 0; i < maplen; i++)
+	    if (compmap[i] > 0)
+		shrtmap[j++] = compmap[i];
     }
     else
     {
-        shrtmap = compmap;
+	shrtmap = compmap;
     }
 
     /* Gather shrtmap from each task in the subset communicator, and
      * put gathered results into iomap. */
     if ((mpierr = MPI_Gatherv(shrtmap, iodesc->scount[0], PIO_OFFSET, iomap, recvcounts,
-                              rdispls, PIO_OFFSET, 0, iodesc->subset_comm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+			      rdispls, PIO_OFFSET, 0, iodesc->subset_comm)))
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     if (shrtmap != compmap)
-        free(shrtmap);
+	free(shrtmap);
 
     /* On IO tasks that have data in the local array ??? */
     if (ios->ioproc && iodesc->llen > 0)
     {
-        int pos = 0;
-        int k = 0;
-        mapsort *mptr;
-        for (i = 0; i < ntasks; i++)
-        {
-            for (j = 0; j < iodesc->rcount[i]; j++)
-            {
-                mptr = &map[k];
-                mptr->rfrom = i;
-                mptr->soffset = srcindex[pos + j];
-                mptr->iomap = iomap[pos + j];
-                k++;
-            }
-            pos += iodesc->rcount[i];
-        }
+	int pos = 0;
+	int k = 0;
+	mapsort *mptr;
+	for (i = 0; i < ntasks; i++)
+	{
+	    for (j = 0; j < iodesc->rcount[i]; j++)
+	    {
+		mptr = &map[k];
+		mptr->rfrom = i;
+		mptr->soffset = srcindex[pos + j];
+		mptr->iomap = iomap[pos + j];
+		k++;
+	    }
+	    pos += iodesc->rcount[i];
+	}
 
-        /* sort the mapping, this will transpose the data into IO order */
-        qsort(map, iodesc->llen, sizeof(mapsort), compare_offsets);
-        
-        if (!(iodesc->rindex = calloc(1, iodesc->llen * sizeof(PIO_Offset))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	/* sort the mapping, this will transpose the data into IO order */
+	qsort(map, iodesc->llen, sizeof(mapsort), compare_offsets);
 
-        if (!(iodesc->rfrom = calloc(1, iodesc->llen * sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(iodesc->rindex = calloc(1, iodesc->llen * sizeof(PIO_Offset))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+
+	if (!(iodesc->rfrom = calloc(1, iodesc->llen * sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     }
 
     int cnt[ntasks];
     for (i = 0; i < ntasks; i++)
     {
-        cnt[i] = rdispls[i];
+	cnt[i] = rdispls[i];
     }
 
     /* For IO tasks init rfrom and rindex arrays (compute tasks have
      * llen of 0). */
     int rllen;
-    for (i = 0, rllen=0; i < iodesc->llen; i++)
+    PIO_Offset soffset;
+    for (i = 0, rllen=1; i < iodesc->llen; i++)
     {
-        mapsort *mptr = &map[i];
-        iodesc->rfrom[i] = mptr->rfrom;
-        iodesc->rindex[i] = i;
-        if(i==0)
-            iomap[0] = mptr->iomap;
-        else if(mptr->iomap > iomap[j])
-            iomap[rllen++] = mptr->iomap;
-        
-        srcindex[(cnt[iodesc->rfrom[i]])++] = mptr->soffset;
+	mapsort *mptr = &map[i];
+	iodesc->rfrom[i] = mptr->rfrom;
+	iodesc->rindex[i] = i;
+	if(i==0)
+	{
+	    iomap[0] = mptr->iomap;
+	    soffset = mptr->soffset;
+	}
+	else if(mptr->iomap > iomap[rllen-1])
+	{
+	    iomap[rllen++] = mptr->iomap;
+	    soffset = mptr->soffset;
+	}
+	srcindex[(cnt[iodesc->rfrom[i]])++] = soffset;
     }
-    
+    iodesc->rllen = rllen;
+
+
+
     /* Handle fill values if needed. */
-    PLOG((4, "ios->ioproc %d iodesc->needsfill %d", ios->ioproc, iodesc->needsfill));
+    PLOG((2, "ios->ioproc %d iodesc->needsfill %d iodesc->rllen %d", ios->ioproc, iodesc->needsfill, iodesc->rllen));
     if (ios->ioproc && iodesc->needsfill)
     {
-        /* we need the list of offsets which are not in the union of iomap */
-        PIO_Offset thisgridsize[ios->num_iotasks];
-        PIO_Offset thisgridmin[ios->num_iotasks], thisgridmax[ios->num_iotasks];
-        int nio;
-        PIO_Offset *myusegrid = NULL;
-        int gcnt[ios->num_iotasks];
-        int displs[ios->num_iotasks];
+	/* we need the list of offsets which are not in the union of iomap */
+	PIO_Offset thisgridsize[ios->num_iotasks];
+	PIO_Offset thisgridmin[ios->num_iotasks], thisgridmax[ios->num_iotasks];
+	int nio;
+	PIO_Offset *myusegrid = NULL;
+	int gcnt[ios->num_iotasks];
+	int displs[ios->num_iotasks];
 
-        thisgridmin[0] = 1;
-        thisgridsize[0] =  totalgridsize / ios->num_iotasks;
-        thisgridmax[0] = thisgridsize[0];
-        int xtra = totalgridsize - thisgridsize[0] * ios->num_iotasks;
+	thisgridmin[0] = 1;
+	thisgridsize[0] =  totalgridsize / ios->num_iotasks;
+	thisgridmax[0] = thisgridsize[0];
+	int xtra = totalgridsize - thisgridsize[0] * ios->num_iotasks;
 
-        PLOG((4, "xtra %d", xtra));
+	PLOG((4, "xtra %d", xtra));
 
-        for (nio = 0; nio < ios->num_iotasks; nio++)
-        {
-            int cnt = 0;
-            int imin = 0;
-            if (nio > 0)
-            {
-                thisgridsize[nio] =  totalgridsize / ios->num_iotasks;
-                if (nio >= ios->num_iotasks - xtra)
-                    thisgridsize[nio]++;
-                thisgridmin[nio] = thisgridmax[nio - 1] + 1;
-                thisgridmax[nio] = thisgridmin[nio] + thisgridsize[nio] - 1;
-                PLOG((4, "nio %d thisgridsize[nio] %d thisgridmin[nio] %d thisgridmax[nio] %d",
-                      nio, thisgridsize[nio], thisgridmin[nio], thisgridmax[nio]));
-            }
-            for (int i = 0; i < rllen; i++)
-            {
-                if (iomap[i] >= thisgridmin[nio] && iomap[i] <= thisgridmax[nio])
-                {
-                    cnt++;
-                    if (cnt == 1)
-                        imin = i;
-                }
-            }
-            PLOG((4, "cnt %d", cnt));
+	for (nio = 0; nio < ios->num_iotasks; nio++)
+	{
+	    int cnt = 0;
+	    int imin = 0;
+	    if (nio > 0)
+	    {
+		thisgridsize[nio] =  totalgridsize / ios->num_iotasks;
+		if (nio >= ios->num_iotasks - xtra)
+		    thisgridsize[nio]++;
+		thisgridmin[nio] = thisgridmax[nio - 1] + 1;
+		thisgridmax[nio] = thisgridmin[nio] + thisgridsize[nio] - 1;
+		PLOG((4, "nio %d thisgridsize[nio] %d thisgridmin[nio] %d thisgridmax[nio] %d",
+		      nio, thisgridsize[nio], thisgridmin[nio], thisgridmax[nio]));
+	    }
+	    for (int i = 0; i < rllen; i++)
+	    {
+		if (iomap[i] >= thisgridmin[nio] && iomap[i] <= thisgridmax[nio])
+		{
+		    cnt++;
+		    if (cnt == 1)
+			imin = i;
+		}
+	    }
+	    PLOG((4, "cnt %d", cnt));
 
-            /* Gather cnt from all tasks in the IO communicator into array gcnt. */
-            if ((mpierr = MPI_Gather(&cnt, 1, MPI_INT, gcnt, 1, MPI_INT, nio, ios->io_comm)))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    /* Gather cnt from all tasks in the IO communicator into array gcnt. */
+	    if ((mpierr = MPI_Gather(&cnt, 1, MPI_INT, gcnt, 1, MPI_INT, nio, ios->io_comm)))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-            if (nio == ios->io_rank)
-            {
-                displs[0] = 0;
-                for (i = 1; i < ios->num_iotasks; i++)
-                    displs[i] = displs[i - 1] + gcnt[i - 1];
+	    if (nio == ios->io_rank)
+	    {
+		displs[0] = 0;
+		for (i = 1; i < ios->num_iotasks; i++)
+		    displs[i] = displs[i - 1] + gcnt[i - 1];
 
-                /* Allocate storage for the grid. */
-                if (!(myusegrid = malloc(thisgridsize[nio] * sizeof(PIO_Offset))))
-                    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+		/* Allocate storage for the grid. */
+		if (!(myusegrid = malloc(thisgridsize[nio] * sizeof(PIO_Offset))))
+		    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-                /* Initialize the grid to all -1. */
-                for (i = 0; i < thisgridsize[nio]; i++)
-                    myusegrid[i] = -1;
-            }
+		/* Initialize the grid to all -1. */
+		for (i = 0; i < thisgridsize[nio]; i++)
+		    myusegrid[i] = -1;
+	    }
 
-            if ((mpierr = MPI_Gatherv(&iomap[imin], cnt, PIO_OFFSET, myusegrid, gcnt,
-                                      displs, PIO_OFFSET, nio, ios->io_comm)))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        }
+	    if ((mpierr = MPI_Gatherv(&iomap[imin], cnt, PIO_OFFSET, myusegrid, gcnt,
+				      displs, PIO_OFFSET, nio, ios->io_comm)))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	}
 
-        /* Allocate and initialize a grid to fill in missing values. ??? */
-        PLOG((2, "thisgridsize[ios->io_rank] %d", thisgridsize[ios->io_rank]));
-        PIO_Offset *grid;
-        if (!(grid = calloc(thisgridsize[ios->io_rank], sizeof(PIO_Offset))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	/* Allocate and initialize a grid to fill in missing values. ??? */
+	PLOG((2, "thisgridsize[ios->io_rank] %d", thisgridsize[ios->io_rank]));
+	PIO_Offset *grid;
+	if (!(grid = calloc(thisgridsize[ios->io_rank], sizeof(PIO_Offset))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
 
-        int cnt = 0;
-        for (i = 0; i < thisgridsize[ios->io_rank]; i++)
-        {
-            int j = myusegrid[i] - thisgridmin[ios->io_rank];
-            pioassert(j < thisgridsize[ios->io_rank], "out of bounds array index",
-                      __FILE__, __LINE__);
-            PLOG((4, "i %d myusegrid[i] %d j %d", i, myusegrid[i], j));
-            if (j >= 0)
-            {
-                grid[j] = 1;
-                cnt++;
-            }
-        }
-        if (myusegrid)
-            free(myusegrid);
+	int cnt = 0;
+	for (i = 0; i < thisgridsize[ios->io_rank]; i++)
+	{
+	    int j = myusegrid[i] - thisgridmin[ios->io_rank];
+	    pioassert(j < thisgridsize[ios->io_rank], "out of bounds array index",
+		      __FILE__, __LINE__);
+	    PLOG((4, "i %d myusegrid[i] %d j %d", i, myusegrid[i], j));
+	    if (j >= 0)
+	    {
+		grid[j] = 1;
+		cnt++;
+	    }
+	}
+	if (myusegrid)
+	    free(myusegrid);
 
-        iodesc->holegridsize = thisgridsize[ios->io_rank] - cnt;
-        PLOG((3, "iodesc->holegridsize %d thisgridsize[%d] %d cnt %d", iodesc->holegridsize,
-              ios->io_rank, thisgridsize[ios->io_rank], cnt));
-        if (iodesc->holegridsize > 0)
-        {
-            /* Allocate space for the fillgrid. */
-            if (!(myfillgrid = malloc(iodesc->holegridsize * sizeof(PIO_Offset))))
-                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        }
+	iodesc->holegridsize = thisgridsize[ios->io_rank] - cnt;
+	PLOG((3, "iodesc->holegridsize %d thisgridsize[%d] %d cnt %d", iodesc->holegridsize,
+	      ios->io_rank, thisgridsize[ios->io_rank], cnt));
+	if (iodesc->holegridsize > 0)
+	{
+	    /* Allocate space for the fillgrid. */
+	    if (!(myfillgrid = malloc(iodesc->holegridsize * sizeof(PIO_Offset))))
+		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	}
 
-        /* Initialize the fillgrid. */
-        for (i = 0; i < iodesc->holegridsize; i++)
-            myfillgrid[i] = -1;
+	/* Initialize the fillgrid. */
+	for (i = 0; i < iodesc->holegridsize; i++)
+	    myfillgrid[i] = -1;
 
-        j = 0;
-        for (i = 0; i < thisgridsize[ios->io_rank]; i++)
-        {
-            if (grid[i] == 0)
-            {
-                if (myfillgrid[j] == -1)
-                    myfillgrid[j++] = thisgridmin[ios->io_rank] + i;
-                else
-                    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
-            }
-        }
-        free(grid);
+	j = 0;
+	for (i = 0; i < thisgridsize[ios->io_rank]; i++)
+	{
+	    if (grid[i] == 0)
+	    {
+		if (myfillgrid[j] == -1)
+		    myfillgrid[j++] = thisgridmin[ios->io_rank] + i;
+		else
+		    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	    }
+	}
+	free(grid);
 
-        maxregions = 0;
-        iodesc->maxfillregions = 0;
-        if (myfillgrid)
-        {
-            /* Allocate a data region to hold fill values. */
-            if ((ret = alloc_region2(ios, iodesc->ndims, &iodesc->fillregion)))
-                return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-            if ((ret = get_regions(iodesc->ndims, gdimlen, iodesc->holegridsize, myfillgrid,
-                                   &iodesc->maxfillregions, iodesc->fillregion)))
-                return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-            free(myfillgrid);
-            maxregions = iodesc->maxfillregions;
-        }
+	maxregions = 0;
+	iodesc->maxfillregions = 0;
+	if (myfillgrid)
+	{
+	    /* Allocate a data region to hold fill values. */
+	    if ((ret = alloc_region2(ios, iodesc->ndims, &iodesc->fillregion)))
+		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	    if ((ret = get_regions(iodesc->ndims, gdimlen, iodesc->holegridsize, myfillgrid,
+				   &iodesc->maxfillregions, iodesc->fillregion)))
+		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	    free(myfillgrid);
+	    maxregions = iodesc->maxfillregions;
+	}
 
-        /* Get the max maxregions, and distribute it to all tasks in
-         * the IO communicator. */
-        if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxregions, 1, MPI_INT, MPI_MAX,
-                                    ios->io_comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        iodesc->maxfillregions = maxregions;
+	/* Get the max maxregions, and distribute it to all tasks in
+	 * the IO communicator. */
+	if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxregions, 1, MPI_INT, MPI_MAX,
+				    ios->io_comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	iodesc->maxfillregions = maxregions;
 
-        /* Get the max maxholegridsize, and distribute it to all tasks
-         * in the IO communicator. */
-        iodesc->maxholegridsize = iodesc->holegridsize;
-        if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &(iodesc->maxholegridsize), 1, MPI_INT,
-                                    MPI_MAX, ios->io_comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	/* Get the max maxholegridsize, and distribute it to all tasks
+	 * in the IO communicator. */
+	iodesc->maxholegridsize = iodesc->holegridsize;
+	if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &(iodesc->maxholegridsize), 1, MPI_INT,
+				    MPI_MAX, ios->io_comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     }
 
     /* Scatter values of srcindex to subset communicator. ??? */
     if ((mpierr = MPI_Scatterv((void *)srcindex, recvcounts, rdispls, PIO_OFFSET,
-                               (void *)iodesc->sindex, iodesc->scount[0],  PIO_OFFSET,
-                               0, iodesc->subset_comm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+			       (void *)iodesc->sindex, iodesc->scount[0],  PIO_OFFSET,
+			       0, iodesc->subset_comm)))
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     if (ios->ioproc)
     {
-        iodesc->maxregions = 0;
-        if ((ret = get_regions(iodesc->ndims, gdimlen, rllen, iomap,
-                               &iodesc->maxregions, iodesc->firstregion)))
-            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-        maxregions = iodesc->maxregions;
+	iodesc->maxregions = 0;
+	if ((ret = get_regions(iodesc->ndims, gdimlen, rllen, iomap,
+			       &iodesc->maxregions, iodesc->firstregion)))
+	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	maxregions = iodesc->maxregions;
 
-        /* Get the max maxregions, and distribute it to all tasks in
-         * the IO communicator. */
-        if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxregions, 1, MPI_INT, MPI_MAX, ios->io_comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        iodesc->maxregions = maxregions;
+	/* Get the max maxregions, and distribute it to all tasks in
+	 * the IO communicator. */
+	if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxregions, 1, MPI_INT, MPI_MAX, ios->io_comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	iodesc->maxregions = maxregions;
 
-        /* Free resources. */
-        if (iomap)
-            free(iomap);
+	/* Free resources. */
+	if (iomap)
+	    free(iomap);
 
-        if (map)
-            free(map);
+	if (map)
+	    free(map);
 
-        if (srcindex)
-            free(srcindex);
+	if (srcindex)
+	    free(srcindex);
 
-        /* Compute the max io buffer size needed for an iodesc. */
-        if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
-            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	/* Compute the max io buffer size needed for an iodesc. */
+	if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
+	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
-        iodesc->nrecvs = ntasks;
+	iodesc->nrecvs = ntasks;
     }
 
     return PIO_NOERR;
@@ -2453,44 +2472,44 @@ performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     assert(iodesc);
     if(iodesc->mpitype == MPI_DATATYPE_NULL)
-        tsize = 0;
+	tsize = 0;
     else
-        if ((mpierr = MPI_Type_size(iodesc->mpitype, &tsize)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Type_size(iodesc->mpitype, &tsize)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     cbuf = NULL;
     ibuf = NULL;
     if (iodesc->ndof > 0)
-        if (!(cbuf = bget(iodesc->ndof * tsize)))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(cbuf = bget(iodesc->ndof * tsize)))
+	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
     if (iodesc->llen > 0)
-        if (!(ibuf = bget(iodesc->llen * tsize)))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(ibuf = bget(iodesc->llen * tsize)))
+	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
     if (iodesc->rearranger == PIO_REARR_BOX)
-        mycomm = ios->union_comm;
+	mycomm = ios->union_comm;
     else
-        mycomm = iodesc->subset_comm;
+	mycomm = iodesc->subset_comm;
 
     if ((mpierr = MPI_Comm_size(mycomm, &nprocs)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_rank(mycomm, &myrank)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     int log2 = log(nprocs) / log(2) + 1;
     if (!(wall = bget(2 * 4 * log2 * sizeof(double))))
-        return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
     double mintime;
 
     if ((mpierr = MPI_Barrier(mycomm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     GPTLstamp(&wall[0], &usr[0], &sys[0]);
     rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
     rearrange_io2comp(ios, iodesc, ibuf, cbuf);
     GPTLstamp(&wall[1], &usr[1], &sys[1]);
     mintime = wall[1]-wall[0];
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &mintime, 1, MPI_DOUBLE, MPI_MAX, mycomm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     handshake = iodesc->rearr_opts.comp2io.hs;
     isend = iodesc->isend;
@@ -2498,47 +2517,47 @@ performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     for (int i = 0; i < 2; i++)
     {
-        if (i == 0)
-            iodesc->rearr_opts.comp2io.hs = false;
-        else
-            iodesc->rearr_opts.comp2io.hs = true;
+	if (i == 0)
+	    iodesc->rearr_opts.comp2io.hs = false;
+	else
+	    iodesc->rearr_opts.comp2io.hs = true;
 
-        for (int j = 0; j < 2; j++)
-        {
-            if (j == 0)
-                iodesc->isend = false;
-            else
-                iodesc->isend = true;
+	for (int j = 0; j < 2; j++)
+	{
+	    if (j == 0)
+		iodesc->isend = false;
+	    else
+		iodesc->isend = true;
 
-            iodesc->max_requests = 0;
+	    iodesc->max_requests = 0;
 
-            for (nreqs = nprocs; nreqs >= 2; nreqs /= 2)
-            {
-                iodesc->max_requests = nreqs;
-                if ((mpierr = MPI_Barrier(mycomm)))
-                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-                GPTLstamp(wall, usr, sys);
-                rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
-                rearrange_io2comp(ios, iodesc, ibuf, cbuf);
-                GPTLstamp(wall+1, usr, sys);
-                wall[1] -= wall[0];
-                if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, wall + 1, 1, MPI_DOUBLE, MPI_MAX,
-                                            mycomm)))
-                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    for (nreqs = nprocs; nreqs >= 2; nreqs /= 2)
+	    {
+		iodesc->max_requests = nreqs;
+		if ((mpierr = MPI_Barrier(mycomm)))
+		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		GPTLstamp(wall, usr, sys);
+		rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
+		rearrange_io2comp(ios, iodesc, ibuf, cbuf);
+		GPTLstamp(wall+1, usr, sys);
+		wall[1] -= wall[0];
+		if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, wall + 1, 1, MPI_DOUBLE, MPI_MAX,
+					    mycomm)))
+		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-                if (wall[1] < mintime * 0.95)
-                {
-                    handshake = iodesc->rearr_opts.comp2io.hs;
-                    isend = iodesc->isend;
-                    maxreqs = nreqs;
-                    mintime = wall[1];
-                }
-                else if (wall[1] > mintime * 1.05)
-                {
-                    exit;
-                }
-            }
-        }
+		if (wall[1] < mintime * 0.95)
+		{
+		    handshake = iodesc->rearr_opts.comp2io.hs;
+		    isend = iodesc->isend;
+		    maxreqs = nreqs;
+		    mintime = wall[1];
+		}
+		else if (wall[1] > mintime * 1.05)
+		{
+		    exit;
+		}
+	    }
+	}
     }
 
     iodesc->rearr_opts.comp2io.hs = handshake;
@@ -2546,7 +2565,7 @@ performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
     iodesc->max_requests = maxreqs;
 
     PLOG((1, "spmd optimization: maxreqs: %d handshake:%d isend:%d mintime=%f\n",
-          maxreqs,handshake,isend,mintime));
+	  maxreqs,handshake,isend,mintime));
 
     /* Free memory. */
     brel(wall);

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -30,25 +30,25 @@
  */
 inline void
 idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
-		PIO_Offset *dim_list)
+                PIO_Offset *dim_list)
 {
     /* Check inputs. */
     pioassert(ndims >= 0 && gdimlen && idx >= -1 && dim_list, "invalid input",
-	      __FILE__, __LINE__);
+              __FILE__, __LINE__);
     PLOG((2, "idx_to_dim_list ndims = %d idx = %d", ndims, idx));
 
     /* Easiest to start from the right and move left. */
     for (int i = ndims - 1; i >= 0; --i)
     {
-	PIO_Offset next_idx;
+        PIO_Offset next_idx;
 
-	/* This way of doing div/mod is slightly faster than using "/"
-	 * and "%". */
-	next_idx = idx / gdimlen[i];
-	dim_list[i] = idx - (next_idx * gdimlen[i]);
-	PLOG((3, "next_idx = %d idx = %d gdimlen[%d] = %d dim_list[%d] = %d",
-	      next_idx, idx, i, gdimlen[i], i, dim_list[i]));
-	idx = next_idx;
+        /* This way of doing div/mod is slightly faster than using "/"
+         * and "%". */
+        next_idx = idx / gdimlen[i];
+        dim_list[i] = idx - (next_idx * gdimlen[i]);
+        PLOG((3, "next_idx = %d idx = %d gdimlen[%d] = %d dim_list[%d] = %d",
+              next_idx, idx, i, gdimlen[i], i, dim_list[i]));
+        idx = next_idx;
     }
 }
 
@@ -77,52 +77,52 @@ idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
  */
 void
 expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
-	      int region_size, int region_stride, const int *max_size,
-	      PIO_Offset *count)
+              int region_size, int region_stride, const int *max_size,
+              PIO_Offset *count)
 {
     /* Flag used to signal that we can no longer expand the region
        along dimension dim. */
     int expansion_done = 0;
     /* Check inputs. */
     pioassert(dim >= 0 && gdimlen && maplen >= 0 && map && region_size >= 0 &&
-	      maplen >= region_size && region_stride >= 0 && max_size && count,
-	      "invalid input", __FILE__, __LINE__);
+              maplen >= region_size && region_stride >= 0 && max_size && count,
+              "invalid input", __FILE__, __LINE__);
 
     /* Expand no greater than max_size along this dimension. */
     for (int i = 1; i <= max_size[dim]; ++i)
     {
-	/* Count so far is at least i. */
-	count[dim] = i;
+        /* Count so far is at least i. */
+        count[dim] = i;
 
-	/* Now see if we can expand to i+1 by checking that the next
-	   region_size elements are ahead by exactly region_stride.
-	   Assuming monotonicity in the map, we could skip this for the
-	   innermost dimension, but it's necessary past that because the
-	   region does not necessarily comprise contiguous values. */
-	for (int j = 0; j < region_size; j++)
-	{
-	    int test_idx; /* Index we are testing. */
+        /* Now see if we can expand to i+1 by checking that the next
+           region_size elements are ahead by exactly region_stride.
+           Assuming monotonicity in the map, we could skip this for the
+           innermost dimension, but it's necessary past that because the
+           region does not necessarily comprise contiguous values. */
+        for (int j = 0; j < region_size; j++)
+        {
+            int test_idx; /* Index we are testing. */
 
-	    test_idx = j + i * region_size;
+            test_idx = j + i * region_size;
 
-	    /* If we have exhausted the map, or the map no longer matches,
-	       we are done, break out of both loops. */
-	    if (test_idx >= maplen || map[test_idx] != map[j] + i * region_stride)
-	    {
-		expansion_done = 1;
-		break;
-	    }
-	}
-	if (expansion_done)
-	    break;
+            /* If we have exhausted the map, or the map no longer matches,
+               we are done, break out of both loops. */
+            if (test_idx >= maplen || map[test_idx] != map[j] + i * region_stride)
+            {
+                expansion_done = 1;
+                break;
+            }
+        }
+        if (expansion_done)
+            break;
 
     }
 
     /* Move on to next outermost dimension if there are more left,
      * else return. */
     if (dim > 0)
-	expand_region(dim - 1, gdimlen, maplen, map, region_size * count[dim],
-		      region_stride * gdimlen[dim], max_size, count);
+        expand_region(dim - 1, gdimlen, maplen, map, region_size * count[dim],
+                      region_stride * gdimlen[dim], max_size, count);
 }
 
 /**
@@ -156,11 +156,11 @@ expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
  */
 int
 find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
-	    PIO_Offset *start, PIO_Offset *count, PIO_Offset *regionlen)
+            PIO_Offset *start, PIO_Offset *count, PIO_Offset *regionlen)
 {
     /* Check inputs. */
     pioassert(ndims > 0 && gdimlen && maplen > 0 && map && start && count &&
-	      regionlen, "invalid input", __FILE__, __LINE__);
+              regionlen, "invalid input", __FILE__, __LINE__);
     PLOG((2, "find_region ndims = %d maplen = %d", ndims, maplen));
 
     *regionlen = 1;
@@ -175,8 +175,8 @@ find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
      * expand_region call below. */
     for (int dim = 0; dim < ndims; ++dim)
     {
-	max_size[dim] = gdimlen[dim] - start[dim];
-	PLOG((3, "max_size[%d] = %d", max_size[dim]));
+        max_size[dim] = gdimlen[dim] - start[dim];
+        PLOG((3, "max_size[%d] = %d", max_size[dim]));
     }
 
     /* For each dimension, figure out how far we can expand in that dimension
@@ -188,7 +188,7 @@ find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
 
     /* Calculate the number of data elements in this region. */
     for (int dim = 0; dim < ndims; dim++)
-	*regionlen *= count[dim];
+        *regionlen *= count[dim];
 
     return PIO_NOERR;
 }
@@ -213,8 +213,8 @@ coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO_Offset *count)
 
     for (int i = ndims - 1; i >= 0; i--)
     {
-	lindex += lcoord[i] * stride;
-	stride = stride * count[i];
+        lindex += lcoord[i] * stride;
+        stride = stride * count[i];
     }
     return lindex;
 }
@@ -242,19 +242,19 @@ compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
      *  combined size of all regions */
     for (io_region *region = iodesc->firstregion; region; region = region->next)
     {
-	if (region->count[0] > 0)
-	{
-	    PIO_Offset iosize = 1;
-	    for (int i = 0; i < iodesc->ndims; i++)
-		iosize *= region->count[i];
-	    totiosize += iosize;
-	}
+        if (region->count[0] > 0)
+        {
+            PIO_Offset iosize = 1;
+            for (int i = 0; i < iodesc->ndims; i++)
+                iosize *= region->count[i];
+            totiosize += iosize;
+        }
     }
     PLOG((2, "compute_maxIObuffersize got totiosize = %lld", totiosize));
 
     /* Share the max io buffer size with all io tasks. */
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &totiosize, 1, MPI_OFFSET, MPI_MAX, io_comm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     pioassert(totiosize > 0, "totiosize <= 0", __FILE__, __LINE__);
     PLOG((2, "after allreduce compute_maxIObuffersize got totiosize = %lld", totiosize));
 
@@ -283,8 +283,8 @@ compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
  */
 int
 create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
-		     const PIO_Offset *mindex, const int *mcount, int *mfrom,
-		     MPI_Datatype *mtype)
+                     const PIO_Offset *mindex, const int *mcount, int *mfrom,
+                     MPI_Datatype *mtype)
 {
     int blocksize;
     int numinds = 0;
@@ -298,22 +298,22 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
     PIO_Offset bsizeT[msgcnt];
 
     PLOG((1, "create_mpi_datatypes mpitype = %d msgcnt = %d", mpitype,
-	  msgcnt));
+          msgcnt));
     PLOG((2, "MPI_BYTE = %d MPI_CHAR = %d MPI_SHORT = %d MPI_INT = %d "
-	  "MPI_FLOAT = %d MPI_DOUBLE = %d", MPI_BYTE, MPI_CHAR, MPI_SHORT,
-	  MPI_INT, MPI_FLOAT, MPI_DOUBLE));
+          "MPI_FLOAT = %d MPI_DOUBLE = %d", MPI_BYTE, MPI_CHAR, MPI_SHORT,
+          MPI_INT, MPI_FLOAT, MPI_DOUBLE));
 
     /* How many indicies in the array? */
     for (int j = 0; j < msgcnt; j++)
-	numinds += mcount[j];
+        numinds += mcount[j];
     PLOG((2, "numinds = %d", numinds));
 
     if (mindex)
     {
-	if (!(lindex = malloc(numinds * sizeof(PIO_Offset))))
-	    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	memcpy(lindex, mindex, (size_t)(numinds * sizeof(PIO_Offset)));
-	PLOG((3, "allocated lindex, copied mindex"));
+        if (!(lindex = malloc(numinds * sizeof(PIO_Offset))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        memcpy(lindex, mindex, (size_t)(numinds * sizeof(PIO_Offset)));
+        PLOG((3, "allocated lindex, copied mindex"));
     }
 
     bsizeT[0] = 0;
@@ -325,24 +325,24 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
      * rearrangers. (If mfrom is NULL, this is the box rearranger.) */
     if (mfrom == NULL)
     {
-	PLOG((3, "mfrom is NULL"));
-	for (int i = 0; i < msgcnt; i++)
-	{
-	    if (mcount[i] > 0)
-	    {
-		/* Look for the largest block of data for io which
-		 * can be expressed in terms of start and
-		 * count. */
-		bsizeT[ii] = GCDblocksize(mcount[i], lindex + pos);
-		ii++;
-		pos += mcount[i];
-	    }
-	}
-	blocksize = (int)lgcd_array(ii, bsizeT);
+        PLOG((3, "mfrom is NULL"));
+        for (int i = 0; i < msgcnt; i++)
+        {
+            if (mcount[i] > 0)
+            {
+                /* Look for the largest block of data for io which
+                 * can be expressed in terms of start and
+                 * count. */
+                bsizeT[ii] = GCDblocksize(mcount[i], lindex + pos);
+                ii++;
+                pos += mcount[i];
+            }
+        }
+        blocksize = (int)lgcd_array(ii, bsizeT);
     }
     else
     {
-	blocksize = 1;
+        blocksize = 1;
     }
     PLOG((3, "blocksize = %d", blocksize));
 
@@ -350,72 +350,72 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
     pos = 0;
     for (int i = 0; i < msgcnt; i++)
     {
-	if (mcount[i] > 0)
-	{
-	    int len = mcount[i] / blocksize;
-	    int *displace;
+        if (mcount[i] > 0)
+        {
+            int len = mcount[i] / blocksize;
+            int *displace;
 
-	    if (!(displace = malloc(sizeof(int) * len)))
-		EXIT1(PIO_ENOMEM);
+            if (!(displace = malloc(sizeof(int) * len)))
+                EXIT1(PIO_ENOMEM);
 
-	    PLOG((2, "blocksize = %d i = %d mcount[%d] = %d len = %d", blocksize, i, i,
-		  mcount[i], len));
-	    if (blocksize == 1)
-	    {
-		if (!mfrom)
-		{
-		    /* Box rearranger. */
-		    for (int j = 0; j < len; j++)
-			displace[j] = (int)(lindex[pos + j]);
-		}
-		else
-		{
-		    /* Subset rearranger. */
-		    int k = 0;
-		    for (int j = 0; j < numinds; j++)
+            PLOG((2, "blocksize = %d i = %d mcount[%d] = %d len = %d", blocksize, i, i,
+                  mcount[i], len));
+            if (blocksize == 1)
+            {
+                if (!mfrom)
+                {
+                    /* Box rearranger. */
+                    for (int j = 0; j < len; j++)
+                        displace[j] = (int)(lindex[pos + j]);
+                }
+                else
+                {
+                    /* Subset rearranger. */
+                    int k = 0;
+                    for (int j = 0; j < numinds; j++)
                     {
-			if (mfrom[j] == i)
-			    displace[k++] = (int)(lindex[j]);
+                        if (mfrom[j] == i)
+                            displace[k++] = (int)(lindex[j]);
                     }
-		}
+                }
 
-	    }
-	    else
-	    {
-		for (int j = 0; j < mcount[i]; j++)
-		    (lindex + pos)[j]++;
+            }
+            else
+            {
+                for (int j = 0; j < mcount[i]; j++)
+                    (lindex + pos)[j]++;
 
-		for (int j = 0; j < len; j++)
-		    displace[j] = ((lindex + pos)[j * blocksize] - 1);
-	    }
+                for (int j = 0; j < len; j++)
+                    displace[j] = ((lindex + pos)[j * blocksize] - 1);
+            }
 
 #if PIO_ENABLE_LOGGING
-	    for (int j = 0; j < len; j++)
+            for (int j = 0; j < len; j++)
             {
                 
-		PLOG((2, "displace[%d] = %d", j, displace[j]));
+                PLOG((2, "displace[%d] = %d", j, displace[j]));
             }
 #endif /* PIO_ENABLE_LOGGING */
 
-	    PLOG((2, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "
-		  "mpitype = %d", len, blocksize, mpitype));
-	    /* Create an indexed datatype with constant-sized blocks. */
-	    mpierr = MPI_Type_create_indexed_block(len, blocksize, displace,
-						   mpitype, &mtype[i]);
+            PLOG((2, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "
+                  "mpitype = %d", len, blocksize, mpitype));
+            /* Create an indexed datatype with constant-sized blocks. */
+            mpierr = MPI_Type_create_indexed_block(len, blocksize, displace,
+                                                   mpitype, &mtype[i]);
 
-	    free(displace);
-	    if (mpierr)
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            free(displace);
+            if (mpierr)
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-	    if (mtype[i] == PIO_DATATYPE_NULL)
-		return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+            if (mtype[i] == PIO_DATATYPE_NULL)
+                return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-	    /* Commit the MPI data type. */
-	    PLOG((3, "about to commit type"));
-	    if ((mpierr = MPI_Type_commit(&mtype[i])))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	    pos += mcount[i];
-	}
+            /* Commit the MPI data type. */
+            PLOG((3, "about to commit type"));
+            if ((mpierr = MPI_Type_commit(&mtype[i])))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            pos += mcount[i];
+        }
     }
 
     PLOG((3, "done with create_mpi_datatypes()"));
@@ -423,7 +423,7 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
 exit:
     /* Free resources. */
     if (lindex)
-	free(lindex);
+        free(lindex);
 
     return ret;
 }
@@ -456,37 +456,37 @@ define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);
     PLOG((3, "define_iodesc_datatypes ios->ioproc = %d iodesc->rtype is %sNULL, "
-	  "iodesc->nrecvs %d", ios->ioproc, iodesc->rtype ? "not " : "",
-	  iodesc->nrecvs));
+          "iodesc->nrecvs %d", ios->ioproc, iodesc->rtype ? "not " : "",
+          iodesc->nrecvs));
 
     /* Set up the to transfer data to and from the IO tasks. */
     if (ios->ioproc)
     {
-	/* If the types for the IO tasks have not been created, then
-	 * create them. */
-	if (!iodesc->rtype)
-	{
-	    if (iodesc->nrecvs > 0)
-	    {
-		/* Allocate memory for array of MPI types for the IO tasks. */
-		if (!(iodesc->rtype = malloc(iodesc->nrecvs * sizeof(MPI_Datatype))))
-		    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-		PLOG((2, "allocated memory for IO task MPI types iodesc->nrecvs = %d "
-		      "iodesc->rearranger = %d", iodesc->nrecvs, iodesc->rearranger));
+        /* If the types for the IO tasks have not been created, then
+         * create them. */
+        if (!iodesc->rtype)
+        {
+            if (iodesc->nrecvs > 0)
+            {
+                /* Allocate memory for array of MPI types for the IO tasks. */
+                if (!(iodesc->rtype = malloc(iodesc->nrecvs * sizeof(MPI_Datatype))))
+                    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+                PLOG((2, "allocated memory for IO task MPI types iodesc->nrecvs = %d "
+                      "iodesc->rearranger = %d", iodesc->nrecvs, iodesc->rearranger));
 
-		/* Initialize data types to NULL. */
-		for (int i = 0; i < iodesc->nrecvs; i++)
-		    iodesc->rtype[i] = PIO_DATATYPE_NULL;
+                /* Initialize data types to NULL. */
+                for (int i = 0; i < iodesc->nrecvs; i++)
+                    iodesc->rtype[i] = PIO_DATATYPE_NULL;
 
-		/* The different rearrangers get different values for mfrom. */
-		int *mfrom = iodesc->rearranger == PIO_REARR_SUBSET ? iodesc->rfrom : NULL;
+                /* The different rearrangers get different values for mfrom. */
+                int *mfrom = iodesc->rearranger == PIO_REARR_SUBSET ? iodesc->rfrom : NULL;
                 
-		/* Create the MPI datatypes. */
-		if ((ret = create_mpi_datatypes(iodesc->mpitype, iodesc->nrecvs, iodesc->rindex,
-						iodesc->rcount, mfrom, iodesc->rtype)))
-		    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-	    }
-	}
+                /* Create the MPI datatypes. */
+                if ((ret = create_mpi_datatypes(iodesc->mpitype, iodesc->nrecvs, iodesc->rindex,
+                                                iodesc->rcount, mfrom, iodesc->rtype)))
+                    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+            }
+        }
     }
 
     /* Define the datatypes for the computation components if they
@@ -494,33 +494,33 @@ define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
      * operation.) */
     if (ios->compproc)
     {
-	if (!iodesc->stype)
-	{
-	    int ntypes;
+        if (!iodesc->stype)
+        {
+            int ntypes;
 
-	    /* Subset rearranger gets one type; box rearranger gets one
-	     * type per IO task. */
-	    ntypes = iodesc->rearranger == PIO_REARR_SUBSET ? 1 : ios->num_iotasks;
+            /* Subset rearranger gets one type; box rearranger gets one
+             * type per IO task. */
+            ntypes = iodesc->rearranger == PIO_REARR_SUBSET ? 1 : ios->num_iotasks;
 
-	    /* Allocate memory for array of MPI types for the computation tasks. */
-	    if (!(iodesc->stype = malloc(ntypes * sizeof(MPI_Datatype))))
-		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	    PLOG((3, "allocated memory for computation MPI types ntypes = %d", ntypes));
+            /* Allocate memory for array of MPI types for the computation tasks. */
+            if (!(iodesc->stype = malloc(ntypes * sizeof(MPI_Datatype))))
+                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+            PLOG((3, "allocated memory for computation MPI types ntypes = %d", ntypes));
 
-	    /* Initialize send types to NULL. */
-	    for (int i = 0; i < ntypes; i++)
-		iodesc->stype[i] = PIO_DATATYPE_NULL;
+            /* Initialize send types to NULL. */
+            for (int i = 0; i < ntypes; i++)
+                iodesc->stype[i] = PIO_DATATYPE_NULL;
 
-	    /* Remember how many types we created for the send side. */
-	    iodesc->num_stypes = ntypes;
+            /* Remember how many types we created for the send side. */
+            iodesc->num_stypes = ntypes;
             
-	    /* Create the MPI data types. */
-	    PLOG((3, "about to call create_mpi_datatypes for computation MPI types"));
-	    if ((ret = create_mpi_datatypes(iodesc->mpitype, ntypes, iodesc->sindex,
-					    iodesc->scount, NULL, iodesc->stype)))
-		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+            /* Create the MPI data types. */
+            PLOG((3, "about to call create_mpi_datatypes for computation MPI types"));
+            if ((ret = create_mpi_datatypes(iodesc->mpitype, ntypes, iodesc->sindex,
+                                            iodesc->scount, NULL, iodesc->stype)))
+                return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
-	}
+        }
     }
 
     PLOG((3, "done with define_iodesc_datatypes()"));
@@ -561,7 +561,7 @@ define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
  */
 int
 compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
-	       const int *dest_ioproc, const PIO_Offset *dest_ioindex)
+               const int *dest_ioproc, const PIO_Offset *dest_ioindex)
 {
     int *recv_buf = NULL;
     int nrecvs = 0;
@@ -569,11 +569,11 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
 
     /* Check inputs. */
     pioassert(ios && iodesc && (iodesc->ndof == 0 ||
-				(iodesc->ndof > 0 && dest_ioproc && dest_ioindex)) &&
-	      iodesc->rearranger == PIO_REARR_BOX && ios->num_uniontasks > 0,
-	      "invalid input", __FILE__, __LINE__);
+                                (iodesc->ndof > 0 && dest_ioproc && dest_ioindex)) &&
+              iodesc->rearranger == PIO_REARR_BOX && ios->num_uniontasks > 0,
+              "invalid input", __FILE__, __LINE__);
     PLOG((1, "compute_counts ios->num_uniontasks = %d ios->compproc %d ios->ioproc %d",
-	  ios->num_uniontasks, ios->compproc, ios->ioproc));
+          ios->num_uniontasks, ios->compproc, ios->ioproc));
 
     /* Arrays for swapm all to all gather calls. */
     MPI_Datatype sr_types[ios->num_uniontasks];
@@ -586,29 +586,29 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     PIO_Offset *s2rindex = NULL;
     if (iodesc->ndof > 0)
     {
-	if (!(s2rindex = malloc(sizeof(PIO_Offset) * iodesc->ndof)))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(s2rindex = malloc(sizeof(PIO_Offset) * iodesc->ndof)))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     }
     /* Allocate memory for the array of counts and init to zero. */
     if (!(iodesc->scount = calloc(ios->num_iotasks, sizeof(int))))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* iodesc->scount is the number of data elements sent to each IO
      * task from the current compute task. dest_ioindex[i] may be
      * -1. */
     if (ios->compproc)
-	for (int i = 0; i < iodesc->ndof; i++)
-	    if (dest_ioindex[i] >= 0)
-		(iodesc->scount[dest_ioproc[i]])++;
+        for (int i = 0; i < iodesc->ndof; i++)
+            if (dest_ioindex[i] >= 0)
+                (iodesc->scount[dest_ioproc[i]])++;
 
     /* Initialize arrays used in swapm call. */
     for (int i = 0; i < ios->num_uniontasks; i++)
     {
-	send_counts[i] = 0;
-	send_displs[i] = 0;
-	recv_counts[i] = 0;
-	recv_displs[i] = 0;
-	sr_types[i] = MPI_INT;
+        send_counts[i] = 0;
+        send_displs[i] = 0;
+        recv_counts[i] = 0;
+        recv_displs[i] = 0;
+        sr_types[i] = MPI_INT;
     }
 
     /* Setup for the swapm call. iodesc->scount is the amount of data
@@ -621,13 +621,13 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
      * rank of that task. */
     if (ios->compproc)
     {
-	for (int i = 0; i < ios->num_iotasks; i++)
-	{
-	    send_counts[ios->ioranks[i]] = 1;
-	    send_displs[ios->ioranks[i]] = i * sizeof(int);
-	    PLOG((3, "send_counts[%d] = %d send_displs[%d] = %d", ios->ioranks[i],
-		  send_counts[ios->ioranks[i]], ios->ioranks[i], send_displs[ios->ioranks[i]]));
-	}
+        for (int i = 0; i < ios->num_iotasks; i++)
+        {
+            send_counts[ios->ioranks[i]] = 1;
+            send_displs[ios->ioranks[i]] = i * sizeof(int);
+            PLOG((3, "send_counts[%d] = %d send_displs[%d] = %d", ios->ioranks[i],
+                  send_counts[ios->ioranks[i]], ios->ioranks[i], send_displs[ios->ioranks[i]]));
+        }
     }
 
     /* IO tasks need to know how many data elements they will receive
@@ -635,63 +635,63 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
      * swapm call. */
     if (ios->ioproc)
     {
-	/* Allocate memory to hold array of the scounts from all
-	 * computation tasks. */
-	if (!(recv_buf = calloc(ios->num_comptasks, sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        /* Allocate memory to hold array of the scounts from all
+         * computation tasks. */
+        if (!(recv_buf = calloc(ios->num_comptasks, sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	/* Initialize arrays that keep track of counts and
-	 * displacements for the all-to-all gather. */
-	for (int i = 0; i < ios->num_comptasks; i++)
-	{
-	    recv_counts[ios->compranks[i]] = 1;
-	    recv_displs[ios->compranks[i]] = i * sizeof(int);
-	    PLOG((3, "recv_counts[%d] = %d recv_displs[%d] = %d", ios->compranks[i],
-		  recv_counts[ios->compranks[i]], ios->compranks[i],
-		  recv_displs[ios->compranks[i]]));
-	}
+        /* Initialize arrays that keep track of counts and
+         * displacements for the all-to-all gather. */
+        for (int i = 0; i < ios->num_comptasks; i++)
+        {
+            recv_counts[ios->compranks[i]] = 1;
+            recv_displs[ios->compranks[i]] = i * sizeof(int);
+            PLOG((3, "recv_counts[%d] = %d recv_displs[%d] = %d", ios->compranks[i],
+                  recv_counts[ios->compranks[i]], ios->compranks[i],
+                  recv_displs[ios->compranks[i]]));
+        }
     }
 
     PLOG((2, "about to share scount from each compute task to all IO tasks."));
     /* Share the iodesc->scount from each compute task to all IO
      * tasks. The scounts will end up in array recv_buf. */
     if ((ierr = pio_swapm(iodesc->scount, send_counts, send_displs, sr_types,
-			  recv_buf, recv_counts, recv_displs, sr_types, ios->union_comm,
-			  &iodesc->rearr_opts.comp2io)))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+                          recv_buf, recv_counts, recv_displs, sr_types, ios->union_comm,
+                          &iodesc->rearr_opts.comp2io)))
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
 
     /* On IO tasks, set up data receives. */
     if (ios->ioproc)
     {
-	/* Count the number of non-zero scounts from the compute
-	 * tasks. */
-	for (int i = 0; i < ios->num_comptasks; i++)
-	{
-	    if (recv_buf[i] != 0)
-		nrecvs++;
-	    PLOG((3, "recv_buf[%d] = %d", i, recv_buf[i]));
-	}
+        /* Count the number of non-zero scounts from the compute
+         * tasks. */
+        for (int i = 0; i < ios->num_comptasks; i++)
+        {
+            if (recv_buf[i] != 0)
+                nrecvs++;
+            PLOG((3, "recv_buf[%d] = %d", i, recv_buf[i]));
+        }
 
-	/* Get memory to hold the count of data receives. */
-	if (!(iodesc->rcount = calloc(max(1, nrecvs), sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        /* Get memory to hold the count of data receives. */
+        if (!(iodesc->rcount = calloc(max(1, nrecvs), sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	/* Get memory to hold the list of task data was from. */
-	if (!(iodesc->rfrom = calloc(max(1, nrecvs), sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	PLOG((3, "allocared rfrom max(1, nrecvs) = %d", max(1, nrecvs)));
+        /* Get memory to hold the list of task data was from. */
+        if (!(iodesc->rfrom = calloc(max(1, nrecvs), sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        PLOG((3, "allocared rfrom max(1, nrecvs) = %d", max(1, nrecvs)));
 
-	nrecvs = 0;
-	for (int i = 0; i < ios->num_comptasks; i++)
-	{
-	    if (recv_buf[i] != 0)
-	    {
-		iodesc->rcount[nrecvs] = recv_buf[i];
-		iodesc->rfrom[nrecvs] = ios->compranks[i];
-		nrecvs++;
-	    }
-	}
-	free(recv_buf);
+        nrecvs = 0;
+        for (int i = 0; i < ios->num_comptasks; i++)
+        {
+            if (recv_buf[i] != 0)
+            {
+                iodesc->rcount[nrecvs] = recv_buf[i];
+                iodesc->rfrom[nrecvs] = ios->compranks[i];
+                nrecvs++;
+            }
+        }
+        free(recv_buf);
     }
 
     /* ??? */
@@ -701,8 +701,8 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     /* Allocate an array for indicies on the computation tasks (the
      * send side when writing). */
     if (iodesc->sindex == NULL && iodesc->ndof > 0)
-	if (!(iodesc->sindex = malloc(iodesc->ndof * sizeof(PIO_Offset))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(iodesc->sindex = malloc(iodesc->ndof * sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     PLOG((2, "iodesc->ndof = %d ios->num_iotasks = %d", iodesc->ndof, ios->num_iotasks));
 
     int tempcount[ios->num_iotasks];
@@ -713,99 +713,99 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     tempcount[0] = 0;
     for (int i = 1; i < ios->num_iotasks; i++)
     {
-	spos[i] = spos[i - 1] + iodesc->scount[i - 1];
-	tempcount[i] = 0;
-	PLOG((3, "spos[%d] = %d tempcount[%d] = %d", i, spos[i], i, tempcount[i]));
+        spos[i] = spos[i - 1] + iodesc->scount[i - 1];
+        tempcount[i] = 0;
+        PLOG((3, "spos[%d] = %d tempcount[%d] = %d", i, spos[i], i, tempcount[i]));
     }
 
     /* ??? */
     for (int i = 0; i < iodesc->ndof; i++)
     {
-	int iorank;
-	int ioindex;
+        int iorank;
+        int ioindex;
 
-	PLOG((3, "dest_ioproc[%d] = %d dest_ioindex[%d] = %d", i, dest_ioproc[i], i,
-	      dest_ioindex[i]));
-	iorank = dest_ioproc[i];
-	ioindex = dest_ioindex[i];
-	if (iorank > -1)
-	{
-	    /* this should be moved to create_box */
-	    iodesc->sindex[spos[iorank] + tempcount[iorank]] = i;
+        PLOG((3, "dest_ioproc[%d] = %d dest_ioindex[%d] = %d", i, dest_ioproc[i], i,
+              dest_ioindex[i]));
+        iorank = dest_ioproc[i];
+        ioindex = dest_ioindex[i];
+        if (iorank > -1)
+        {
+            /* this should be moved to create_box */
+            iodesc->sindex[spos[iorank] + tempcount[iorank]] = i;
 
-	    s2rindex[spos[iorank] + tempcount[iorank]] = ioindex;
-	    (tempcount[iorank])++;
-	    PLOG((3, "iorank = %d ioindex = %d tempcount[iorank] = %d", iorank, ioindex,
-		  tempcount[iorank]));
-	}
+            s2rindex[spos[iorank] + tempcount[iorank]] = ioindex;
+            (tempcount[iorank])++;
+            PLOG((3, "iorank = %d ioindex = %d tempcount[iorank] = %d", iorank, ioindex,
+                  tempcount[iorank]));
+        }
     }
 
     /* Initialize arrays to zeros. */
     for (int i = 0; i < ios->num_uniontasks; i++)
     {
-	send_counts[i] = 0;
-	send_displs[i] = 0;
-	recv_counts[i] = 0;
-	recv_displs[i] = 0;
+        send_counts[i] = 0;
+        send_displs[i] = 0;
+        recv_counts[i] = 0;
+        recv_displs[i] = 0;
     }
 
     /* ??? */
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-	/* Subset rearranger needs one type, box rearranger needs one for
-	 * each IO task. */
-	send_counts[ios->ioranks[i]] = iodesc->scount[i];
-	if (send_counts[ios->ioranks[i]] > 0)
-	    send_displs[ios->ioranks[i]] = spos[i] * SIZEOF_MPI_OFFSET;
-	PLOG((3, "ios->ioranks[i] = %d iodesc->scount[%d] = %d spos[%d] = %d",
-	      ios->ioranks[i], i, iodesc->scount[i], i, spos[i]));
+        /* Subset rearranger needs one type, box rearranger needs one for
+         * each IO task. */
+        send_counts[ios->ioranks[i]] = iodesc->scount[i];
+        if (send_counts[ios->ioranks[i]] > 0)
+            send_displs[ios->ioranks[i]] = spos[i] * SIZEOF_MPI_OFFSET;
+        PLOG((3, "ios->ioranks[i] = %d iodesc->scount[%d] = %d spos[%d] = %d",
+              ios->ioranks[i], i, iodesc->scount[i], i, spos[i]));
     }
 
     /* Only do this on IO tasks. */
     if (ios->ioproc)
     {
-	int totalrecv = 0;
-	for (int i = 0; i < nrecvs; i++)
-	{
-	    recv_counts[iodesc->rfrom[i]] = iodesc->rcount[i];
-	    totalrecv += iodesc->rcount[i];
-	}
+        int totalrecv = 0;
+        for (int i = 0; i < nrecvs; i++)
+        {
+            recv_counts[iodesc->rfrom[i]] = iodesc->rcount[i];
+            totalrecv += iodesc->rcount[i];
+        }
 
-	recv_displs[0] = 0;
-	for (int i = 1; i < nrecvs; i++)
-	{
-	    recv_displs[iodesc->rfrom[i]] = recv_displs[iodesc->rfrom[i - 1]] +
-		iodesc->rcount[i - 1] * SIZEOF_MPI_OFFSET;
-	    PLOG((3, "iodesc->rfrom[%d] = %d recv_displs[iodesc->rfrom[i]] = %d", i,
-		  iodesc->rfrom[i], recv_displs[iodesc->rfrom[i]]));
-	}
+        recv_displs[0] = 0;
+        for (int i = 1; i < nrecvs; i++)
+        {
+            recv_displs[iodesc->rfrom[i]] = recv_displs[iodesc->rfrom[i - 1]] +
+                iodesc->rcount[i - 1] * SIZEOF_MPI_OFFSET;
+            PLOG((3, "iodesc->rfrom[%d] = %d recv_displs[iodesc->rfrom[i]] = %d", i,
+                  iodesc->rfrom[i], recv_displs[iodesc->rfrom[i]]));
+        }
 
-	/* rindex is an array of the indices of the data to be sent from
-	   this io task to each compute task. */
-	PLOG((3, "totalrecv = %d", totalrecv));
-	if (totalrecv > 0)
-	{
-	    totalrecv = iodesc->llen;  /* can reduce memory usage here */
-	    if (!(iodesc->rindex = calloc(totalrecv, sizeof(PIO_Offset))))
-		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	    PLOG((3, "allocated totalrecv elements in rindex array"));
-	}
+        /* rindex is an array of the indices of the data to be sent from
+           this io task to each compute task. */
+        PLOG((3, "totalrecv = %d", totalrecv));
+        if (totalrecv > 0)
+        {
+            totalrecv = iodesc->llen;  /* can reduce memory usage here */
+            if (!(iodesc->rindex = calloc(totalrecv, sizeof(PIO_Offset))))
+                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+            PLOG((3, "allocated totalrecv elements in rindex array"));
+        }
     }
 
     /* For the swapm call below, init the types to MPI_OFFSET. */
     for (int i = 0; i < ios->num_uniontasks; i++)
-	sr_types[i] = MPI_OFFSET;
+        sr_types[i] = MPI_OFFSET;
 
     /* Here we are sending the mapping from the index on the compute
      * task to the index on the io task. */
     /* s2rindex is the list of indeces on each compute task */
     PLOG((3, "sending mapping"));
     if ((ierr = pio_swapm(s2rindex, send_counts, send_displs, sr_types, iodesc->rindex,
-			  recv_counts, recv_displs, sr_types, ios->union_comm,
-			  &iodesc->rearr_opts.comp2io)))
-	return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+                          recv_counts, recv_displs, sr_types, ios->union_comm,
+                          &iodesc->rearr_opts.comp2io)))
+        return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     if(s2rindex)
-	free(s2rindex);
+        free(s2rindex);
 
     return PIO_NOERR;
 }
@@ -824,7 +824,7 @@ compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
  */
 int
 rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
-		  void *rbuf, int nvars)
+                  void *rbuf, int nvars)
 {
     int ntasks;       /* Number of tasks in communicator. */
     int niotasks;     /* Number of IO tasks. */
@@ -835,30 +835,30 @@ rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ret = pio_start_timer("PIO:rearrange_comp2io")))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Caller must provide these. */
     pioassert(ios && iodesc && nvars > 0, "invalid input", __FILE__, __LINE__);
 
     PLOG((1, "rearrange_comp2io nvars = %d iodesc->rearranger = %d", nvars,
-	  iodesc->rearranger));
+          iodesc->rearranger));
 
     /* Different rearraangers use different communicators. */
     if (iodesc->rearranger == PIO_REARR_BOX)
     {
-	mycomm = ios->union_comm;
-	niotasks = ios->num_iotasks;
+        mycomm = ios->union_comm;
+        niotasks = ios->num_iotasks;
     }
     else
     {
-	mycomm = iodesc->subset_comm;
-	niotasks = 1;
+        mycomm = iodesc->subset_comm;
+        niotasks = 1;
     }
 
     /* Get the number of tasks. */
     if ((mpierr = MPI_Comm_size(mycomm, &ntasks)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     /* These are parameters to pio_swapm to send data from compute to
      * IO tasks. */
@@ -872,127 +872,127 @@ rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     /* Initialize pio_swapm parameter arrays. */
     for (int i = 0; i < ntasks; i++)
     {
-	sendcounts[i] = 0;
-	recvcounts[i] = 0;
-	sdispls[i] = 0;
-	rdispls[i] = 0;
-	recvtypes[i] = PIO_DATATYPE_NULL;
-	sendtypes[i] =  PIO_DATATYPE_NULL;
+        sendcounts[i] = 0;
+        recvcounts[i] = 0;
+        sdispls[i] = 0;
+        rdispls[i] = 0;
+        recvtypes[i] = PIO_DATATYPE_NULL;
+        sendtypes[i] =  PIO_DATATYPE_NULL;
     }
     PLOG((3, "ntasks = %d iodesc->mpitype_size = %d niotasks = %d", ntasks,
-	  iodesc->mpitype_size, niotasks));
+          iodesc->mpitype_size, niotasks));
 
     /* If it has not already been done, define the MPI data types that
      * will be used for this io_desc_t. */
     if ((ret = define_iodesc_datatypes(ios, iodesc)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* If this io proc, we need to exchange data with compute
      * tasks. Create a MPI DataType for that exchange. */
     PLOG((2, "ios->ioproc %d iodesc->nrecvs = %d", ios->ioproc, iodesc->nrecvs));
     if (ios->ioproc && iodesc->nrecvs > 0)
     {
-	for (int i = 0; i < iodesc->nrecvs; i++)
-	{
-	    if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
-	    {
-		PLOG((3, "iodesc->rtype[%d] = %d iodesc->rearranger = %d", i, iodesc->rtype[i],
-		      iodesc->rearranger));
-		if (iodesc->rearranger == PIO_REARR_SUBSET)
-		{
-		    PLOG((3, "exchanging data for subset rearranger"));
-		    recvcounts[i] = 1;
+        for (int i = 0; i < iodesc->nrecvs; i++)
+        {
+            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
+            {
+                PLOG((3, "iodesc->rtype[%d] = %d iodesc->rearranger = %d", i, iodesc->rtype[i],
+                      iodesc->rearranger));
+                if (iodesc->rearranger == PIO_REARR_SUBSET)
+                {
+                    PLOG((3, "exchanging data for subset rearranger"));
+                    recvcounts[i] = 1;
 
-		    /*  Create an MPI derived data type from equally
-		     *  spaced blocks of the same size. The block size
-		     *  is 1, the stride here is the length of the
-		     *  collected array (llen). */
-		    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
-							  iodesc->rtype[i], &recvtypes[i])))
-			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                    /*  Create an MPI derived data type from equally
+                     *  spaced blocks of the same size. The block size
+                     *  is 1, the stride here is the length of the
+                     *  collected array (llen). */
+                    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
+                                                          iodesc->rtype[i], &recvtypes[i])))
+                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-		    pioassert(recvtypes[i] != PIO_DATATYPE_NULL, "bad mpi type", __FILE__, __LINE__);
+                    pioassert(recvtypes[i] != PIO_DATATYPE_NULL, "bad mpi type", __FILE__, __LINE__);
 
-		    if ((mpierr = MPI_Type_commit(&recvtypes[i])))
-			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-		}
-		else
-		{
-		    recvcounts[iodesc->rfrom[i]] = 1;
-		    PLOG((3, "exchanging data for box rearranger i = %d iodesc->rfrom[i] = %d "
-			  "recvcounts[iodesc->rfrom[i]] = %d", i, iodesc->rfrom[i],
-			  recvcounts[iodesc->rfrom[i]]));
+                    if ((mpierr = MPI_Type_commit(&recvtypes[i])))
+                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
+                else
+                {
+                    recvcounts[iodesc->rfrom[i]] = 1;
+                    PLOG((3, "exchanging data for box rearranger i = %d iodesc->rfrom[i] = %d "
+                          "recvcounts[iodesc->rfrom[i]] = %d", i, iodesc->rfrom[i],
+                          recvcounts[iodesc->rfrom[i]]));
 
-		    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
-							  iodesc->rtype[i], &recvtypes[iodesc->rfrom[i]])))
-			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                    if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
+                                                          iodesc->rtype[i], &recvtypes[iodesc->rfrom[i]])))
+                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-		    pioassert(recvtypes[iodesc->rfrom[i]] != PIO_DATATYPE_NULL,  "bad mpi type",
-			      __FILE__, __LINE__);
+                    pioassert(recvtypes[iodesc->rfrom[i]] != PIO_DATATYPE_NULL,  "bad mpi type",
+                              __FILE__, __LINE__);
 
-		    if ((mpierr = MPI_Type_commit(&recvtypes[iodesc->rfrom[i]])))
-			return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                    if ((mpierr = MPI_Type_commit(&recvtypes[iodesc->rfrom[i]])))
+                        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-		    rdispls[iodesc->rfrom[i]] = 0;
-		}
-	    }
-	}
+                    rdispls[iodesc->rfrom[i]] = 0;
+                }
+            }
+        }
     }
 
     /* On compute tasks loop over iotasks and create a data type for
      * each exchange.  */
     if(!ios->async || ios->compproc)
     {
-	for (int i = 0; i < niotasks; i++)
-	{
-	    int io_comprank = ios->ioranks[i];
-	    PLOG((3, "ios->ioranks[%d] = %d", i, ios->ioranks[i]));
-	    if (iodesc->rearranger == PIO_REARR_SUBSET)
-		io_comprank = 0;
+        for (int i = 0; i < niotasks; i++)
+        {
+            int io_comprank = ios->ioranks[i];
+            PLOG((3, "ios->ioranks[%d] = %d", i, ios->ioranks[i]));
+            if (iodesc->rearranger == PIO_REARR_SUBSET)
+                io_comprank = 0;
 
-	    PLOG((3, "i = %d iodesc->scount[i] = %d", i, iodesc->scount[i]));
-	    if (iodesc->scount[i] > 0 && sbuf)
-	    {
-		PLOG((3, "io task %d creating sendtypes[%d]", i, io_comprank));
-		sendcounts[io_comprank] = 1;
-		if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->ndof * iodesc->mpitype_size,
-						      iodesc->stype[i], &sendtypes[io_comprank])))
-		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-		pioassert(sendtypes[io_comprank] != PIO_DATATYPE_NULL,  "bad mpi type", __FILE__, __LINE__);
+            PLOG((3, "i = %d iodesc->scount[i] = %d", i, iodesc->scount[i]));
+            if (iodesc->scount[i] > 0 && sbuf)
+            {
+                PLOG((3, "io task %d creating sendtypes[%d]", i, io_comprank));
+                sendcounts[io_comprank] = 1;
+                if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->ndof * iodesc->mpitype_size,
+                                                      iodesc->stype[i], &sendtypes[io_comprank])))
+                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                pioassert(sendtypes[io_comprank] != PIO_DATATYPE_NULL,  "bad mpi type", __FILE__, __LINE__);
 
-		if ((mpierr = MPI_Type_commit(&sendtypes[io_comprank])))
-		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	    }
-	    else
-	    {
-		sendcounts[io_comprank] = 0;
-	    }
-	}
+                if ((mpierr = MPI_Type_commit(&sendtypes[io_comprank])))
+                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            }
+            else
+            {
+                sendcounts[io_comprank] = 0;
+            }
+        }
     }
 
     /* Data in sbuf on the compute nodes is sent to rbuf on the ionodes */
     PLOG((2, "about to call pio_swapm for sbuf"));
     if ((ret = pio_swapm(sbuf, sendcounts, sdispls, sendtypes,
-			 rbuf, recvcounts, rdispls, recvtypes, mycomm,
-			 &iodesc->rearr_opts.comp2io)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                         rbuf, recvcounts, rdispls, recvtypes, mycomm,
+                         &iodesc->rearr_opts.comp2io)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Free the MPI types. */
     for (int i = 0; i < ntasks; i++)
     {
-	PLOG((3, "freeing MPI types for task %d", i));
-	if (sendtypes[i] != PIO_DATATYPE_NULL)
-	    if ((mpierr = MPI_Type_free(&sendtypes[i])))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        PLOG((3, "freeing MPI types for task %d", i));
+        if (sendtypes[i] != PIO_DATATYPE_NULL)
+            if ((mpierr = MPI_Type_free(&sendtypes[i])))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-	if (recvtypes[i] != PIO_DATATYPE_NULL)
-	    if ((mpierr = MPI_Type_free(&recvtypes[i])))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if (recvtypes[i] != PIO_DATATYPE_NULL)
+            if ((mpierr = MPI_Type_free(&recvtypes[i])))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     }
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:rearrange_comp2io")))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return PIO_NOERR;
@@ -1011,7 +1011,7 @@ rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  */
 int
 rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
-		  void *rbuf)
+                  void *rbuf)
 {
     MPI_Comm mycomm;
     int ntasks;
@@ -1026,31 +1026,31 @@ rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ret = pio_start_timer("PIO:rearrange_io2comp")))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Different rearrangers use different communicators and number of
      * IO tasks. */
     if (iodesc->rearranger == PIO_REARR_BOX)
     {
-	mycomm = ios->union_comm;
-	niotasks = ios->num_iotasks;
+        mycomm = ios->union_comm;
+        niotasks = ios->num_iotasks;
     }
     else
     {
-	mycomm = iodesc->subset_comm;
-	niotasks = 1;
+        mycomm = iodesc->subset_comm;
+        niotasks = 1;
     }
 
     /* Get the size of this communicator. */
     if ((mpierr = MPI_Comm_size(mycomm, &ntasks)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     PLOG((3, "niotasks %d ntasks %d", niotasks, ntasks));
 
     /* Define the MPI data types that will be used for this
      * io_desc_t. */
     if ((ret = define_iodesc_datatypes(ios, iodesc)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Allocate arrays needed by the pio_swapm() function. */
     int sendcounts[ntasks];
@@ -1063,37 +1063,37 @@ rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     /* Initialize arrays. */
     for (int i = 0; i < ntasks; i++)
     {
-	sendcounts[i] = 0;
-	recvcounts[i] = 0;
-	sdispls[i] = 0;
-	rdispls[i] = 0;
-	sendtypes[i] = PIO_DATATYPE_NULL;
-	recvtypes[i] = PIO_DATATYPE_NULL;
+        sendcounts[i] = 0;
+        recvcounts[i] = 0;
+        sdispls[i] = 0;
+        rdispls[i] = 0;
+        sendtypes[i] = PIO_DATATYPE_NULL;
+        recvtypes[i] = PIO_DATATYPE_NULL;
     }
 
     /* In IO tasks set up sendcounts/sendtypes for pio_swapm() call
      * below. */
     if (ios->ioproc)
     {
-	for (int i = 0; i < iodesc->nrecvs; i++)
-	{
-	    if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
-	    {
-		if (iodesc->rearranger == PIO_REARR_SUBSET)
-		{
-		    if (sbuf)
-		    {
-			sendcounts[i] = 1;
-			sendtypes[i] = iodesc->rtype[i];
-		    }
-		}
-		else
-		{
-		    sendcounts[iodesc->rfrom[i]] = 1;
-		    sendtypes[iodesc->rfrom[i]] = iodesc->rtype[i];
-		}
-	    }
-	}
+        for (int i = 0; i < iodesc->nrecvs; i++)
+        {
+            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
+            {
+                if (iodesc->rearranger == PIO_REARR_SUBSET)
+                {
+                    if (sbuf)
+                    {
+                        sendcounts[i] = 1;
+                        sendtypes[i] = iodesc->rtype[i];
+                    }
+                }
+                else
+                {
+                    sendcounts[iodesc->rfrom[i]] = 1;
+                    sendtypes[iodesc->rfrom[i]] = iodesc->rtype[i];
+                }
+            }
+        }
     }
 
     /* In the box rearranger each comp task may communicate with
@@ -1102,28 +1102,28 @@ rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
      * task. */
     for (int i = 0; i < niotasks; i++)
     {
-	int io_comprank = ios->ioranks[i];
+        int io_comprank = ios->ioranks[i];
 
-	if (iodesc->rearranger == PIO_REARR_SUBSET)
-	    io_comprank = 0;
+        if (iodesc->rearranger == PIO_REARR_SUBSET)
+            io_comprank = 0;
 
-	if (iodesc->scount[i] > 0 && iodesc->stype[i] != PIO_DATATYPE_NULL)
-	{
-	    recvcounts[io_comprank] = 1;
-	    recvtypes[io_comprank] = iodesc->stype[i];
-	}
+        if (iodesc->scount[i] > 0 && iodesc->stype[i] != PIO_DATATYPE_NULL)
+        {
+            recvcounts[io_comprank] = 1;
+            recvtypes[io_comprank] = iodesc->stype[i];
+        }
     }
 
     /* Data in sbuf on the ionodes is sent to rbuf on the compute
      * nodes. */
 
     if ((ret = pio_swapm(sbuf, sendcounts, sdispls, sendtypes, rbuf, recvcounts,
-			 rdispls, recvtypes, mycomm, &iodesc->rearr_opts.io2comp)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                         rdispls, recvtypes, mycomm, &iodesc->rearr_opts.io2comp)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:rearrange_io2comp")))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif
 
     return PIO_NOERR;
@@ -1146,7 +1146,7 @@ rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  */
 int
 determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
-	       const PIO_Offset *compmap)
+               const PIO_Offset *compmap)
 {
     PIO_Offset totalllen = 0;
     PIO_Offset totalgridsize = 1;
@@ -1154,26 +1154,26 @@ determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
 
     /* Check inputs. */
     pioassert(ios && iodesc && gdimlen && compmap, "invalid input",
-	      __FILE__, __LINE__);
+              __FILE__, __LINE__);
 
     /* Determine size of data space. */
     for (int i = 0; i < iodesc->ndims; i++)
-	totalgridsize *= gdimlen[i];
+        totalgridsize *= gdimlen[i];
 
     /* Determine how many values we have locally. */
     if (iodesc->rearranger == PIO_REARR_SUBSET)
-	totalllen = iodesc->llen;
+        totalllen = iodesc->llen;
     else
-	for (int i = 0; i < iodesc->ndof; i++)
-	    if (compmap[i] > 0)
-		totalllen++;
+        for (int i = 0; i < iodesc->ndof; i++)
+            if (compmap[i] > 0)
+                totalllen++;
 
     /* Add results accross communicator. */
     PLOG((2, "determine_fill before allreduce totalllen = %d totalgridsize = %d",
-	  totalllen, totalgridsize));
+          totalllen, totalgridsize));
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &totalllen, 1, PIO_OFFSET, MPI_SUM,
-				ios->union_comm)))
-	check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                                ios->union_comm)))
+        check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     PLOG((2, "after allreduce totalllen = %d", totalllen));
 
     /* If the total size of the data provided to be written is < the
@@ -1181,7 +1181,7 @@ determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
     iodesc->needsfill = totalllen < totalgridsize;
 
     /*  TURN OFF FILL for timing test
-	iodesc->needsfill=false; */
+        iodesc->needsfill=false; */
 
     return PIO_NOERR;
 }
@@ -1228,15 +1228,15 @@ determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
  */
 int
 box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap,
-		     const int *gdimlen, int ndims, io_desc_t *iodesc)
+                     const int *gdimlen, int ndims, io_desc_t *iodesc)
 {
     int ret;
 
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims > 0 && iodesc,
-	      "invalid input", __FILE__, __LINE__);
+              "invalid input", __FILE__, __LINE__);
     PLOG((1, "box_rearrange_create maplen = %d ndims = %d ios->num_comptasks = %d "
-	  "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
+          "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
 
     /* Allocate arrays needed for this function. */
     int *dest_ioproc = NULL; /* Destination IO task for each data element on compute task. */
@@ -1259,7 +1259,7 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ret = pio_start_timer("PIO:box_rearrange_create")))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* This is the box rearranger. */
@@ -1270,26 +1270,26 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
 
     if (maplen > 0)
     {
-	if (!(dest_ioproc = malloc(maplen * sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(dest_ioproc = malloc(maplen * sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	if (!(gcoord_map = malloc(maplen * sizeof(PIO_Offset*))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(gcoord_map = malloc(maplen * sizeof(PIO_Offset*))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	for (int i = 0; i < maplen; i++)
-	{
-	    if (!(gcoord_map[i] = calloc(ndims, sizeof(PIO_Offset))))
-		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	}
+        for (int i = 0; i < maplen; i++)
+        {
+            if (!(gcoord_map[i] = calloc(ndims, sizeof(PIO_Offset))))
+                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        }
     }
 
     /* Initialize the sc_info send and recv messages */
     for(int i=0; i<sc_info_msg_sz; i++)
     {
-	sc_info_msg_send[i] = 0;
+        sc_info_msg_send[i] = 0;
     }
 
     /* The sc_info_msg_recv[i * sc_msg_info_sz] contains the sc_info from
@@ -1298,24 +1298,24 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
      */
     for(int i=0; i<ios->num_iotasks * sc_info_msg_sz; i++)
     {
-	sc_info_msg_recv[i] = 0;
+        sc_info_msg_recv[i] = 0;
     }
 
     /* Initialize array values. */
     for (int i = 0; i < maplen; i++)
     {
-	dest_ioproc[i] = -1;
-	dest_ioindex[i] = -1;
+        dest_ioproc[i] = -1;
+        dest_ioindex[i] = -1;
     }
 
     /* Initialize arrays used in swapm. */
     for (int i = 0; i < ios->num_uniontasks; i++)
     {
-	sendcounts[i] = 0;
-	sdispls[i] = 0;
-	recvcounts[i] = 0;
-	rdispls[i] = 0;
-	dtypes[i] = MPI_OFFSET;
+        sendcounts[i] = 0;
+        sdispls[i] = 0;
+        recvcounts[i] = 0;
+        rdispls[i] = 0;
+        dtypes[i] = MPI_OFFSET;
     }
 
     /* For IO tasks, determine llen, the length of the data array on
@@ -1323,28 +1323,28 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
      * set up arrays for the allgather which will give every IO task a
      * complete list of llens for each IO task. */
     PLOG((3, "ios->ioproc = %d ios->num_uniontasks = %d", ios->ioproc,
-	  ios->num_uniontasks));
+          ios->num_uniontasks));
     pioassert(iodesc->llen == 0, "error", __FILE__, __LINE__);
     if (ios->ioproc)
     {
-	/* Determine llen, the length of the data array on this IO
-	 * node, by multipliying the counts in the
-	 * iodesc->firstregion. */
-	iodesc->llen = 1;
-	for (int i = 0; i < ndims; i++)
-	{
-	    iodesc->llen *= iodesc->firstregion->count[i];
-	    PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
-		  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
-	}
-	PLOG((2, "iodesc->llen = %d", iodesc->llen));
+        /* Determine llen, the length of the data array on this IO
+         * node, by multipliying the counts in the
+         * iodesc->firstregion. */
+        iodesc->llen = 1;
+        for (int i = 0; i < ndims; i++)
+        {
+            iodesc->llen *= iodesc->firstregion->count[i];
+            PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
+                  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
+        }
+        PLOG((2, "iodesc->llen = %d", iodesc->llen));
     }
 
     /* Determine whether fill values will be needed. */
     if ((ret = determine_fill(ios, iodesc, gdimlen, compmap)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((2, "a iodesc->needsfill = %d ios->num_iotasks = %d", iodesc->needsfill,
-	  ios->num_iotasks));
+          ios->num_iotasks));
 
     /* Set the iomaplen in the sc_info msg */
     sc_info_msg_send[0] = iodesc->llen;
@@ -1352,149 +1352,149 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
     /* start/count array to be sent: 1st half for start, 2nd half for count */
     for (int j = 0; j < ndims; j++)
     {
-	/* The first data in sc_info_msg_send[] is the iomaplen */
-	sc_info_msg_send[j + 1] = iodesc->firstregion->start[j];
-	sc_info_msg_send[ndims + j + 1] = iodesc->firstregion->count[j];
+        /* The first data in sc_info_msg_send[] is the iomaplen */
+        sc_info_msg_send[j + 1] = iodesc->firstregion->start[j];
+        sc_info_msg_send[ndims + j + 1] = iodesc->firstregion->count[j];
     }
 
     /* Set the recvcounts/recv displs for the sc_info msg from each io task */
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-	/* From each iotask all procs (compute and I/O procs) receive an
-	 * sc_info message containing [iomaplen, start_for_all_dims,
-	 * count_for_all_dims] and the size of this message is
-	 * [sizeof(MPI_OFFSET) + ndims * sizeof(MPI_OFFSET) + ndims *
-	 * sizeof(MPI_OFFSET)]
-	 * Note: The displacements are in bytes
-	 */
-	recvcounts[ios->ioranks[i]] = sc_info_msg_sz;
-	rdispls[ios->ioranks[i]] = i * sc_info_msg_sz * SIZEOF_MPI_OFFSET;
+        /* From each iotask all procs (compute and I/O procs) receive an
+         * sc_info message containing [iomaplen, start_for_all_dims,
+         * count_for_all_dims] and the size of this message is
+         * [sizeof(MPI_OFFSET) + ndims * sizeof(MPI_OFFSET) + ndims *
+         * sizeof(MPI_OFFSET)]
+         * Note: The displacements are in bytes
+         */
+        recvcounts[ios->ioranks[i]] = sc_info_msg_sz;
+        rdispls[ios->ioranks[i]] = i * sc_info_msg_sz * SIZEOF_MPI_OFFSET;
     }
 
     /* Set the sendcounts/send displs for the sc_info msg sent from each
      * I/O task
      */
     for(int i=0; i<ios->num_uniontasks; i++){
-	sendcounts[i] = 0;
-	sdispls[i] = 0;
+        sendcounts[i] = 0;
+        sdispls[i] = 0;
     }
     if(ios->ioproc){
-	/* Only I/O procs send sc_info messages */
-	for (int i = 0; i < ios->num_comptasks; i++)
-	{
-	    sendcounts[ios->compranks[i]] = sc_info_msg_sz;
-	    sdispls[ios->compranks[i]] = 0;
-	}
-	for (int i = 0; i < ios->num_iotasks; i++)
-	{
-	    sendcounts[ios->ioranks[i]] = sc_info_msg_sz;
-	    sdispls[ios->ioranks[i]] = 0;
-	}
+        /* Only I/O procs send sc_info messages */
+        for (int i = 0; i < ios->num_comptasks; i++)
+        {
+            sendcounts[ios->compranks[i]] = sc_info_msg_sz;
+            sdispls[ios->compranks[i]] = 0;
+        }
+        for (int i = 0; i < ios->num_iotasks; i++)
+        {
+            sendcounts[ios->ioranks[i]] = sc_info_msg_sz;
+            sdispls[ios->ioranks[i]] = 0;
+        }
     }
 
     /* Send sc_info msg from iotasks (all iotasks) to all procs(compute and I/O procs)*/
     PLOG((3, "about to call pio_swapm with start/count from iotask ndims = %d",
-	  ndims));
+          ndims));
     if ((ret = pio_swapm(sc_info_msg_send, sendcounts, sdispls, dtypes, sc_info_msg_recv,
-			 recvcounts, rdispls, dtypes, ios->union_comm,
-			 &iodesc->rearr_opts.io2comp)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                         recvcounts, rdispls, dtypes, ios->union_comm,
+                         &iodesc->rearr_opts.io2comp)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
 #if PIO_ENABLE_LOGGING
     /* First entry in the sc_info msg for each iorank is the iomaplen */
     for (int i = 0; i < ios->num_iotasks; i++)
-	PLOG((3, "iomaplen[%d] = %d", i, sc_info_msg_recv[i * sc_info_msg_sz]));
+        PLOG((3, "iomaplen[%d] = %d", i, sc_info_msg_recv[i * sc_info_msg_sz]));
 #endif /* PIO_ENABLE_LOGGING */
 
     /* Convert a 1-D index into a global coordinate value for each data element */
     for (int k = 0; k < maplen; k++)
     {
-	/* The compmap array is 1 based but calculations are 0 based */
-	PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
-	idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
+        /* The compmap array is 1 based but calculations are 0 based */
+        PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
+        idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
 #if PIO_ENABLE_LOGGING
-	for (int d = 0; d < ndims; d++)
-	    PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
+        for (int d = 0; d < ndims; d++)
+            PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-	/* First entry in the sc_info msg is the iomaplen */
-	iomaplen[i] = sc_info_msg_recv[i * sc_info_msg_sz];
-	if(iomaplen[i] > 0)
-	{
-	    /* The rest of the entries in the sc_info msg are the start and
-	     * count arrays
-	     */
-	    PIO_Offset *start = &(sc_info_msg_recv[i * sc_info_msg_sz + 1]);
-	    PIO_Offset *count = &(sc_info_msg_recv[i * sc_info_msg_sz + 1 + ndims]);
+        /* First entry in the sc_info msg is the iomaplen */
+        iomaplen[i] = sc_info_msg_recv[i * sc_info_msg_sz];
+        if(iomaplen[i] > 0)
+        {
+            /* The rest of the entries in the sc_info msg are the start and
+             * count arrays
+             */
+            PIO_Offset *start = &(sc_info_msg_recv[i * sc_info_msg_sz + 1]);
+            PIO_Offset *count = &(sc_info_msg_recv[i * sc_info_msg_sz + 1 + ndims]);
 
 #if PIO_ENABLE_LOGGING
-	    for (int d = 0; d < ndims; d++)
-		PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
+            for (int d = 0; d < ndims; d++)
+                PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
 #endif /* PIO_ENABLE_LOGGING */
 
-	    /* Moved this outside of loop over maplen, for performance. */
-	    PIO_Offset lcoord[ndims];
+            /* Moved this outside of loop over maplen, for performance. */
+            PIO_Offset lcoord[ndims];
 
-	    /* For each element of the data array on the compute task,
-	     * find the IO task to send the data element to, and its
-	     * offset into the global data array. */
-	    for (int k = 0; k < maplen; k++)
-	    {
-		/* An IO task has already been found for this element */
-		if (dest_ioproc[k] >= 0)
-		    continue;
+            /* For each element of the data array on the compute task,
+             * find the IO task to send the data element to, and its
+             * offset into the global data array. */
+            for (int k = 0; k < maplen; k++)
+            {
+                /* An IO task has already been found for this element */
+                if (dest_ioproc[k] >= 0)
+                    continue;
 
-		bool found = true;
+                bool found = true;
 
-		/* Find a destination for each entry in the compmap. */
-		for (int j = 0; j < ndims; j++)
-		{
-		    if (gcoord_map[k][j] >= start[j] && gcoord_map[k][j] < start[j] + count[j])
-		    {
-			lcoord[j] = gcoord_map[k][j] - start[j];
-		    }
-		    else
-		    {
-			found = false;
-			break;
-		    }
-		}
+                /* Find a destination for each entry in the compmap. */
+                for (int j = 0; j < ndims; j++)
+                {
+                    if (gcoord_map[k][j] >= start[j] && gcoord_map[k][j] < start[j] + count[j])
+                    {
+                        lcoord[j] = gcoord_map[k][j] - start[j];
+                    }
+                    else
+                    {
+                        found = false;
+                        break;
+                    }
+                }
 
-		/* Did we find a destination IO task for this element
-		 * of the computation task data array? If so, remember
-		 * the destination IO task, and determine the index
-		 * for that element in the IO task data. */
-		if (found)
-		{
-		    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
-		    dest_ioproc[k] = i;
-		    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
-			  k, dest_ioproc[k]));
-		}
-	    }
-	}
+                /* Did we find a destination IO task for this element
+                 * of the computation task data array? If so, remember
+                 * the destination IO task, and determine the index
+                 * for that element in the IO task data. */
+                if (found)
+                {
+                    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
+                    dest_ioproc[k] = i;
+                    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
+                          k, dest_ioproc[k]));
+                }
+            }
+        }
     }
 
     for (int i = 0; i < maplen; i++)
-	free(gcoord_map[i]);
+        free(gcoord_map[i]);
     free(gcoord_map);
     gcoord_map = NULL;
 
     /* Check that a destination is found for each compmap entry. */
     for (int k = 0; k < maplen; k++)
-	if (dest_ioproc[k] < 0 && compmap[k] > 0)
-	{
-	    PLOG((1, "Error: Found dest_ioproc[%d] = %d and compmap[%d] = %lld", k, dest_ioproc[k], k, compmap[k]));
-	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
-	}
+        if (dest_ioproc[k] < 0 && compmap[k] > 0)
+        {
+            PLOG((1, "Error: Found dest_ioproc[%d] = %d and compmap[%d] = %lld", k, dest_ioproc[k], k, compmap[k]));
+            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        }
 
     /* Completes the mapping for the box rearranger. */
     PLOG((2, "calling compute_counts maplen = %d", maplen));
     if ((ret = compute_counts(ios, iodesc, dest_ioproc, dest_ioindex)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     free(dest_ioproc);
     free(dest_ioindex);
@@ -1504,20 +1504,20 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
     /* Compute the max io buffer size needed for an iodesc. */
     if (ios->ioproc)
     {
-	if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
-	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-	PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
+        if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
+            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
     }
 
     /* Using maxiobuflen compute the maximum number of bytes that the
      * io task buffer can handle. */
     if ((ret = compute_maxaggregate_bytes(ios, iodesc)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:box_rearrange_create")))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif
 
     return PIO_NOERR;
@@ -1541,23 +1541,23 @@ box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap
  */
 int
 box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
-				const PIO_Offset *compmap,
-				const int *gdimlen, int ndims,
-				io_desc_t *iodesc)
+                                const PIO_Offset *compmap,
+                                const int *gdimlen, int ndims,
+                                io_desc_t *iodesc)
 {
     int ret;
 
 #ifdef TIMING
     /* Start timer if desired. */
     if ((ret = pio_start_timer("PIO:box_rearrange_create_with_holes")))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims > 0 && iodesc,
-	      "invalid input", __FILE__, __LINE__);
+              "invalid input", __FILE__, __LINE__);
     PLOG((1, "box_rearrange_create maplen = %d ndims = %d ios->num_comptasks = %d "
-	  "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
+          "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
 
     /* Allocate arrays needed for this function. */
     int *dest_ioproc = NULL; /* Destination IO task for each data element on compute task. */
@@ -1578,37 +1578,37 @@ box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
 
     if (maplen > 0)
     {
-	if (!(dest_ioproc = malloc(maplen * sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(dest_ioproc = malloc(maplen * sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	if (!(gcoord_map = malloc(maplen * sizeof(PIO_Offset*))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(gcoord_map = malloc(maplen * sizeof(PIO_Offset*))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	for (int i = 0; i < maplen; i++)
-	{
-	    if (!(gcoord_map[i] = calloc(ndims, sizeof(PIO_Offset))))
-		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	}
+        for (int i = 0; i < maplen; i++)
+        {
+            if (!(gcoord_map[i] = calloc(ndims, sizeof(PIO_Offset))))
+                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        }
     }
 
     /* Initialize array values. */
     for (int i = 0; i < maplen; i++)
     {
-	dest_ioproc[i] = -1;
-	dest_ioindex[i] = -1;
+        dest_ioproc[i] = -1;
+        dest_ioindex[i] = -1;
     }
 
     /* Initialize arrays used in swapm. */
     for (int i = 0; i < ios->num_uniontasks; i++)
     {
-	sendcounts[i] = 0;
-	sdispls[i] = 0;
-	recvcounts[i] = 0;
-	rdispls[i] = 0;
-	dtypes[i] = MPI_OFFSET;
+        sendcounts[i] = 0;
+        sdispls[i] = 0;
+        recvcounts[i] = 0;
+        rdispls[i] = 0;
+        dtypes[i] = MPI_OFFSET;
     }
 
     /* For IO tasks, determine llen, the length of the data array on
@@ -1616,177 +1616,177 @@ box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
      * set up arrays for the allgather which will give every IO task a
      * complete list of llens for each IO task. */
     PLOG((3, "ios->ioproc = %d ios->num_uniontasks = %d", ios->ioproc,
-	  ios->num_uniontasks));
+          ios->num_uniontasks));
     pioassert(iodesc->llen == 0, "error", __FILE__, __LINE__);
     if (ios->ioproc)
     {
-	/* Set up send counts for sending llen in all to all
-	 * gather. We are sending to all tasks, IO and computation. */
-	for (int i = 0; i < ios->num_comptasks; i++)
-	    sendcounts[ios->compranks[i]] = 1;
-	for (int i = 0; i < ios->num_iotasks; i++)
-	    sendcounts[ios->ioranks[i]] = 1;
+        /* Set up send counts for sending llen in all to all
+         * gather. We are sending to all tasks, IO and computation. */
+        for (int i = 0; i < ios->num_comptasks; i++)
+            sendcounts[ios->compranks[i]] = 1;
+        for (int i = 0; i < ios->num_iotasks; i++)
+            sendcounts[ios->ioranks[i]] = 1;
 
-	/* Determine llen, the lenght of the data array on this IO
-	 * node, by multipliying the counts in the
-	 * iodesc->firstregion. */
-	iodesc->llen = 1;
-	for (int i = 0; i < ndims; i++)
-	{
-	    iodesc->llen *= iodesc->firstregion->count[i];
-	    PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
-		  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
-	}
-	PLOG((2, "iodesc->llen = %d", iodesc->llen));
+        /* Determine llen, the lenght of the data array on this IO
+         * node, by multipliying the counts in the
+         * iodesc->firstregion. */
+        iodesc->llen = 1;
+        for (int i = 0; i < ndims; i++)
+        {
+            iodesc->llen *= iodesc->firstregion->count[i];
+            PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
+                  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
+        }
+        PLOG((2, "iodesc->llen = %d", iodesc->llen));
     }
 
     /* Determine whether fill values will be needed. */
     if ((ret = determine_fill(ios, iodesc, gdimlen, compmap)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((2, "b iodesc->needsfill = %d ios->num_iotasks = %d", iodesc->needsfill,
-	  ios->num_iotasks));
+          ios->num_iotasks));
 
     /* Set up receive counts and displacements to for an AllToAll
      * gather of llen. */
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-	recvcounts[ios->ioranks[i]] = 1;
-	rdispls[ios->ioranks[i]] = i * SIZEOF_MPI_OFFSET;
-	PLOG((3, "i = %d ios->ioranks[%d] = %d recvcounts[%d] = %d rdispls[%d] = %d",
-	      i, i, ios->ioranks[i], ios->ioranks[i], recvcounts[ios->ioranks[i]],
-	      ios->ioranks[i], rdispls[ios->ioranks[i]]));
+        recvcounts[ios->ioranks[i]] = 1;
+        rdispls[ios->ioranks[i]] = i * SIZEOF_MPI_OFFSET;
+        PLOG((3, "i = %d ios->ioranks[%d] = %d recvcounts[%d] = %d rdispls[%d] = %d",
+              i, i, ios->ioranks[i], ios->ioranks[i], recvcounts[ios->ioranks[i]],
+              ios->ioranks[i], rdispls[ios->ioranks[i]]));
     }
 
     /* All-gather the llen to all tasks into array iomaplen. */
     PLOG((3, "calling pio_swapm to allgather llen into array iomaplen, ndims = %d dtypes[0] = %d",
-	  ndims, dtypes));
+          ndims, dtypes));
     if ((ret = pio_swapm(&iodesc->llen, sendcounts, sdispls, dtypes, iomaplen, recvcounts,
-			 rdispls, dtypes, ios->union_comm, &iodesc->rearr_opts.io2comp)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                         rdispls, dtypes, ios->union_comm, &iodesc->rearr_opts.io2comp)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "iodesc->llen = %d", iodesc->llen));
 #if PIO_ENABLE_LOGGING
     for (int i = 0; i < ios->num_iotasks; i++)
-	PLOG((3, "iomaplen[%d] = %d", i, iomaplen[i]));
+        PLOG((3, "iomaplen[%d] = %d", i, iomaplen[i]));
 #endif /* PIO_ENABLE_LOGGING */
 
     /* Convert a 1-D index into a global coordinate value for each data element */
     for (int k = 0; k < maplen; k++)
     {
-	/* The compmap array is 1 based but calculations are 0 based */
-	PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
-	idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
+        /* The compmap array is 1 based but calculations are 0 based */
+        PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
+        idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
 #if PIO_ENABLE_LOGGING
-	for (int d = 0; d < ndims; d++)
-	    PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
+        for (int d = 0; d < ndims; d++)
+            PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
     /* For each IO task send starts/counts to all compute tasks. */
     for (int i = 0; i < ios->num_iotasks; i++)
     {
-	/* The ipmaplen contains the llen (number of data elements)
-	 * for this IO task. */
-	PLOG((2, "iomaplen[%d] = %d", i, iomaplen[i]));
+        /* The ipmaplen contains the llen (number of data elements)
+         * for this IO task. */
+        PLOG((2, "iomaplen[%d] = %d", i, iomaplen[i]));
 
-	/* If there is data for this IO task, send start/count to all
-	 * compute tasks. */
-	if (iomaplen[i] > 0)
-	{
-	    PIO_Offset start_count_send[ndims * 2];
-	    PIO_Offset start_count_recv[ndims * 2];
+        /* If there is data for this IO task, send start/count to all
+         * compute tasks. */
+        if (iomaplen[i] > 0)
+        {
+            PIO_Offset start_count_send[ndims * 2];
+            PIO_Offset start_count_recv[ndims * 2];
 
-	    /* start/count array to be sent: 1st half for start, 2nd half for count */
-	    for (int j = 0; j < ndims; j++)
-	    {
-		start_count_send[j] = iodesc->firstregion->start[j];
-		start_count_send[ndims + j] = iodesc->firstregion->count[j];
-	    }
+            /* start/count array to be sent: 1st half for start, 2nd half for count */
+            for (int j = 0; j < ndims; j++)
+            {
+                start_count_send[j] = iodesc->firstregion->start[j];
+                start_count_send[ndims + j] = iodesc->firstregion->count[j];
+            }
 
-	    /* Set up send/recv parameters for all to all gather of
-	     * counts and starts. */
-	    for (int j = 0; j < ios->num_uniontasks; j++)
-	    {
-		sendcounts[j] = 0;
-		sdispls[j] = 0;
-		rdispls[j] = 0;
-		recvcounts[j] = 0;
-		if (ios->union_rank == ios->ioranks[i])
-		    sendcounts[j] = ndims * 2;
-	    }
-	    recvcounts[ios->ioranks[i]] = ndims * 2;
+            /* Set up send/recv parameters for all to all gather of
+             * counts and starts. */
+            for (int j = 0; j < ios->num_uniontasks; j++)
+            {
+                sendcounts[j] = 0;
+                sdispls[j] = 0;
+                rdispls[j] = 0;
+                recvcounts[j] = 0;
+                if (ios->union_rank == ios->ioranks[i])
+                    sendcounts[j] = ndims * 2;
+            }
+            recvcounts[ios->ioranks[i]] = ndims * 2;
 
-	    /* The start/count array from iotask i is sent to all compute tasks. */
-	    PLOG((3, "about to call pio_swapm with start/count from iotask %d ndims = %d",
-		  i, ndims));
-	    if ((ret = pio_swapm(start_count_send, sendcounts, sdispls, dtypes, start_count_recv,
-				 recvcounts, rdispls, dtypes, ios->union_comm,
-				 &iodesc->rearr_opts.io2comp)))
-		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+            /* The start/count array from iotask i is sent to all compute tasks. */
+            PLOG((3, "about to call pio_swapm with start/count from iotask %d ndims = %d",
+                  i, ndims));
+            if ((ret = pio_swapm(start_count_send, sendcounts, sdispls, dtypes, start_count_recv,
+                                 recvcounts, rdispls, dtypes, ios->union_comm,
+                                 &iodesc->rearr_opts.io2comp)))
+                return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
-	    /* start/count array received: 1st half for start, 2nd half for count */
-	    PIO_Offset *start = start_count_recv;
-	    PIO_Offset *count = start_count_recv + ndims;
+            /* start/count array received: 1st half for start, 2nd half for count */
+            PIO_Offset *start = start_count_recv;
+            PIO_Offset *count = start_count_recv + ndims;
 
 #if PIO_ENABLE_LOGGING
-	    for (int d = 0; d < ndims; d++)
-		PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
+            for (int d = 0; d < ndims; d++)
+                PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
 #endif /* PIO_ENABLE_LOGGING */
 
-	    /* For each element of the data array on the compute task,
-	     * find the IO task to send the data element to, and its
-	     * offset into the global data array. */
-	    for (int k = 0; k < maplen; k++)
-	    {
-		/* An IO task has already been found for this element */
-		if (dest_ioproc[k] >= 0)
-		    continue;
+            /* For each element of the data array on the compute task,
+             * find the IO task to send the data element to, and its
+             * offset into the global data array. */
+            for (int k = 0; k < maplen; k++)
+            {
+                /* An IO task has already been found for this element */
+                if (dest_ioproc[k] >= 0)
+                    continue;
 
-		PIO_Offset lcoord[ndims];
-		bool found = true;
+                PIO_Offset lcoord[ndims];
+                bool found = true;
 
-		/* Find a destination for each entry in the compmap. */
-		for (int j = 0; j < ndims; j++)
-		{
-		    if (gcoord_map[k][j] >= start[j] && gcoord_map[k][j] < start[j] + count[j])
-		    {
-			lcoord[j] = gcoord_map[k][j] - start[j];
-		    }
-		    else
-		    {
-			found = false;
-			break;
-		    }
-		}
+                /* Find a destination for each entry in the compmap. */
+                for (int j = 0; j < ndims; j++)
+                {
+                    if (gcoord_map[k][j] >= start[j] && gcoord_map[k][j] < start[j] + count[j])
+                    {
+                        lcoord[j] = gcoord_map[k][j] - start[j];
+                    }
+                    else
+                    {
+                        found = false;
+                        break;
+                    }
+                }
 
-		/* Did we find a destination IO task for this element
-		 * of the computation task data array? If so, remember
-		 * the destination IO task, and determine the index
-		 * for that element in the IO task data. */
-		if (found)
-		{
-		    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
-		    dest_ioproc[k] = i;
-		    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
-			  k, dest_ioproc[k]));
-		}
-	    }
-	}
+                /* Did we find a destination IO task for this element
+                 * of the computation task data array? If so, remember
+                 * the destination IO task, and determine the index
+                 * for that element in the IO task data. */
+                if (found)
+                {
+                    dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
+                    dest_ioproc[k] = i;
+                    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
+                          k, dest_ioproc[k]));
+                }
+            }
+        }
     }
 
     for (int i = 0; i < maplen; i++)
-	free(gcoord_map[i]);
+        free(gcoord_map[i]);
     free(gcoord_map);
     gcoord_map = NULL;
 
     /* Check that a destination is found for each compmap entry. */
     for (int k = 0; k < maplen; k++)
-	if (dest_ioproc[k] < 0 && compmap[k] > 0)
-	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        if (dest_ioproc[k] < 0 && compmap[k] > 0)
+            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* Completes the mapping for the box rearranger. */
     PLOG((2, "calling compute_counts maplen = %d", maplen));
     if ((ret = compute_counts(ios, iodesc, dest_ioproc, dest_ioindex)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     free(dest_ioproc);
     free(dest_ioindex);
@@ -1796,20 +1796,20 @@ box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
     /* Compute the max io buffer size needed for an iodesc. */
     if (ios->ioproc)
     {
-	if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
-	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-	PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
+        if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
+            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
     }
 
     /* Using maxiobuflen compute the maximum number of bytes that the
      * io task buffer can handle. */
     if ((ret = compute_maxaggregate_bytes(ios, iodesc)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:box_rearrange_create_with_holes")))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 #endif /* TIMING */
 
     return PIO_NOERR;
@@ -1830,7 +1830,7 @@ compare_offsets(const void *a, const void *b)
     mapsort *x = (mapsort *)a;
     mapsort *y = (mapsort *)b;
     if (!x || !y)
-	return 0;
+        return 0;
     return (int)(x->iomap - y->iomap);
 }
 
@@ -1855,7 +1855,7 @@ compare_offsets(const void *a, const void *b)
  */
 int
 get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
-	    int *maxregions, io_region *firstregion)
+            int *maxregions, io_region *firstregion)
 {
     int nmaplen = 0;
     PIO_Offset regionlen;
@@ -1864,18 +1864,18 @@ get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
 
     /* Check inputs. */
     pioassert(ndims >= 0 && gdimlen && maplen >= 0 && maxregions && firstregion,
-	      "invalid input", __FILE__, __LINE__);
+              "invalid input", __FILE__, __LINE__);
     PLOG((1, "get_regions ndims = %d maplen = %d", ndims, maplen));
 
     region = firstregion;
     if (map)
     {
-	while (map[nmaplen++] <= 0)
-	{
-	    PLOG((3, "map[%d] = %d", nmaplen, map[nmaplen]));
-	    ;
-	}
-	nmaplen--;
+        while (map[nmaplen++] <= 0)
+        {
+            PLOG((3, "map[%d] = %d", nmaplen, map[nmaplen]));
+            ;
+        }
+        nmaplen--;
     }
     region->loffset = nmaplen;
     PLOG((2, "region->loffset = %d", region->loffset));
@@ -1884,41 +1884,41 @@ get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
 
     while (nmaplen < maplen)
     {
-	/* Here we find the largest region from the current offset
-	   into the iomap. regionlen is the size of that region and we
-	   step to that point in the map array until we reach the
-	   end. */
-	for (int i = 0; i < ndims; i++)
-	    region->count[i] = 1;
+        /* Here we find the largest region from the current offset
+           into the iomap. regionlen is the size of that region and we
+           step to that point in the map array until we reach the
+           end. */
+        for (int i = 0; i < ndims; i++)
+            region->count[i] = 1;
 
-	/* Set start/count to describe first region in map. */
-	if ((ret = find_region(ndims, gdimlen, maplen-nmaplen,
-			       &map[nmaplen], region->start, region->count, &regionlen)))
-	    return ret;
-	pioassert(region->start[0] >= 0, "failed to find region", __FILE__, __LINE__);
+        /* Set start/count to describe first region in map. */
+        if ((ret = find_region(ndims, gdimlen, maplen-nmaplen,
+                               &map[nmaplen], region->start, region->count, &regionlen)))
+            return ret;
+        pioassert(region->start[0] >= 0, "failed to find region", __FILE__, __LINE__);
 
-	nmaplen = nmaplen + regionlen;
-	PLOG((2, "regionlen = %d nmaplen = %d", regionlen, nmaplen));
+        nmaplen = nmaplen + regionlen;
+        PLOG((2, "regionlen = %d nmaplen = %d", regionlen, nmaplen));
 
-	/* If we need to, allocate the next region. */
-	if (region->next == NULL && nmaplen < maplen)
-	{
-	    PLOG((2, "allocating next region"));
-	    if ((ret = alloc_region2(NULL, ndims, &region->next)))
-		return ret;
+        /* If we need to, allocate the next region. */
+        if (region->next == NULL && nmaplen < maplen)
+        {
+            PLOG((2, "allocating next region"));
+            if ((ret = alloc_region2(NULL, ndims, &region->next)))
+                return ret;
 
-	    /* The offset into the local array buffer is the sum of
-	     * the sizes of all of the previous regions (loffset) */
-	    region = region->next;
-	    region->loffset = nmaplen;
+            /* The offset into the local array buffer is the sum of
+             * the sizes of all of the previous regions (loffset) */
+            region = region->next;
+            region->loffset = nmaplen;
 
-	    /* The calls to the io library are collective and so we
-	       must have the same number of regions on each io task
-	       maxregions will be the total number of regions on this
-	       task. */
-	    (*maxregions)++;
-	    PLOG((2, "*maxregions = %d", *maxregions));
-	}
+            /* The calls to the io library are collective and so we
+               must have the same number of regions on each io task
+               maxregions will be the total number of regions on this
+               task. */
+            (*maxregions)++;
+            PLOG((2, "*maxregions = %d", *maxregions));
+        }
     }
 
     return PIO_NOERR;
@@ -1951,26 +1951,26 @@ default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);
     PLOG((1, "default_subset_partition ios->ioproc = %d ios->io_rank = %d "
-	  "ios->comp_rank = %d", ios->ioproc, ios->io_rank, ios->comp_rank));
+          "ios->comp_rank = %d", ios->ioproc, ios->io_rank, ios->comp_rank));
 
     /* Create a new comm for each subset group with the io task in
        rank 0 and only 1 io task per group */
     if (ios->ioproc)
     {
-	key = 0;
-	color= ios->io_rank;
+        key = 0;
+        color= ios->io_rank;
     }
     else
     {
-	int taskratio = max(1,ios->num_comptasks / ios->num_iotasks);
-	key = max(1, ios->comp_rank % taskratio + 1);
-	color = min(ios->num_iotasks - 1, ios->comp_rank / taskratio);
+        int taskratio = max(1,ios->num_comptasks / ios->num_iotasks);
+        key = max(1, ios->comp_rank % taskratio + 1);
+        color = min(ios->num_iotasks - 1, ios->comp_rank / taskratio);
     }
     PLOG((3, "key = %d color = %d", key, color));
 
     /* Create new communicators. */
     if ((mpierr = MPI_Comm_split(ios->union_comm, color, key, &iodesc->subset_comm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -2026,7 +2026,7 @@ default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
  */
 int
 subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
-			const int *gdimlen, int ndims, io_desc_t *iodesc)
+                        const int *gdimlen, int ndims, io_desc_t *iodesc)
 {
     int i, j;
     PIO_Offset *iomap = NULL;
@@ -2042,7 +2042,7 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
 
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims >= 0 && iodesc,
-	      "invalid input", __FILE__, __LINE__);
+              "invalid input", __FILE__, __LINE__);
 
     PLOG((2, "subset_rearrange_create maplen = %d ndims = %d", maplen, ndims));
 
@@ -2050,76 +2050,76 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
      * of that subset_comm */
     /* TODO: introduce a mechanism for users to define partitions */
     if ((ret = default_subset_partition(ios, iodesc)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     iodesc->rearranger = PIO_REARR_SUBSET;
 
     /* Get size of this subset communicator and rank of this task in it. */
     if ((mpierr = MPI_Comm_rank(iodesc->subset_comm, &rank)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_size(iodesc->subset_comm, &ntasks)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Check rank for correctness. */
     if (ios->ioproc)
-	pioassert(rank == 0, "Bad io rank in subset create", __FILE__, __LINE__);
+        pioassert(rank == 0, "Bad io rank in subset create", __FILE__, __LINE__);
     else
-	pioassert(rank > 0 && rank < ntasks, "Bad comp rank in subset create",
-		  __FILE__, __LINE__);
+        pioassert(rank > 0 && rank < ntasks, "Bad comp rank in subset create",
+                  __FILE__, __LINE__);
 
     /* Remember the maplen for this computation task. */
     iodesc->ndof = maplen;
 
     if (ios->ioproc)
     {
-	/* Allocate space to hold count of data to be received in pio_swapm(). */
-	if (!(iodesc->rcount = malloc(ntasks * sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        /* Allocate space to hold count of data to be received in pio_swapm(). */
+        if (!(iodesc->rcount = malloc(ntasks * sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	rcnt = 1;
+        rcnt = 1;
 
-	if(ios->async)
-	    iodesc->ndof = 0;
+        if(ios->async)
+            iodesc->ndof = 0;
 
     }
 
     /* Allocate space to hold count of data to be sent in pio_swapm(). */
     if (!(iodesc->scount = malloc(sizeof(int))))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     iodesc->scount[0] = 0;
 
     /* Find the total size of the global data array. */
     totalgridsize = 1;
     for (i = 0; i < ndims; i++)
-	totalgridsize *= gdimlen[i];
+        totalgridsize *= gdimlen[i];
 
     /* Determine scount[0], the number of data elements in the
      * computation task that are to be written, by looking at
      * compmap. */
     for (i = 0; i < iodesc->ndof; i++)
     {
-//	pioassert(compmap[i]>=-1 && compmap[i]<=totalgridsize, "Compmap value out of bounds",
-//	    __FILE__,__LINE__);
-	if (compmap[i] > 0)
-	    (iodesc->scount[0])++;
+//      pioassert(compmap[i]>=-1 && compmap[i]<=totalgridsize, "Compmap value out of bounds",
+//          __FILE__,__LINE__);
+        if (compmap[i] > 0)
+            (iodesc->scount[0])++;
     }
 
     /* Allocate an array for indicies on the computation tasks (the
      * send side when writing). */
     if (iodesc->scount[0] > 0)
-	if (!(iodesc->sindex = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(iodesc->sindex = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     j = 0;
     for (i = 0; i < iodesc->ndof; i++)
-	if (compmap[i] > 0)
-	    iodesc->sindex[j++] = i;
+        if (compmap[i] > 0)
+            iodesc->sindex[j++] = i;
 
     /* Pass the reduced maplen (without holes) from each compute task
      * to its associated IO task. */
     if ((mpierr = MPI_Gather(iodesc->scount, 1, MPI_INT, iodesc->rcount, rcnt,
-			     MPI_INT, 0, iodesc->subset_comm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                             MPI_INT, 0, iodesc->subset_comm)))
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
 
     iodesc->llen = 0;
@@ -2130,110 +2130,110 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
     /* On IO tasks determine llen. */
     if (ios->ioproc)
     {
-	for (i = 0; i < ntasks; i++)
-	{
-	    iodesc->llen += iodesc->rcount[i];
-	    rdispls[i] = 0;
-	    recvcounts[i] = iodesc->rcount[i];
-	    if (i > 0)
-		rdispls[i] = rdispls[i - 1] + iodesc->rcount[i - 1];
-	}
+        for (i = 0; i < ntasks; i++)
+        {
+            iodesc->llen += iodesc->rcount[i];
+            rdispls[i] = 0;
+            recvcounts[i] = iodesc->rcount[i];
+            if (i > 0)
+                rdispls[i] = rdispls[i - 1] + iodesc->rcount[i - 1];
+        }
 
-	if (iodesc->llen > 0)
-	{
-	    if (!(srcindex = calloc(iodesc->llen, sizeof(PIO_Offset))))
-		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	}
+        if (iodesc->llen > 0)
+        {
+            if (!(srcindex = calloc(iodesc->llen, sizeof(PIO_Offset))))
+                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        }
     }
     else
     {
-	for (i = 0; i < ntasks; i++)
-	{
-	    recvcounts[i] = 0;
-	    rdispls[i] = 0;
-	}
+        for (i = 0; i < ntasks; i++)
+        {
+            recvcounts[i] = 0;
+            rdispls[i] = 0;
+        }
     }
 
     /* Determine whether fill values will be needed. */
     if ((ret = determine_fill(ios, iodesc, gdimlen, compmap)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Pass the sindex from each compute task to its associated IO task. */
     if ((mpierr = MPI_Gatherv(iodesc->sindex, iodesc->scount[0], PIO_OFFSET,
-			      srcindex, recvcounts, rdispls, PIO_OFFSET, 0,
-			      iodesc->subset_comm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                              srcindex, recvcounts, rdispls, PIO_OFFSET, 0,
+                              iodesc->subset_comm)))
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     /* On IO tasks which need it, allocate memory for the map and the
      * iomap. */
     if (ios->ioproc && iodesc->llen > 0)
     {
-	if (!(map = calloc(iodesc->llen, sizeof(mapsort))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(map = calloc(iodesc->llen, sizeof(mapsort))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	if (!(iomap = calloc(iodesc->llen, sizeof(PIO_Offset))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(iomap = calloc(iodesc->llen, sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     }
 
     /* Now pass the compmap, skipping the holes. */
     PIO_Offset *shrtmap;
     if (maplen > iodesc->scount[0] && iodesc->scount[0] > 0)
     {
-	if (!(shrtmap = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(shrtmap = calloc(iodesc->scount[0], sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	j = 0;
-	for (int i = 0; i < maplen; i++)
-	    if (compmap[i] > 0)
-		shrtmap[j++] = compmap[i];
+        j = 0;
+        for (int i = 0; i < maplen; i++)
+            if (compmap[i] > 0)
+                shrtmap[j++] = compmap[i];
     }
     else
     {
-	shrtmap = compmap;
+        shrtmap = compmap;
     }
 
     /* Gather shrtmap from each task in the subset communicator, and
      * put gathered results into iomap. */
     if ((mpierr = MPI_Gatherv(shrtmap, iodesc->scount[0], PIO_OFFSET, iomap, recvcounts,
-			      rdispls, PIO_OFFSET, 0, iodesc->subset_comm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                              rdispls, PIO_OFFSET, 0, iodesc->subset_comm)))
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     if (shrtmap != compmap)
-	free(shrtmap);
+        free(shrtmap);
 
     /* On IO tasks that have data in the local array ??? */
     if (ios->ioproc && iodesc->llen > 0)
     {
-	int pos = 0;
-	int k = 0;
-	mapsort *mptr;
-	for (i = 0; i < ntasks; i++)
-	{
-	    for (j = 0; j < iodesc->rcount[i]; j++)
-	    {
-		mptr = &map[k];
-		mptr->rfrom = i;
-		mptr->soffset = srcindex[pos + j];
-		mptr->iomap = iomap[pos + j];
-		k++;
-	    }
-	    pos += iodesc->rcount[i];
-	}
+        int pos = 0;
+        int k = 0;
+        mapsort *mptr;
+        for (i = 0; i < ntasks; i++)
+        {
+            for (j = 0; j < iodesc->rcount[i]; j++)
+            {
+                mptr = &map[k];
+                mptr->rfrom = i;
+                mptr->soffset = srcindex[pos + j];
+                mptr->iomap = iomap[pos + j];
+                k++;
+            }
+            pos += iodesc->rcount[i];
+        }
 
-	/* sort the mapping, this will transpose the data into IO order */
-	qsort(map, iodesc->llen, sizeof(mapsort), compare_offsets);
+        /* sort the mapping, this will transpose the data into IO order */
+        qsort(map, iodesc->llen, sizeof(mapsort), compare_offsets);
 
-	if (!(iodesc->rindex = calloc(1, iodesc->llen * sizeof(PIO_Offset))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(iodesc->rindex = calloc(1, iodesc->llen * sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	if (!(iodesc->rfrom = calloc(1, iodesc->llen * sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(iodesc->rfrom = calloc(1, iodesc->llen * sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
     }
 
     int cnt[ntasks];
     for (i = 0; i < ntasks; i++)
     {
-	cnt[i] = rdispls[i];
+        cnt[i] = rdispls[i];
     }
 
     /* For IO tasks init rfrom and rindex arrays (compute tasks have
@@ -2244,19 +2244,19 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
        in a read operation */
     for (i = 0, rllen=0; i < iodesc->llen; i++)
     {
-	mapsort *mptr = &map[i];
-	iodesc->rfrom[i] = mptr->rfrom;
-	if(i==0)
-	{
+        mapsort *mptr = &map[i];
+        iodesc->rfrom[i] = mptr->rfrom;
+        if(i==0)
+        {
             iodesc->rindex[i] = i;
-	    iomap[0] = mptr->iomap;
-	    soffset = mptr->soffset;
-	}
-	else if(mptr->iomap > iomap[rllen])
-	{
-	    iomap[++rllen] = mptr->iomap;
-	    soffset = mptr->soffset;
-	}
+            iomap[0] = mptr->iomap;
+            soffset = mptr->soffset;
+        }
+        else if(mptr->iomap > iomap[rllen])
+        {
+            iomap[++rllen] = mptr->iomap;
+            soffset = mptr->soffset;
+        }
         iodesc->rindex[i] = rllen;
         iodesc->rllen = rllen+1;
     
@@ -2266,187 +2266,187 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
     PLOG((2, "ios->ioproc %d iodesc->needsfill %d iodesc->rllen %d", ios->ioproc, iodesc->needsfill, iodesc->rllen));
     if (ios->ioproc && iodesc->needsfill)
     {
-	/* we need the list of offsets which are not in the union of iomap */
-	PIO_Offset thisgridsize[ios->num_iotasks];
-	PIO_Offset thisgridmin[ios->num_iotasks], thisgridmax[ios->num_iotasks];
-	int nio;
-	PIO_Offset *myusegrid = NULL;
-	int gcnt[ios->num_iotasks];
-	int displs[ios->num_iotasks];
+        /* we need the list of offsets which are not in the union of iomap */
+        PIO_Offset thisgridsize[ios->num_iotasks];
+        PIO_Offset thisgridmin[ios->num_iotasks], thisgridmax[ios->num_iotasks];
+        int nio;
+        PIO_Offset *myusegrid = NULL;
+        int gcnt[ios->num_iotasks];
+        int displs[ios->num_iotasks];
 
-	thisgridmin[0] = 1;
-	thisgridsize[0] =  totalgridsize / ios->num_iotasks;
-	thisgridmax[0] = thisgridsize[0];
-	int xtra = totalgridsize - thisgridsize[0] * ios->num_iotasks;
+        thisgridmin[0] = 1;
+        thisgridsize[0] =  totalgridsize / ios->num_iotasks;
+        thisgridmax[0] = thisgridsize[0];
+        int xtra = totalgridsize - thisgridsize[0] * ios->num_iotasks;
 
-	PLOG((4, "xtra %d", xtra));
+        PLOG((4, "xtra %d", xtra));
 
-	for (nio = 0; nio < ios->num_iotasks; nio++)
-	{
-	    int cnt = 0;
-	    int imin = 0;
-	    if (nio > 0)
-	    {
-		thisgridsize[nio] =  totalgridsize / ios->num_iotasks;
-		if (nio >= ios->num_iotasks - xtra)
-		    thisgridsize[nio]++;
-		thisgridmin[nio] = thisgridmax[nio - 1] + 1;
-		thisgridmax[nio] = thisgridmin[nio] + thisgridsize[nio] - 1;
-		PLOG((4, "nio %d thisgridsize[nio] %d thisgridmin[nio] %d thisgridmax[nio] %d",
-		      nio, thisgridsize[nio], thisgridmin[nio], thisgridmax[nio]));
-	    }
-	    for (int i = 0; i < iodesc->rllen; i++)
-	    {
-		if (iomap[i] >= thisgridmin[nio] && iomap[i] <= thisgridmax[nio])
-		{
-		    cnt++;
-		    if (cnt == 1)
-			imin = i;
-		}
-	    }
-	    PLOG((4, "cnt %d", cnt));
+        for (nio = 0; nio < ios->num_iotasks; nio++)
+        {
+            int cnt = 0;
+            int imin = 0;
+            if (nio > 0)
+            {
+                thisgridsize[nio] =  totalgridsize / ios->num_iotasks;
+                if (nio >= ios->num_iotasks - xtra)
+                    thisgridsize[nio]++;
+                thisgridmin[nio] = thisgridmax[nio - 1] + 1;
+                thisgridmax[nio] = thisgridmin[nio] + thisgridsize[nio] - 1;
+                PLOG((4, "nio %d thisgridsize[nio] %d thisgridmin[nio] %d thisgridmax[nio] %d",
+                      nio, thisgridsize[nio], thisgridmin[nio], thisgridmax[nio]));
+            }
+            for (int i = 0; i < iodesc->rllen; i++)
+            {
+                if (iomap[i] >= thisgridmin[nio] && iomap[i] <= thisgridmax[nio])
+                {
+                    cnt++;
+                    if (cnt == 1)
+                        imin = i;
+                }
+            }
+            PLOG((4, "cnt %d", cnt));
 
-	    /* Gather cnt from all tasks in the IO communicator into array gcnt. */
-	    if ((mpierr = MPI_Gather(&cnt, 1, MPI_INT, gcnt, 1, MPI_INT, nio, ios->io_comm)))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            /* Gather cnt from all tasks in the IO communicator into array gcnt. */
+            if ((mpierr = MPI_Gather(&cnt, 1, MPI_INT, gcnt, 1, MPI_INT, nio, ios->io_comm)))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-	    if (nio == ios->io_rank)
-	    {
-		displs[0] = 0;
-		for (i = 1; i < ios->num_iotasks; i++)
-		    displs[i] = displs[i - 1] + gcnt[i - 1];
+            if (nio == ios->io_rank)
+            {
+                displs[0] = 0;
+                for (i = 1; i < ios->num_iotasks; i++)
+                    displs[i] = displs[i - 1] + gcnt[i - 1];
 
-		/* Allocate storage for the grid. */
-		if (!(myusegrid = malloc(thisgridsize[nio] * sizeof(PIO_Offset))))
-		    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+                /* Allocate storage for the grid. */
+                if (!(myusegrid = malloc(thisgridsize[nio] * sizeof(PIO_Offset))))
+                    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-		/* Initialize the grid to all -1. */
-		for (i = 0; i < thisgridsize[nio]; i++)
-		    myusegrid[i] = -1;
-	    }
+                /* Initialize the grid to all -1. */
+                for (i = 0; i < thisgridsize[nio]; i++)
+                    myusegrid[i] = -1;
+            }
 
-	    if ((mpierr = MPI_Gatherv(&iomap[imin], cnt, PIO_OFFSET, myusegrid, gcnt,
-				      displs, PIO_OFFSET, nio, ios->io_comm)))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	}
+            if ((mpierr = MPI_Gatherv(&iomap[imin], cnt, PIO_OFFSET, myusegrid, gcnt,
+                                      displs, PIO_OFFSET, nio, ios->io_comm)))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        }
 
-	/* Allocate and initialize a grid to fill in missing values. ??? */
-	PLOG((2, "thisgridsize[ios->io_rank] %d", thisgridsize[ios->io_rank]));
-	PIO_Offset *grid;
-	if (!(grid = calloc(thisgridsize[ios->io_rank], sizeof(PIO_Offset))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        /* Allocate and initialize a grid to fill in missing values. ??? */
+        PLOG((2, "thisgridsize[ios->io_rank] %d", thisgridsize[ios->io_rank]));
+        PIO_Offset *grid;
+        if (!(grid = calloc(thisgridsize[ios->io_rank], sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
 
-	int cnt = 0;
-	for (i = 0; i < thisgridsize[ios->io_rank]; i++)
-	{
-	    int j = myusegrid[i] - thisgridmin[ios->io_rank];
-	    pioassert(j < thisgridsize[ios->io_rank], "out of bounds array index",
-		      __FILE__, __LINE__);
-	    PLOG((4, "i %d myusegrid[i] %d j %d", i, myusegrid[i], j));
-	    if (j >= 0)
-	    {
-		grid[j] = 1;
-		cnt++;
-	    }
-	}
-	if (myusegrid)
-	    free(myusegrid);
+        int cnt = 0;
+        for (i = 0; i < thisgridsize[ios->io_rank]; i++)
+        {
+            int j = myusegrid[i] - thisgridmin[ios->io_rank];
+            pioassert(j < thisgridsize[ios->io_rank], "out of bounds array index",
+                      __FILE__, __LINE__);
+            PLOG((4, "i %d myusegrid[i] %d j %d", i, myusegrid[i], j));
+            if (j >= 0)
+            {
+                grid[j] = 1;
+                cnt++;
+            }
+        }
+        if (myusegrid)
+            free(myusegrid);
 
-	iodesc->holegridsize = thisgridsize[ios->io_rank] - cnt;
-	PLOG((3, "iodesc->holegridsize %d thisgridsize[%d] %d cnt %d", iodesc->holegridsize,
-	      ios->io_rank, thisgridsize[ios->io_rank], cnt));
-	if (iodesc->holegridsize > 0)
-	{
-	    /* Allocate space for the fillgrid. */
-	    if (!(myfillgrid = malloc(iodesc->holegridsize * sizeof(PIO_Offset))))
-		return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	}
+        iodesc->holegridsize = thisgridsize[ios->io_rank] - cnt;
+        PLOG((3, "iodesc->holegridsize %d thisgridsize[%d] %d cnt %d", iodesc->holegridsize,
+              ios->io_rank, thisgridsize[ios->io_rank], cnt));
+        if (iodesc->holegridsize > 0)
+        {
+            /* Allocate space for the fillgrid. */
+            if (!(myfillgrid = malloc(iodesc->holegridsize * sizeof(PIO_Offset))))
+                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        }
 
-	/* Initialize the fillgrid. */
-	for (i = 0; i < iodesc->holegridsize; i++)
-	    myfillgrid[i] = -1;
+        /* Initialize the fillgrid. */
+        for (i = 0; i < iodesc->holegridsize; i++)
+            myfillgrid[i] = -1;
 
-	j = 0;
-	for (i = 0; i < thisgridsize[ios->io_rank]; i++)
-	{
-	    if (grid[i] == 0)
-	    {
-		if (myfillgrid[j] == -1)
-		    myfillgrid[j++] = thisgridmin[ios->io_rank] + i;
-		else
-		    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
-	    }
-	}
-	free(grid);
+        j = 0;
+        for (i = 0; i < thisgridsize[ios->io_rank]; i++)
+        {
+            if (grid[i] == 0)
+            {
+                if (myfillgrid[j] == -1)
+                    myfillgrid[j++] = thisgridmin[ios->io_rank] + i;
+                else
+                    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+            }
+        }
+        free(grid);
 
-	maxregions = 0;
-	iodesc->maxfillregions = 0;
-	if (myfillgrid)
-	{
-	    /* Allocate a data region to hold fill values. */
-	    if ((ret = alloc_region2(ios, iodesc->ndims, &iodesc->fillregion)))
-		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-	    if ((ret = get_regions(iodesc->ndims, gdimlen, iodesc->holegridsize, myfillgrid,
-				   &iodesc->maxfillregions, iodesc->fillregion)))
-		return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-	    free(myfillgrid);
-	    maxregions = iodesc->maxfillregions;
-	}
+        maxregions = 0;
+        iodesc->maxfillregions = 0;
+        if (myfillgrid)
+        {
+            /* Allocate a data region to hold fill values. */
+            if ((ret = alloc_region2(ios, iodesc->ndims, &iodesc->fillregion)))
+                return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+            if ((ret = get_regions(iodesc->ndims, gdimlen, iodesc->holegridsize, myfillgrid,
+                                   &iodesc->maxfillregions, iodesc->fillregion)))
+                return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+            free(myfillgrid);
+            maxregions = iodesc->maxfillregions;
+        }
 
-	/* Get the max maxregions, and distribute it to all tasks in
-	 * the IO communicator. */
-	if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxregions, 1, MPI_INT, MPI_MAX,
-				    ios->io_comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	iodesc->maxfillregions = maxregions;
+        /* Get the max maxregions, and distribute it to all tasks in
+         * the IO communicator. */
+        if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxregions, 1, MPI_INT, MPI_MAX,
+                                    ios->io_comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        iodesc->maxfillregions = maxregions;
 
-	/* Get the max maxholegridsize, and distribute it to all tasks
-	 * in the IO communicator. */
-	iodesc->maxholegridsize = iodesc->holegridsize;
-	if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &(iodesc->maxholegridsize), 1, MPI_INT,
-				    MPI_MAX, ios->io_comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        /* Get the max maxholegridsize, and distribute it to all tasks
+         * in the IO communicator. */
+        iodesc->maxholegridsize = iodesc->holegridsize;
+        if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &(iodesc->maxholegridsize), 1, MPI_INT,
+                                    MPI_MAX, ios->io_comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     }
 
     /* Scatter values of srcindex to subset communicator. */
     if ((mpierr = MPI_Scatterv((void *)srcindex, recvcounts, rdispls, PIO_OFFSET,
-			       (void *)iodesc->sindex, iodesc->scount[0],  PIO_OFFSET,
-			       0, iodesc->subset_comm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                               (void *)iodesc->sindex, iodesc->scount[0],  PIO_OFFSET,
+                               0, iodesc->subset_comm)))
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     if (ios->ioproc)
     {
 //        for(i=0; i < iodesc->llen; i++)
 //            printf("rindex[%d]=%d rfrom=%d\n",i,iodesc->rindex[i], iodesc->rfrom[i]);
 
-	iodesc->maxregions = 0;
-	if ((ret = get_regions(iodesc->ndims, gdimlen, iodesc->rllen, iomap,
-			       &iodesc->maxregions, iodesc->firstregion)))
-	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-	maxregions = iodesc->maxregions;
+        iodesc->maxregions = 0;
+        if ((ret = get_regions(iodesc->ndims, gdimlen, iodesc->rllen, iomap,
+                               &iodesc->maxregions, iodesc->firstregion)))
+            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        maxregions = iodesc->maxregions;
 
-	/* Get the max maxregions, and distribute it to all tasks in
-	 * the IO communicator. */
-	if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxregions, 1, MPI_INT, MPI_MAX, ios->io_comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	iodesc->maxregions = maxregions;
+        /* Get the max maxregions, and distribute it to all tasks in
+         * the IO communicator. */
+        if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxregions, 1, MPI_INT, MPI_MAX, ios->io_comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        iodesc->maxregions = maxregions;
 
-	/* Free resources. */
-	if (iomap)
-	    free(iomap);
+        /* Free resources. */
+        if (iomap)
+            free(iomap);
 
-	if (map)
-	    free(map);
+        if (map)
+            free(map);
 
-	if (srcindex)
-	    free(srcindex);
+        if (srcindex)
+            free(srcindex);
 
-	/* Compute the max io buffer size needed for an iodesc. */
-	if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
-	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        /* Compute the max io buffer size needed for an iodesc. */
+        if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
+            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
-	iodesc->nrecvs = ntasks;
+        iodesc->nrecvs = ntasks;
     }
 
     return PIO_NOERR;
@@ -2473,44 +2473,44 @@ performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     assert(iodesc);
     if(iodesc->mpitype == MPI_DATATYPE_NULL)
-	tsize = 0;
+        tsize = 0;
     else
-	if ((mpierr = MPI_Type_size(iodesc->mpitype, &tsize)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Type_size(iodesc->mpitype, &tsize)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     cbuf = NULL;
     ibuf = NULL;
     if (iodesc->ndof > 0)
-	if (!(cbuf = bget(iodesc->ndof * tsize)))
-	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(cbuf = bget(iodesc->ndof * tsize)))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
     if (iodesc->llen > 0)
-	if (!(ibuf = bget(iodesc->llen * tsize)))
-	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(ibuf = bget(iodesc->llen * tsize)))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
     if (iodesc->rearranger == PIO_REARR_BOX)
-	mycomm = ios->union_comm;
+        mycomm = ios->union_comm;
     else
-	mycomm = iodesc->subset_comm;
+        mycomm = iodesc->subset_comm;
 
     if ((mpierr = MPI_Comm_size(mycomm, &nprocs)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_rank(mycomm, &myrank)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     int log2 = log(nprocs) / log(2) + 1;
     if (!(wall = bget(2 * 4 * log2 * sizeof(double))))
-	return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
     double mintime;
 
     if ((mpierr = MPI_Barrier(mycomm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     GPTLstamp(&wall[0], &usr[0], &sys[0]);
     rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
     rearrange_io2comp(ios, iodesc, ibuf, cbuf);
     GPTLstamp(&wall[1], &usr[1], &sys[1]);
     mintime = wall[1]-wall[0];
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &mintime, 1, MPI_DOUBLE, MPI_MAX, mycomm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     handshake = iodesc->rearr_opts.comp2io.hs;
     isend = iodesc->isend;
@@ -2518,47 +2518,47 @@ performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     for (int i = 0; i < 2; i++)
     {
-	if (i == 0)
-	    iodesc->rearr_opts.comp2io.hs = false;
-	else
-	    iodesc->rearr_opts.comp2io.hs = true;
+        if (i == 0)
+            iodesc->rearr_opts.comp2io.hs = false;
+        else
+            iodesc->rearr_opts.comp2io.hs = true;
 
-	for (int j = 0; j < 2; j++)
-	{
-	    if (j == 0)
-		iodesc->isend = false;
-	    else
-		iodesc->isend = true;
+        for (int j = 0; j < 2; j++)
+        {
+            if (j == 0)
+                iodesc->isend = false;
+            else
+                iodesc->isend = true;
 
-	    iodesc->max_requests = 0;
+            iodesc->max_requests = 0;
 
-	    for (nreqs = nprocs; nreqs >= 2; nreqs /= 2)
-	    {
-		iodesc->max_requests = nreqs;
-		if ((mpierr = MPI_Barrier(mycomm)))
-		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-		GPTLstamp(wall, usr, sys);
-		rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
-		rearrange_io2comp(ios, iodesc, ibuf, cbuf);
-		GPTLstamp(wall+1, usr, sys);
-		wall[1] -= wall[0];
-		if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, wall + 1, 1, MPI_DOUBLE, MPI_MAX,
-					    mycomm)))
-		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            for (nreqs = nprocs; nreqs >= 2; nreqs /= 2)
+            {
+                iodesc->max_requests = nreqs;
+                if ((mpierr = MPI_Barrier(mycomm)))
+                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                GPTLstamp(wall, usr, sys);
+                rearrange_comp2io(ios, iodesc, cbuf, ibuf, 1);
+                rearrange_io2comp(ios, iodesc, ibuf, cbuf);
+                GPTLstamp(wall+1, usr, sys);
+                wall[1] -= wall[0];
+                if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, wall + 1, 1, MPI_DOUBLE, MPI_MAX,
+                                            mycomm)))
+                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-		if (wall[1] < mintime * 0.95)
-		{
-		    handshake = iodesc->rearr_opts.comp2io.hs;
-		    isend = iodesc->isend;
-		    maxreqs = nreqs;
-		    mintime = wall[1];
-		}
-		else if (wall[1] > mintime * 1.05)
-		{
-		    exit;
-		}
-	    }
-	}
+                if (wall[1] < mintime * 0.95)
+                {
+                    handshake = iodesc->rearr_opts.comp2io.hs;
+                    isend = iodesc->isend;
+                    maxreqs = nreqs;
+                    mintime = wall[1];
+                }
+                else if (wall[1] > mintime * 1.05)
+                {
+                    exit;
+                }
+            }
+        }
     }
 
     iodesc->rearr_opts.comp2io.hs = handshake;
@@ -2566,7 +2566,7 @@ performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
     iodesc->max_requests = maxreqs;
 
     PLOG((1, "spmd optimization: maxreqs: %d handshake:%d isend:%d mintime=%f\n",
-	  maxreqs,handshake,isend,mintime));
+          maxreqs,handshake,isend,mintime));
 
     /* Free memory. */
     brel(wall);

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -394,7 +394,7 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
 
 #if PIO_ENABLE_LOGGING
 	    for (int j = 0; j < 8; j++)
-		PLOG((2, "displace[%d] = %d mfrom[%d] %d", j, displace[j], j, mfrom[j]));
+		PLOG((2, "displace[%d] = %d", j, displace[j]));
 #endif /* PIO_ENABLE_LOGGING */
 
 	    PLOG((2, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -373,10 +373,8 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
                     /* Subset rearranger. */
                     int k = 0;
                     for (int j = 0; j < numinds; j++)
-                    {
                         if (mfrom[j] == i)
                             displace[k++] = (int)(lindex[j]);
-                    }
                 }
 
             }
@@ -391,13 +389,10 @@ create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
 
 #if PIO_ENABLE_LOGGING
             for (int j = 0; j < len; j++)
-            {
-                
-                PLOG((2, "displace[%d] = %d", j, displace[j]));
-            }
+                PLOG((3, "displace[%d] = %d", j, displace[j]));
 #endif /* PIO_ENABLE_LOGGING */
 
-            PLOG((2, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "
+            PLOG((3, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "
                   "mpitype = %d", len, blocksize, mpitype));
             /* Create an indexed datatype with constant-sized blocks. */
             mpierr = MPI_Type_create_indexed_block(len, blocksize, displace,
@@ -2098,8 +2093,9 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
      * compmap. */
     for (i = 0; i < iodesc->ndof; i++)
     {
-//      pioassert(compmap[i]>=-1 && compmap[i]<=totalgridsize, "Compmap value out of bounds",
-//          __FILE__,__LINE__);
+        // This is allowed in some cases
+        //      pioassert(compmap[i]>=-1 && compmap[i]<=totalgridsize, "Compmap value out of bounds",
+        //          __FILE__,__LINE__);
         if (compmap[i] > 0)
             (iodesc->scount[0])++;
     }
@@ -2263,7 +2259,7 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
     }
 
     /* Handle fill values if needed. */
-    PLOG((2, "ios->ioproc %d iodesc->needsfill %d iodesc->rllen %d", ios->ioproc, iodesc->needsfill, iodesc->rllen));
+    PLOG((3, "ios->ioproc %d iodesc->needsfill %d iodesc->rllen %d", ios->ioproc, iodesc->needsfill, iodesc->rllen));
     if (ios->ioproc && iodesc->needsfill)
     {
         /* we need the list of offsets which are not in the union of iomap */
@@ -2417,9 +2413,6 @@ subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
 
     if (ios->ioproc)
     {
-//        for(i=0; i < iodesc->llen; i++)
-//            printf("rindex[%d]=%d rfrom=%d\n",i,iodesc->rindex[i], iodesc->rfrom[i]);
-
         iodesc->maxregions = 0;
         if ((ret = get_regions(iodesc->ndims, gdimlen, iodesc->rllen, iomap,
                                &iodesc->maxregions, iodesc->firstregion)))

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -595,6 +595,10 @@ PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, int ma
     /* Remember the maplen. */
     iodesc->maplen = maplen;
 
+    /* check if the decomp is valid for write or is read-only */
+    /* this check is expensive and memory intensive on compute task 0 */
+//    iodesc->readonly = check_compmap(ios, iodesc, compmap);
+
     /* Remember the map. */
     if (!(iodesc->map = malloc(sizeof(PIO_Offset) * maplen)))
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -971,12 +971,13 @@ PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int base,
     if ((mpierr = MPI_Comm_size(comp_comm, &num_comptasks)))
         return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
+    PLOG((1, "PIOc_Init_Intracomm comp_comm = %d num_iotasks = %d stride = %d base = %d "
+          "rearr = %d", comp_comm, num_iotasks, stride, base, rearr));
+
     /* Check the inputs. */
     if (!iosysidp || num_iotasks < 1 || num_iotasks * stride > num_comptasks)
         return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-    PLOG((1, "PIOc_Init_Intracomm comp_comm = %d num_iotasks = %d stride = %d base = %d "
-          "rearr = %d", comp_comm, num_iotasks, stride, base, rearr));
 
     /* Allocate memory for the iosystem info. */
     if (!(ios = calloc(1, sizeof(iosystem_desc_t))))

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1413,9 +1413,10 @@ PIOc_free_iosystem(int iosysid)
         ios->my_comm = MPI_COMM_NULL;
 
     /* Free the MPI Info object. */
+#ifndef _MPISERIAL
     if (ios->info != MPI_INFO_NULL)
         MPI_Info_free(&ios->info);
-
+#endif
     /* Delete the iosystem_desc_t data associated with this id. */
     PLOG((2, "About to delete iosysid %d.", iosysid));
     if ((ierr = pio_delete_iosystem_from_list(iosysid)))

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -101,41 +101,41 @@ PIOc_strerror(int pioerr, char *errmsg)
 
     /* Caller must provide this. */
     pioassert(errmsg, "pointer to errmsg string must be provided", __FILE__,
-              __LINE__);
+	      __LINE__);
 
     /* System error? NetCDF and pNetCDF errors are always negative. */
     if (pioerr > 0)
     {
-        const char *cp = (const char *)strerror(pioerr);
-        if (cp)
-            strncpy(errmsg, cp, PIO_MAX_NAME);
-        else
-            strcpy(errmsg, "Unknown Error");
+	const char *cp = (const char *)strerror(pioerr);
+	if (cp)
+	    strncpy(errmsg, cp, PIO_MAX_NAME);
+	else
+	    strcpy(errmsg, "Unknown Error");
     }
     else if (pioerr == PIO_NOERR)
-        strcpy(errmsg, "No error");
+	strcpy(errmsg, "No error");
     else if (pioerr <= NC2_ERR && pioerr >= NC4_LAST_ERROR)     /* NetCDF error? */
-        strncpy(errmsg, nc_strerror(pioerr), PIO_MAX_NAME);
+	strncpy(errmsg, nc_strerror(pioerr), PIO_MAX_NAME);
 #if defined(_PNETCDF)
     else if (pioerr > PIO_FIRST_ERROR_CODE)     /* pNetCDF error? */
-        strncpy(errmsg, ncmpi_strerror(pioerr), PIO_MAX_NAME);
+	strncpy(errmsg, ncmpi_strerror(pioerr), PIO_MAX_NAME);
 #endif /* defined( _PNETCDF) */
     else
-        /* Handle PIO errors. */
-        switch(pioerr)
-        {
-        case PIO_EBADIOTYPE:
-            strcpy(errmsg, "Bad IO type");
-            break;
-        case PIO_EVARDIMMISMATCH:
-            strcpy(errmsg, "Variable dim mismatch in multivar call");
-            break;
-        case PIO_EBADREARR:
-            strcpy(errmsg, "Rearranger mismatch in async mode");
-            break;
-        default:
-            strcpy(errmsg, "Unknown Error: Unrecognized error code");
-        }
+	/* Handle PIO errors. */
+	switch(pioerr)
+	{
+	case PIO_EBADIOTYPE:
+	    strcpy(errmsg, "Bad IO type");
+	    break;
+	case PIO_EVARDIMMISMATCH:
+	    strcpy(errmsg, "Variable dim mismatch in multivar call");
+	    break;
+	case PIO_EBADREARR:
+	    strcpy(errmsg, "Rearranger mismatch in async mode");
+	    break;
+	default:
+	    strcpy(errmsg, "Unknown Error: Unrecognized error code");
+	}
 
     return PIO_NOERR;
 }
@@ -165,7 +165,7 @@ PIOc_set_log_level(int level)
     /* Set the log level. */
     pio_log_level = level;
     if(!LOG_FILE)
-        pio_init_logging();
+	pio_init_logging();
     PLOG((0,"set loglevel to %d", level));
 #endif /* PIO_ENABLE_LOGGING */
 
@@ -197,28 +197,28 @@ int PIOc_set_global_log_level(int iosysid, int level)
     int mpierr=0, mpierr2;
 
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     if (ios->async)
     {
-        if(!ios->ioproc)
-        {
-            int msg = PIO_MSG_SETLOGLEVEL;
-            if (ios->compmaster == MPI_ROOT)
-                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-        }
+	if(!ios->ioproc)
+	{
+	    int msg = PIO_MSG_SETLOGLEVEL;
+	    if (ios->compmaster == MPI_ROOT)
+		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	}
 
     }
     if (!mpierr)
-        mpierr = MPI_Bcast(&level, 1, MPI_INT, ios->comproot, ios->union_comm);
+	mpierr = MPI_Bcast(&level, 1, MPI_INT, ios->comproot, ios->union_comm);
 
     /* Handle MPI errors. */
     if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-        check_mpi(ios, NULL, mpierr2, __FILE__, __LINE__);
+	check_mpi(ios, NULL, mpierr2, __FILE__, __LINE__);
     if (mpierr)
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
 
     /* Set the log level on all tasks */
@@ -251,7 +251,7 @@ init_mpe(int my_rank)
 {
     /* If we've already initialized MPE states, just return. */
     if (mpe_logging_initialized++)
-        return 0;
+	return 0;
 
     /* Get a bunch of event numbers. */
     event_num[START][INIT] = MPE_Log_get_event_number();
@@ -272,27 +272,27 @@ init_mpe(int my_rank)
     /* On rank 0, set up the info states. */
     if (!my_rank)
     {
-        /* Available colors: "white", "black", "red", "yellow", "green",
-           "cyan", "blue", "magenta", "aquamarine", "forestgreen",
-           "orange", "marroon", "brown", "pink", "coral", "gray" */
-        MPE_Describe_info_state(event_num[START][INIT], event_num[END][INIT],
-                                "PIO init", "green", "%s");
-        MPE_Describe_info_state(event_num[START][DECOMP],
-                                event_num[END][DECOMP], "PIO decomposition",
-                                "cyan", "%s");
-        MPE_Describe_info_state(event_num[START][CREATE], event_num[END][CREATE],
-                                "PIO create file", "red", "%s");
-        MPE_Describe_info_state(event_num[START][OPEN], event_num[END][OPEN],
-                                "PIO open file", "orange", "%s");
-        MPE_Describe_info_state(event_num[START][DARRAY_WRITE],
-                                event_num[END][DARRAY_WRITE], "PIO darray write",
-                                "pink", "%s");
-        MPE_Describe_info_state(event_num[START][DARRAY_READ],
-                                event_num[END][DARRAY_READ], "PIO darray read",
-                                "magenta", "%s");
-        MPE_Describe_info_state(event_num[START][CLOSE],
-                                event_num[END][CLOSE], "PIO close",
-                                "white", "%s");
+	/* Available colors: "white", "black", "red", "yellow", "green",
+	   "cyan", "blue", "magenta", "aquamarine", "forestgreen",
+	   "orange", "marroon", "brown", "pink", "coral", "gray" */
+	MPE_Describe_info_state(event_num[START][INIT], event_num[END][INIT],
+				"PIO init", "green", "%s");
+	MPE_Describe_info_state(event_num[START][DECOMP],
+				event_num[END][DECOMP], "PIO decomposition",
+				"cyan", "%s");
+	MPE_Describe_info_state(event_num[START][CREATE], event_num[END][CREATE],
+				"PIO create file", "red", "%s");
+	MPE_Describe_info_state(event_num[START][OPEN], event_num[END][OPEN],
+				"PIO open file", "orange", "%s");
+	MPE_Describe_info_state(event_num[START][DARRAY_WRITE],
+				event_num[END][DARRAY_WRITE], "PIO darray write",
+				"pink", "%s");
+	MPE_Describe_info_state(event_num[START][DARRAY_READ],
+				event_num[END][DARRAY_READ], "PIO darray read",
+				"magenta", "%s");
+	MPE_Describe_info_state(event_num[START][CLOSE],
+				event_num[END][CLOSE], "PIO close",
+				"white", "%s");
     }
     return 0;
 }
@@ -307,7 +307,7 @@ void
 pio_start_mpe_log(int state)
 {
     if (MPE_Log_event(event_num[START][state], 0, NULL))
-        pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+	pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
 }
 
 /**
@@ -332,7 +332,7 @@ pio_stop_mpe_log(int state, const char *msg)
     /* Tell MPE to stop the state, with a message. */
     MPE_Log_pack(bytebuf, &pos, 's', msglen, msg);
     if ((ret = MPE_Log_event(event_num[END][state], 0, bytebuf)))
-        pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+	pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
 }
 
 #endif /* USE_MPE */
@@ -350,37 +350,37 @@ pio_init_logging(void)
 
 #ifdef USE_MPE
     {
-        int mpe_rank;
-        int mpierr;
+	int mpe_rank;
+	int mpierr;
 
-        if ((mpierr = MPI_Comm_rank(MPI_COMM_WORLD, &mpe_rank)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Comm_rank(MPI_COMM_WORLD, &mpe_rank)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-        if ((ret = init_mpe(mpe_rank)))
-            return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
+	if ((ret = init_mpe(mpe_rank)))
+	    return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
     }
 #endif /* USE_MPE */
 
 #if PIO_ENABLE_LOGGING
     if (!LOG_FILE && pio_log_level > 0)
     {
-        char log_filename[PIO_MAX_NAME];
-        int mpierr;
+	char log_filename[PIO_MAX_NAME];
+	int mpierr;
 
-        /* Create a filename with the rank in it. */
-        if ((mpierr = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        sprintf(log_filename, "pio_log_%d.log", my_rank);
+	/* Create a filename with the rank in it. */
+	if ((mpierr = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	sprintf(log_filename, "pio_log_%d.log", my_rank);
 
-        /* Open a file for this rank to log messages. */
-        if (!(LOG_FILE = fopen(log_filename, "w")))
-            return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+	/* Open a file for this rank to log messages. */
+	if (!(LOG_FILE = fopen(log_filename, "w")))
+	    return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
 
-        pio_log_ref_cnt = 1;
+	pio_log_ref_cnt = 1;
     }
     else if(LOG_FILE)
     {
-        pio_log_ref_cnt++;
+	pio_log_ref_cnt++;
     }
 #endif /* PIO_ENABLE_LOGGING */
 
@@ -397,14 +397,14 @@ pio_finalize_logging(void)
     pio_log_ref_cnt -= 1;
     if (LOG_FILE)
     {
-        if (pio_log_ref_cnt == 0)
-        {
-            fclose(LOG_FILE);
-            LOG_FILE = NULL;
-        }
-        else
-            PLOG((2, "pio_finalize_logging, postpone close, ref_cnt = %d",
-                  pio_log_ref_cnt));
+	if (pio_log_ref_cnt == 0)
+	{
+	    fclose(LOG_FILE);
+	    LOG_FILE = NULL;
+	}
+	else
+	    PLOG((2, "pio_finalize_logging, postpone close, ref_cnt = %d",
+		  pio_log_ref_cnt));
     }
 #endif /* PIO_ENABLE_LOGGING */
 }
@@ -443,25 +443,25 @@ pio_log(int severity, const char *fmt, ...)
     /* If the severity is greater than the log level, we don't print
        this message. */
     if (severity > pio_log_level)
-        return;
+	return;
 
     /* If the severity is 0, only print on rank 0. */
     if (severity < 1 && my_rank != 0)
-        return;
+	return;
 
     /* If the severity is zero, this is an error. Otherwise insert that
        many tabs before the message. */
     if (!severity)
     {
-        strncpy(ptr, ERROR_PREFIX, (rem_len > 0) ? rem_len : 0);
-        ptr += strlen(ERROR_PREFIX);
-        rem_len -= strlen(ERROR_PREFIX);
+	strncpy(ptr, ERROR_PREFIX, (rem_len > 0) ? rem_len : 0);
+	ptr += strlen(ERROR_PREFIX);
+	rem_len -= strlen(ERROR_PREFIX);
     }
 
     for (t = 0; t < severity; t++)
     {
-        strncpy(ptr++, "\t", (rem_len > 0) ? rem_len : 0);
-        rem_len--;
+	strncpy(ptr++, "\t", (rem_len > 0) ? rem_len : 0);
+	rem_len--;
     }
 
     /* Show the rank. */
@@ -491,12 +491,12 @@ pio_log(int severity, const char *fmt, ...)
 
     /* Send message to log file. */
     if (LOG_FILE)
-        fprintf(LOG_FILE, "%s", msg);
+	fprintf(LOG_FILE, "%s", msg);
 
     /* Ensure an immediate flush of stdout. */
     fflush(stdout);
     if (LOG_FILE)
-        fflush(LOG_FILE);
+	fflush(LOG_FILE);
 }
 #endif /* PIO_ENABLE_LOGGING */
 
@@ -529,7 +529,7 @@ print_trace(FILE *fp)
 
     /* Note that this won't actually work. */
     if (fp == NULL)
-        fp = stderr;
+	fp = stderr;
 
     size = backtrace(array, 10);
     strings = backtrace_symbols(array, size);
@@ -537,7 +537,7 @@ print_trace(FILE *fp)
     fprintf(fp,"Obtained %zd stack frames.\n", size);
 
     for (i = 0; i < size; i++)
-        fprintf(fp,"%s\n", strings[i]);
+	fprintf(fp,"%s\n", strings[i]);
 
     free(strings);
 }
@@ -554,7 +554,7 @@ void
 piodie(const char *msg, const char *fname, int line)
 {
     fprintf(stderr,"Abort with message %s in file %s at line %d\n",
-            msg ? msg : "_", fname ? fname : "_", line);
+	    msg ? msg : "_", fname ? fname : "_", line);
 
     print_trace(stderr);
 #ifdef MPI_SERIAL
@@ -579,7 +579,7 @@ pioassert(_Bool expression, const char *msg, const char *fname, int line)
 {
 #ifndef NDEBUG
     if (!expression)
-        piodie(msg, fname, line);
+	piodie(msg, fname, line);
 #endif
 }
 
@@ -597,20 +597,20 @@ pioassert(_Bool expression, const char *msg, const char *fname, int line)
  */
 int
 check_mpi(iosystem_desc_t *ios, file_desc_t *file, int mpierr,
-          const char *filename, int line)
+	  const char *filename, int line)
 {
     if (mpierr)
     {
-        char errstring[MPI_MAX_ERROR_STRING];
-        int errstrlen;
+	char errstring[MPI_MAX_ERROR_STRING];
+	int errstrlen;
 
-        /* If we can get an error string from MPI, print it to stderr. */
-        if (!MPI_Error_string(mpierr, errstring, &errstrlen))
-            fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n",
-                    errstring, filename ? filename : "_", line);
+	/* If we can get an error string from MPI, print it to stderr. */
+	if (!MPI_Error_string(mpierr, errstring, &errstrlen))
+	    fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n",
+		    errstring, filename ? filename : "_", line);
 
-        /* Handle all MPI errors as PIO_EIO. */
-        return pio_err(ios, file, PIO_EIO, filename, line);
+	/* Handle all MPI errors as PIO_EIO. */
+	return pio_err(ios, file, PIO_EIO, filename, line);
     }
     return PIO_NOERR;
 }
@@ -648,7 +648,7 @@ check_netcdf(file_desc_t *file, int status, const char *fname, int line)
  */
 int
 check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
-              const char *fname, int line)
+	      const char *fname, int line)
 {
     int eh = default_error_handler; /* Error handler that will be used. */
     int rbuf;
@@ -656,39 +656,39 @@ check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
     pioassert(fname, "code file name must be provided", __FILE__, __LINE__);
 
     if (file && file->iosystem->ioproc &&
-        (file->iotype == PIO_IOTYPE_PNETCDF || file->iotype == PIO_IOTYPE_NETCDF4P))
+	(file->iotype == PIO_IOTYPE_PNETCDF || file->iotype == PIO_IOTYPE_NETCDF4P))
     {
-        if (file->iosystem->io_rank == 0)
-            MPI_Reduce(MPI_IN_PLACE, &status, 1, MPI_INT, MPI_MIN, 0, file->iosystem->io_comm);
-        else
-            MPI_Reduce(&status, &rbuf, 1, MPI_INT, MPI_MIN, 0, file->iosystem->io_comm);
+	if (file->iosystem->io_rank == 0)
+	    MPI_Reduce(MPI_IN_PLACE, &status, 1, MPI_INT, MPI_MIN, 0, file->iosystem->io_comm);
+	else
+	    MPI_Reduce(&status, &rbuf, 1, MPI_INT, MPI_MIN, 0, file->iosystem->io_comm);
     }
 
     PLOG((1, "check_netcdf2 status = %d fname = %s line = %d", status, fname, line));
 
     /* Pick an error handler. */
     if (ios)
-        eh = ios->error_handler;
+	eh = ios->error_handler;
     if (file)
-        eh = file->iosystem->error_handler;
+	eh = file->iosystem->error_handler;
     pioassert(eh == PIO_INTERNAL_ERROR || eh == PIO_BCAST_ERROR || eh == PIO_RETURN_ERROR,
-              "invalid error handler", __FILE__, __LINE__);
+	      "invalid error handler", __FILE__, __LINE__);
     PLOG((2, "check_netcdf2 chose error handler = %d", eh));
 
     /* Decide what to do based on the error handler. */
     if (eh == PIO_INTERNAL_ERROR && status != PIO_NOERR)
     {
-        char errmsg[PIO_MAX_NAME + 1];  /* Error message. */
-        PIOc_strerror(status, errmsg);
-        piodie(errmsg, fname, line);        /* Die! */
+	char errmsg[PIO_MAX_NAME + 1];  /* Error message. */
+	PIOc_strerror(status, errmsg);
+	piodie(errmsg, fname, line);        /* Die! */
     }
     else if (eh == PIO_BCAST_ERROR)
     {
-        if (ios)
-            MPI_Bcast(&status, 1, MPI_INT, ios->ioroot, ios->my_comm);
-        else if (file)
-            MPI_Bcast(&status, 1, MPI_INT, file->iosystem->ioroot, file->iosystem->my_comm);
-        PLOG((2, "check_netcdf2 status returned = %d", status));
+	if (ios)
+	    MPI_Bcast(&status, 1, MPI_INT, ios->ioroot, ios->my_comm);
+	else if (file)
+	    MPI_Bcast(&status, 1, MPI_INT, file->iosystem->ioroot, file->iosystem->my_comm);
+	PLOG((2, "check_netcdf2 status returned = %d", status));
     }
 
     /* For PIO_RETURN_ERROR, just return the error. */
@@ -719,7 +719,7 @@ check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
  */
 int
 pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fname,
-        int line)
+	int line)
 {
     char err_msg[PIO_MAX_NAME + 1];
     int err_handler = default_error_handler; /* Default error handler. */
@@ -730,35 +730,35 @@ pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fname,
 
     /* No harm, no foul. */
     if (err_num == PIO_NOERR)
-        return PIO_NOERR;
+	return PIO_NOERR;
 
     /* Get the error message. */
     if ((ret = PIOc_strerror(err_num, err_msg)))
-        return ret;
+	return ret;
 
     /* If logging is in use, log an error message. */
     PLOG((0, "%s err_num = %d fname = %s line = %d", err_msg, err_num, fname ? fname : '\0', line));
 
     /* What error handler should we use? */
     if (file)
-        err_handler = file->iosystem->error_handler;
+	err_handler = file->iosystem->error_handler;
     else if (ios)
-        err_handler = ios->error_handler;
+	err_handler = ios->error_handler;
 
     PLOG((2, "pio_err chose error handler = %d", err_handler));
 
     /* Should we abort? */
     if (err_handler == PIO_INTERNAL_ERROR)
     {
-        /* For debugging only, this will print a traceback of the call tree.  */
-        print_trace(stderr);
-        MPI_Abort(MPI_COMM_WORLD, -1);
+	/* For debugging only, this will print a traceback of the call tree.  */
+	print_trace(stderr);
+	MPI_Abort(MPI_COMM_WORLD, -1);
     }
 
     /* What should we do here??? */
     if (err_handler == PIO_BCAST_ERROR)
     {
-        /* ??? */
+	/* ??? */
     }
 
     /* If abort was not called, we'll get here. */
@@ -784,19 +784,19 @@ alloc_region2(iosystem_desc_t *ios, int ndims, io_region **regionp)
     /* Check inputs. */
     pioassert(ndims >= 0 && regionp, "invalid input", __FILE__, __LINE__);
     PLOG((1, "alloc_region2 ndims = %d sizeof(io_region) = %d", ndims,
-          sizeof(io_region)));
+	  sizeof(io_region)));
 
     /* Allocate memory for the io_region struct. */
     if (!(region = calloc(1, sizeof(io_region))))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Allocate memory for the array of start indicies. */
     if (!(region->start = calloc(ndims, sizeof(PIO_Offset))))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Allocate memory for the array of counts. */
     if (!(region->count = calloc(ndims, sizeof(PIO_Offset))))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Return pointer to new region to caller. */
     *regionp = region;
@@ -825,66 +825,66 @@ find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size)
     switch(pio_type)
     {
     case PIO_BYTE:
-        my_mpi_type = MPI_SIGNED_CHAR;
-        my_type_size = NETCDF_CHAR_SIZE;
-        break;
+	my_mpi_type = MPI_SIGNED_CHAR;
+	my_type_size = NETCDF_CHAR_SIZE;
+	break;
     case PIO_CHAR:
-        my_mpi_type = MPI_CHAR;
-        my_type_size = NETCDF_CHAR_SIZE;
-        break;
+	my_mpi_type = MPI_CHAR;
+	my_type_size = NETCDF_CHAR_SIZE;
+	break;
     case PIO_SHORT:
-        my_mpi_type = MPI_SHORT;
-        my_type_size = NETCDF_SHORT_SIZE;
-        break;
+	my_mpi_type = MPI_SHORT;
+	my_type_size = NETCDF_SHORT_SIZE;
+	break;
     case PIO_INT:
-        my_mpi_type = MPI_INT;
-        my_type_size = NETCDF_INT_FLOAT_SIZE;
-        break;
+	my_mpi_type = MPI_INT;
+	my_type_size = NETCDF_INT_FLOAT_SIZE;
+	break;
     case PIO_FLOAT:
-        my_mpi_type = MPI_FLOAT;
-        my_type_size = NETCDF_INT_FLOAT_SIZE;
-        break;
+	my_mpi_type = MPI_FLOAT;
+	my_type_size = NETCDF_INT_FLOAT_SIZE;
+	break;
     case PIO_DOUBLE:
-        my_mpi_type = MPI_DOUBLE;
-        my_type_size = NETCDF_DOUBLE_INT64_SIZE;
-        break;
+	my_mpi_type = MPI_DOUBLE;
+	my_type_size = NETCDF_DOUBLE_INT64_SIZE;
+	break;
 #ifdef _NETCDF4
     case PIO_UBYTE:
-        my_mpi_type = MPI_UNSIGNED_CHAR;
-        my_type_size = NETCDF_CHAR_SIZE;
-        break;
+	my_mpi_type = MPI_UNSIGNED_CHAR;
+	my_type_size = NETCDF_CHAR_SIZE;
+	break;
     case PIO_USHORT:
-        my_mpi_type = MPI_UNSIGNED_SHORT;
-        my_type_size = NETCDF_SHORT_SIZE;
-        break;
+	my_mpi_type = MPI_UNSIGNED_SHORT;
+	my_type_size = NETCDF_SHORT_SIZE;
+	break;
     case PIO_UINT:
-        my_mpi_type = MPI_UNSIGNED;
-        my_type_size = NETCDF_INT_FLOAT_SIZE;
-        break;
+	my_mpi_type = MPI_UNSIGNED;
+	my_type_size = NETCDF_INT_FLOAT_SIZE;
+	break;
     case PIO_INT64:
-        my_mpi_type = MPI_LONG_LONG;
-        my_type_size = NETCDF_DOUBLE_INT64_SIZE;
-        break;
+	my_mpi_type = MPI_LONG_LONG;
+	my_type_size = NETCDF_DOUBLE_INT64_SIZE;
+	break;
     case PIO_UINT64:
-        my_mpi_type = MPI_UNSIGNED_LONG_LONG;
-        my_type_size = NETCDF_DOUBLE_INT64_SIZE;
-        break;
+	my_mpi_type = MPI_UNSIGNED_LONG_LONG;
+	my_type_size = NETCDF_DOUBLE_INT64_SIZE;
+	break;
     case PIO_STRING:
-        my_mpi_type = MPI_CHAR;
-        my_type_size = NETCDF_CHAR_SIZE;
-        break;
+	my_mpi_type = MPI_CHAR;
+	my_type_size = NETCDF_CHAR_SIZE;
+	break;
 #endif /* _NETCDF4 */
     default:
-        return PIO_EBADTYPE;
+	return PIO_EBADTYPE;
     }
 
     /* If caller wants MPI type, set it. */
     if (mpi_type)
-        *mpi_type = my_mpi_type;
+	*mpi_type = my_mpi_type;
 
     /* If caller wants type size, set it. */
     if (type_size)
-        *type_size = my_type_size;
+	*type_size = my_type_size;
 
     return PIO_NOERR;
 }
@@ -902,7 +902,7 @@ find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size)
  */
 int
 malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
-              io_desc_t **iodesc)
+	      io_desc_t **iodesc)
 {
     MPI_Datatype mpi_type;
     PIO_Offset type_size;
@@ -911,21 +911,21 @@ malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
 
     /* Check input. */
     pioassert(ios && piotype > 0 && ndims >= 0 && iodesc,
-              "invalid input", __FILE__, __LINE__);
+	      "invalid input", __FILE__, __LINE__);
 
     PLOG((1, "malloc_iodesc piotype = %d ndims = %d", piotype, ndims));
 
     /* Get the MPI type corresponding with the PIO type. */
     if ((ret = find_mpi_type(piotype, &mpi_type, NULL)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* What is the size of the pio type? */
     if ((ret = pioc_pnetcdf_inq_type(0, piotype, NULL, &type_size)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Allocate space for the io_desc_t struct. */
     if (!(*iodesc = calloc(1, sizeof(io_desc_t))))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Remember the pio type and its size. */
     (*iodesc)->piotype = piotype;
@@ -936,10 +936,10 @@ malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
 
     /* Get the size of the type. */
     if (mpi_type == MPI_DATATYPE_NULL)
-        (*iodesc)->mpitype_size = 0;
+	(*iodesc)->mpitype_size = 0;
     else
-        if ((mpierr = MPI_Type_size((*iodesc)->mpitype, &(*iodesc)->mpitype_size)))
-            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Type_size((*iodesc)->mpitype, &(*iodesc)->mpitype_size)))
+	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Initialize some values in the struct. */
     (*iodesc)->maxregions = 1;
@@ -948,7 +948,7 @@ malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
 
     /* Allocate space for, and initialize, the first region. */
     if ((ret = alloc_region2(ios, ndims, &((*iodesc)->firstregion))))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Set the swap memory settings to defaults for this IO system. */
     (*iodesc)->rearr_opts = ios->rearr_opts;
@@ -970,13 +970,13 @@ free_region_list(io_region *top)
     ptr = top;
     while (ptr)
     {
-        if (ptr->start)
-            free(ptr->start);
-        if (ptr->count)
-            free(ptr->count);
-        tptr = ptr;
-        ptr = ptr->next;
-        free(tptr);
+	if (ptr->start)
+	    free(ptr->start);
+	if (ptr->count)
+	    free(ptr->count);
+	tptr = ptr;
+	ptr = ptr->next;
+	free(tptr);
     }
 }
 
@@ -999,35 +999,35 @@ PIOc_freedecomp(int iosysid, int ioid)
     PLOG((1, "PIOc_freedecomp iosysid = %d ioid = %d", iosysid, ioid));
 
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
-        return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
     {
-        if (!ios->ioproc)
-        {
-            int msg = PIO_MSG_FREEDECOMP; /* Message for async notification. */
+	if (!ios->ioproc)
+	{
+	    int msg = PIO_MSG_FREEDECOMP; /* Message for async notification. */
 
-            if (ios->compmaster == MPI_ROOT)
-                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+	    if (ios->compmaster == MPI_ROOT)
+		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-            if (!mpierr)
-                mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&ioid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            PLOG((2, "PIOc_freedecomp iosysid = %d ioid = %d", iosysid, ioid));
-        }
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&ioid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    PLOG((2, "PIOc_freedecomp iosysid = %d ioid = %d", iosysid, ioid));
+	}
 
-        /* Handle MPI errors. */
-        PLOG((3, "handling mpierr %d ios->comproot %d", mpierr, ios->comproot));
-        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            return check_mpi(NULL, NULL, mpierr2, __FILE__, __LINE__);
-        PLOG((3, "handling mpierr2 %d", mpierr2));
-        if (mpierr)
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	/* Handle MPI errors. */
+	PLOG((3, "handling mpierr %d ios->comproot %d", mpierr, ios->comproot));
+	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+	    return check_mpi(NULL, NULL, mpierr2, __FILE__, __LINE__);
+	PLOG((3, "handling mpierr2 %d", mpierr2));
+	if (mpierr)
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     }
 
     PLOG((3, "freeing map, dimlen"));
@@ -1038,56 +1038,56 @@ PIOc_freedecomp(int iosysid, int ioid)
     free(iodesc->dimlen);
 
     if (iodesc->remap)
-        free(iodesc->remap);
+	free(iodesc->remap);
 
     PLOG((3, "freeing rfrom, rtype"));
     if (iodesc->rfrom)
-        free(iodesc->rfrom);
+	free(iodesc->rfrom);
 
     if (iodesc->rtype)
     {
-        for (int i = 0; i < iodesc->nrecvs; i++)
-            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
-                if ((mpierr = MPI_Type_free(&iodesc->rtype[i])))
-                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	for (int i = 0; i < iodesc->nrecvs; i++)
+	    if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
+		if ((mpierr = MPI_Type_free(&iodesc->rtype[i])))
+		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-        free(iodesc->rtype);
+	free(iodesc->rtype);
     }
 
     PLOG((3, "freeing stype, scount"));
     if (iodesc->stype)
     {
-        for (int i = 0; i < iodesc->num_stypes; i++)
-            if (iodesc->stype[i] != PIO_DATATYPE_NULL)
-                if ((mpierr = MPI_Type_free(iodesc->stype + i)))
-                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	for (int i = 0; i < iodesc->num_stypes; i++)
+	    if (iodesc->stype[i] != PIO_DATATYPE_NULL)
+		if ((mpierr = MPI_Type_free(iodesc->stype + i)))
+		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-        iodesc->num_stypes = 0;
-        free(iodesc->stype);
+	iodesc->num_stypes = 0;
+	free(iodesc->stype);
     }
 
     if (iodesc->scount)
-        free(iodesc->scount);
+	free(iodesc->scount);
 
     if (iodesc->rcount)
-        free(iodesc->rcount);
+	free(iodesc->rcount);
 
     if (iodesc->sindex)
-        free(iodesc->sindex);
+	free(iodesc->sindex);
 
     if (iodesc->rindex)
-        free(iodesc->rindex);
+	free(iodesc->rindex);
 
     PLOG((3, "freeing regions"));
     if (iodesc->firstregion)
-        free_region_list(iodesc->firstregion);
+	free_region_list(iodesc->firstregion);
 
     if (iodesc->fillregion)
-        free_region_list(iodesc->fillregion);
+	free_region_list(iodesc->fillregion);
 
     if (iodesc->rearranger == PIO_REARR_SUBSET)
-        if ((mpierr = MPI_Comm_free(&iodesc->subset_comm)))
-            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Comm_free(&iodesc->subset_comm)))
+	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     return pio_delete_iodesc_from_list(ioid);
 }
@@ -1107,7 +1107,7 @@ PIOc_freedecomp(int iosysid, int ioid)
  */
 int
 PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
-             PIO_Offset **map, MPI_Comm comm)
+	     PIO_Offset **map, MPI_Comm comm)
 {
     int npes, myrank;
     int rnpes, rversno;
@@ -1120,95 +1120,95 @@ PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
 
     /* Check inputs. */
     if (!file || !ndims || !gdims || !fmaplen || !map)
-        return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     if ((mpierr = MPI_Comm_size(comm, &npes)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_rank(comm, &myrank)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     if (myrank == 0)
     {
-        FILE *fp = fopen(file, "r");
-        if (!fp)
-            pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	FILE *fp = fopen(file, "r");
+	if (!fp)
+	    pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-        if (fscanf(fp,"version %d npes %d ndims %d\n", &rversno, &rnpes, ndims) != 3)
-            pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
-        if (rversno != VERSNO)
-            return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	if (fscanf(fp,"version %d npes %d ndims %d\n", &rversno, &rnpes, ndims) != 3)
+	    pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	if (rversno != VERSNO)
+	    return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-        if (rnpes < 1 || rnpes > npes)
-            return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	if (rnpes < 1 || rnpes > npes)
+	    return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-        if ((mpierr = MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(ndims, 1, MPI_INT, 0, comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        if (!(tdims = calloc(*ndims, sizeof(int))))
-            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        for (int i = 0; i < *ndims; i++)
-            if (fscanf(fp,"%d ", tdims + i) != 1)
-                pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(ndims, 1, MPI_INT, 0, comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if (!(tdims = calloc(*ndims, sizeof(int))))
+	    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	for (int i = 0; i < *ndims; i++)
+	    if (fscanf(fp,"%d ", tdims + i) != 1)
+		pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-        if ((mpierr = MPI_Bcast(tdims, *ndims, MPI_INT, 0, comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(tdims, *ndims, MPI_INT, 0, comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-        for (int i = 0; i < rnpes; i++)
-        {
-            if (fscanf(fp, "%d %lld", &j, &maplen) != 2)
-                pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
-            if (j != i)  // Not sure how this could be possible
-                return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
-            if (!(tmap = malloc(maplen * sizeof(PIO_Offset))))
-                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-            for (j = 0; j < maplen; j++)
-                if (fscanf(fp, "%lld ", tmap + j) != 1)
-                    pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	for (int i = 0; i < rnpes; i++)
+	{
+	    if (fscanf(fp, "%d %lld", &j, &maplen) != 2)
+		pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	    if (j != i)  // Not sure how this could be possible
+		return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	    if (!(tmap = malloc(maplen * sizeof(PIO_Offset))))
+		return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	    for (j = 0; j < maplen; j++)
+		if (fscanf(fp, "%lld ", tmap + j) != 1)
+		    pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-            if (i > 0)
-            {
-                if ((mpierr = MPI_Send(&maplen, 1, PIO_OFFSET, i, i + npes, comm)))
-                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-                if ((mpierr = MPI_Send(tmap, maplen, PIO_OFFSET, i, i, comm)))
-                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-                free(tmap);
-            }
-            else
-            {
-                *map = tmap;
-                *fmaplen = maplen;
-            }
-        }
-        fclose(fp);
+	    if (i > 0)
+	    {
+		if ((mpierr = MPI_Send(&maplen, 1, PIO_OFFSET, i, i + npes, comm)))
+		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		if ((mpierr = MPI_Send(tmap, maplen, PIO_OFFSET, i, i, comm)))
+		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+		free(tmap);
+	    }
+	    else
+	    {
+		*map = tmap;
+		*fmaplen = maplen;
+	    }
+	}
+	fclose(fp);
     }
     else
     {
-        if ((mpierr = MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(ndims, 1, MPI_INT, 0, comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        if (!(tdims = calloc(*ndims, sizeof(int))))
-            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(tdims, *ndims, MPI_INT, 0, comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(ndims, 1, MPI_INT, 0, comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	if (!(tdims = calloc(*ndims, sizeof(int))))
+	    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(tdims, *ndims, MPI_INT, 0, comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-        if (myrank < rnpes)
-        {
-            if ((mpierr = MPI_Recv(&maplen, 1, PIO_OFFSET, 0, myrank + npes, comm, &status)))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            if (!(tmap = malloc(maplen * sizeof(PIO_Offset))))
-                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-            if ((mpierr = MPI_Recv(tmap, maplen, PIO_OFFSET, 0, myrank, comm, &status)))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            *map = tmap;
-        }
-        else
-        {
-            tmap = NULL;
-            maplen = 0;
-        }
-        *fmaplen = maplen;
+	if (myrank < rnpes)
+	{
+	    if ((mpierr = MPI_Recv(&maplen, 1, PIO_OFFSET, 0, myrank + npes, comm, &status)))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    if (!(tmap = malloc(maplen * sizeof(PIO_Offset))))
+		return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	    if ((mpierr = MPI_Recv(tmap, maplen, PIO_OFFSET, 0, myrank, comm, &status)))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    *map = tmap;
+	}
+	else
+	{
+	    tmap = NULL;
+	    maplen = 0;
+	}
+	*fmaplen = maplen;
     }
     *gdims = tdims;
     return PIO_NOERR;
@@ -1228,7 +1228,7 @@ PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
  */
 int
 PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset *maplen,
-                      PIO_Offset **map, int f90_comm)
+		      PIO_Offset **map, int f90_comm)
 {
     return PIOc_readmap(file, ndims, gdims, maplen, map, MPI_Comm_f2c(f90_comm));
 }
@@ -1252,7 +1252,7 @@ PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset *map
  */
 int
 PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
-                     char *title, char *history, int fortran_order)
+		     char *title, char *history, int fortran_order)
 {
     iosystem_desc_t *ios; /* IO system info. */
     io_desc_t *iodesc;    /* Decomposition info. */
@@ -1264,24 +1264,24 @@ PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
 
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Check inputs. */
     if (!filename)
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
     if (title)
-        if (strlen(title) > PIO_MAX_NAME)
-            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	if (strlen(title) > PIO_MAX_NAME)
+	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
     if (history)
-        if (strlen(history) > PIO_MAX_NAME)
-            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	if (strlen(history) > PIO_MAX_NAME)
+	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((1, "PIOc_write_nc_decomp filename = %s iosysid = %d ioid = %d "
-          "ios->num_comptasks = %d", filename, iosysid, ioid, ios->num_comptasks));
+	  "ios->num_comptasks = %d", filename, iosysid, ioid, ios->num_comptasks));
 
     /* Get the IO desc, which describes the decomposition. */
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
-        return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Allocate memory for array which will contain the length of the
      * map on each task, for all computation tasks. */
@@ -1291,46 +1291,46 @@ PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
     /* Gather maplens from all computation tasks and fill the
      * task_maplen array on all tasks. */
     if ((mpierr = MPI_Allgather(&iodesc->maplen, 1, MPI_INT, task_maplen, 1, MPI_INT,
-                                ios->comp_comm)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+				ios->comp_comm)))
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Find the max maplen. */
     if ((mpierr = MPI_Allreduce(&iodesc->maplen, &max_maplen, 1, MPI_INT, MPI_MAX,
-                                ios->comp_comm)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+				ios->comp_comm)))
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     PLOG((3, "max_maplen = %d", max_maplen));
 
     if (!(full_map = malloc(sizeof(int) * ios->num_comptasks * max_maplen)))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     if (!(my_map = malloc(sizeof(int) * max_maplen)))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Fill local array with my map. Use the fill value for unused */
     /* elements at the end if max_maplen is longer than maplen. Also
      * subtract 1 because the iodesc->map is 1-based. */
     for (int e = 0; e < max_maplen; e++)
     {
-        my_map[e] = e < iodesc->maplen ? iodesc->map[e] - 1 : NC_FILL_INT;
-        PLOG((3, "my_map[%d] = %d", e, my_map[e]));
+	my_map[e] = e < iodesc->maplen ? iodesc->map[e] - 1 : NC_FILL_INT;
+	PLOG((3, "my_map[%d] = %d", e, my_map[e]));
     }
 
     /* Gather my_map from all computation tasks and fill the full_map array. */
     if ((mpierr = MPI_Allgather(my_map, max_maplen, MPI_INT, full_map, max_maplen,
-                                MPI_INT, ios->comp_comm)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+				MPI_INT, ios->comp_comm)))
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     free(my_map);
 
     for (int p = 0; p < ios->num_comptasks; p++)
-        for (int e = 0; e < max_maplen; e++)
-            PLOG((3, "full_map[%d][%d] = %d", p, e, full_map[p * max_maplen + e]));
+	for (int e = 0; e < max_maplen; e++)
+	    PLOG((3, "full_map[%d][%d] = %d", p, e, full_map[p * max_maplen + e]));
 
     /* Write the netCDF decomp file. */
     if ((ret = pioc_write_nc_decomp_int(ios, filename, cmode, iodesc->ndims, iodesc->dimlen,
-                                        ios->num_comptasks, task_maplen, full_map, title,
-                                        history, fortran_order)))
-        return ret;
+					ios->num_comptasks, task_maplen, full_map, title,
+					history, fortran_order)))
+	return ret;
 
     free(full_map);
     return PIO_NOERR;
@@ -1359,7 +1359,7 @@ PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
  */
 int
 PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm comm,
-                    int pio_type, char *title, char *history, int *fortran_order)
+		    int pio_type, char *title, char *history, int *fortran_order)
 {
     iosystem_desc_t *ios; /* Pointer to the IO system info. */
     int ndims;            /* The number of data dims (except unlim). */
@@ -1377,53 +1377,53 @@ PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm comm
 
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Check inputs. */
     if (!filename || !ioidp)
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((1, "PIOc_read_nc_decomp filename = %s iosysid = %d pio_type = %d",
-          filename, iosysid, pio_type));
+	  filename, iosysid, pio_type));
 
     /* Get the communicator size and task rank. */
     if ((mpierr = MPI_Comm_size(comm, &size)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_rank(comm, &my_rank)))
-        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     PLOG((2, "size = %d my_rank = %d", size, my_rank));
 
     /* Read the file. This allocates three arrays that we have to
      * free. */
     if ((ret = pioc_read_nc_decomp_int(iosysid, filename, &ndims, &global_dimlen, &num_tasks_decomp,
-                                       &task_maplen, &max_maplen, &full_map, title, history,
-                                       source_in, version_in, fortran_order)))
-        return ret;
+				       &task_maplen, &max_maplen, &full_map, title, history,
+				       source_in, version_in, fortran_order)))
+	return ret;
     PLOG((2, "ndims = %d num_tasks_decomp = %d max_maplen = %d", ndims, num_tasks_decomp,
-          max_maplen));
+	  max_maplen));
 
     /* If the size does not match the number of tasks in the decomp,
      * that's an error. */
     if (size != num_tasks_decomp)
-        ret = PIO_EINVAL;
+	ret = PIO_EINVAL;
 
     /* Now initialize the iodesc on each task for this decomposition. */
     if (!ret)
     {
-        PIO_Offset *compmap;
+	PIO_Offset *compmap;
 
-        if (!(compmap = malloc(sizeof(PIO_Offset) * task_maplen[my_rank])))
-            return PIO_ENOMEM;
+	if (!(compmap = malloc(sizeof(PIO_Offset) * task_maplen[my_rank])))
+	    return PIO_ENOMEM;
 
-        /* Copy array into PIO_Offset array. Make it 1 based. */
-        for (int e = 0; e < task_maplen[my_rank]; e++)
-            compmap[e] = full_map[my_rank * max_maplen + e] + 1;
+	/* Copy array into PIO_Offset array. Make it 1 based. */
+	for (int e = 0; e < task_maplen[my_rank]; e++)
+	    compmap[e] = full_map[my_rank * max_maplen + e] + 1;
 
-        /* Initialize the decomposition. */
-        ret = PIOc_InitDecomp(iosysid, pio_type, ndims, global_dimlen, task_maplen[my_rank],
-                              compmap, ioidp, NULL, NULL, NULL);
+	/* Initialize the decomposition. */
+	ret = PIOc_InitDecomp(iosysid, pio_type, ndims, global_dimlen, task_maplen[my_rank],
+			      compmap, ioidp, NULL, NULL, NULL);
 
-        free(compmap);
+	free(compmap);
     }
 
     /* Free resources. */
@@ -1462,8 +1462,8 @@ PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm comm
  */
 int
 pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, int ndims,
-                         int *global_dimlen, int num_tasks, int *task_maplen, int *map,
-                         const char *title, const char *history, int fortran_order)
+			 int *global_dimlen, int num_tasks, int *task_maplen, int *map,
+			 const char *title, const char *history, int fortran_order)
 {
     int max_maplen = 0;
     int ncid;
@@ -1471,60 +1471,60 @@ pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, 
 
     /* Check inputs. */
     pioassert(ios && filename && global_dimlen && task_maplen &&
-              (!title || strlen(title) <= PIO_MAX_NAME) &&
-              (!history || strlen(history) <= PIO_MAX_NAME), "invalid input",
-              __FILE__, __LINE__);
+	      (!title || strlen(title) <= PIO_MAX_NAME) &&
+	      (!history || strlen(history) <= PIO_MAX_NAME), "invalid input",
+	      __FILE__, __LINE__);
 
     PLOG((2, "pioc_write_nc_decomp_int filename = %s ndims = %d num_tasks = %d", filename,
-          ndims, num_tasks));
+	  ndims, num_tasks));
 
     /* Find the maximum maplen. */
     for (int t = 0; t < num_tasks; t++)
-        if (task_maplen[t] > max_maplen)
-            max_maplen = task_maplen[t];
+	if (task_maplen[t] > max_maplen)
+	    max_maplen = task_maplen[t];
     PLOG((3, "max_maplen = %d", max_maplen));
 
     /* Create the netCDF decomp file. */
     if ((ret = PIOc_create(ios->iosysid, filename, cmode | NC_WRITE, &ncid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with the version of this file. */
     char version[PIO_MAX_NAME + 1];
     sprintf(version, "%d.%d.%d", PIO_VERSION_MAJOR, PIO_VERSION_MINOR, PIO_VERSION_PATCH);
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_VERSION_ATT_NAME,
-                                 strlen(version) + 1, version)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+				 strlen(version) + 1, version)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with the max map len. */
     if ((ret = PIOc_put_att_int(ncid, NC_GLOBAL, DECOMP_MAX_MAPLEN_ATT_NAME,
-                                PIO_INT, 1, &max_maplen)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+				PIO_INT, 1, &max_maplen)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write title attribute, if the user provided one. */
     if (title)
-        if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_TITLE_ATT_NAME,
-                                     strlen(title) + 1, title)))
-            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_TITLE_ATT_NAME,
+				     strlen(title) + 1, title)))
+	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write history attribute, if the user provided one. */
     if (history)
-        if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_HISTORY_ATT_NAME,
-                                     strlen(history) + 1, history)))
-            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_HISTORY_ATT_NAME,
+				     strlen(history) + 1, history)))
+	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write a source attribute. */
     char source[] = "Decomposition file produced by PIO library.";
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_SOURCE_ATT_NAME,
-                                 strlen(source) + 1, source)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+				 strlen(source) + 1, source)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with array ordering (C or Fortran). */
     char c_order_str[] = DECOMP_C_ORDER_STR;
     char fortran_order_str[] = DECOMP_FORTRAN_ORDER_STR;
     char *my_order_str = fortran_order ? fortran_order_str : c_order_str;
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_ORDER_ATT_NAME,
-                                 strlen(my_order_str) + 1, my_order_str)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+				 strlen(my_order_str) + 1, my_order_str)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with the stack trace. This can be helpful
      * for debugging. */
@@ -1537,85 +1537,85 @@ pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, 
     /* Find the max size. */
     int max_bt_size = 0;
     for (int b = 0; b < bt_size; b++)
-        if (strlen(bt_strings[b]) > max_bt_size)
-            max_bt_size = strlen(bt_strings[b]);
+	if (strlen(bt_strings[b]) > max_bt_size)
+	    max_bt_size = strlen(bt_strings[b]);
     if (max_bt_size > PIO_MAX_NAME)
-        max_bt_size = PIO_MAX_NAME;
+	max_bt_size = PIO_MAX_NAME;
 
     /* Copy the backtrace into one long string. */
     char full_bt[max_bt_size * bt_size + bt_size + 1];
     full_bt[0] = '\0';
     for (int b = 0; b < bt_size; b++)
     {
-        strncat(full_bt, bt_strings[b], max_bt_size);
-        strcat(full_bt, "\n");
+	strncat(full_bt, bt_strings[b], max_bt_size);
+	strcat(full_bt, "\n");
     }
     free(bt_strings);
 
     /* Write the stack trace as an attribute. */
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_BACKTRACE_ATT_NAME,
-                                 strlen(full_bt) + 1, full_bt)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+				 strlen(full_bt) + 1, full_bt)))
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* We need a dimension for the dimensions in the data. (Example:
      * for 4D data we will need to store 4 dimension IDs.) */
     int dim_dimid;
     if ((ret = PIOc_def_dim(ncid, DECOMP_DIM_DIM, ndims, &dim_dimid)))
-        return ret;
+	return ret;
 
     /* We need a dimension for tasks. If we have 4 tasks, we need to
      * store an array of length 4 with the size of the local array on
      * each task. */
     int task_dimid;
     if ((ret = PIOc_def_dim(ncid, DECOMP_TASK_DIM_NAME, num_tasks, &task_dimid)))
-        return ret;
+	return ret;
 
     /* We need a dimension for the map. It's length may vary, we will
      * use the max_maplen for the dimension size. */
     int mapelem_dimid;
     if ((ret = PIOc_def_dim(ncid, DECOMP_MAPELEM_DIM_NAME, max_maplen,
-                            &mapelem_dimid)))
-        return ret;
+			    &mapelem_dimid)))
+	return ret;
 
     /* Define a var to hold the global size of the array for each
      * dimension. */
     int gsize_varid;
     if ((ret = PIOc_def_var(ncid, DECOMP_GLOBAL_SIZE_VAR_NAME, NC_INT, 1,
-                            &dim_dimid, &gsize_varid)))
-        return ret;
+			    &dim_dimid, &gsize_varid)))
+	return ret;
 
     /* Define a var to hold the length of the local array on each task. */
     int maplen_varid;
     if ((ret = PIOc_def_var(ncid, DECOMP_MAPLEN_VAR_NAME, NC_INT, 1, &task_dimid,
-                            &maplen_varid)))
-        return ret;
+			    &maplen_varid)))
+	return ret;
 
     /* Define a 2D var to hold the length of the local array on each task. */
     int map_varid;
     int map_dimids[2] = {task_dimid, mapelem_dimid};
     if ((ret = PIOc_def_var(ncid, DECOMP_MAP_VAR_NAME, NC_INT, 2, map_dimids,
-                            &map_varid)))
-        return ret;
+			    &map_varid)))
+	return ret;
 
     /* End define mode, to write data. */
     if ((ret = PIOc_enddef(ncid)))
-        return ret;
+	return ret;
 
     /* Write the global dimension sizes. */
     if ((PIOc_put_var_int(ncid, gsize_varid, global_dimlen)))
-        return ret;
+	return ret;
 
     /* Write the size of the local array on each task. */
     if ((PIOc_put_var_int(ncid, maplen_varid, task_maplen)))
-        return ret;
+	return ret;
 
     /* Write the map. */
     if ((PIOc_put_var_int(ncid, map_varid, map)))
-        return ret;
+	return ret;
 
     /* Close the netCDF decomp file. */
     if ((ret = PIOc_closefile(ncid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -1661,125 +1661,126 @@ pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, 
  */
 int
 pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **global_dimlen,
-                        int *num_tasks, int **task_maplen, int *max_maplen, int **map, char *title,
-                        char *history, char *source, char *version, int *fortran_order)
+			int *num_tasks, int **task_maplen, int *max_maplen, int **map, char *title,
+			char *history, char *source, char *version, int *fortran_order)
 {
     iosystem_desc_t *ios;
     int ncid;
     int ret;
-
+    int peh;
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Check inputs. */
     if (!filename)
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((1, "pioc_read_nc_decomp_int iosysid = %d filename = %s", iosysid, filename));
 
     /* Open the netCDF decomp file. */
     if ((ret = PIOc_open(iosysid, filename, NC_WRITE, &ncid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Read version attribute. */
     char version_in[PIO_MAX_NAME + 1];
     if ((ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_VERSION_ATT_NAME, version_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "version_in = %s", version_in));
     if (version)
-        strncpy(version, version_in, PIO_MAX_NAME + 1);
+	strncpy(version, version_in, PIO_MAX_NAME + 1);
 
     /* Read order attribute. */
     char order_in[PIO_MAX_NAME + 1];
     if ((ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_ORDER_ATT_NAME, order_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "order_in = %s", order_in));
     if (fortran_order)
     {
-        if (!strncmp(order_in, DECOMP_C_ORDER_STR, PIO_MAX_NAME + 1))
-            *fortran_order = 0;
-        else if (!strncmp(order_in, DECOMP_FORTRAN_ORDER_STR, PIO_MAX_NAME + 1))
-            *fortran_order = 1;
-        else
-            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	if (!strncmp(order_in, DECOMP_C_ORDER_STR, PIO_MAX_NAME + 1))
+	    *fortran_order = 0;
+	else if (!strncmp(order_in, DECOMP_FORTRAN_ORDER_STR, PIO_MAX_NAME + 1))
+	    *fortran_order = 1;
+	else
+	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
     }
 
     /* Read attribute with the max map len. */
     int max_maplen_in;
     if ((ret = PIOc_get_att_int(ncid, NC_GLOBAL, DECOMP_MAX_MAPLEN_ATT_NAME, &max_maplen_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "max_maplen_in = %d", max_maplen_in));
     if (max_maplen)
-        *max_maplen = max_maplen_in;
+	*max_maplen = max_maplen_in;
 
     /* Read title attribute, if it is in the file. */
+    peh = PIOc_Set_File_Error_Handling(ncid, PIO_BCAST_ERROR);
     char title_in[PIO_MAX_NAME + 1];
     ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_TITLE_ATT_NAME, title_in);
     if (ret == PIO_NOERR)
     {
-        /* If the caller wants it, copy the title for them. */
-        if (title)
-            strncpy(title, title_in, PIO_MAX_NAME + 1);
+	/* If the caller wants it, copy the title for them. */
+	if (title)
+	    strncpy(title, title_in, PIO_MAX_NAME + 1);
     }
     else if (ret == PIO_ENOTATT)
     {
-        /* No title attribute. */
-        if (title)
-            title[0] = '\0';
+	/* No title attribute. */
+	if (title)
+	    title[0] = '\0';
     }
     else
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Read history attribute, if it is in the file. */
     char history_in[PIO_MAX_NAME + 1];
     ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_HISTORY_ATT_NAME, history_in);
     if (ret == PIO_NOERR)
     {
-        /* If the caller wants it, copy the history for them. */
-        if (history)
-            strncpy(history, history_in, PIO_MAX_NAME + 1);
+	/* If the caller wants it, copy the history for them. */
+	if (history)
+	    strncpy(history, history_in, PIO_MAX_NAME + 1);
     }
     else if (ret == PIO_ENOTATT)
     {
-        /* No history attribute. */
-        if (history)
-            history[0] = '\0';
+	/* No history attribute. */
+	if (history)
+	    history[0] = '\0';
     }
     else
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+    PIOc_Set_File_Error_Handling(ncid, peh);
     /* Read source attribute. */
     char source_in[PIO_MAX_NAME + 1];
     if ((ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_SOURCE_ATT_NAME, source_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (source)
-        strncpy(source, source_in, PIO_MAX_NAME + 1);
+	strncpy(source, source_in, PIO_MAX_NAME + 1);
 
     /* Read dimension for the dimensions in the data. (Example: for 4D
      * data we will need to store 4 dimension IDs.) */
     int dim_dimid;
     PIO_Offset ndims_in;
     if ((ret = PIOc_inq_dimid(ncid, DECOMP_DIM_DIM, &dim_dimid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_inq_dim(ncid, dim_dimid, NULL, &ndims_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (ndims)
-        *ndims = ndims_in;
+	*ndims = ndims_in;
 
     /* Read the global sizes of the array. */
     int gsize_varid;
     int global_dimlen_in[ndims_in];
     if ((ret = PIOc_inq_varid(ncid, DECOMP_GLOBAL_SIZE_VAR_NAME, &gsize_varid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_get_var_int(ncid, gsize_varid, global_dimlen_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (global_dimlen)
     {
-        if (!(*global_dimlen = malloc(ndims_in * sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        for (int d = 0; d < ndims_in; d++)
-            (*global_dimlen)[d] = global_dimlen_in[d];
+	if (!(*global_dimlen = malloc(ndims_in * sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	for (int d = 0; d < ndims_in; d++)
+	    (*global_dimlen)[d] = global_dimlen_in[d];
     }
 
     /* Read dimension for tasks. If we have 4 tasks, we need to store
@@ -1788,25 +1789,25 @@ pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **glo
     int task_dimid;
     PIO_Offset num_tasks_in;
     if ((ret = PIOc_inq_dimid(ncid, DECOMP_TASK_DIM_NAME, &task_dimid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_inq_dim(ncid, task_dimid, NULL, &num_tasks_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (num_tasks)
-        *num_tasks = num_tasks_in;
+	*num_tasks = num_tasks_in;
 
     /* Read the length if the local array on each task. */
     int maplen_varid;
     int task_maplen_in[num_tasks_in];
     if ((ret = PIOc_inq_varid(ncid, DECOMP_MAPLEN_VAR_NAME, &maplen_varid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_get_var_int(ncid, maplen_varid, task_maplen_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (task_maplen)
     {
-        if (!(*task_maplen = malloc(num_tasks_in * sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        for (int t = 0; t < num_tasks_in; t++)
-            (*task_maplen)[t] = task_maplen_in[t];
+	if (!(*task_maplen = malloc(num_tasks_in * sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	for (int t = 0; t < num_tasks_in; t++)
+	    (*task_maplen)[t] = task_maplen_in[t];
     }
 
     /* Read the map. */
@@ -1814,26 +1815,26 @@ pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **glo
     int *map_in;
 
     if (!(map_in = malloc(sizeof(int) * num_tasks_in * max_maplen_in)))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     if ((ret = PIOc_inq_varid(ncid, DECOMP_MAP_VAR_NAME, &map_varid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_get_var_int(ncid, map_varid, map_in)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (map)
     {
-        if (!(*map = malloc(num_tasks_in * max_maplen_in * sizeof(int))))
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        for (int t = 0; t < num_tasks_in; t++)
-            for (int l = 0; l < max_maplen_in; l++)
-                (*map)[t * max_maplen_in + l] = map_in[t * max_maplen_in + l];
+	if (!(*map = malloc(num_tasks_in * max_maplen_in * sizeof(int))))
+	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	for (int t = 0; t < num_tasks_in; t++)
+	    for (int l = 0; l < max_maplen_in; l++)
+		(*map)[t * max_maplen_in + l] = map_in[t * max_maplen_in + l];
     }
     free(map_in);
 
     /* Close the netCDF decomp file. */
     PLOG((2, "pioc_read_nc_decomp_int about to close file ncid = %d", ncid));
     if ((ret = PIOc_closefile(ncid)))
-        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((2, "pioc_read_nc_decomp_int closed file"));
 
     return PIO_NOERR;
@@ -1858,13 +1859,13 @@ PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm)
     PLOG((1, "PIOc_write_decomp file = %s iosysid = %d ioid = %d", file, iosysid, ioid));
 
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
-        return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     return PIOc_writemap(file, iodesc->ndims, iodesc->dimlen, iodesc->maplen, iodesc->map,
-                         comm);
+			 comm);
 }
 
 /**
@@ -1881,7 +1882,7 @@ PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm)
  */
 int
 PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
-              PIO_Offset *map, MPI_Comm comm)
+	      PIO_Offset *map, MPI_Comm comm)
 {
     int npes, myrank;
     PIO_Offset *nmaplen = NULL;
@@ -1893,76 +1894,76 @@ PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
     PLOG((1, "PIOc_writemap file = %s ndims = %d maplen = %d", file, ndims, maplen));
 
     if ((mpierr = MPI_Comm_size(comm, &npes)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_rank(comm, &myrank)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     PLOG((2, "npes = %d myrank = %d", npes, myrank));
 
     /* Allocate memory for the nmaplen. */
     if (myrank == 0)
-        if (!(nmaplen = malloc(npes * sizeof(PIO_Offset))))
-            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(nmaplen = malloc(npes * sizeof(PIO_Offset))))
+	    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     if ((mpierr = MPI_Gather(&maplen, 1, PIO_OFFSET, nmaplen, 1, PIO_OFFSET, 0, comm)))
-        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     /* Only rank 0 writes the file. */
     if (myrank == 0)
     {
-        FILE *fp;
+	FILE *fp;
 
-        /* Open the file to write. */
-        if (!(fp = fopen(file, "w")))
-            return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+	/* Open the file to write. */
+	if (!(fp = fopen(file, "w")))
+	    return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
 
-        /* Write the version and dimension info. */
-        fprintf(fp,"version %d npes %d ndims %d \n", VERSNO, npes, ndims);
-        for (i = 0; i < ndims; i++)
-            fprintf(fp, "%d ", gdims[i]);
-        fprintf(fp, "\n");
+	/* Write the version and dimension info. */
+	fprintf(fp,"version %d npes %d ndims %d \n", VERSNO, npes, ndims);
+	for (i = 0; i < ndims; i++)
+	    fprintf(fp, "%d ", gdims[i]);
+	fprintf(fp, "\n");
 
-        /* Write the map. */
-        fprintf(fp, "0 %lld\n", nmaplen[0]);
-        for (i = 0; i < nmaplen[0]; i++)
-            fprintf(fp, "%lld ", map[i]);
-        fprintf(fp,"\n");
+	/* Write the map. */
+	fprintf(fp, "0 %lld\n", nmaplen[0]);
+	for (i = 0; i < nmaplen[0]; i++)
+	    fprintf(fp, "%lld ", map[i]);
+	fprintf(fp,"\n");
 
-        for (i = 1; i < npes; i++)
-        {
-            PLOG((2, "creating nmap for i = %d", i));
-            nmap = (PIO_Offset *)malloc(nmaplen[i] * sizeof(PIO_Offset));
+	for (i = 1; i < npes; i++)
+	{
+	    PLOG((2, "creating nmap for i = %d", i));
+	    nmap = (PIO_Offset *)malloc(nmaplen[i] * sizeof(PIO_Offset));
 
-            if ((mpierr = MPI_Send(&i, 1, MPI_INT, i, npes + i, comm)))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            if ((mpierr = MPI_Recv(nmap, nmaplen[i], PIO_OFFSET, i, i, comm, &status)))
-                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            PLOG((2,"MPI_Recv map complete"));
+	    if ((mpierr = MPI_Send(&i, 1, MPI_INT, i, npes + i, comm)))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    if ((mpierr = MPI_Recv(nmap, nmaplen[i], PIO_OFFSET, i, i, comm, &status)))
+		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	    PLOG((2,"MPI_Recv map complete"));
 
-            fprintf(fp, "%d %lld\n", i, nmaplen[i]);
-            for (int j = 0; j < nmaplen[i]; j++)
-                fprintf(fp, "%lld ", nmap[j]);
-            fprintf(fp, "\n");
+	    fprintf(fp, "%d %lld\n", i, nmaplen[i]);
+	    for (int j = 0; j < nmaplen[i]; j++)
+		fprintf(fp, "%lld ", nmap[j]);
+	    fprintf(fp, "\n");
 
-            free(nmap);
-        }
-        /* Free memory for the nmaplen. */
-        free(nmaplen);
-        fprintf(fp, "\n");
-        print_trace(fp);
+	    free(nmap);
+	}
+	/* Free memory for the nmaplen. */
+	free(nmaplen);
+	fprintf(fp, "\n");
+	print_trace(fp);
 
-        /* Close the file. */
-        fclose(fp);
-        PLOG((2,"decomp file closed."));
+	/* Close the file. */
+	fclose(fp);
+	PLOG((2,"decomp file closed."));
     }
     else
     {
-        PLOG((2,"ready to MPI_Recv..."));
-        if ((mpierr = MPI_Recv(&i, 1, MPI_INT, 0, npes+myrank, comm, &status)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        PLOG((2,"MPI_Recv got %d", i));
-        if ((mpierr = MPI_Send(map, maplen, PIO_OFFSET, 0, myrank, comm)))
-            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        PLOG((2,"MPI_Send map complete"));
+	PLOG((2,"ready to MPI_Recv..."));
+	if ((mpierr = MPI_Recv(&i, 1, MPI_INT, 0, npes+myrank, comm, &status)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	PLOG((2,"MPI_Recv got %d", i));
+	if ((mpierr = MPI_Send(map, maplen, PIO_OFFSET, 0, myrank, comm)))
+	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+	PLOG((2,"MPI_Send map complete"));
     }
 
     return PIO_NOERR;
@@ -1982,10 +1983,10 @@ PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
  */
 int
 PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
-                       PIO_Offset maplen, const PIO_Offset *map, int f90_comm)
+		       PIO_Offset maplen, const PIO_Offset *map, int f90_comm)
 {
     return PIOc_writemap(file, ndims, gdims, maplen, (PIO_Offset *)map,
-                         MPI_Comm_f2c(f90_comm));
+			 MPI_Comm_f2c(f90_comm));
 }
 
 /**
@@ -2016,7 +2017,7 @@ PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
  */
 int
 PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
-                    int mode, int use_ext_ncid)
+		    int mode, int use_ext_ncid)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -2029,22 +2030,22 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename || strlen(filename) > PIO_MAX_NAME)
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* A valid iotype must be specified. */
     if (!iotype_is_valid(*iotype))
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((1, "PIOc_createfile_int iosysid %d iotype %d filename %s mode %d "
-          "use_ext_ncid %d", iosysid, *iotype, filename, mode, use_ext_ncid));
+	  "use_ext_ncid %d", iosysid, *iotype, filename, mode, use_ext_ncid));
 
     /* Allocate space for the file info. */
     if (!(file = calloc(sizeof(file_desc_t), 1)))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Fill in some file values. */
     file->fh = -1;
@@ -2056,8 +2057,8 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
     /* Set to true if this task should participate in IO (only true for
      * one task with netcdf serial files. */
     if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
-        ios->io_rank == 0)
-        file->do_io = 1;
+	ios->io_rank == 0)
+	file->do_io = 1;
 
     PLOG((2, "file->do_io = %d ios->async = %d", file->do_io, ios->async));
 
@@ -2065,99 +2066,99 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
      * parameters. */
     if (ios->async)
     {
-        if (!ios->ioproc)
-        {
-            int msg = PIO_MSG_CREATE_FILE;
-            size_t len = strlen(filename);
-            char ncidp_present = ncidp ? 1 : 0;
+	if (!ios->ioproc)
+	{
+	    int msg = PIO_MSG_CREATE_FILE;
+	    size_t len = strlen(filename);
+	    char ncidp_present = ncidp ? 1 : 0;
 
-            /* Send the message to the message handler. */
-            PLOG((3, "msg %d ios->union_comm %d MPI_COMM_NULL %d", msg, ios->union_comm, MPI_COMM_NULL));
-            if (ios->compmaster == MPI_ROOT)
-                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+	    /* Send the message to the message handler. */
+	    PLOG((3, "msg %d ios->union_comm %d MPI_COMM_NULL %d", msg, ios->union_comm, MPI_COMM_NULL));
+	    if (ios->compmaster == MPI_ROOT)
+		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-            /* Send the parameters of the function call. */
-            if (!mpierr)
-                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&use_ext_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&ncidp_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            if (ncidp_present)
-                if (!mpierr)
-                    mpierr = MPI_Bcast(ncidp, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    /* Send the parameters of the function call. */
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&use_ext_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&ncidp_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+	    if (ncidp_present)
+		if (!mpierr)
+		    mpierr = MPI_Bcast(ncidp, 1, MPI_INT, ios->compmaster, ios->intercomm);
 #ifdef NETCDF_INTEGRATION
-            if (!mpierr)
-                mpierr = MPI_Bcast(&diosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&diosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
 #endif /* NETCDF_INTEGRATION */
-            PLOG((2, "len %d filename %s iotype %d mode %d use_ext_ncid %d "
-                  "ncidp_present %d", len, filename, file->iotype, mode,
-                  use_ext_ncid, ncidp_present));
-        }
+	    PLOG((2, "len %d filename %s iotype %d mode %d use_ext_ncid %d "
+		  "ncidp_present %d", len, filename, file->iotype, mode,
+		  use_ext_ncid, ncidp_present));
+	}
 
-        /* Handle MPI errors. */
-        PLOG((2, "handling mpi errors mpierr = %d", mpierr));
-        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
-        if (mpierr)
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	/* Handle MPI errors. */
+	PLOG((2, "handling mpi errors mpierr = %d", mpierr));
+	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
+	if (mpierr)
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this task is in the IO component, do the IO. */
     if (ios->ioproc)
     {
-        switch (file->iotype)
-        {
+	switch (file->iotype)
+	{
 #ifdef _NETCDF4
-        case PIO_IOTYPE_NETCDF4P:
-            mode = mode |  NC_MPIIO | NC_NETCDF4;
-            PLOG((2, "Calling nc_create_par io_comm = %d mode = %d fh = %d",
-                  ios->io_comm, mode, file->fh));
-            ierr = nc_create_par(filename, mode, ios->io_comm, ios->info, &file->fh);
-            PLOG((2, "nc_create_par returned %d file->fh = %d", ierr, file->fh));
-            break;
-        case PIO_IOTYPE_NETCDF4C:
-            mode = mode | NC_NETCDF4;
+	case PIO_IOTYPE_NETCDF4P:
+	    mode = mode |  NC_MPIIO | NC_NETCDF4;
+	    PLOG((2, "Calling nc_create_par io_comm = %d mode = %d fh = %d",
+		  ios->io_comm, mode, file->fh));
+	    ierr = nc_create_par(filename, mode, ios->io_comm, ios->info, &file->fh);
+	    PLOG((2, "nc_create_par returned %d file->fh = %d", ierr, file->fh));
+	    break;
+	case PIO_IOTYPE_NETCDF4C:
+	    mode = mode | NC_NETCDF4;
 #endif
-        case PIO_IOTYPE_NETCDF:
-            if (!ios->io_rank)
-            {
-                PLOG((2, "Calling nc_create mode = %d", mode));
-                ierr = nc_create(filename, mode, &file->fh);
-            }
-            break;
+	case PIO_IOTYPE_NETCDF:
+	    if (!ios->io_rank)
+	    {
+		PLOG((2, "Calling nc_create mode = %d", mode));
+		ierr = nc_create(filename, mode, &file->fh);
+	    }
+	    break;
 #ifdef _PNETCDF
-        case PIO_IOTYPE_PNETCDF:
-            PLOG((2, "Calling ncmpi_create mode = %d", mode));
-            ierr = ncmpi_create(ios->io_comm, filename, mode, ios->info, &file->fh);
-            if (!ierr)
-                ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
-            break;
+	case PIO_IOTYPE_PNETCDF:
+	    PLOG((2, "Calling ncmpi_create mode = %d", mode));
+	    ierr = ncmpi_create(ios->io_comm, filename, mode, ios->info, &file->fh);
+	    if (!ierr)
+		ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
+	    break;
 #endif
-        }
-        PLOG((3, "create call complete file->fh %d", file->fh));
+	}
+	PLOG((3, "create call complete file->fh %d", file->fh));
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     /* If there was an error, free the memory we allocated and handle error. */
     if (ierr)
     {
-        free(file);
-        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+	free(file);
+	return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
     }
 
     /* Broadcast writablility to all tasks. */
     if ((mpierr = MPI_Bcast(&file->writable, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     /* Broadcast next ncid to all tasks from io root, necessary
      * because files may be opened on mutilple iosystems, causing the
@@ -2165,10 +2166,10 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
      * ensues. */
     if (ios->async)
     {
-        PLOG((3, "createfile bcasting pio_next_ncid %d", pio_next_ncid));
-        if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        PLOG((3, "createfile bcast pio_next_ncid %d", pio_next_ncid));
+	PLOG((3, "createfile bcasting pio_next_ncid %d", pio_next_ncid));
+	if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	PLOG((3, "createfile bcast pio_next_ncid %d", pio_next_ncid));
     }
 
     /* Assign the PIO ncid. */
@@ -2181,14 +2182,14 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
 #ifdef NETCDF_INTEGRATION
     if (use_ext_ncid)
     {
-        /* The ncid was assigned on the computational
-         * processors. Change the ncid to one that I/O and
-         * computational components can agree on. */
-        if ((ierr = nc4_file_change_ncid(*ncidp, file->pio_ncid)))
-            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-        file->pio_ncid = file->pio_ncid << ID_SHIFT;
-        file->ncint_file++;
-        PLOG((2, "changed ncid to file->pio_ncid = %d", file->pio_ncid));
+	/* The ncid was assigned on the computational
+	 * processors. Change the ncid to one that I/O and
+	 * computational components can agree on. */
+	if ((ierr = nc4_file_change_ncid(*ncidp, file->pio_ncid)))
+	    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	file->pio_ncid = file->pio_ncid << ID_SHIFT;
+	file->ncint_file++;
+	PLOG((2, "changed ncid to file->pio_ncid = %d", file->pio_ncid));
     }
 #endif /* NETCDF_INTEGRATION */
     PLOG((2, "file->fh = %d file->pio_ncid = %d", file->fh, file->pio_ncid));
@@ -2204,7 +2205,7 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
     pio_stop_mpe_log(CREATE, __func__);
 #endif /* USE_MPE */
     PLOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
-          file->fh, file->pio_ncid));
+	  file->fh, file->pio_ncid));
 
     return ierr;
 }
@@ -2229,37 +2230,37 @@ check_unlim_use(int ncid)
 
     /* Are there 2 or more unlimited dims in this file? */
     if ((ierr = nc_inq_unlimdims(ncid, &nunlimdims, NULL)))
-        return ierr;
+	return ierr;
     if (nunlimdims < 2)
-        return PIO_NOERR;
+	return PIO_NOERR;
 
     /* How many vars in file? */
     if ((ierr = nc_inq_nvars(ncid, &nvars)))
-        return ierr;
+	return ierr;
 
     /* Check each var. */
     for (int v = 0; v < nvars && !ierr; v++)
     {
-        int nvardims;
-        if ((ierr = nc_inq_varndims(ncid, v, &nvardims)))
-            return ierr;
-        int vardimid[nvardims];
-        if ((ierr = nc_inq_vardimid(ncid, v, vardimid)))
-            return ierr;
+	int nvardims;
+	if ((ierr = nc_inq_varndims(ncid, v, &nvardims)))
+	    return ierr;
+	int vardimid[nvardims];
+	if ((ierr = nc_inq_vardimid(ncid, v, vardimid)))
+	    return ierr;
 
-        /* Check all var dimensions, except the first. If we find
-         * unlimited, that's a problem. */
-        for (int vd = 1; vd < nvardims; vd++)
-        {
-            size_t dimlen;
-            if ((ierr = nc_inq_dimlen(ncid, vardimid[vd], &dimlen)))
-                return ierr;
-            if (dimlen == NC_UNLIMITED)
-            {
-                nc_close(ncid);
-                return PIO_EINVAL;
-            }
-        }
+	/* Check all var dimensions, except the first. If we find
+	 * unlimited, that's a problem. */
+	for (int vd = 1; vd < nvardims; vd++)
+	{
+	    size_t dimlen;
+	    if ((ierr = nc_inq_dimlen(ncid, vardimid[vd], &dimlen)))
+		return ierr;
+	    if (dimlen == NC_UNLIMITED)
+	    {
+		nc_close(ncid);
+		return PIO_EINVAL;
+	    }
+	}
     }
 #endif /* _NETCDF4 */
 
@@ -2298,8 +2299,8 @@ check_unlim_use(int ncid)
  */
 static int
 inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
-                  int **rec_var, int **pio_type, int **pio_type_size,
-                  MPI_Datatype **mpi_type, int **mpi_type_size, int **ndims)
+		  int **rec_var, int **pio_type, int **pio_type_size,
+		  MPI_Datatype **mpi_type, int **mpi_type_size, int **ndims)
 {
     int nunlimdims = 0;        /* The number of unlimited dimensions. */
     int unlimdimid;
@@ -2309,181 +2310,181 @@ inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
 
     /* Check inputs. */
     pioassert(rec_var && pio_type && pio_type_size && mpi_type && mpi_type_size,
-              "pointers must be provided", __FILE__, __LINE__);
+	      "pointers must be provided", __FILE__, __LINE__);
 
     /* How many vars in the file? */
     if (iotype == PIO_IOTYPE_PNETCDF)
     {
 #ifdef _PNETCDF
-        if ((ret = ncmpi_inq_nvars(ncid, nvars)))
-            return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if ((ret = ncmpi_inq_nvars(ncid, nvars)))
+	    return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
 #endif /* _PNETCDF */
     }
     else
     {
-        if ((ret = nc_inq_nvars(ncid, nvars)))
-            return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if ((ret = nc_inq_nvars(ncid, nvars)))
+	    return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
     }
 
     /* Allocate storage for info about each var. */
     if (*nvars)
     {
-        if (!(*rec_var = malloc(*nvars * sizeof(int))))
-            return PIO_ENOMEM;
-        if (!(*pio_type = malloc(*nvars * sizeof(int))))
-            return PIO_ENOMEM;
-        if (!(*pio_type_size = malloc(*nvars * sizeof(int))))
-            return PIO_ENOMEM;
-        if (!(*mpi_type = malloc(*nvars * sizeof(MPI_Datatype))))
-            return PIO_ENOMEM;
-        if (!(*mpi_type_size = malloc(*nvars * sizeof(int))))
-            return PIO_ENOMEM;
-        if (!(*ndims = malloc(*nvars * sizeof(int))))
-            return PIO_ENOMEM;
+	if (!(*rec_var = malloc(*nvars * sizeof(int))))
+	    return PIO_ENOMEM;
+	if (!(*pio_type = malloc(*nvars * sizeof(int))))
+	    return PIO_ENOMEM;
+	if (!(*pio_type_size = malloc(*nvars * sizeof(int))))
+	    return PIO_ENOMEM;
+	if (!(*mpi_type = malloc(*nvars * sizeof(MPI_Datatype))))
+	    return PIO_ENOMEM;
+	if (!(*mpi_type_size = malloc(*nvars * sizeof(int))))
+	    return PIO_ENOMEM;
+	if (!(*ndims = malloc(*nvars * sizeof(int))))
+	    return PIO_ENOMEM;
     }
 
     /* How many unlimited dims for this file? */
     if (iotype == PIO_IOTYPE_PNETCDF)
     {
 #ifdef _PNETCDF
-        if ((ret = ncmpi_inq_unlimdim(ncid, &unlimdimid)))
-            return pio_err(NULL, file, ret, __FILE__, __LINE__);
-        nunlimdims = unlimdimid == -1 ? 0 : 1;
+	if ((ret = ncmpi_inq_unlimdim(ncid, &unlimdimid)))
+	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	nunlimdims = unlimdimid == -1 ? 0 : 1;
 #endif /* _PNETCDF */
     }
     else if (iotype == PIO_IOTYPE_NETCDF)
     {
-        if ((ret = nc_inq_unlimdim(ncid, &unlimdimid)))
-            return pio_err(NULL, file, ret, __FILE__, __LINE__);
-        nunlimdims = unlimdimid == -1 ? 0 : 1;
+	if ((ret = nc_inq_unlimdim(ncid, &unlimdimid)))
+	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	nunlimdims = unlimdimid == -1 ? 0 : 1;
     }
     else
     {
 #ifdef _NETCDF4
-        if ((ret = nc_inq_unlimdims(ncid, &nunlimdims, NULL)))
-            return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	if ((ret = nc_inq_unlimdims(ncid, &nunlimdims, NULL)))
+	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
 #endif /* _NETCDF4 */
     }
 
     /* Learn the unlimited dimension ID(s), if there are any. */
     if (nunlimdims)
     {
-        if (!(unlimdimids = malloc(nunlimdims * sizeof(int))))
-            return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
-        if (iotype == PIO_IOTYPE_PNETCDF || iotype == PIO_IOTYPE_NETCDF)
-        {
-            unlimdimids[0] = unlimdimid;
-        }
-        else
-        {
+	if (!(unlimdimids = malloc(nunlimdims * sizeof(int))))
+	    return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (iotype == PIO_IOTYPE_PNETCDF || iotype == PIO_IOTYPE_NETCDF)
+	{
+	    unlimdimids[0] = unlimdimid;
+	}
+	else
+	{
 #ifdef _NETCDF4
-            if ((ret = nc_inq_unlimdims(ncid, NULL, unlimdimids)))
-                return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	    if ((ret = nc_inq_unlimdims(ncid, NULL, unlimdimids)))
+		return pio_err(NULL, file, ret, __FILE__, __LINE__);
 #endif /* _NETCDF4 */
-        }
+	}
     }
 
     /* Learn about each variable in the file. */
     for (int v = 0; v < *nvars; v++)
     {
-        int var_ndims;   /* Number of dims for this var. */
-        nc_type my_type;
+	int var_ndims;   /* Number of dims for this var. */
+	nc_type my_type;
 
-        /* Find type of the var and number of dims in this var. Also
-         * learn about type. */
-        if (iotype == PIO_IOTYPE_PNETCDF)
-        {
+	/* Find type of the var and number of dims in this var. Also
+	 * learn about type. */
+	if (iotype == PIO_IOTYPE_PNETCDF)
+	{
 #ifdef _PNETCDF
-            PIO_Offset type_size;
+	    PIO_Offset type_size;
 
-            if ((ret = ncmpi_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
-                return pio_err(NULL, file, ret, __FILE__, __LINE__);
-            (*pio_type)[v] = (int)my_type;
-            (*ndims)[v] = var_ndims;
-            if ((ret = pioc_pnetcdf_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
-                return check_netcdf(file, ret, __FILE__, __LINE__);
-            (*pio_type_size)[v] = type_size;
+	    if ((ret = ncmpi_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
+		return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	    (*pio_type)[v] = (int)my_type;
+	    (*ndims)[v] = var_ndims;
+	    if ((ret = pioc_pnetcdf_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
+		return check_netcdf(file, ret, __FILE__, __LINE__);
+	    (*pio_type_size)[v] = type_size;
 #endif /* _PNETCDF */
-        }
-        else
-        {
-            size_t type_size;
+	}
+	else
+	{
+	    size_t type_size;
 
-            if ((ret = nc_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
-                return pio_err(NULL, file, ret, __FILE__, __LINE__);
-            (*pio_type)[v] = (int)my_type;
-            (*ndims)[v] = var_ndims;
-            if ((ret = nc_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
-                return check_netcdf(file, ret, __FILE__, __LINE__);
-            (*pio_type_size)[v] = type_size;
-        }
+	    if ((ret = nc_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
+		return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	    (*pio_type)[v] = (int)my_type;
+	    (*ndims)[v] = var_ndims;
+	    if ((ret = nc_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
+		return check_netcdf(file, ret, __FILE__, __LINE__);
+	    (*pio_type_size)[v] = type_size;
+	}
 
-        /* Get the MPI type corresponding with the PIO type. */
-        if ((ret = find_mpi_type((*pio_type)[v], &(*mpi_type)[v], NULL)))
-            return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	/* Get the MPI type corresponding with the PIO type. */
+	if ((ret = find_mpi_type((*pio_type)[v], &(*mpi_type)[v], NULL)))
+	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
 
-        /* Get the size of the MPI type. */
-        if ((*mpi_type)[v] == MPI_DATATYPE_NULL)
-            (*mpi_type_size)[v] = 0;
-        else
-            if ((mpierr = MPI_Type_size((*mpi_type)[v], &(*mpi_type_size)[v])))
-                return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	/* Get the size of the MPI type. */
+	if ((*mpi_type)[v] == MPI_DATATYPE_NULL)
+	    (*mpi_type_size)[v] = 0;
+	else
+	    if ((mpierr = MPI_Type_size((*mpi_type)[v], &(*mpi_type_size)[v])))
+		return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
-        /* What are the dimids associated with this var? */
-        if (var_ndims)
-        {
-            int var_dimids[var_ndims];
-            if (iotype == PIO_IOTYPE_PNETCDF)
-            {
+	/* What are the dimids associated with this var? */
+	if (var_ndims)
+	{
+	    int var_dimids[var_ndims];
+	    if (iotype == PIO_IOTYPE_PNETCDF)
+	    {
 #ifdef _PNETCDF
-                if ((ret = ncmpi_inq_vardimid(ncid, v, var_dimids)))
-                    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+		if ((ret = ncmpi_inq_vardimid(ncid, v, var_dimids)))
+		    return pio_err(NULL, file, ret, __FILE__, __LINE__);
 #endif /* _PNETCDF */
-            }
-            else
-            {
-                if ((ret = nc_inq_vardimid(ncid, v, var_dimids)))
-                    return pio_err(NULL, file, ret, __FILE__, __LINE__);
-            }
+	    }
+	    else
+	    {
+		if ((ret = nc_inq_vardimid(ncid, v, var_dimids)))
+		    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+	    }
 
-            /* Check against each variable dimid agains each unlimited
-             * dimid. */
-            for (int d = 0; d < var_ndims; d++)
-            {
-                int unlim_found = 0;
+	    /* Check against each variable dimid agains each unlimited
+	     * dimid. */
+	    for (int d = 0; d < var_ndims; d++)
+	    {
+		int unlim_found = 0;
 
-                /* Check against each unlimited dimid. */
-                for (int ud = 0; ud < nunlimdims; ud++)
-                {
-                    if (var_dimids[d] == unlimdimids[ud])
-                    {
-                        unlim_found++;
-                        break;
-                    }
-                }
+		/* Check against each unlimited dimid. */
+		for (int ud = 0; ud < nunlimdims; ud++)
+		{
+		    if (var_dimids[d] == unlimdimids[ud])
+		    {
+			unlim_found++;
+			break;
+		    }
+		}
 
-                /* Only first dim may be unlimited, for PIO. */
-                if (unlim_found)
-                {
-                    if (d == 0){
-                        (*rec_var)[v] = 1;
-                        break;
-                    }
-                    else
-                        return pio_err(NULL, file, PIO_EINVAL, __FILE__, __LINE__);
+		/* Only first dim may be unlimited, for PIO. */
+		if (unlim_found)
+		{
+		    if (d == 0){
+			(*rec_var)[v] = 1;
+			break;
+		    }
+		    else
+			return pio_err(NULL, file, PIO_EINVAL, __FILE__, __LINE__);
 
-                }
-                else
-                    (*rec_var)[v] = 0;
+		}
+		else
+		    (*rec_var)[v] = 0;
 
-            }
-        }
+	    }
+	}
 
     } /* next var */
 
     /* Free resources. */
     if (nunlimdims)
-        free(unlimdimids);
+	free(unlimdimids);
 
     return PIO_NOERR;
 }
@@ -2510,17 +2511,17 @@ find_iotype_from_omode(int mode, int *iotype)
     /* Figure out the iotype. */
     if (mode & NC_NETCDF4)
     {
-        if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
-            *iotype = PIO_IOTYPE_NETCDF4P;
-        else
-            *iotype = PIO_IOTYPE_NETCDF4C;
+	if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
+	    *iotype = PIO_IOTYPE_NETCDF4P;
+	else
+	    *iotype = PIO_IOTYPE_NETCDF4C;
     }
     else
     {
-        if (mode & NC_PNETCDF || mode & NC_MPIIO)
-            *iotype = PIO_IOTYPE_PNETCDF;
-        else
-            *iotype = PIO_IOTYPE_NETCDF;
+	if (mode & NC_PNETCDF || mode & NC_MPIIO)
+	    *iotype = PIO_IOTYPE_PNETCDF;
+	else
+	    *iotype = PIO_IOTYPE_NETCDF;
     }
 
     return PIO_NOERR;
@@ -2545,17 +2546,17 @@ find_iotype_from_cmode(int cmode, int *iotype)
     /* Figure out the iotype. */
     if (cmode & NC_NETCDF4)
     {
-        if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
-            *iotype = PIO_IOTYPE_NETCDF4P;
-        else
-            *iotype = PIO_IOTYPE_NETCDF4C;
+	if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
+	    *iotype = PIO_IOTYPE_NETCDF4P;
+	else
+	    *iotype = PIO_IOTYPE_NETCDF4C;
     }
     else
     {
-        if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
-            *iotype = PIO_IOTYPE_PNETCDF;
-        else
-            *iotype = PIO_IOTYPE_NETCDF;
+	if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
+	    *iotype = PIO_IOTYPE_PNETCDF;
+	else
+	    *iotype = PIO_IOTYPE_NETCDF;
     }
 
     return PIO_NOERR;
@@ -2590,7 +2591,7 @@ find_iotype_from_cmode(int cmode, int *iotype)
  */
 int
 PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
-                    int mode, int retry, int use_ext_ncid)
+		    int mode, int retry, int use_ext_ncid)
 {
     iosystem_desc_t *ios;      /* Pointer to io system information. */
     file_desc_t *file;         /* Pointer to file information. */
@@ -2611,20 +2612,20 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename)
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
     if (*iotype < PIO_IOTYPE_PNETCDF || *iotype > PIO_IOTYPE_NETCDF4P)
-        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((2, "PIOc_openfile_retry iosysid = %d iotype = %d filename = %s mode = %d retry = %d",
-          iosysid, *iotype, filename, mode, retry));
+	  iosysid, *iotype, filename, mode, retry));
 
     /* Allocate space for the file info. */
     if (!(file = calloc(sizeof(*file), 1)))
-        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Fill in some file values. */
     file->fh = -1;
@@ -2635,228 +2636,228 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
     /* Set to true if this task should participate in IO (only true
      * for one task with netcdf serial files. */
     if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
-        ios->io_rank == 0)
-        file->do_io = 1;
+	ios->io_rank == 0)
+	file->do_io = 1;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
     {
-        int msg = PIO_MSG_OPEN_FILE;
-        size_t len = strlen(filename);
+	int msg = PIO_MSG_OPEN_FILE;
+	size_t len = strlen(filename);
 
-        if (!ios->ioproc)
-        {
-            /* Send the message to the message handler. */
-            if (ios->compmaster == MPI_ROOT)
-                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+	if (!ios->ioproc)
+	{
+	    /* Send the message to the message handler. */
+	    if (ios->compmaster == MPI_ROOT)
+		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-            /* Send the parameters of the function call. */
-            if (!mpierr)
-                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            if (!mpierr)
-                mpierr = MPI_Bcast(&use_ext_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    /* Send the parameters of the function call. */
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&use_ext_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
 #ifdef NETCDF_INTEGRATION
-            if (!mpierr)
-                mpierr = MPI_Bcast(&diosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&diosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
 #endif /* NETCDF_INTEGRATION */
-        }
+	}
 
-        /* Handle MPI errors. */
-        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
-        if (mpierr)
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	/* Handle MPI errors. */
+	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
+	if (mpierr)
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-        switch (file->iotype)
-        {
+	switch (file->iotype)
+	{
 #ifdef _NETCDF4
 
-        case PIO_IOTYPE_NETCDF4P:
+	case PIO_IOTYPE_NETCDF4P:
 #ifdef _MPISERIAL
-            ierr = nc_open(filename, mode, &file->fh);
+	    ierr = nc_open(filename, mode, &file->fh);
 #else
-            imode = mode |  NC_MPIIO;
-            if ((ierr = nc_open_par(filename, imode, ios->io_comm, ios->info,
-                                    &file->fh)))
-                break;
+	    imode = mode |  NC_MPIIO;
+	    if ((ierr = nc_open_par(filename, imode, ios->io_comm, ios->info,
+				    &file->fh)))
+		break;
 
-            /* Check the vars for valid use of unlim dims. */
-            if ((ierr = check_unlim_use(file->fh)))
-                break;
+	    /* Check the vars for valid use of unlim dims. */
+	    if ((ierr = check_unlim_use(file->fh)))
+		break;
 
-            if ((ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4P,
-                                          &nvars, &rec_var, &pio_type,
-                                          &pio_type_size, &mpi_type,
-                                          &mpi_type_size, &ndims)))
-                break;
-            PLOG((2, "PIOc_openfile_retry:nc_open_par filename = %s mode = %d "
-                  "imode = %d ierr = %d", filename, mode, imode, ierr));
+	    if ((ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4P,
+					  &nvars, &rec_var, &pio_type,
+					  &pio_type_size, &mpi_type,
+					  &mpi_type_size, &ndims)))
+		break;
+	    PLOG((2, "PIOc_openfile_retry:nc_open_par filename = %s mode = %d "
+		  "imode = %d ierr = %d", filename, mode, imode, ierr));
 #endif
-            break;
+	    break;
 
-        case PIO_IOTYPE_NETCDF4C:
-            if (ios->io_rank == 0)
-            {
-                if ((ierr = nc_open(filename, mode, &file->fh)))
-                    break;
-                /* Check the vars for valid use of unlim dims. */
-                if ((ierr = check_unlim_use(file->fh)))
-                    break;
-                ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4C,
-                                         &nvars, &rec_var, &pio_type,
-                                         &pio_type_size, &mpi_type,
-                                         &mpi_type_size, &ndims);
-                PLOG((2, "PIOc_openfile_retry:nc_open for 4C filename = %s mode = %d "
-                      "ierr = %d", filename, mode, ierr));
-            }
-            break;
+	case PIO_IOTYPE_NETCDF4C:
+	    if (ios->io_rank == 0)
+	    {
+		if ((ierr = nc_open(filename, mode, &file->fh)))
+		    break;
+		/* Check the vars for valid use of unlim dims. */
+		if ((ierr = check_unlim_use(file->fh)))
+		    break;
+		ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4C,
+					 &nvars, &rec_var, &pio_type,
+					 &pio_type_size, &mpi_type,
+					 &mpi_type_size, &ndims);
+		PLOG((2, "PIOc_openfile_retry:nc_open for 4C filename = %s mode = %d "
+		      "ierr = %d", filename, mode, ierr));
+	    }
+	    break;
 #endif /* _NETCDF4 */
 
-        case PIO_IOTYPE_NETCDF:
-            if (ios->io_rank == 0)
-            {
-                if ((ierr = nc_open(filename, mode, &file->fh)))
-                    break;
-                ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
-                                         &nvars, &rec_var, &pio_type,
-                                         &pio_type_size, &mpi_type,
-                                         &mpi_type_size, &ndims);
-                PLOG((2, "PIOc_openfile_retry:nc_open for classic filename = %s mode = %d "
-                      "ierr = %d", filename, mode, ierr));
-            }
-            break;
+	case PIO_IOTYPE_NETCDF:
+	    if (ios->io_rank == 0)
+	    {
+		if ((ierr = nc_open(filename, mode, &file->fh)))
+		    break;
+		ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
+					 &nvars, &rec_var, &pio_type,
+					 &pio_type_size, &mpi_type,
+					 &mpi_type_size, &ndims);
+		PLOG((2, "PIOc_openfile_retry:nc_open for classic filename = %s mode = %d "
+		      "ierr = %d", filename, mode, ierr));
+	    }
+	    break;
 
 #ifdef _PNETCDF
-        case PIO_IOTYPE_PNETCDF:
-            ierr = ncmpi_open(ios->io_comm, filename, mode, ios->info, &file->fh);
+	case PIO_IOTYPE_PNETCDF:
+	    ierr = ncmpi_open(ios->io_comm, filename, mode, ios->info, &file->fh);
 
-            // This should only be done with a file opened to append
-            if (ierr == PIO_NOERR && (mode & PIO_WRITE))
-            {
-                if (ios->iomaster == MPI_ROOT)
-                    PLOG((2, "%d Setting IO buffer %ld", __LINE__,
-                          pio_buffer_size_limit));
-                ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
-            }
-            PLOG((2, "ncmpi_open(%s) : fd = %d", filename, file->fh));
+	    // This should only be done with a file opened to append
+	    if (ierr == PIO_NOERR && (mode & PIO_WRITE))
+	    {
+		if (ios->iomaster == MPI_ROOT)
+		    PLOG((2, "%d Setting IO buffer %ld", __LINE__,
+			  pio_buffer_size_limit));
+		ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
+	    }
+	    PLOG((2, "ncmpi_open(%s) : fd = %d", filename, file->fh));
 
-            if (!ierr)
-                ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_PNETCDF,
-                                         &nvars, &rec_var, &pio_type,
-                                         &pio_type_size, &mpi_type,
-                                         &mpi_type_size, &ndims);
-            break;
+	    if (!ierr)
+		ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_PNETCDF,
+					 &nvars, &rec_var, &pio_type,
+					 &pio_type_size, &mpi_type,
+					 &mpi_type_size, &ndims);
+	    break;
 #endif
 
-        default:
-            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
-        }
+	default:
+	    return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
+	}
 
-        /* If the caller requested a retry, and we failed to open a
-           file due to an incompatible type of NetCDF, try it once
-           with just plain old basic NetCDF. */
-        if (retry)
-        {
-            PLOG((2, "retry error code ierr = %d io_rank %d", ierr, ios->io_rank));
-            if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
-            {
-                if (ios->iomaster == MPI_ROOT)
-                    printf("PIO2 pio_file.c retry NETCDF\n");
+	/* If the caller requested a retry, and we failed to open a
+	   file due to an incompatible type of NetCDF, try it once
+	   with just plain old basic NetCDF. */
+	if (retry)
+	{
+	    PLOG((2, "retry error code ierr = %d io_rank %d", ierr, ios->io_rank));
+	    if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
+	    {
+		if (ios->iomaster == MPI_ROOT)
+		    printf("PIO2 pio_file.c retry NETCDF\n");
 
-                /* reset ierr on all tasks */
-                ierr = PIO_NOERR;
+		/* reset ierr on all tasks */
+		ierr = PIO_NOERR;
 
-                /* reset file markers for NETCDF on all tasks */
-                file->iotype = PIO_IOTYPE_NETCDF;
+		/* reset file markers for NETCDF on all tasks */
+		file->iotype = PIO_IOTYPE_NETCDF;
 
-                /* open netcdf file serially on main task */
-                if (ios->io_rank == 0)
-                {
-                    ierr = nc_open(filename, mode, &file->fh);
-                    if (ierr == PIO_NOERR)
-                        ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
-                                                 &nvars, &rec_var, &pio_type,
-                                                 &pio_type_size, &mpi_type,
-                                                 &mpi_type_size, &ndims);
-                }
-                else
-                    file->do_io = 0;
-            }
-            PLOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d",
-                  filename, file->fh, file->iotype, file->do_io, ierr));
-        }
+		/* open netcdf file serially on main task */
+		if (ios->io_rank == 0)
+		{
+		    ierr = nc_open(filename, mode, &file->fh);
+		    if (ierr == PIO_NOERR)
+			ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
+						 &nvars, &rec_var, &pio_type,
+						 &pio_type_size, &mpi_type,
+						 &mpi_type_size, &ndims);
+		}
+		else
+		    file->do_io = 0;
+	    }
+	    PLOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d",
+		  filename, file->fh, file->iotype, file->do_io, ierr));
+	}
     }
 
     /* Broadcast and check the return code. */
     if (ios->ioroot == ios->union_rank)
-        PLOG((2, "Bcasting error code ierr %d ios->ioroot %d ios->my_comm %d",
-              ierr, ios->ioroot, ios->my_comm));
+	PLOG((2, "Bcasting error code ierr %d ios->ioroot %d ios->my_comm %d",
+	      ierr, ios->ioroot, ios->my_comm));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     PLOG((2, "Bcast openfile_retry error code ierr = %d", ierr));
 
     /* If there was an error, free allocated memory and deal with the error. */
     if (ierr)
     {
-        free(file);
-        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+	free(file);
+	return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
     }
 
     /* Broadcast writability to all tasks. */
     if ((mpierr = MPI_Bcast(&file->writable, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     /* Broadcast some values to all tasks from io root. */
     if (ios->async)
     {
-        PLOG((3, "open bcasting pio_next_ncid %d ios->ioroot %d", pio_next_ncid, ios->ioroot));
-        if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	PLOG((3, "open bcasting pio_next_ncid %d ios->ioroot %d", pio_next_ncid, ios->ioroot));
+	if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     if ((mpierr = MPI_Bcast(&nvars, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     /* Non io tasks need to allocate to store info about variables. */
     if (nvars && !rec_var)
     {
-        if (!(rec_var = malloc(nvars * sizeof(int))))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        if (!(pio_type = malloc(nvars * sizeof(int))))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        if (!(pio_type_size = malloc(nvars * sizeof(int))))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        if (!(mpi_type = malloc(nvars * sizeof(MPI_Datatype))))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        if (!(mpi_type_size = malloc(nvars * sizeof(int))))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        if (!(ndims = malloc(nvars * sizeof(int))))
-            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(rec_var = malloc(nvars * sizeof(int))))
+	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(pio_type = malloc(nvars * sizeof(int))))
+	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(pio_type_size = malloc(nvars * sizeof(int))))
+	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(mpi_type = malloc(nvars * sizeof(MPI_Datatype))))
+	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(mpi_type_size = malloc(nvars * sizeof(int))))
+	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+	if (!(ndims = malloc(nvars * sizeof(int))))
+	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
     }
     if (nvars)
     {
-        if ((mpierr = MPI_Bcast(rec_var, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(pio_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(pio_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(mpi_type, nvars*(int)(sizeof(MPI_Datatype)/sizeof(int)), MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(mpi_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(ndims, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(rec_var, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(pio_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(pio_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(mpi_type, nvars*(int)(sizeof(MPI_Datatype)/sizeof(int)), MPI_INT, ios->ioroot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(mpi_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	if ((mpierr = MPI_Bcast(ndims, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* With the netCDF integration layer, the ncid is assigned for PIO
@@ -2865,26 +2866,26 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
 #ifdef NETCDF_INTEGRATION
     if (use_ext_ncid)
     {
-        /* The ncid was assigned on the computational
-         * processors. Change the ncid to one that I/O and
-         * computational components can agree on. */
-        file->pio_ncid = pio_next_ncid++;
-        if ((ierr = nc4_file_change_ncid(*ncidp, file->pio_ncid)))
-            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-        file->pio_ncid = file->pio_ncid << ID_SHIFT;
-        file->ncint_file++;
-        PLOG((2, "changed ncid to file->pio_ncid = %d", file->pio_ncid));
+	/* The ncid was assigned on the computational
+	 * processors. Change the ncid to one that I/O and
+	 * computational components can agree on. */
+	file->pio_ncid = pio_next_ncid++;
+	if ((ierr = nc4_file_change_ncid(*ncidp, file->pio_ncid)))
+	    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+	file->pio_ncid = file->pio_ncid << ID_SHIFT;
+	file->ncint_file++;
+	PLOG((2, "changed ncid to file->pio_ncid = %d", file->pio_ncid));
     }
     else
 #endif /* NETCDF_INTEGRATION */
     {
-        /* Create the ncid that the user will see. This is necessary
-         * because otherwise ncids will be reused if files are opened
-         * on multiple iosystems. */
-        file->pio_ncid = pio_next_ncid++;
+	/* Create the ncid that the user will see. This is necessary
+	 * because otherwise ncids will be reused if files are opened
+	 * on multiple iosystems. */
+	file->pio_ncid = pio_next_ncid++;
 
-        /* Return the PIO ncid to the user. */
-        *ncidp = file->pio_ncid;
+	/* Return the PIO ncid to the user. */
+	*ncidp = file->pio_ncid;
     }
 
     /* Add this file to the list of currently open files. */
@@ -2892,34 +2893,34 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
 
     /* Add info about the variables to the file_desc_t struct. */
     for (int v = 0; v < nvars; v++)
-        if ((ierr = add_to_varlist(v, rec_var[v], pio_type[v], pio_type_size[v],
-                                   mpi_type[v], mpi_type_size[v], ndims[v],
-                                   &file->varlist)))
-            return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+	if ((ierr = add_to_varlist(v, rec_var[v], pio_type[v], pio_type_size[v],
+				   mpi_type[v], mpi_type_size[v], ndims[v],
+				   &file->varlist)))
+	    return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     file->nvars = nvars;
 
     /* Free resources. */
     if (nvars)
     {
-        if (rec_var)
-            free(rec_var);
-        if (pio_type)
-            free(pio_type);
-        if (pio_type_size)
-            free(pio_type_size);
-        if (mpi_type)
-            free(mpi_type);
-        if (mpi_type_size)
-            free(mpi_type_size);
-        if (ndims)
-            free(ndims);
+	if (rec_var)
+	    free(rec_var);
+	if (pio_type)
+	    free(pio_type);
+	if (pio_type_size)
+	    free(pio_type_size);
+	if (mpi_type)
+	    free(mpi_type);
+	if (mpi_type_size)
+	    free(mpi_type_size);
+	if (ndims)
+	    free(ndims);
     }
 
 #ifdef USE_MPE
     pio_stop_mpe_log(OPEN, __func__);
 #endif /* USE_MPE */
     PLOG((2, "Opened file %s file->pio_ncid = %d file->fh = %d ierr = %d",
-          filename, file->pio_ncid, file->fh, ierr));
+	  filename, file->pio_ncid, file->fh, ierr));
 
     return ierr;
 }
@@ -2937,7 +2938,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
  */
 int
 pioc_pnetcdf_inq_type(int ncid, nc_type xtype, char *name,
-                      PIO_Offset *sizep)
+		      PIO_Offset *sizep)
 {
     int typelen;
 
@@ -2946,31 +2947,31 @@ pioc_pnetcdf_inq_type(int ncid, nc_type xtype, char *name,
     case NC_UBYTE:
     case NC_BYTE:
     case NC_CHAR:
-        typelen = 1;
-        break;
+	typelen = 1;
+	break;
     case NC_SHORT:
     case NC_USHORT:
-        typelen = 2;
-        break;
+	typelen = 2;
+	break;
     case NC_UINT:
     case NC_INT:
     case NC_FLOAT:
-        typelen = 4;
-        break;
+	typelen = 4;
+	break;
     case NC_UINT64:
     case NC_INT64:
     case NC_DOUBLE:
-        typelen = 8;
-        break;
+	typelen = 8;
+	break;
     default:
-        return PIO_EBADTYPE;
+	return PIO_EBADTYPE;
     }
 
     /* If pointers were supplied, copy results. */
     if (sizep)
-        *sizep = typelen;
+	*sizep = typelen;
     if (name)
-        strcpy(name, "some type");
+	strcpy(name, "some type");
 
     return PIO_NOERR;
 }
@@ -2997,66 +2998,66 @@ pioc_change_def(int ncid, int is_enddef)
     /* Find the info about this file. When I check the return code
      * here, some tests fail. ???*/
     if ((ierr = pio_get_file(ncid, &file)))
-        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
     {
-        if (!ios->ioproc)
-        {
-            int msg = is_enddef ? PIO_MSG_ENDDEF : PIO_MSG_REDEF;
-            if (ios->compmaster == MPI_ROOT)
-              {
-                PLOG((2, "pioc_change_def request sent"));
-                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-              }
-            if (!mpierr)
-                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            PLOG((3, "pioc_change_def ncid = %d mpierr = %d", ncid, mpierr));
-        }
+	if (!ios->ioproc)
+	{
+	    int msg = is_enddef ? PIO_MSG_ENDDEF : PIO_MSG_REDEF;
+	    if (ios->compmaster == MPI_ROOT)
+	      {
+		PLOG((2, "pioc_change_def request sent"));
+		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+	      }
+	    if (!mpierr)
+		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+	    PLOG((3, "pioc_change_def ncid = %d mpierr = %d", ncid, mpierr));
+	}
 
-        /* Handle MPI errors. */
-        PLOG((3, "pioc_change_def handling MPI errors my_comm=%d", ios->my_comm));
-        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
-        if (mpierr)
-            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	/* Handle MPI errors. */
+	PLOG((3, "pioc_change_def handling MPI errors my_comm=%d", ios->my_comm));
+	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+	    check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
+	if (mpierr)
+	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
     PLOG((3, "pioc_change_def ios->ioproc = %d", ios->ioproc));
     if (ios->ioproc)
     {
-        PLOG((3, "pioc_change_def calling netcdf function file->fh = %d file->do_io = %d iotype = %d",
-              file->fh, file->do_io, file->iotype));
+	PLOG((3, "pioc_change_def calling netcdf function file->fh = %d file->do_io = %d iotype = %d",
+	      file->fh, file->do_io, file->iotype));
 #ifdef _PNETCDF
-        if (file->iotype == PIO_IOTYPE_PNETCDF)
-        {
-            if (is_enddef)
-                ierr = ncmpi_enddef(file->fh);
-            else
-                ierr = ncmpi_redef(file->fh);
-        }
+	if (file->iotype == PIO_IOTYPE_PNETCDF)
+	{
+	    if (is_enddef)
+		ierr = ncmpi_enddef(file->fh);
+	    else
+		ierr = ncmpi_redef(file->fh);
+	}
 #endif /* _PNETCDF */
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
-        {
-            if (is_enddef)
-            {
-                PLOG((3, "pioc_change_def calling nc_enddef file->fh = %d", file->fh));
-                ierr = nc_enddef(file->fh);
-            }
-            else
-                ierr = nc_redef(file->fh);
-        }
+	if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
+	{
+	    if (is_enddef)
+	    {
+		PLOG((3, "pioc_change_def calling nc_enddef file->fh = %d", file->fh));
+		ierr = nc_enddef(file->fh);
+	    }
+	    else
+		ierr = nc_redef(file->fh);
+	}
     }
 
     /* Broadcast and check the return code. */
     PLOG((3, "pioc_change_def bcasting return code ierr = %d", ierr));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     if (ierr)
-        return check_netcdf(file, ierr, __FILE__, __LINE__);
+	return check_netcdf(file, ierr, __FILE__, __LINE__);
     PLOG((3, "pioc_change_def succeeded"));
 
     return ierr;
@@ -3077,17 +3078,17 @@ iotype_is_valid(int iotype)
 
     /* All builds include netCDF. */
     if (iotype == PIO_IOTYPE_NETCDF)
-        ret++;
+	ret++;
 
     /* Some builds include netCDF-4. */
 #ifdef _NETCDF4
     if (iotype == PIO_IOTYPE_NETCDF4C || iotype == PIO_IOTYPE_NETCDF4P)
-        ret++;
+	ret++;
 #endif /* _NETCDF4 */
 
     /* Some builds include pnetcdf. */
     if (iotype == PIO_IOTYPE_PNETCDF)
-        ret++;
+	ret++;
 #ifdef _PNETCDF
 #endif /* _PNETCDF */
 
@@ -3131,27 +3132,27 @@ iotype_is_valid(int iotype)
  */
 int
 PIOc_set_rearr_opts(int iosysid, int comm_type, int fcd, bool enable_hs_c2i,
-                    bool enable_isend_c2i, int max_pend_req_c2i,
-                    bool enable_hs_i2c, bool enable_isend_i2c,
-                    int max_pend_req_i2c)
+		    bool enable_isend_c2i, int max_pend_req_c2i,
+		    bool enable_hs_i2c, bool enable_isend_i2c,
+		    int max_pend_req_i2c)
 {
     iosystem_desc_t *ios;
     rearr_opt_t user_rearr_opts = {
-        comm_type, fcd,
-        {enable_hs_c2i,enable_isend_c2i, max_pend_req_c2i},
-        {enable_hs_i2c, enable_isend_i2c, max_pend_req_i2c}
+	comm_type, fcd,
+	{enable_hs_c2i,enable_isend_c2i, max_pend_req_c2i},
+	{enable_hs_i2c, enable_isend_i2c, max_pend_req_i2c}
     };
 
     /* Check inputs. */
     if ((comm_type != PIO_REARR_COMM_P2P && comm_type != PIO_REARR_COMM_FC_1D_COMP2IO) ||
-        (fcd < 0 || fcd > PIO_REARR_COMM_FC_2D_DISABLE) ||
-        (max_pend_req_c2i != PIO_REARR_COMM_UNLIMITED_PEND_REQ && max_pend_req_c2i < 0) ||
-        (max_pend_req_i2c != PIO_REARR_COMM_UNLIMITED_PEND_REQ && max_pend_req_i2c < 0))
-        return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+	(fcd < 0 || fcd > PIO_REARR_COMM_FC_2D_DISABLE) ||
+	(max_pend_req_c2i != PIO_REARR_COMM_UNLIMITED_PEND_REQ && max_pend_req_c2i < 0) ||
+	(max_pend_req_i2c != PIO_REARR_COMM_UNLIMITED_PEND_REQ && max_pend_req_i2c < 0))
+	return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Set the options. */
     ios->rearr_opts = user_rearr_opts;
@@ -3188,42 +3189,42 @@ PIOc_set_rearr_opts(int iosysid, int comm_type, int fcd, bool enable_hs_c2i,
  */
 int
 determine_procs(int num_io_procs, int component_count, int *num_procs_per_comp,
-                int **proc_list, int **my_proc_list)
+		int **proc_list, int **my_proc_list)
 {
     /* If the user did not provide a list of processes for each
      * component, create one. */
     if (!proc_list)
     {
-        int last_proc = num_io_procs;
+	int last_proc = num_io_procs;
 
-        /* Fill the array of arrays. */
-        for (int cmp = 0; cmp < component_count; cmp++)
-        {
-            PLOG((3, "calculating processors for component %d num_procs_per_comp[cmp] = %d",
-                  cmp, num_procs_per_comp[cmp]));
+	/* Fill the array of arrays. */
+	for (int cmp = 0; cmp < component_count; cmp++)
+	{
+	    PLOG((3, "calculating processors for component %d num_procs_per_comp[cmp] = %d",
+		  cmp, num_procs_per_comp[cmp]));
 
-            /* Allocate space for each array. */
-            if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
-                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	    /* Allocate space for each array. */
+	    if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
+		return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-            int proc;
-            for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
-            {
-                my_proc_list[cmp][proc - last_proc] = proc;
-                PLOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
-            }
-            last_proc = proc;
-        }
+	    int proc;
+	    for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
+	    {
+		my_proc_list[cmp][proc - last_proc] = proc;
+		PLOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
+	    }
+	    last_proc = proc;
+	}
     }
     else
     {
-        for (int cmp = 0; cmp < component_count; cmp++)
-        {
-            /* Allocate space for each array. */
-            if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
-                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-            memcpy(my_proc_list[cmp], proc_list[cmp], num_procs_per_comp[cmp] * sizeof(int));
-        }
+	for (int cmp = 0; cmp < component_count; cmp++)
+	{
+	    /* Allocate space for each array. */
+	    if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
+		return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+	    memcpy(my_proc_list[cmp], proc_list[cmp], num_procs_per_comp[cmp] * sizeof(int));
+	}
     }
     return PIO_NOERR;
 }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -557,7 +557,7 @@ piodie(const char *msg, const char *fname, int line)
             msg ? msg : "_", fname ? fname : "_", line);
 
     print_trace(stderr);
-#ifdef MPI_SERIAL
+#ifdef _MPISERIAL
     abort();
 #else
     MPI_Abort(MPI_COMM_WORLD, -1);
@@ -825,7 +825,11 @@ find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size)
     switch(pio_type)
     {
     case PIO_BYTE:
+#ifdef _MPISERIAL
+        my_mpi_type = MPI_BYTE;
+#else
         my_mpi_type = MPI_SIGNED_CHAR;
+#endif
         my_type_size = NETCDF_CHAR_SIZE;
         break;
     case PIO_CHAR:

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1242,7 +1242,7 @@ PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset *map
  * @param filename the filename to be used.
  * @param cmode for PIOc_create(). Will be bitwise or'd with NC_WRITE.
  * @param ioid the ID of the IO description.
- * @param title optial title attribute for the file. Must be less than
+ * @param title optional title attribute for the file. Must be less than
  * PIO_MAX_NAME + 1 if provided. Ignored if NULL.
  * @param history optial history attribute for the file. Must be less
  * than PIO_MAX_NAME + 1 if provided. Ignored if NULL.

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -3242,10 +3242,34 @@ determine_procs(int num_io_procs, int component_count, int *num_procs_per_comp,
     return PIO_NOERR;
 }
 
+/**
+ * Used in check_compmap to sort the compmap in accending order.
+ * 
+ * @param a pointer to an offset
+ * @param b pointer to another offset
+ * @returns 0 if offsets are the same or if either pointer is NULL
+ * @author Jim Edwards
+ */
+
 int offsetsort(const void *a,const void *b)
 {
     return (*(PIO_Offset *)a - *(PIO_Offset *)b);
 }
+
+/**
+ * check_compmap gathers the entire compmap to comp task 0, sorts it into accending order
+ * then looks for repeated values > 0.  If any repeated values are found the iodesc is marked 
+ * read only.
+ *
+ * @param ios pointer to the iosystem_desc_t struct.
+ * @param iodesc a pointer to the io_desc_t struct.
+ * @param compmap a 1 based array of offsets into the array record on
+ * file. A 0 in this array indicates a value which should not be
+ * transfered.
+ * @returns True if a repeated value is found, False otherwise.
+ * @author Jim Edwards
+ */
+
 
 bool check_compmap(iosystem_desc_t *ios, io_desc_t *iodesc,const PIO_Offset *compmap)
 {

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -101,41 +101,41 @@ PIOc_strerror(int pioerr, char *errmsg)
 
     /* Caller must provide this. */
     pioassert(errmsg, "pointer to errmsg string must be provided", __FILE__,
-	      __LINE__);
+              __LINE__);
 
     /* System error? NetCDF and pNetCDF errors are always negative. */
     if (pioerr > 0)
     {
-	const char *cp = (const char *)strerror(pioerr);
-	if (cp)
-	    strncpy(errmsg, cp, PIO_MAX_NAME);
-	else
-	    strcpy(errmsg, "Unknown Error");
+        const char *cp = (const char *)strerror(pioerr);
+        if (cp)
+            strncpy(errmsg, cp, PIO_MAX_NAME);
+        else
+            strcpy(errmsg, "Unknown Error");
     }
     else if (pioerr == PIO_NOERR)
-	strcpy(errmsg, "No error");
+        strcpy(errmsg, "No error");
     else if (pioerr <= NC2_ERR && pioerr >= NC4_LAST_ERROR)     /* NetCDF error? */
-	strncpy(errmsg, nc_strerror(pioerr), PIO_MAX_NAME);
+        strncpy(errmsg, nc_strerror(pioerr), PIO_MAX_NAME);
 #if defined(_PNETCDF)
     else if (pioerr > PIO_FIRST_ERROR_CODE)     /* pNetCDF error? */
-	strncpy(errmsg, ncmpi_strerror(pioerr), PIO_MAX_NAME);
+        strncpy(errmsg, ncmpi_strerror(pioerr), PIO_MAX_NAME);
 #endif /* defined( _PNETCDF) */
     else
-	/* Handle PIO errors. */
-	switch(pioerr)
-	{
-	case PIO_EBADIOTYPE:
-	    strcpy(errmsg, "Bad IO type");
-	    break;
-	case PIO_EVARDIMMISMATCH:
-	    strcpy(errmsg, "Variable dim mismatch in multivar call");
-	    break;
-	case PIO_EBADREARR:
-	    strcpy(errmsg, "Rearranger mismatch in async mode");
-	    break;
-	default:
-	    strcpy(errmsg, "Unknown Error: Unrecognized error code");
-	}
+        /* Handle PIO errors. */
+        switch(pioerr)
+        {
+        case PIO_EBADIOTYPE:
+            strcpy(errmsg, "Bad IO type");
+            break;
+        case PIO_EVARDIMMISMATCH:
+            strcpy(errmsg, "Variable dim mismatch in multivar call");
+            break;
+        case PIO_EBADREARR:
+            strcpy(errmsg, "Rearranger mismatch in async mode");
+            break;
+        default:
+            strcpy(errmsg, "Unknown Error: Unrecognized error code");
+        }
 
     return PIO_NOERR;
 }
@@ -165,7 +165,7 @@ PIOc_set_log_level(int level)
     /* Set the log level. */
     pio_log_level = level;
     if(!LOG_FILE)
-	pio_init_logging();
+        pio_init_logging();
     PLOG((0,"set loglevel to %d", level));
 #endif /* PIO_ENABLE_LOGGING */
 
@@ -197,28 +197,28 @@ int PIOc_set_global_log_level(int iosysid, int level)
     int mpierr=0, mpierr2;
 
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     if (ios->async)
     {
-	if(!ios->ioproc)
-	{
-	    int msg = PIO_MSG_SETLOGLEVEL;
-	    if (ios->compmaster == MPI_ROOT)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	}
+        if(!ios->ioproc)
+        {
+            int msg = PIO_MSG_SETLOGLEVEL;
+            if (ios->compmaster == MPI_ROOT)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+        }
 
     }
     if (!mpierr)
-	mpierr = MPI_Bcast(&level, 1, MPI_INT, ios->comproot, ios->union_comm);
+        mpierr = MPI_Bcast(&level, 1, MPI_INT, ios->comproot, ios->union_comm);
 
     /* Handle MPI errors. */
     if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	check_mpi(ios, NULL, mpierr2, __FILE__, __LINE__);
+        check_mpi(ios, NULL, mpierr2, __FILE__, __LINE__);
     if (mpierr)
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
 
     /* Set the log level on all tasks */
@@ -251,7 +251,7 @@ init_mpe(int my_rank)
 {
     /* If we've already initialized MPE states, just return. */
     if (mpe_logging_initialized++)
-	return 0;
+        return 0;
 
     /* Get a bunch of event numbers. */
     event_num[START][INIT] = MPE_Log_get_event_number();
@@ -272,27 +272,27 @@ init_mpe(int my_rank)
     /* On rank 0, set up the info states. */
     if (!my_rank)
     {
-	/* Available colors: "white", "black", "red", "yellow", "green",
-	   "cyan", "blue", "magenta", "aquamarine", "forestgreen",
-	   "orange", "marroon", "brown", "pink", "coral", "gray" */
-	MPE_Describe_info_state(event_num[START][INIT], event_num[END][INIT],
-				"PIO init", "green", "%s");
-	MPE_Describe_info_state(event_num[START][DECOMP],
-				event_num[END][DECOMP], "PIO decomposition",
-				"cyan", "%s");
-	MPE_Describe_info_state(event_num[START][CREATE], event_num[END][CREATE],
-				"PIO create file", "red", "%s");
-	MPE_Describe_info_state(event_num[START][OPEN], event_num[END][OPEN],
-				"PIO open file", "orange", "%s");
-	MPE_Describe_info_state(event_num[START][DARRAY_WRITE],
-				event_num[END][DARRAY_WRITE], "PIO darray write",
-				"pink", "%s");
-	MPE_Describe_info_state(event_num[START][DARRAY_READ],
-				event_num[END][DARRAY_READ], "PIO darray read",
-				"magenta", "%s");
-	MPE_Describe_info_state(event_num[START][CLOSE],
-				event_num[END][CLOSE], "PIO close",
-				"white", "%s");
+        /* Available colors: "white", "black", "red", "yellow", "green",
+           "cyan", "blue", "magenta", "aquamarine", "forestgreen",
+           "orange", "marroon", "brown", "pink", "coral", "gray" */
+        MPE_Describe_info_state(event_num[START][INIT], event_num[END][INIT],
+                                "PIO init", "green", "%s");
+        MPE_Describe_info_state(event_num[START][DECOMP],
+                                event_num[END][DECOMP], "PIO decomposition",
+                                "cyan", "%s");
+        MPE_Describe_info_state(event_num[START][CREATE], event_num[END][CREATE],
+                                "PIO create file", "red", "%s");
+        MPE_Describe_info_state(event_num[START][OPEN], event_num[END][OPEN],
+                                "PIO open file", "orange", "%s");
+        MPE_Describe_info_state(event_num[START][DARRAY_WRITE],
+                                event_num[END][DARRAY_WRITE], "PIO darray write",
+                                "pink", "%s");
+        MPE_Describe_info_state(event_num[START][DARRAY_READ],
+                                event_num[END][DARRAY_READ], "PIO darray read",
+                                "magenta", "%s");
+        MPE_Describe_info_state(event_num[START][CLOSE],
+                                event_num[END][CLOSE], "PIO close",
+                                "white", "%s");
     }
     return 0;
 }
@@ -307,7 +307,7 @@ void
 pio_start_mpe_log(int state)
 {
     if (MPE_Log_event(event_num[START][state], 0, NULL))
-	pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+        pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
 }
 
 /**
@@ -332,7 +332,7 @@ pio_stop_mpe_log(int state, const char *msg)
     /* Tell MPE to stop the state, with a message. */
     MPE_Log_pack(bytebuf, &pos, 's', msglen, msg);
     if ((ret = MPE_Log_event(event_num[END][state], 0, bytebuf)))
-	pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+        pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
 }
 
 #endif /* USE_MPE */
@@ -350,37 +350,37 @@ pio_init_logging(void)
 
 #ifdef USE_MPE
     {
-	int mpe_rank;
-	int mpierr;
+        int mpe_rank;
+        int mpierr;
 
-	if ((mpierr = MPI_Comm_rank(MPI_COMM_WORLD, &mpe_rank)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Comm_rank(MPI_COMM_WORLD, &mpe_rank)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-	if ((ret = init_mpe(mpe_rank)))
-	    return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
+        if ((ret = init_mpe(mpe_rank)))
+            return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
     }
 #endif /* USE_MPE */
 
 #if PIO_ENABLE_LOGGING
     if (!LOG_FILE && pio_log_level > 0)
     {
-	char log_filename[PIO_MAX_NAME];
-	int mpierr;
+        char log_filename[PIO_MAX_NAME];
+        int mpierr;
 
-	/* Create a filename with the rank in it. */
-	if ((mpierr = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	sprintf(log_filename, "pio_log_%d.log", my_rank);
+        /* Create a filename with the rank in it. */
+        if ((mpierr = MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        sprintf(log_filename, "pio_log_%d.log", my_rank);
 
-	/* Open a file for this rank to log messages. */
-	if (!(LOG_FILE = fopen(log_filename, "w")))
-	    return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+        /* Open a file for this rank to log messages. */
+        if (!(LOG_FILE = fopen(log_filename, "w")))
+            return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
 
-	pio_log_ref_cnt = 1;
+        pio_log_ref_cnt = 1;
     }
     else if(LOG_FILE)
     {
-	pio_log_ref_cnt++;
+        pio_log_ref_cnt++;
     }
 #endif /* PIO_ENABLE_LOGGING */
 
@@ -397,14 +397,14 @@ pio_finalize_logging(void)
     pio_log_ref_cnt -= 1;
     if (LOG_FILE)
     {
-	if (pio_log_ref_cnt == 0)
-	{
-	    fclose(LOG_FILE);
-	    LOG_FILE = NULL;
-	}
-	else
-	    PLOG((2, "pio_finalize_logging, postpone close, ref_cnt = %d",
-		  pio_log_ref_cnt));
+        if (pio_log_ref_cnt == 0)
+        {
+            fclose(LOG_FILE);
+            LOG_FILE = NULL;
+        }
+        else
+            PLOG((2, "pio_finalize_logging, postpone close, ref_cnt = %d",
+                  pio_log_ref_cnt));
     }
 #endif /* PIO_ENABLE_LOGGING */
 }
@@ -443,25 +443,25 @@ pio_log(int severity, const char *fmt, ...)
     /* If the severity is greater than the log level, we don't print
        this message. */
     if (severity > pio_log_level)
-	return;
+        return;
 
     /* If the severity is 0, only print on rank 0. */
     if (severity < 1 && my_rank != 0)
-	return;
+        return;
 
     /* If the severity is zero, this is an error. Otherwise insert that
        many tabs before the message. */
     if (!severity)
     {
-	strncpy(ptr, ERROR_PREFIX, (rem_len > 0) ? rem_len : 0);
-	ptr += strlen(ERROR_PREFIX);
-	rem_len -= strlen(ERROR_PREFIX);
+        strncpy(ptr, ERROR_PREFIX, (rem_len > 0) ? rem_len : 0);
+        ptr += strlen(ERROR_PREFIX);
+        rem_len -= strlen(ERROR_PREFIX);
     }
 
     for (t = 0; t < severity; t++)
     {
-	strncpy(ptr++, "\t", (rem_len > 0) ? rem_len : 0);
-	rem_len--;
+        strncpy(ptr++, "\t", (rem_len > 0) ? rem_len : 0);
+        rem_len--;
     }
 
     /* Show the rank. */
@@ -491,12 +491,12 @@ pio_log(int severity, const char *fmt, ...)
 
     /* Send message to log file. */
     if (LOG_FILE)
-	fprintf(LOG_FILE, "%s", msg);
+        fprintf(LOG_FILE, "%s", msg);
 
     /* Ensure an immediate flush of stdout. */
     fflush(stdout);
     if (LOG_FILE)
-	fflush(LOG_FILE);
+        fflush(LOG_FILE);
 }
 #endif /* PIO_ENABLE_LOGGING */
 
@@ -529,7 +529,7 @@ print_trace(FILE *fp)
 
     /* Note that this won't actually work. */
     if (fp == NULL)
-	fp = stderr;
+        fp = stderr;
 
     size = backtrace(array, 10);
     strings = backtrace_symbols(array, size);
@@ -537,7 +537,7 @@ print_trace(FILE *fp)
     fprintf(fp,"Obtained %zd stack frames.\n", size);
 
     for (i = 0; i < size; i++)
-	fprintf(fp,"%s\n", strings[i]);
+        fprintf(fp,"%s\n", strings[i]);
 
     free(strings);
 }
@@ -554,7 +554,7 @@ void
 piodie(const char *msg, const char *fname, int line)
 {
     fprintf(stderr,"Abort with message %s in file %s at line %d\n",
-	    msg ? msg : "_", fname ? fname : "_", line);
+            msg ? msg : "_", fname ? fname : "_", line);
 
     print_trace(stderr);
 #ifdef MPI_SERIAL
@@ -579,7 +579,7 @@ pioassert(_Bool expression, const char *msg, const char *fname, int line)
 {
 #ifndef NDEBUG
     if (!expression)
-	piodie(msg, fname, line);
+        piodie(msg, fname, line);
 #endif
 }
 
@@ -597,20 +597,20 @@ pioassert(_Bool expression, const char *msg, const char *fname, int line)
  */
 int
 check_mpi(iosystem_desc_t *ios, file_desc_t *file, int mpierr,
-	  const char *filename, int line)
+          const char *filename, int line)
 {
     if (mpierr)
     {
-	char errstring[MPI_MAX_ERROR_STRING];
-	int errstrlen;
+        char errstring[MPI_MAX_ERROR_STRING];
+        int errstrlen;
 
-	/* If we can get an error string from MPI, print it to stderr. */
-	if (!MPI_Error_string(mpierr, errstring, &errstrlen))
-	    fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n",
-		    errstring, filename ? filename : "_", line);
+        /* If we can get an error string from MPI, print it to stderr. */
+        if (!MPI_Error_string(mpierr, errstring, &errstrlen))
+            fprintf(stderr, "MPI ERROR: %s in file %s at line %d\n",
+                    errstring, filename ? filename : "_", line);
 
-	/* Handle all MPI errors as PIO_EIO. */
-	return pio_err(ios, file, PIO_EIO, filename, line);
+        /* Handle all MPI errors as PIO_EIO. */
+        return pio_err(ios, file, PIO_EIO, filename, line);
     }
     return PIO_NOERR;
 }
@@ -648,7 +648,7 @@ check_netcdf(file_desc_t *file, int status, const char *fname, int line)
  */
 int
 check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
-	      const char *fname, int line)
+              const char *fname, int line)
 {
     int eh = default_error_handler; /* Error handler that will be used. */
     int rbuf;
@@ -656,39 +656,39 @@ check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
     pioassert(fname, "code file name must be provided", __FILE__, __LINE__);
 
     if (file && file->iosystem->ioproc &&
-	(file->iotype == PIO_IOTYPE_PNETCDF || file->iotype == PIO_IOTYPE_NETCDF4P))
+        (file->iotype == PIO_IOTYPE_PNETCDF || file->iotype == PIO_IOTYPE_NETCDF4P))
     {
-	if (file->iosystem->io_rank == 0)
-	    MPI_Reduce(MPI_IN_PLACE, &status, 1, MPI_INT, MPI_MIN, 0, file->iosystem->io_comm);
-	else
-	    MPI_Reduce(&status, &rbuf, 1, MPI_INT, MPI_MIN, 0, file->iosystem->io_comm);
+        if (file->iosystem->io_rank == 0)
+            MPI_Reduce(MPI_IN_PLACE, &status, 1, MPI_INT, MPI_MIN, 0, file->iosystem->io_comm);
+        else
+            MPI_Reduce(&status, &rbuf, 1, MPI_INT, MPI_MIN, 0, file->iosystem->io_comm);
     }
 
     PLOG((1, "check_netcdf2 status = %d fname = %s line = %d", status, fname, line));
 
     /* Pick an error handler. */
     if (ios)
-	eh = ios->error_handler;
+        eh = ios->error_handler;
     if (file)
-	eh = file->iosystem->error_handler;
+        eh = file->iosystem->error_handler;
     pioassert(eh == PIO_INTERNAL_ERROR || eh == PIO_BCAST_ERROR || eh == PIO_RETURN_ERROR,
-	      "invalid error handler", __FILE__, __LINE__);
+              "invalid error handler", __FILE__, __LINE__);
     PLOG((2, "check_netcdf2 chose error handler = %d", eh));
 
     /* Decide what to do based on the error handler. */
     if (eh == PIO_INTERNAL_ERROR && status != PIO_NOERR)
     {
-	char errmsg[PIO_MAX_NAME + 1];  /* Error message. */
-	PIOc_strerror(status, errmsg);
-	piodie(errmsg, fname, line);        /* Die! */
+        char errmsg[PIO_MAX_NAME + 1];  /* Error message. */
+        PIOc_strerror(status, errmsg);
+        piodie(errmsg, fname, line);        /* Die! */
     }
     else if (eh == PIO_BCAST_ERROR)
     {
-	if (ios)
-	    MPI_Bcast(&status, 1, MPI_INT, ios->ioroot, ios->my_comm);
-	else if (file)
-	    MPI_Bcast(&status, 1, MPI_INT, file->iosystem->ioroot, file->iosystem->my_comm);
-	PLOG((2, "check_netcdf2 status returned = %d", status));
+        if (ios)
+            MPI_Bcast(&status, 1, MPI_INT, ios->ioroot, ios->my_comm);
+        else if (file)
+            MPI_Bcast(&status, 1, MPI_INT, file->iosystem->ioroot, file->iosystem->my_comm);
+        PLOG((2, "check_netcdf2 status returned = %d", status));
     }
 
     /* For PIO_RETURN_ERROR, just return the error. */
@@ -719,7 +719,7 @@ check_netcdf2(iosystem_desc_t *ios, file_desc_t *file, int status,
  */
 int
 pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fname,
-	int line)
+        int line)
 {
     char err_msg[PIO_MAX_NAME + 1];
     int err_handler = default_error_handler; /* Default error handler. */
@@ -730,35 +730,35 @@ pio_err(iosystem_desc_t *ios, file_desc_t *file, int err_num, const char *fname,
 
     /* No harm, no foul. */
     if (err_num == PIO_NOERR)
-	return PIO_NOERR;
+        return PIO_NOERR;
 
     /* Get the error message. */
     if ((ret = PIOc_strerror(err_num, err_msg)))
-	return ret;
+        return ret;
 
     /* If logging is in use, log an error message. */
     PLOG((0, "%s err_num = %d fname = %s line = %d", err_msg, err_num, fname ? fname : '\0', line));
 
     /* What error handler should we use? */
     if (file)
-	err_handler = file->iosystem->error_handler;
+        err_handler = file->iosystem->error_handler;
     else if (ios)
-	err_handler = ios->error_handler;
+        err_handler = ios->error_handler;
 
     PLOG((2, "pio_err chose error handler = %d", err_handler));
 
     /* Should we abort? */
     if (err_handler == PIO_INTERNAL_ERROR)
     {
-	/* For debugging only, this will print a traceback of the call tree.  */
-	print_trace(stderr);
-	MPI_Abort(MPI_COMM_WORLD, -1);
+        /* For debugging only, this will print a traceback of the call tree.  */
+        print_trace(stderr);
+        MPI_Abort(MPI_COMM_WORLD, -1);
     }
 
     /* What should we do here??? */
     if (err_handler == PIO_BCAST_ERROR)
     {
-	/* ??? */
+        /* ??? */
     }
 
     /* If abort was not called, we'll get here. */
@@ -784,19 +784,19 @@ alloc_region2(iosystem_desc_t *ios, int ndims, io_region **regionp)
     /* Check inputs. */
     pioassert(ndims >= 0 && regionp, "invalid input", __FILE__, __LINE__);
     PLOG((1, "alloc_region2 ndims = %d sizeof(io_region) = %d", ndims,
-	  sizeof(io_region)));
+          sizeof(io_region)));
 
     /* Allocate memory for the io_region struct. */
     if (!(region = calloc(1, sizeof(io_region))))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Allocate memory for the array of start indicies. */
     if (!(region->start = calloc(ndims, sizeof(PIO_Offset))))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Allocate memory for the array of counts. */
     if (!(region->count = calloc(ndims, sizeof(PIO_Offset))))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Return pointer to new region to caller. */
     *regionp = region;
@@ -825,66 +825,66 @@ find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size)
     switch(pio_type)
     {
     case PIO_BYTE:
-	my_mpi_type = MPI_SIGNED_CHAR;
-	my_type_size = NETCDF_CHAR_SIZE;
-	break;
+        my_mpi_type = MPI_SIGNED_CHAR;
+        my_type_size = NETCDF_CHAR_SIZE;
+        break;
     case PIO_CHAR:
-	my_mpi_type = MPI_CHAR;
-	my_type_size = NETCDF_CHAR_SIZE;
-	break;
+        my_mpi_type = MPI_CHAR;
+        my_type_size = NETCDF_CHAR_SIZE;
+        break;
     case PIO_SHORT:
-	my_mpi_type = MPI_SHORT;
-	my_type_size = NETCDF_SHORT_SIZE;
-	break;
+        my_mpi_type = MPI_SHORT;
+        my_type_size = NETCDF_SHORT_SIZE;
+        break;
     case PIO_INT:
-	my_mpi_type = MPI_INT;
-	my_type_size = NETCDF_INT_FLOAT_SIZE;
-	break;
+        my_mpi_type = MPI_INT;
+        my_type_size = NETCDF_INT_FLOAT_SIZE;
+        break;
     case PIO_FLOAT:
-	my_mpi_type = MPI_FLOAT;
-	my_type_size = NETCDF_INT_FLOAT_SIZE;
-	break;
+        my_mpi_type = MPI_FLOAT;
+        my_type_size = NETCDF_INT_FLOAT_SIZE;
+        break;
     case PIO_DOUBLE:
-	my_mpi_type = MPI_DOUBLE;
-	my_type_size = NETCDF_DOUBLE_INT64_SIZE;
-	break;
+        my_mpi_type = MPI_DOUBLE;
+        my_type_size = NETCDF_DOUBLE_INT64_SIZE;
+        break;
 #ifdef _NETCDF4
     case PIO_UBYTE:
-	my_mpi_type = MPI_UNSIGNED_CHAR;
-	my_type_size = NETCDF_CHAR_SIZE;
-	break;
+        my_mpi_type = MPI_UNSIGNED_CHAR;
+        my_type_size = NETCDF_CHAR_SIZE;
+        break;
     case PIO_USHORT:
-	my_mpi_type = MPI_UNSIGNED_SHORT;
-	my_type_size = NETCDF_SHORT_SIZE;
-	break;
+        my_mpi_type = MPI_UNSIGNED_SHORT;
+        my_type_size = NETCDF_SHORT_SIZE;
+        break;
     case PIO_UINT:
-	my_mpi_type = MPI_UNSIGNED;
-	my_type_size = NETCDF_INT_FLOAT_SIZE;
-	break;
+        my_mpi_type = MPI_UNSIGNED;
+        my_type_size = NETCDF_INT_FLOAT_SIZE;
+        break;
     case PIO_INT64:
-	my_mpi_type = MPI_LONG_LONG;
-	my_type_size = NETCDF_DOUBLE_INT64_SIZE;
-	break;
+        my_mpi_type = MPI_LONG_LONG;
+        my_type_size = NETCDF_DOUBLE_INT64_SIZE;
+        break;
     case PIO_UINT64:
-	my_mpi_type = MPI_UNSIGNED_LONG_LONG;
-	my_type_size = NETCDF_DOUBLE_INT64_SIZE;
-	break;
+        my_mpi_type = MPI_UNSIGNED_LONG_LONG;
+        my_type_size = NETCDF_DOUBLE_INT64_SIZE;
+        break;
     case PIO_STRING:
-	my_mpi_type = MPI_CHAR;
-	my_type_size = NETCDF_CHAR_SIZE;
-	break;
+        my_mpi_type = MPI_CHAR;
+        my_type_size = NETCDF_CHAR_SIZE;
+        break;
 #endif /* _NETCDF4 */
     default:
-	return PIO_EBADTYPE;
+        return PIO_EBADTYPE;
     }
 
     /* If caller wants MPI type, set it. */
     if (mpi_type)
-	*mpi_type = my_mpi_type;
+        *mpi_type = my_mpi_type;
 
     /* If caller wants type size, set it. */
     if (type_size)
-	*type_size = my_type_size;
+        *type_size = my_type_size;
 
     return PIO_NOERR;
 }
@@ -902,7 +902,7 @@ find_mpi_type(int pio_type, MPI_Datatype *mpi_type, int *type_size)
  */
 int
 malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
-	      io_desc_t **iodesc)
+              io_desc_t **iodesc)
 {
     MPI_Datatype mpi_type;
     PIO_Offset type_size;
@@ -911,21 +911,21 @@ malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
 
     /* Check input. */
     pioassert(ios && piotype > 0 && ndims >= 0 && iodesc,
-	      "invalid input", __FILE__, __LINE__);
+              "invalid input", __FILE__, __LINE__);
 
     PLOG((1, "malloc_iodesc piotype = %d ndims = %d", piotype, ndims));
 
     /* Get the MPI type corresponding with the PIO type. */
     if ((ret = find_mpi_type(piotype, &mpi_type, NULL)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* What is the size of the pio type? */
     if ((ret = pioc_pnetcdf_inq_type(0, piotype, NULL, &type_size)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Allocate space for the io_desc_t struct. */
     if (!(*iodesc = calloc(1, sizeof(io_desc_t))))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Remember the pio type and its size. */
     (*iodesc)->piotype = piotype;
@@ -936,10 +936,10 @@ malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
 
     /* Get the size of the type. */
     if (mpi_type == MPI_DATATYPE_NULL)
-	(*iodesc)->mpitype_size = 0;
+        (*iodesc)->mpitype_size = 0;
     else
-	if ((mpierr = MPI_Type_size((*iodesc)->mpitype, &(*iodesc)->mpitype_size)))
-	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Type_size((*iodesc)->mpitype, &(*iodesc)->mpitype_size)))
+            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Initialize some values in the struct. */
     (*iodesc)->maxregions = 1;
@@ -949,7 +949,7 @@ malloc_iodesc(iosystem_desc_t *ios, int piotype, int ndims,
 
     /* Allocate space for, and initialize, the first region. */
     if ((ret = alloc_region2(ios, ndims, &((*iodesc)->firstregion))))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Set the swap memory settings to defaults for this IO system. */
     (*iodesc)->rearr_opts = ios->rearr_opts;
@@ -971,13 +971,13 @@ free_region_list(io_region *top)
     ptr = top;
     while (ptr)
     {
-	if (ptr->start)
-	    free(ptr->start);
-	if (ptr->count)
-	    free(ptr->count);
-	tptr = ptr;
-	ptr = ptr->next;
-	free(tptr);
+        if (ptr->start)
+            free(ptr->start);
+        if (ptr->count)
+            free(ptr->count);
+        tptr = ptr;
+        ptr = ptr->next;
+        free(tptr);
     }
 }
 
@@ -1000,35 +1000,35 @@ PIOc_freedecomp(int iosysid, int ioid)
     PLOG((1, "PIOc_freedecomp iosysid = %d ioid = %d", iosysid, ioid));
 
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
-	return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = PIO_MSG_FREEDECOMP; /* Message for async notification. */
+        if (!ios->ioproc)
+        {
+            int msg = PIO_MSG_FREEDECOMP; /* Message for async notification. */
 
-	    if (ios->compmaster == MPI_ROOT)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+            if (ios->compmaster == MPI_ROOT)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ioid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    PLOG((2, "PIOc_freedecomp iosysid = %d ioid = %d", iosysid, ioid));
-	}
+            if (!mpierr)
+                mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ioid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            PLOG((2, "PIOc_freedecomp iosysid = %d ioid = %d", iosysid, ioid));
+        }
 
-	/* Handle MPI errors. */
-	PLOG((3, "handling mpierr %d ios->comproot %d", mpierr, ios->comproot));
-	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    return check_mpi(NULL, NULL, mpierr2, __FILE__, __LINE__);
-	PLOG((3, "handling mpierr2 %d", mpierr2));
-	if (mpierr)
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        /* Handle MPI errors. */
+        PLOG((3, "handling mpierr %d ios->comproot %d", mpierr, ios->comproot));
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(NULL, NULL, mpierr2, __FILE__, __LINE__);
+        PLOG((3, "handling mpierr2 %d", mpierr2));
+        if (mpierr)
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     }
 
     PLOG((3, "freeing map, dimlen"));
@@ -1039,56 +1039,56 @@ PIOc_freedecomp(int iosysid, int ioid)
     free(iodesc->dimlen);
 
     if (iodesc->remap)
-	free(iodesc->remap);
+        free(iodesc->remap);
 
     PLOG((3, "freeing rfrom, rtype"));
     if (iodesc->rfrom)
-	free(iodesc->rfrom);
+        free(iodesc->rfrom);
 
     if (iodesc->rtype)
     {
-	for (int i = 0; i < iodesc->nrecvs; i++)
-	    if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
-		if ((mpierr = MPI_Type_free(&iodesc->rtype[i])))
-		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        for (int i = 0; i < iodesc->nrecvs; i++)
+            if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
+                if ((mpierr = MPI_Type_free(&iodesc->rtype[i])))
+                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-	free(iodesc->rtype);
+        free(iodesc->rtype);
     }
 
     PLOG((3, "freeing stype, scount"));
     if (iodesc->stype)
     {
-	for (int i = 0; i < iodesc->num_stypes; i++)
-	    if (iodesc->stype[i] != PIO_DATATYPE_NULL)
-		if ((mpierr = MPI_Type_free(iodesc->stype + i)))
-		    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        for (int i = 0; i < iodesc->num_stypes; i++)
+            if (iodesc->stype[i] != PIO_DATATYPE_NULL)
+                if ((mpierr = MPI_Type_free(iodesc->stype + i)))
+                    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-	iodesc->num_stypes = 0;
-	free(iodesc->stype);
+        iodesc->num_stypes = 0;
+        free(iodesc->stype);
     }
 
     if (iodesc->scount)
-	free(iodesc->scount);
+        free(iodesc->scount);
 
     if (iodesc->rcount)
-	free(iodesc->rcount);
+        free(iodesc->rcount);
 
     if (iodesc->sindex)
-	free(iodesc->sindex);
+        free(iodesc->sindex);
 
     if (iodesc->rindex)
-	free(iodesc->rindex);
+        free(iodesc->rindex);
 
     PLOG((3, "freeing regions"));
     if (iodesc->firstregion)
-	free_region_list(iodesc->firstregion);
+        free_region_list(iodesc->firstregion);
 
     if (iodesc->fillregion)
-	free_region_list(iodesc->fillregion);
+        free_region_list(iodesc->fillregion);
 
     if (iodesc->rearranger == PIO_REARR_SUBSET)
-	if ((mpierr = MPI_Comm_free(&iodesc->subset_comm)))
-	    return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Comm_free(&iodesc->subset_comm)))
+            return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     return pio_delete_iodesc_from_list(ioid);
 }
@@ -1108,7 +1108,7 @@ PIOc_freedecomp(int iosysid, int ioid)
  */
 int
 PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
-	     PIO_Offset **map, MPI_Comm comm)
+             PIO_Offset **map, MPI_Comm comm)
 {
     int npes, myrank;
     int rnpes, rversno;
@@ -1121,95 +1121,95 @@ PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
 
     /* Check inputs. */
     if (!file || !ndims || !gdims || !fmaplen || !map)
-	return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     if ((mpierr = MPI_Comm_size(comm, &npes)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_rank(comm, &myrank)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     if (myrank == 0)
     {
-	FILE *fp = fopen(file, "r");
-	if (!fp)
-	    pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        FILE *fp = fopen(file, "r");
+        if (!fp)
+            pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-	if (fscanf(fp,"version %d npes %d ndims %d\n", &rversno, &rnpes, ndims) != 3)
-	    pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
-	if (rversno != VERSNO)
-	    return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        if (fscanf(fp,"version %d npes %d ndims %d\n", &rversno, &rnpes, ndims) != 3)
+            pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        if (rversno != VERSNO)
+            return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-	if (rnpes < 1 || rnpes > npes)
-	    return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        if (rnpes < 1 || rnpes > npes)
+            return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-	if ((mpierr = MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(ndims, 1, MPI_INT, 0, comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	if (!(tdims = calloc(*ndims, sizeof(int))))
-	    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	for (int i = 0; i < *ndims; i++)
-	    if (fscanf(fp,"%d ", tdims + i) != 1)
-		pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(ndims, 1, MPI_INT, 0, comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if (!(tdims = calloc(*ndims, sizeof(int))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        for (int i = 0; i < *ndims; i++)
+            if (fscanf(fp,"%d ", tdims + i) != 1)
+                pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-	if ((mpierr = MPI_Bcast(tdims, *ndims, MPI_INT, 0, comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(tdims, *ndims, MPI_INT, 0, comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-	for (int i = 0; i < rnpes; i++)
-	{
-	    if (fscanf(fp, "%d %lld", &j, &maplen) != 2)
-		pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
-	    if (j != i)  // Not sure how this could be possible
-		return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
-	    if (!(tmap = malloc(maplen * sizeof(PIO_Offset))))
-		return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	    for (j = 0; j < maplen; j++)
-		if (fscanf(fp, "%lld ", tmap + j) != 1)
-		    pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        for (int i = 0; i < rnpes; i++)
+        {
+            if (fscanf(fp, "%d %lld", &j, &maplen) != 2)
+                pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+            if (j != i)  // Not sure how this could be possible
+                return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+            if (!(tmap = malloc(maplen * sizeof(PIO_Offset))))
+                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+            for (j = 0; j < maplen; j++)
+                if (fscanf(fp, "%lld ", tmap + j) != 1)
+                    pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
-	    if (i > 0)
-	    {
-		if ((mpierr = MPI_Send(&maplen, 1, PIO_OFFSET, i, i + npes, comm)))
-		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-		if ((mpierr = MPI_Send(tmap, maplen, PIO_OFFSET, i, i, comm)))
-		    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-		free(tmap);
-	    }
-	    else
-	    {
-		*map = tmap;
-		*fmaplen = maplen;
-	    }
-	}
-	fclose(fp);
+            if (i > 0)
+            {
+                if ((mpierr = MPI_Send(&maplen, 1, PIO_OFFSET, i, i + npes, comm)))
+                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                if ((mpierr = MPI_Send(tmap, maplen, PIO_OFFSET, i, i, comm)))
+                    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                free(tmap);
+            }
+            else
+            {
+                *map = tmap;
+                *fmaplen = maplen;
+            }
+        }
+        fclose(fp);
     }
     else
     {
-	if ((mpierr = MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(ndims, 1, MPI_INT, 0, comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	if (!(tdims = calloc(*ndims, sizeof(int))))
-	    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(tdims, *ndims, MPI_INT, 0, comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(&rnpes, 1, MPI_INT, 0, comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(ndims, 1, MPI_INT, 0, comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        if (!(tdims = calloc(*ndims, sizeof(int))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(tdims, *ndims, MPI_INT, 0, comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
-	if (myrank < rnpes)
-	{
-	    if ((mpierr = MPI_Recv(&maplen, 1, PIO_OFFSET, 0, myrank + npes, comm, &status)))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	    if (!(tmap = malloc(maplen * sizeof(PIO_Offset))))
-		return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	    if ((mpierr = MPI_Recv(tmap, maplen, PIO_OFFSET, 0, myrank, comm, &status)))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	    *map = tmap;
-	}
-	else
-	{
-	    tmap = NULL;
-	    maplen = 0;
-	}
-	*fmaplen = maplen;
+        if (myrank < rnpes)
+        {
+            if ((mpierr = MPI_Recv(&maplen, 1, PIO_OFFSET, 0, myrank + npes, comm, &status)))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            if (!(tmap = malloc(maplen * sizeof(PIO_Offset))))
+                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+            if ((mpierr = MPI_Recv(tmap, maplen, PIO_OFFSET, 0, myrank, comm, &status)))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            *map = tmap;
+        }
+        else
+        {
+            tmap = NULL;
+            maplen = 0;
+        }
+        *fmaplen = maplen;
     }
     *gdims = tdims;
     return PIO_NOERR;
@@ -1229,7 +1229,7 @@ PIOc_readmap(const char *file, int *ndims, int **gdims, PIO_Offset *fmaplen,
  */
 int
 PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset *maplen,
-		      PIO_Offset **map, int f90_comm)
+                      PIO_Offset **map, int f90_comm)
 {
     return PIOc_readmap(file, ndims, gdims, maplen, map, MPI_Comm_f2c(f90_comm));
 }
@@ -1253,7 +1253,7 @@ PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset *map
  */
 int
 PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
-		     char *title, char *history, int fortran_order)
+                     char *title, char *history, int fortran_order)
 {
     iosystem_desc_t *ios; /* IO system info. */
     io_desc_t *iodesc;    /* Decomposition info. */
@@ -1265,24 +1265,24 @@ PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
 
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Check inputs. */
     if (!filename)
-	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
     if (title)
-	if (strlen(title) > PIO_MAX_NAME)
-	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        if (strlen(title) > PIO_MAX_NAME)
+            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
     if (history)
-	if (strlen(history) > PIO_MAX_NAME)
-	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        if (strlen(history) > PIO_MAX_NAME)
+            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((1, "PIOc_write_nc_decomp filename = %s iosysid = %d ioid = %d "
-	  "ios->num_comptasks = %d", filename, iosysid, ioid, ios->num_comptasks));
+          "ios->num_comptasks = %d", filename, iosysid, ioid, ios->num_comptasks));
 
     /* Get the IO desc, which describes the decomposition. */
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
-	return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Allocate memory for array which will contain the length of the
      * map on each task, for all computation tasks. */
@@ -1292,46 +1292,46 @@ PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
     /* Gather maplens from all computation tasks and fill the
      * task_maplen array on all tasks. */
     if ((mpierr = MPI_Allgather(&iodesc->maplen, 1, MPI_INT, task_maplen, 1, MPI_INT,
-				ios->comp_comm)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                                ios->comp_comm)))
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     /* Find the max maplen. */
     if ((mpierr = MPI_Allreduce(&iodesc->maplen, &max_maplen, 1, MPI_INT, MPI_MAX,
-				ios->comp_comm)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                                ios->comp_comm)))
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     PLOG((3, "max_maplen = %d", max_maplen));
 
     if (!(full_map = malloc(sizeof(int) * ios->num_comptasks * max_maplen)))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     if (!(my_map = malloc(sizeof(int) * max_maplen)))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Fill local array with my map. Use the fill value for unused */
     /* elements at the end if max_maplen is longer than maplen. Also
      * subtract 1 because the iodesc->map is 1-based. */
     for (int e = 0; e < max_maplen; e++)
     {
-	my_map[e] = e < iodesc->maplen ? iodesc->map[e] - 1 : NC_FILL_INT;
-	PLOG((3, "my_map[%d] = %d", e, my_map[e]));
+        my_map[e] = e < iodesc->maplen ? iodesc->map[e] - 1 : NC_FILL_INT;
+        PLOG((3, "my_map[%d] = %d", e, my_map[e]));
     }
 
     /* Gather my_map from all computation tasks and fill the full_map array. */
     if ((mpierr = MPI_Allgather(my_map, max_maplen, MPI_INT, full_map, max_maplen,
-				MPI_INT, ios->comp_comm)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                                MPI_INT, ios->comp_comm)))
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
     free(my_map);
 
     for (int p = 0; p < ios->num_comptasks; p++)
-	for (int e = 0; e < max_maplen; e++)
-	    PLOG((3, "full_map[%d][%d] = %d", p, e, full_map[p * max_maplen + e]));
+        for (int e = 0; e < max_maplen; e++)
+            PLOG((3, "full_map[%d][%d] = %d", p, e, full_map[p * max_maplen + e]));
 
     /* Write the netCDF decomp file. */
     if ((ret = pioc_write_nc_decomp_int(ios, filename, cmode, iodesc->ndims, iodesc->dimlen,
-					ios->num_comptasks, task_maplen, full_map, title,
-					history, fortran_order)))
-	return ret;
+                                        ios->num_comptasks, task_maplen, full_map, title,
+                                        history, fortran_order)))
+        return ret;
 
     free(full_map);
     return PIO_NOERR;
@@ -1360,7 +1360,7 @@ PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
  */
 int
 PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm comm,
-		    int pio_type, char *title, char *history, int *fortran_order)
+                    int pio_type, char *title, char *history, int *fortran_order)
 {
     iosystem_desc_t *ios; /* Pointer to the IO system info. */
     int ndims;            /* The number of data dims (except unlim). */
@@ -1378,53 +1378,53 @@ PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm comm
 
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Check inputs. */
     if (!filename || !ioidp)
-	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((1, "PIOc_read_nc_decomp filename = %s iosysid = %d pio_type = %d",
-	  filename, iosysid, pio_type));
+          filename, iosysid, pio_type));
 
     /* Get the communicator size and task rank. */
     if ((mpierr = MPI_Comm_size(comm, &size)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_rank(comm, &my_rank)))
-	return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     PLOG((2, "size = %d my_rank = %d", size, my_rank));
 
     /* Read the file. This allocates three arrays that we have to
      * free. */
     if ((ret = pioc_read_nc_decomp_int(iosysid, filename, &ndims, &global_dimlen, &num_tasks_decomp,
-				       &task_maplen, &max_maplen, &full_map, title, history,
-				       source_in, version_in, fortran_order)))
-	return ret;
+                                       &task_maplen, &max_maplen, &full_map, title, history,
+                                       source_in, version_in, fortran_order)))
+        return ret;
     PLOG((2, "ndims = %d num_tasks_decomp = %d max_maplen = %d", ndims, num_tasks_decomp,
-	  max_maplen));
+          max_maplen));
 
     /* If the size does not match the number of tasks in the decomp,
      * that's an error. */
     if (size != num_tasks_decomp)
-	ret = PIO_EINVAL;
+        ret = PIO_EINVAL;
 
     /* Now initialize the iodesc on each task for this decomposition. */
     if (!ret)
     {
-	PIO_Offset *compmap;
+        PIO_Offset *compmap;
 
-	if (!(compmap = malloc(sizeof(PIO_Offset) * task_maplen[my_rank])))
-	    return PIO_ENOMEM;
+        if (!(compmap = malloc(sizeof(PIO_Offset) * task_maplen[my_rank])))
+            return PIO_ENOMEM;
 
-	/* Copy array into PIO_Offset array. Make it 1 based. */
-	for (int e = 0; e < task_maplen[my_rank]; e++)
-	    compmap[e] = full_map[my_rank * max_maplen + e] + 1;
+        /* Copy array into PIO_Offset array. Make it 1 based. */
+        for (int e = 0; e < task_maplen[my_rank]; e++)
+            compmap[e] = full_map[my_rank * max_maplen + e] + 1;
 
-	/* Initialize the decomposition. */
-	ret = PIOc_InitDecomp(iosysid, pio_type, ndims, global_dimlen, task_maplen[my_rank],
-			      compmap, ioidp, NULL, NULL, NULL);
+        /* Initialize the decomposition. */
+        ret = PIOc_InitDecomp(iosysid, pio_type, ndims, global_dimlen, task_maplen[my_rank],
+                              compmap, ioidp, NULL, NULL, NULL);
 
-	free(compmap);
+        free(compmap);
     }
 
     /* Free resources. */
@@ -1463,8 +1463,8 @@ PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm comm
  */
 int
 pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, int ndims,
-			 int *global_dimlen, int num_tasks, int *task_maplen, int *map,
-			 const char *title, const char *history, int fortran_order)
+                         int *global_dimlen, int num_tasks, int *task_maplen, int *map,
+                         const char *title, const char *history, int fortran_order)
 {
     int max_maplen = 0;
     int ncid;
@@ -1472,60 +1472,60 @@ pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, 
 
     /* Check inputs. */
     pioassert(ios && filename && global_dimlen && task_maplen &&
-	      (!title || strlen(title) <= PIO_MAX_NAME) &&
-	      (!history || strlen(history) <= PIO_MAX_NAME), "invalid input",
-	      __FILE__, __LINE__);
+              (!title || strlen(title) <= PIO_MAX_NAME) &&
+              (!history || strlen(history) <= PIO_MAX_NAME), "invalid input",
+              __FILE__, __LINE__);
 
     PLOG((2, "pioc_write_nc_decomp_int filename = %s ndims = %d num_tasks = %d", filename,
-	  ndims, num_tasks));
+          ndims, num_tasks));
 
     /* Find the maximum maplen. */
     for (int t = 0; t < num_tasks; t++)
-	if (task_maplen[t] > max_maplen)
-	    max_maplen = task_maplen[t];
+        if (task_maplen[t] > max_maplen)
+            max_maplen = task_maplen[t];
     PLOG((3, "max_maplen = %d", max_maplen));
 
     /* Create the netCDF decomp file. */
     if ((ret = PIOc_create(ios->iosysid, filename, cmode | NC_WRITE, &ncid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with the version of this file. */
     char version[PIO_MAX_NAME + 1];
     sprintf(version, "%d.%d.%d", PIO_VERSION_MAJOR, PIO_VERSION_MINOR, PIO_VERSION_PATCH);
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_VERSION_ATT_NAME,
-				 strlen(version) + 1, version)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                                 strlen(version) + 1, version)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with the max map len. */
     if ((ret = PIOc_put_att_int(ncid, NC_GLOBAL, DECOMP_MAX_MAPLEN_ATT_NAME,
-				PIO_INT, 1, &max_maplen)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                                PIO_INT, 1, &max_maplen)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write title attribute, if the user provided one. */
     if (title)
-	if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_TITLE_ATT_NAME,
-				     strlen(title) + 1, title)))
-	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_TITLE_ATT_NAME,
+                                     strlen(title) + 1, title)))
+            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write history attribute, if the user provided one. */
     if (history)
-	if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_HISTORY_ATT_NAME,
-				     strlen(history) + 1, history)))
-	    return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_HISTORY_ATT_NAME,
+                                     strlen(history) + 1, history)))
+            return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write a source attribute. */
     char source[] = "Decomposition file produced by PIO library.";
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_SOURCE_ATT_NAME,
-				 strlen(source) + 1, source)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                                 strlen(source) + 1, source)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with array ordering (C or Fortran). */
     char c_order_str[] = DECOMP_C_ORDER_STR;
     char fortran_order_str[] = DECOMP_FORTRAN_ORDER_STR;
     char *my_order_str = fortran_order ? fortran_order_str : c_order_str;
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_ORDER_ATT_NAME,
-				 strlen(my_order_str) + 1, my_order_str)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                                 strlen(my_order_str) + 1, my_order_str)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Write an attribute with the stack trace. This can be helpful
      * for debugging. */
@@ -1538,85 +1538,85 @@ pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, 
     /* Find the max size. */
     int max_bt_size = 0;
     for (int b = 0; b < bt_size; b++)
-	if (strlen(bt_strings[b]) > max_bt_size)
-	    max_bt_size = strlen(bt_strings[b]);
+        if (strlen(bt_strings[b]) > max_bt_size)
+            max_bt_size = strlen(bt_strings[b]);
     if (max_bt_size > PIO_MAX_NAME)
-	max_bt_size = PIO_MAX_NAME;
+        max_bt_size = PIO_MAX_NAME;
 
     /* Copy the backtrace into one long string. */
     char full_bt[max_bt_size * bt_size + bt_size + 1];
     full_bt[0] = '\0';
     for (int b = 0; b < bt_size; b++)
     {
-	strncat(full_bt, bt_strings[b], max_bt_size);
-	strcat(full_bt, "\n");
+        strncat(full_bt, bt_strings[b], max_bt_size);
+        strcat(full_bt, "\n");
     }
     free(bt_strings);
 
     /* Write the stack trace as an attribute. */
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_BACKTRACE_ATT_NAME,
-				 strlen(full_bt) + 1, full_bt)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+                                 strlen(full_bt) + 1, full_bt)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* We need a dimension for the dimensions in the data. (Example:
      * for 4D data we will need to store 4 dimension IDs.) */
     int dim_dimid;
     if ((ret = PIOc_def_dim(ncid, DECOMP_DIM_DIM, ndims, &dim_dimid)))
-	return ret;
+        return ret;
 
     /* We need a dimension for tasks. If we have 4 tasks, we need to
      * store an array of length 4 with the size of the local array on
      * each task. */
     int task_dimid;
     if ((ret = PIOc_def_dim(ncid, DECOMP_TASK_DIM_NAME, num_tasks, &task_dimid)))
-	return ret;
+        return ret;
 
     /* We need a dimension for the map. It's length may vary, we will
      * use the max_maplen for the dimension size. */
     int mapelem_dimid;
     if ((ret = PIOc_def_dim(ncid, DECOMP_MAPELEM_DIM_NAME, max_maplen,
-			    &mapelem_dimid)))
-	return ret;
+                            &mapelem_dimid)))
+        return ret;
 
     /* Define a var to hold the global size of the array for each
      * dimension. */
     int gsize_varid;
     if ((ret = PIOc_def_var(ncid, DECOMP_GLOBAL_SIZE_VAR_NAME, NC_INT, 1,
-			    &dim_dimid, &gsize_varid)))
-	return ret;
+                            &dim_dimid, &gsize_varid)))
+        return ret;
 
     /* Define a var to hold the length of the local array on each task. */
     int maplen_varid;
     if ((ret = PIOc_def_var(ncid, DECOMP_MAPLEN_VAR_NAME, NC_INT, 1, &task_dimid,
-			    &maplen_varid)))
-	return ret;
+                            &maplen_varid)))
+        return ret;
 
     /* Define a 2D var to hold the length of the local array on each task. */
     int map_varid;
     int map_dimids[2] = {task_dimid, mapelem_dimid};
     if ((ret = PIOc_def_var(ncid, DECOMP_MAP_VAR_NAME, NC_INT, 2, map_dimids,
-			    &map_varid)))
-	return ret;
+                            &map_varid)))
+        return ret;
 
     /* End define mode, to write data. */
     if ((ret = PIOc_enddef(ncid)))
-	return ret;
+        return ret;
 
     /* Write the global dimension sizes. */
     if ((PIOc_put_var_int(ncid, gsize_varid, global_dimlen)))
-	return ret;
+        return ret;
 
     /* Write the size of the local array on each task. */
     if ((PIOc_put_var_int(ncid, maplen_varid, task_maplen)))
-	return ret;
+        return ret;
 
     /* Write the map. */
     if ((PIOc_put_var_int(ncid, map_varid, map)))
-	return ret;
+        return ret;
 
     /* Close the netCDF decomp file. */
     if ((ret = PIOc_closefile(ncid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -1662,8 +1662,8 @@ pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, 
  */
 int
 pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **global_dimlen,
-			int *num_tasks, int **task_maplen, int *max_maplen, int **map, char *title,
-			char *history, char *source, char *version, int *fortran_order)
+                        int *num_tasks, int **task_maplen, int *max_maplen, int **map, char *title,
+                        char *history, char *source, char *version, int *fortran_order)
 {
     iosystem_desc_t *ios;
     int ncid;
@@ -1672,49 +1672,49 @@ pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **glo
 
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Check inputs. */
     if (!filename)
-	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((1, "pioc_read_nc_decomp_int iosysid = %d filename = %s", iosysid, filename));
     
     
     /* Open the netCDF decomp file. */
     if ((ret = PIOc_open(iosysid, filename, NC_WRITE, &ncid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Read version attribute. */
     char version_in[PIO_MAX_NAME + 1];
     if ((ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_VERSION_ATT_NAME, version_in)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "version_in = %s", version_in));
     if (version)
-	strncpy(version, version_in, PIO_MAX_NAME + 1);
+        strncpy(version, version_in, PIO_MAX_NAME + 1);
 
     /* Read order attribute. */
     char order_in[PIO_MAX_NAME + 1];
     if ((ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_ORDER_ATT_NAME, order_in)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "order_in = %s", order_in));
     if (fortran_order)
     {
-	if (!strncmp(order_in, DECOMP_C_ORDER_STR, PIO_MAX_NAME + 1))
-	    *fortran_order = 0;
-	else if (!strncmp(order_in, DECOMP_FORTRAN_ORDER_STR, PIO_MAX_NAME + 1))
-	    *fortran_order = 1;
-	else
-	    return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        if (!strncmp(order_in, DECOMP_C_ORDER_STR, PIO_MAX_NAME + 1))
+            *fortran_order = 0;
+        else if (!strncmp(order_in, DECOMP_FORTRAN_ORDER_STR, PIO_MAX_NAME + 1))
+            *fortran_order = 1;
+        else
+            return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
     }
 
     /* Read attribute with the max map len. */
     int max_maplen_in;
     if ((ret = PIOc_get_att_int(ncid, NC_GLOBAL, DECOMP_MAX_MAPLEN_ATT_NAME, &max_maplen_in)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((3, "max_maplen_in = %d", max_maplen_in));
     if (max_maplen)
-	*max_maplen = max_maplen_in;
+        *max_maplen = max_maplen_in;
 
     /* Read title attribute, if it is in the file. */
     peh = PIOc_Set_File_Error_Handling(ncid, PIO_BCAST_ERROR);
@@ -1722,36 +1722,36 @@ pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **glo
     ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_TITLE_ATT_NAME, title_in);
     if (ret == PIO_NOERR)
     {
-	/* If the caller wants it, copy the title for them. */
-	if (title)
-	    strncpy(title, title_in, PIO_MAX_NAME + 1);
+        /* If the caller wants it, copy the title for them. */
+        if (title)
+            strncpy(title, title_in, PIO_MAX_NAME + 1);
     }
     else if (ret == PIO_ENOTATT)
     {
-	/* No title attribute. */
-	if (title)
-	    title[0] = '\0';
+        /* No title attribute. */
+        if (title)
+            title[0] = '\0';
     }
     else
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Read history attribute, if it is in the file. */
     char history_in[PIO_MAX_NAME + 1];
     ret = PIOc_get_att_text(ncid, NC_GLOBAL, DECOMP_HISTORY_ATT_NAME, history_in);
     if (ret == PIO_NOERR)
     {
-	/* If the caller wants it, copy the history for them. */
-	if (history)
-	    strncpy(history, history_in, PIO_MAX_NAME + 1);
+        /* If the caller wants it, copy the history for them. */
+        if (history)
+            strncpy(history, history_in, PIO_MAX_NAME + 1);
     }
     else if (ret == PIO_ENOTATT)
     {
-	/* No history attribute. */
-	if (history)
-	    history[0] = '\0';
+        /* No history attribute. */
+        if (history)
+            history[0] = '\0';
     }
     else
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Read source attribute. */
     char source_in[PIO_MAX_NAME + 1];
@@ -1767,7 +1767,7 @@ pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **glo
             source[0] = '\0';
     }
     else
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     PIOc_Set_File_Error_Handling(ncid, peh);
     /* Read dimension for the dimensions in the data. (Example: for 4D
@@ -1775,25 +1775,25 @@ pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **glo
     int dim_dimid;
     PIO_Offset ndims_in;
     if ((ret = PIOc_inq_dimid(ncid, DECOMP_DIM_DIM, &dim_dimid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_inq_dim(ncid, dim_dimid, NULL, &ndims_in)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (ndims)
-	*ndims = ndims_in;
+        *ndims = ndims_in;
 
     /* Read the global sizes of the array. */
     int gsize_varid;
     int global_dimlen_in[ndims_in];
     if ((ret = PIOc_inq_varid(ncid, DECOMP_GLOBAL_SIZE_VAR_NAME, &gsize_varid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_get_var_int(ncid, gsize_varid, global_dimlen_in)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (global_dimlen)
     {
-	if (!(*global_dimlen = malloc(ndims_in * sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	for (int d = 0; d < ndims_in; d++)
-	    (*global_dimlen)[d] = global_dimlen_in[d];
+        if (!(*global_dimlen = malloc(ndims_in * sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        for (int d = 0; d < ndims_in; d++)
+            (*global_dimlen)[d] = global_dimlen_in[d];
     }
 
     /* Read dimension for tasks. If we have 4 tasks, we need to store
@@ -1802,25 +1802,25 @@ pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **glo
     int task_dimid;
     PIO_Offset num_tasks_in;
     if ((ret = PIOc_inq_dimid(ncid, DECOMP_TASK_DIM_NAME, &task_dimid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_inq_dim(ncid, task_dimid, NULL, &num_tasks_in)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (num_tasks)
-	*num_tasks = num_tasks_in;
+        *num_tasks = num_tasks_in;
 
     /* Read the length if the local array on each task. */
     int maplen_varid;
     int task_maplen_in[num_tasks_in];
     if ((ret = PIOc_inq_varid(ncid, DECOMP_MAPLEN_VAR_NAME, &maplen_varid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_get_var_int(ncid, maplen_varid, task_maplen_in)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (task_maplen)
     {
-	if (!(*task_maplen = malloc(num_tasks_in * sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	for (int t = 0; t < num_tasks_in; t++)
-	    (*task_maplen)[t] = task_maplen_in[t];
+        if (!(*task_maplen = malloc(num_tasks_in * sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        for (int t = 0; t < num_tasks_in; t++)
+            (*task_maplen)[t] = task_maplen_in[t];
     }
 
     /* Read the map. */
@@ -1828,26 +1828,26 @@ pioc_read_nc_decomp_int(int iosysid, const char *filename, int *ndims, int **glo
     int *map_in;
 
     if (!(map_in = malloc(sizeof(int) * num_tasks_in * max_maplen_in)))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     if ((ret = PIOc_inq_varid(ncid, DECOMP_MAP_VAR_NAME, &map_varid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if ((ret = PIOc_get_var_int(ncid, map_varid, map_in)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     if (map)
     {
-	if (!(*map = malloc(num_tasks_in * max_maplen_in * sizeof(int))))
-	    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	for (int t = 0; t < num_tasks_in; t++)
-	    for (int l = 0; l < max_maplen_in; l++)
-		(*map)[t * max_maplen_in + l] = map_in[t * max_maplen_in + l];
+        if (!(*map = malloc(num_tasks_in * max_maplen_in * sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        for (int t = 0; t < num_tasks_in; t++)
+            for (int l = 0; l < max_maplen_in; l++)
+                (*map)[t * max_maplen_in + l] = map_in[t * max_maplen_in + l];
     }
     free(map_in);
 
     /* Close the netCDF decomp file. */
     PLOG((2, "pioc_read_nc_decomp_int about to close file ncid = %d", ncid));
     if ((ret = PIOc_closefile(ncid)))
-	return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
     PLOG((2, "pioc_read_nc_decomp_int closed file"));
 
     return PIO_NOERR;
@@ -1872,13 +1872,13 @@ PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm)
     PLOG((1, "PIOc_write_decomp file = %s iosysid = %d ioid = %d", file, iosysid, ioid));
 
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
-	return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     return PIOc_writemap(file, iodesc->ndims, iodesc->dimlen, iodesc->maplen, iodesc->map,
-			 comm);
+                         comm);
 }
 
 /**
@@ -1895,7 +1895,7 @@ PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm)
  */
 int
 PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
-	      PIO_Offset *map, MPI_Comm comm)
+              PIO_Offset *map, MPI_Comm comm)
 {
     int npes, myrank;
     PIO_Offset *nmaplen = NULL;
@@ -1907,76 +1907,76 @@ PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
     PLOG((1, "PIOc_writemap file = %s ndims = %d maplen = %d", file, ndims, maplen));
 
     if ((mpierr = MPI_Comm_size(comm, &npes)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Comm_rank(comm, &myrank)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     PLOG((2, "npes = %d myrank = %d", npes, myrank));
 
     /* Allocate memory for the nmaplen. */
     if (myrank == 0)
-	if (!(nmaplen = malloc(npes * sizeof(PIO_Offset))))
-	    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(nmaplen = malloc(npes * sizeof(PIO_Offset))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     if ((mpierr = MPI_Gather(&maplen, 1, PIO_OFFSET, nmaplen, 1, PIO_OFFSET, 0, comm)))
-	return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
 
     /* Only rank 0 writes the file. */
     if (myrank == 0)
     {
-	FILE *fp;
+        FILE *fp;
 
-	/* Open the file to write. */
-	if (!(fp = fopen(file, "w")))
-	    return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
+        /* Open the file to write. */
+        if (!(fp = fopen(file, "w")))
+            return pio_err(NULL, NULL, PIO_EIO, __FILE__, __LINE__);
 
-	/* Write the version and dimension info. */
-	fprintf(fp,"version %d npes %d ndims %d \n", VERSNO, npes, ndims);
-	for (i = 0; i < ndims; i++)
-	    fprintf(fp, "%d ", gdims[i]);
-	fprintf(fp, "\n");
+        /* Write the version and dimension info. */
+        fprintf(fp,"version %d npes %d ndims %d \n", VERSNO, npes, ndims);
+        for (i = 0; i < ndims; i++)
+            fprintf(fp, "%d ", gdims[i]);
+        fprintf(fp, "\n");
 
-	/* Write the map. */
-	fprintf(fp, "0 %lld\n", nmaplen[0]);
-	for (i = 0; i < nmaplen[0]; i++)
-	    fprintf(fp, "%lld ", map[i]);
-	fprintf(fp,"\n");
+        /* Write the map. */
+        fprintf(fp, "0 %lld\n", nmaplen[0]);
+        for (i = 0; i < nmaplen[0]; i++)
+            fprintf(fp, "%lld ", map[i]);
+        fprintf(fp,"\n");
 
-	for (i = 1; i < npes; i++)
-	{
-	    PLOG((2, "creating nmap for i = %d", i));
-	    nmap = (PIO_Offset *)malloc(nmaplen[i] * sizeof(PIO_Offset));
+        for (i = 1; i < npes; i++)
+        {
+            PLOG((2, "creating nmap for i = %d", i));
+            nmap = (PIO_Offset *)malloc(nmaplen[i] * sizeof(PIO_Offset));
 
-	    if ((mpierr = MPI_Send(&i, 1, MPI_INT, i, npes + i, comm)))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	    if ((mpierr = MPI_Recv(nmap, nmaplen[i], PIO_OFFSET, i, i, comm, &status)))
-		return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	    PLOG((2,"MPI_Recv map complete"));
+            if ((mpierr = MPI_Send(&i, 1, MPI_INT, i, npes + i, comm)))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            if ((mpierr = MPI_Recv(nmap, nmaplen[i], PIO_OFFSET, i, i, comm, &status)))
+                return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            PLOG((2,"MPI_Recv map complete"));
 
-	    fprintf(fp, "%d %lld\n", i, nmaplen[i]);
-	    for (int j = 0; j < nmaplen[i]; j++)
-		fprintf(fp, "%lld ", nmap[j]);
-	    fprintf(fp, "\n");
+            fprintf(fp, "%d %lld\n", i, nmaplen[i]);
+            for (int j = 0; j < nmaplen[i]; j++)
+                fprintf(fp, "%lld ", nmap[j]);
+            fprintf(fp, "\n");
 
-	    free(nmap);
-	}
-	/* Free memory for the nmaplen. */
-	free(nmaplen);
-	fprintf(fp, "\n");
-	print_trace(fp);
+            free(nmap);
+        }
+        /* Free memory for the nmaplen. */
+        free(nmaplen);
+        fprintf(fp, "\n");
+        print_trace(fp);
 
-	/* Close the file. */
-	fclose(fp);
-	PLOG((2,"decomp file closed."));
+        /* Close the file. */
+        fclose(fp);
+        PLOG((2,"decomp file closed."));
     }
     else
     {
-	PLOG((2,"ready to MPI_Recv..."));
-	if ((mpierr = MPI_Recv(&i, 1, MPI_INT, 0, npes+myrank, comm, &status)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	PLOG((2,"MPI_Recv got %d", i));
-	if ((mpierr = MPI_Send(map, maplen, PIO_OFFSET, 0, myrank, comm)))
-	    return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-	PLOG((2,"MPI_Send map complete"));
+        PLOG((2,"ready to MPI_Recv..."));
+        if ((mpierr = MPI_Recv(&i, 1, MPI_INT, 0, npes+myrank, comm, &status)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        PLOG((2,"MPI_Recv got %d", i));
+        if ((mpierr = MPI_Send(map, maplen, PIO_OFFSET, 0, myrank, comm)))
+            return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        PLOG((2,"MPI_Send map complete"));
     }
 
     return PIO_NOERR;
@@ -1996,10 +1996,10 @@ PIOc_writemap(const char *file, int ndims, const int *gdims, PIO_Offset maplen,
  */
 int
 PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
-		       PIO_Offset maplen, const PIO_Offset *map, int f90_comm)
+                       PIO_Offset maplen, const PIO_Offset *map, int f90_comm)
 {
     return PIOc_writemap(file, ndims, gdims, maplen, (PIO_Offset *)map,
-			 MPI_Comm_f2c(f90_comm));
+                         MPI_Comm_f2c(f90_comm));
 }
 
 /**
@@ -2030,7 +2030,7 @@ PIOc_writemap_from_f90(const char *file, int ndims, const int *gdims,
  */
 int
 PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
-		    int mode, int use_ext_ncid)
+                    int mode, int use_ext_ncid)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -2043,22 +2043,22 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename || strlen(filename) > PIO_MAX_NAME)
-	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* A valid iotype must be specified. */
     if (!iotype_is_valid(*iotype))
-	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((1, "PIOc_createfile_int iosysid %d iotype %d filename %s mode %d "
-	  "use_ext_ncid %d", iosysid, *iotype, filename, mode, use_ext_ncid));
+          "use_ext_ncid %d", iosysid, *iotype, filename, mode, use_ext_ncid));
 
     /* Allocate space for the file info. */
     if (!(file = calloc(sizeof(file_desc_t), 1)))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Fill in some file values. */
     file->fh = -1;
@@ -2070,8 +2070,8 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
     /* Set to true if this task should participate in IO (only true for
      * one task with netcdf serial files. */
     if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
-	ios->io_rank == 0)
-	file->do_io = 1;
+        ios->io_rank == 0)
+        file->do_io = 1;
 
     PLOG((2, "file->do_io = %d ios->async = %d", file->do_io, ios->async));
 
@@ -2079,99 +2079,99 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
      * parameters. */
     if (ios->async)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = PIO_MSG_CREATE_FILE;
-	    size_t len = strlen(filename);
-	    char ncidp_present = ncidp ? 1 : 0;
+        if (!ios->ioproc)
+        {
+            int msg = PIO_MSG_CREATE_FILE;
+            size_t len = strlen(filename);
+            char ncidp_present = ncidp ? 1 : 0;
 
-	    /* Send the message to the message handler. */
-	    PLOG((3, "msg %d ios->union_comm %d MPI_COMM_NULL %d", msg, ios->union_comm, MPI_COMM_NULL));
-	    if (ios->compmaster == MPI_ROOT)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+            /* Send the message to the message handler. */
+            PLOG((3, "msg %d ios->union_comm %d MPI_COMM_NULL %d", msg, ios->union_comm, MPI_COMM_NULL));
+            if (ios->compmaster == MPI_ROOT)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    /* Send the parameters of the function call. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&use_ext_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncidp_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (ncidp_present)
-		if (!mpierr)
-		    mpierr = MPI_Bcast(ncidp, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            /* Send the parameters of the function call. */
+            if (!mpierr)
+                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&use_ext_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncidp_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (ncidp_present)
+                if (!mpierr)
+                    mpierr = MPI_Bcast(ncidp, 1, MPI_INT, ios->compmaster, ios->intercomm);
 #ifdef NETCDF_INTEGRATION
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&diosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&diosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
 #endif /* NETCDF_INTEGRATION */
-	    PLOG((2, "len %d filename %s iotype %d mode %d use_ext_ncid %d "
-		  "ncidp_present %d", len, filename, file->iotype, mode,
-		  use_ext_ncid, ncidp_present));
-	}
+            PLOG((2, "len %d filename %s iotype %d mode %d use_ext_ncid %d "
+                  "ncidp_present %d", len, filename, file->iotype, mode,
+                  use_ext_ncid, ncidp_present));
+        }
 
-	/* Handle MPI errors. */
-	PLOG((2, "handling mpi errors mpierr = %d", mpierr));
-	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        /* Handle MPI errors. */
+        PLOG((2, "handling mpi errors mpierr = %d", mpierr));
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this task is in the IO component, do the IO. */
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF4
-	case PIO_IOTYPE_NETCDF4P:
-	    mode = mode |  NC_MPIIO | NC_NETCDF4;
-	    PLOG((2, "Calling nc_create_par io_comm = %d mode = %d fh = %d",
-		  ios->io_comm, mode, file->fh));
-	    ierr = nc_create_par(filename, mode, ios->io_comm, ios->info, &file->fh);
-	    PLOG((2, "nc_create_par returned %d file->fh = %d", ierr, file->fh));
-	    break;
-	case PIO_IOTYPE_NETCDF4C:
-	    mode = mode | NC_NETCDF4;
+        case PIO_IOTYPE_NETCDF4P:
+            mode = mode |  NC_MPIIO | NC_NETCDF4;
+            PLOG((2, "Calling nc_create_par io_comm = %d mode = %d fh = %d",
+                  ios->io_comm, mode, file->fh));
+            ierr = nc_create_par(filename, mode, ios->io_comm, ios->info, &file->fh);
+            PLOG((2, "nc_create_par returned %d file->fh = %d", ierr, file->fh));
+            break;
+        case PIO_IOTYPE_NETCDF4C:
+            mode = mode | NC_NETCDF4;
 #endif
-	case PIO_IOTYPE_NETCDF:
-	    if (!ios->io_rank)
-	    {
-		PLOG((2, "Calling nc_create mode = %d", mode));
-		ierr = nc_create(filename, mode, &file->fh);
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if (!ios->io_rank)
+            {
+                PLOG((2, "Calling nc_create mode = %d", mode));
+                ierr = nc_create(filename, mode, &file->fh);
+            }
+            break;
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    PLOG((2, "Calling ncmpi_create mode = %d", mode));
-	    ierr = ncmpi_create(ios->io_comm, filename, mode, ios->info, &file->fh);
-	    if (!ierr)
-		ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
-	    break;
+        case PIO_IOTYPE_PNETCDF:
+            PLOG((2, "Calling ncmpi_create mode = %d", mode));
+            ierr = ncmpi_create(ios->io_comm, filename, mode, ios->info, &file->fh);
+            if (!ierr)
+                ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
+            break;
 #endif
-	}
-	PLOG((3, "create call complete file->fh %d", file->fh));
+        }
+        PLOG((3, "create call complete file->fh %d", file->fh));
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     /* If there was an error, free the memory we allocated and handle error. */
     if (ierr)
     {
-	free(file);
-	return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+        free(file);
+        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
     }
 
     /* Broadcast writablility to all tasks. */
     if ((mpierr = MPI_Bcast(&file->writable, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     /* Broadcast next ncid to all tasks from io root, necessary
      * because files may be opened on mutilple iosystems, causing the
@@ -2179,10 +2179,10 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
      * ensues. */
     if (ios->async)
     {
-	PLOG((3, "createfile bcasting pio_next_ncid %d", pio_next_ncid));
-	if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-	PLOG((3, "createfile bcast pio_next_ncid %d", pio_next_ncid));
+        PLOG((3, "createfile bcasting pio_next_ncid %d", pio_next_ncid));
+        if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        PLOG((3, "createfile bcast pio_next_ncid %d", pio_next_ncid));
     }
 
     /* Assign the PIO ncid. */
@@ -2195,14 +2195,14 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
 #ifdef NETCDF_INTEGRATION
     if (use_ext_ncid)
     {
-	/* The ncid was assigned on the computational
-	 * processors. Change the ncid to one that I/O and
-	 * computational components can agree on. */
-	if ((ierr = nc4_file_change_ncid(*ncidp, file->pio_ncid)))
-	    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-	file->pio_ncid = file->pio_ncid << ID_SHIFT;
-	file->ncint_file++;
-	PLOG((2, "changed ncid to file->pio_ncid = %d", file->pio_ncid));
+        /* The ncid was assigned on the computational
+         * processors. Change the ncid to one that I/O and
+         * computational components can agree on. */
+        if ((ierr = nc4_file_change_ncid(*ncidp, file->pio_ncid)))
+            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+        file->pio_ncid = file->pio_ncid << ID_SHIFT;
+        file->ncint_file++;
+        PLOG((2, "changed ncid to file->pio_ncid = %d", file->pio_ncid));
     }
 #endif /* NETCDF_INTEGRATION */
     PLOG((2, "file->fh = %d file->pio_ncid = %d", file->fh, file->pio_ncid));
@@ -2218,7 +2218,7 @@ PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
     pio_stop_mpe_log(CREATE, __func__);
 #endif /* USE_MPE */
     PLOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
-	  file->fh, file->pio_ncid));
+          file->fh, file->pio_ncid));
 
     return ierr;
 }
@@ -2243,37 +2243,37 @@ check_unlim_use(int ncid)
 
     /* Are there 2 or more unlimited dims in this file? */
     if ((ierr = nc_inq_unlimdims(ncid, &nunlimdims, NULL)))
-	return ierr;
+        return ierr;
     if (nunlimdims < 2)
-	return PIO_NOERR;
+        return PIO_NOERR;
 
     /* How many vars in file? */
     if ((ierr = nc_inq_nvars(ncid, &nvars)))
-	return ierr;
+        return ierr;
 
     /* Check each var. */
     for (int v = 0; v < nvars && !ierr; v++)
     {
-	int nvardims;
-	if ((ierr = nc_inq_varndims(ncid, v, &nvardims)))
-	    return ierr;
-	int vardimid[nvardims];
-	if ((ierr = nc_inq_vardimid(ncid, v, vardimid)))
-	    return ierr;
+        int nvardims;
+        if ((ierr = nc_inq_varndims(ncid, v, &nvardims)))
+            return ierr;
+        int vardimid[nvardims];
+        if ((ierr = nc_inq_vardimid(ncid, v, vardimid)))
+            return ierr;
 
-	/* Check all var dimensions, except the first. If we find
-	 * unlimited, that's a problem. */
-	for (int vd = 1; vd < nvardims; vd++)
-	{
-	    size_t dimlen;
-	    if ((ierr = nc_inq_dimlen(ncid, vardimid[vd], &dimlen)))
-		return ierr;
-	    if (dimlen == NC_UNLIMITED)
-	    {
-		nc_close(ncid);
-		return PIO_EINVAL;
-	    }
-	}
+        /* Check all var dimensions, except the first. If we find
+         * unlimited, that's a problem. */
+        for (int vd = 1; vd < nvardims; vd++)
+        {
+            size_t dimlen;
+            if ((ierr = nc_inq_dimlen(ncid, vardimid[vd], &dimlen)))
+                return ierr;
+            if (dimlen == NC_UNLIMITED)
+            {
+                nc_close(ncid);
+                return PIO_EINVAL;
+            }
+        }
     }
 #endif /* _NETCDF4 */
 
@@ -2312,8 +2312,8 @@ check_unlim_use(int ncid)
  */
 static int
 inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
-		  int **rec_var, int **pio_type, int **pio_type_size,
-		  MPI_Datatype **mpi_type, int **mpi_type_size, int **ndims)
+                  int **rec_var, int **pio_type, int **pio_type_size,
+                  MPI_Datatype **mpi_type, int **mpi_type_size, int **ndims)
 {
     int nunlimdims = 0;        /* The number of unlimited dimensions. */
     int unlimdimid;
@@ -2323,181 +2323,181 @@ inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars,
 
     /* Check inputs. */
     pioassert(rec_var && pio_type && pio_type_size && mpi_type && mpi_type_size,
-	      "pointers must be provided", __FILE__, __LINE__);
+              "pointers must be provided", __FILE__, __LINE__);
 
     /* How many vars in the file? */
     if (iotype == PIO_IOTYPE_PNETCDF)
     {
 #ifdef _PNETCDF
-	if ((ret = ncmpi_inq_nvars(ncid, nvars)))
-	    return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if ((ret = ncmpi_inq_nvars(ncid, nvars)))
+            return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
 #endif /* _PNETCDF */
     }
     else
     {
-	if ((ret = nc_inq_nvars(ncid, nvars)))
-	    return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if ((ret = nc_inq_nvars(ncid, nvars)))
+            return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
     }
 
     /* Allocate storage for info about each var. */
     if (*nvars)
     {
-	if (!(*rec_var = malloc(*nvars * sizeof(int))))
-	    return PIO_ENOMEM;
-	if (!(*pio_type = malloc(*nvars * sizeof(int))))
-	    return PIO_ENOMEM;
-	if (!(*pio_type_size = malloc(*nvars * sizeof(int))))
-	    return PIO_ENOMEM;
-	if (!(*mpi_type = malloc(*nvars * sizeof(MPI_Datatype))))
-	    return PIO_ENOMEM;
-	if (!(*mpi_type_size = malloc(*nvars * sizeof(int))))
-	    return PIO_ENOMEM;
-	if (!(*ndims = malloc(*nvars * sizeof(int))))
-	    return PIO_ENOMEM;
+        if (!(*rec_var = malloc(*nvars * sizeof(int))))
+            return PIO_ENOMEM;
+        if (!(*pio_type = malloc(*nvars * sizeof(int))))
+            return PIO_ENOMEM;
+        if (!(*pio_type_size = malloc(*nvars * sizeof(int))))
+            return PIO_ENOMEM;
+        if (!(*mpi_type = malloc(*nvars * sizeof(MPI_Datatype))))
+            return PIO_ENOMEM;
+        if (!(*mpi_type_size = malloc(*nvars * sizeof(int))))
+            return PIO_ENOMEM;
+        if (!(*ndims = malloc(*nvars * sizeof(int))))
+            return PIO_ENOMEM;
     }
 
     /* How many unlimited dims for this file? */
     if (iotype == PIO_IOTYPE_PNETCDF)
     {
 #ifdef _PNETCDF
-	if ((ret = ncmpi_inq_unlimdim(ncid, &unlimdimid)))
-	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
-	nunlimdims = unlimdimid == -1 ? 0 : 1;
+        if ((ret = ncmpi_inq_unlimdim(ncid, &unlimdimid)))
+            return pio_err(NULL, file, ret, __FILE__, __LINE__);
+        nunlimdims = unlimdimid == -1 ? 0 : 1;
 #endif /* _PNETCDF */
     }
     else if (iotype == PIO_IOTYPE_NETCDF)
     {
-	if ((ret = nc_inq_unlimdim(ncid, &unlimdimid)))
-	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
-	nunlimdims = unlimdimid == -1 ? 0 : 1;
+        if ((ret = nc_inq_unlimdim(ncid, &unlimdimid)))
+            return pio_err(NULL, file, ret, __FILE__, __LINE__);
+        nunlimdims = unlimdimid == -1 ? 0 : 1;
     }
     else
     {
 #ifdef _NETCDF4
-	if ((ret = nc_inq_unlimdims(ncid, &nunlimdims, NULL)))
-	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+        if ((ret = nc_inq_unlimdims(ncid, &nunlimdims, NULL)))
+            return pio_err(NULL, file, ret, __FILE__, __LINE__);
 #endif /* _NETCDF4 */
     }
 
     /* Learn the unlimited dimension ID(s), if there are any. */
     if (nunlimdims)
     {
-	if (!(unlimdimids = malloc(nunlimdims * sizeof(int))))
-	    return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
-	if (iotype == PIO_IOTYPE_PNETCDF || iotype == PIO_IOTYPE_NETCDF)
-	{
-	    unlimdimids[0] = unlimdimid;
-	}
-	else
-	{
+        if (!(unlimdimids = malloc(nunlimdims * sizeof(int))))
+            return pio_err(NULL, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (iotype == PIO_IOTYPE_PNETCDF || iotype == PIO_IOTYPE_NETCDF)
+        {
+            unlimdimids[0] = unlimdimid;
+        }
+        else
+        {
 #ifdef _NETCDF4
-	    if ((ret = nc_inq_unlimdims(ncid, NULL, unlimdimids)))
-		return pio_err(NULL, file, ret, __FILE__, __LINE__);
+            if ((ret = nc_inq_unlimdims(ncid, NULL, unlimdimids)))
+                return pio_err(NULL, file, ret, __FILE__, __LINE__);
 #endif /* _NETCDF4 */
-	}
+        }
     }
 
     /* Learn about each variable in the file. */
     for (int v = 0; v < *nvars; v++)
     {
-	int var_ndims;   /* Number of dims for this var. */
-	nc_type my_type;
+        int var_ndims;   /* Number of dims for this var. */
+        nc_type my_type;
 
-	/* Find type of the var and number of dims in this var. Also
-	 * learn about type. */
-	if (iotype == PIO_IOTYPE_PNETCDF)
-	{
+        /* Find type of the var and number of dims in this var. Also
+         * learn about type. */
+        if (iotype == PIO_IOTYPE_PNETCDF)
+        {
 #ifdef _PNETCDF
-	    PIO_Offset type_size;
+            PIO_Offset type_size;
 
-	    if ((ret = ncmpi_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
-		return pio_err(NULL, file, ret, __FILE__, __LINE__);
-	    (*pio_type)[v] = (int)my_type;
-	    (*ndims)[v] = var_ndims;
-	    if ((ret = pioc_pnetcdf_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
-		return check_netcdf(file, ret, __FILE__, __LINE__);
-	    (*pio_type_size)[v] = type_size;
+            if ((ret = ncmpi_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
+                return pio_err(NULL, file, ret, __FILE__, __LINE__);
+            (*pio_type)[v] = (int)my_type;
+            (*ndims)[v] = var_ndims;
+            if ((ret = pioc_pnetcdf_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
+                return check_netcdf(file, ret, __FILE__, __LINE__);
+            (*pio_type_size)[v] = type_size;
 #endif /* _PNETCDF */
-	}
-	else
-	{
-	    size_t type_size;
+        }
+        else
+        {
+            size_t type_size;
 
-	    if ((ret = nc_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
-		return pio_err(NULL, file, ret, __FILE__, __LINE__);
-	    (*pio_type)[v] = (int)my_type;
-	    (*ndims)[v] = var_ndims;
-	    if ((ret = nc_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
-		return check_netcdf(file, ret, __FILE__, __LINE__);
-	    (*pio_type_size)[v] = type_size;
-	}
+            if ((ret = nc_inq_var(ncid, v, NULL, &my_type, &var_ndims, NULL, NULL)))
+                return pio_err(NULL, file, ret, __FILE__, __LINE__);
+            (*pio_type)[v] = (int)my_type;
+            (*ndims)[v] = var_ndims;
+            if ((ret = nc_inq_type(ncid, (*pio_type)[v], NULL, &type_size)))
+                return check_netcdf(file, ret, __FILE__, __LINE__);
+            (*pio_type_size)[v] = type_size;
+        }
 
-	/* Get the MPI type corresponding with the PIO type. */
-	if ((ret = find_mpi_type((*pio_type)[v], &(*mpi_type)[v], NULL)))
-	    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+        /* Get the MPI type corresponding with the PIO type. */
+        if ((ret = find_mpi_type((*pio_type)[v], &(*mpi_type)[v], NULL)))
+            return pio_err(NULL, file, ret, __FILE__, __LINE__);
 
-	/* Get the size of the MPI type. */
-	if ((*mpi_type)[v] == MPI_DATATYPE_NULL)
-	    (*mpi_type_size)[v] = 0;
-	else
-	    if ((mpierr = MPI_Type_size((*mpi_type)[v], &(*mpi_type_size)[v])))
-		return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        /* Get the size of the MPI type. */
+        if ((*mpi_type)[v] == MPI_DATATYPE_NULL)
+            (*mpi_type_size)[v] = 0;
+        else
+            if ((mpierr = MPI_Type_size((*mpi_type)[v], &(*mpi_type_size)[v])))
+                return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
-	/* What are the dimids associated with this var? */
-	if (var_ndims)
-	{
-	    int var_dimids[var_ndims];
-	    if (iotype == PIO_IOTYPE_PNETCDF)
-	    {
+        /* What are the dimids associated with this var? */
+        if (var_ndims)
+        {
+            int var_dimids[var_ndims];
+            if (iotype == PIO_IOTYPE_PNETCDF)
+            {
 #ifdef _PNETCDF
-		if ((ret = ncmpi_inq_vardimid(ncid, v, var_dimids)))
-		    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+                if ((ret = ncmpi_inq_vardimid(ncid, v, var_dimids)))
+                    return pio_err(NULL, file, ret, __FILE__, __LINE__);
 #endif /* _PNETCDF */
-	    }
-	    else
-	    {
-		if ((ret = nc_inq_vardimid(ncid, v, var_dimids)))
-		    return pio_err(NULL, file, ret, __FILE__, __LINE__);
-	    }
+            }
+            else
+            {
+                if ((ret = nc_inq_vardimid(ncid, v, var_dimids)))
+                    return pio_err(NULL, file, ret, __FILE__, __LINE__);
+            }
 
-	    /* Check against each variable dimid agains each unlimited
-	     * dimid. */
-	    for (int d = 0; d < var_ndims; d++)
-	    {
-		int unlim_found = 0;
+            /* Check against each variable dimid agains each unlimited
+             * dimid. */
+            for (int d = 0; d < var_ndims; d++)
+            {
+                int unlim_found = 0;
 
-		/* Check against each unlimited dimid. */
-		for (int ud = 0; ud < nunlimdims; ud++)
-		{
-		    if (var_dimids[d] == unlimdimids[ud])
-		    {
-			unlim_found++;
-			break;
-		    }
-		}
+                /* Check against each unlimited dimid. */
+                for (int ud = 0; ud < nunlimdims; ud++)
+                {
+                    if (var_dimids[d] == unlimdimids[ud])
+                    {
+                        unlim_found++;
+                        break;
+                    }
+                }
 
-		/* Only first dim may be unlimited, for PIO. */
-		if (unlim_found)
-		{
-		    if (d == 0){
-			(*rec_var)[v] = 1;
-			break;
-		    }
-		    else
-			return pio_err(NULL, file, PIO_EINVAL, __FILE__, __LINE__);
+                /* Only first dim may be unlimited, for PIO. */
+                if (unlim_found)
+                {
+                    if (d == 0){
+                        (*rec_var)[v] = 1;
+                        break;
+                    }
+                    else
+                        return pio_err(NULL, file, PIO_EINVAL, __FILE__, __LINE__);
 
-		}
-		else
-		    (*rec_var)[v] = 0;
+                }
+                else
+                    (*rec_var)[v] = 0;
 
-	    }
-	}
+            }
+        }
 
     } /* next var */
 
     /* Free resources. */
     if (nunlimdims)
-	free(unlimdimids);
+        free(unlimdimids);
 
     return PIO_NOERR;
 }
@@ -2524,17 +2524,17 @@ find_iotype_from_omode(int mode, int *iotype)
     /* Figure out the iotype. */
     if (mode & NC_NETCDF4)
     {
-	if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
-	    *iotype = PIO_IOTYPE_NETCDF4P;
-	else
-	    *iotype = PIO_IOTYPE_NETCDF4C;
+        if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
+            *iotype = PIO_IOTYPE_NETCDF4P;
+        else
+            *iotype = PIO_IOTYPE_NETCDF4C;
     }
     else
     {
-	if (mode & NC_PNETCDF || mode & NC_MPIIO)
-	    *iotype = PIO_IOTYPE_PNETCDF;
-	else
-	    *iotype = PIO_IOTYPE_NETCDF;
+        if (mode & NC_PNETCDF || mode & NC_MPIIO)
+            *iotype = PIO_IOTYPE_PNETCDF;
+        else
+            *iotype = PIO_IOTYPE_NETCDF;
     }
 
     return PIO_NOERR;
@@ -2559,17 +2559,17 @@ find_iotype_from_cmode(int cmode, int *iotype)
     /* Figure out the iotype. */
     if (cmode & NC_NETCDF4)
     {
-	if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
-	    *iotype = PIO_IOTYPE_NETCDF4P;
-	else
-	    *iotype = PIO_IOTYPE_NETCDF4C;
+        if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
+            *iotype = PIO_IOTYPE_NETCDF4P;
+        else
+            *iotype = PIO_IOTYPE_NETCDF4C;
     }
     else
     {
-	if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
-	    *iotype = PIO_IOTYPE_PNETCDF;
-	else
-	    *iotype = PIO_IOTYPE_NETCDF;
+        if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
+            *iotype = PIO_IOTYPE_PNETCDF;
+        else
+            *iotype = PIO_IOTYPE_NETCDF;
     }
 
     return PIO_NOERR;
@@ -2604,7 +2604,7 @@ find_iotype_from_cmode(int cmode, int *iotype)
  */
 int
 PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
-		    int mode, int retry, int use_ext_ncid)
+                    int mode, int retry, int use_ext_ncid)
 {
     iosystem_desc_t *ios;      /* Pointer to io system information. */
     file_desc_t *file;         /* Pointer to file information. */
@@ -2625,20 +2625,20 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename)
-	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
     if (*iotype < PIO_IOTYPE_PNETCDF || *iotype > PIO_IOTYPE_NETCDF4P)
-	return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     PLOG((2, "PIOc_openfile_retry iosysid = %d iotype = %d filename = %s mode = %d retry = %d",
-	  iosysid, *iotype, filename, mode, retry));
+          iosysid, *iotype, filename, mode, retry));
 
     /* Allocate space for the file info. */
     if (!(file = calloc(sizeof(*file), 1)))
-	return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* Fill in some file values. */
     file->fh = -1;
@@ -2649,228 +2649,228 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
     /* Set to true if this task should participate in IO (only true
      * for one task with netcdf serial files. */
     if (file->iotype == PIO_IOTYPE_NETCDF4P || file->iotype == PIO_IOTYPE_PNETCDF ||
-	ios->io_rank == 0)
-	file->do_io = 1;
+        ios->io_rank == 0)
+        file->do_io = 1;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
     {
-	int msg = PIO_MSG_OPEN_FILE;
-	size_t len = strlen(filename);
+        int msg = PIO_MSG_OPEN_FILE;
+        size_t len = strlen(filename);
 
-	if (!ios->ioproc)
-	{
-	    /* Send the message to the message handler. */
-	    if (ios->compmaster == MPI_ROOT)
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+        if (!ios->ioproc)
+        {
+            /* Send the message to the message handler. */
+            if (ios->compmaster == MPI_ROOT)
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
 
-	    /* Send the parameters of the function call. */
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&use_ext_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            /* Send the parameters of the function call. */
+            if (!mpierr)
+                mpierr = MPI_Bcast(&len, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&mode, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&use_ext_ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
 #ifdef NETCDF_INTEGRATION
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&diosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
+                mpierr = MPI_Bcast(&diosysid, 1, MPI_INT, ios->compmaster, ios->intercomm);
 #endif /* NETCDF_INTEGRATION */
-	}
+        }
 
-	/* Handle MPI errors. */
-	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        /* Handle MPI errors. */
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-	switch (file->iotype)
-	{
+        switch (file->iotype)
+        {
 #ifdef _NETCDF4
 
-	case PIO_IOTYPE_NETCDF4P:
+        case PIO_IOTYPE_NETCDF4P:
 #ifdef _MPISERIAL
-	    ierr = nc_open(filename, mode, &file->fh);
+            ierr = nc_open(filename, mode, &file->fh);
 #else
-	    imode = mode |  NC_MPIIO;
-	    if ((ierr = nc_open_par(filename, imode, ios->io_comm, ios->info,
-				    &file->fh)))
-		break;
+            imode = mode |  NC_MPIIO;
+            if ((ierr = nc_open_par(filename, imode, ios->io_comm, ios->info,
+                                    &file->fh)))
+                break;
 
-	    /* Check the vars for valid use of unlim dims. */
-	    if ((ierr = check_unlim_use(file->fh)))
-		break;
+            /* Check the vars for valid use of unlim dims. */
+            if ((ierr = check_unlim_use(file->fh)))
+                break;
 
-	    if ((ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4P,
-					  &nvars, &rec_var, &pio_type,
-					  &pio_type_size, &mpi_type,
-					  &mpi_type_size, &ndims)))
-		break;
-	    PLOG((2, "PIOc_openfile_retry:nc_open_par filename = %s mode = %d "
-		  "imode = %d ierr = %d", filename, mode, imode, ierr));
+            if ((ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4P,
+                                          &nvars, &rec_var, &pio_type,
+                                          &pio_type_size, &mpi_type,
+                                          &mpi_type_size, &ndims)))
+                break;
+            PLOG((2, "PIOc_openfile_retry:nc_open_par filename = %s mode = %d "
+                  "imode = %d ierr = %d", filename, mode, imode, ierr));
 #endif
-	    break;
+            break;
 
-	case PIO_IOTYPE_NETCDF4C:
-	    if (ios->io_rank == 0)
-	    {
-		if ((ierr = nc_open(filename, mode, &file->fh)))
-		    break;
-		/* Check the vars for valid use of unlim dims. */
-		if ((ierr = check_unlim_use(file->fh)))
-		    break;
-		ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4C,
-					 &nvars, &rec_var, &pio_type,
-					 &pio_type_size, &mpi_type,
-					 &mpi_type_size, &ndims);
-		PLOG((2, "PIOc_openfile_retry:nc_open for 4C filename = %s mode = %d "
-		      "ierr = %d", filename, mode, ierr));
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF4C:
+            if (ios->io_rank == 0)
+            {
+                if ((ierr = nc_open(filename, mode, &file->fh)))
+                    break;
+                /* Check the vars for valid use of unlim dims. */
+                if ((ierr = check_unlim_use(file->fh)))
+                    break;
+                ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF4C,
+                                         &nvars, &rec_var, &pio_type,
+                                         &pio_type_size, &mpi_type,
+                                         &mpi_type_size, &ndims);
+                PLOG((2, "PIOc_openfile_retry:nc_open for 4C filename = %s mode = %d "
+                      "ierr = %d", filename, mode, ierr));
+            }
+            break;
 #endif /* _NETCDF4 */
 
-	case PIO_IOTYPE_NETCDF:
-	    if (ios->io_rank == 0)
-	    {
-		if ((ierr = nc_open(filename, mode, &file->fh)))
-		    break;
-		ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
-					 &nvars, &rec_var, &pio_type,
-					 &pio_type_size, &mpi_type,
-					 &mpi_type_size, &ndims);
-		PLOG((2, "PIOc_openfile_retry:nc_open for classic filename = %s mode = %d "
-		      "ierr = %d", filename, mode, ierr));
-	    }
-	    break;
+        case PIO_IOTYPE_NETCDF:
+            if (ios->io_rank == 0)
+            {
+                if ((ierr = nc_open(filename, mode, &file->fh)))
+                    break;
+                ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
+                                         &nvars, &rec_var, &pio_type,
+                                         &pio_type_size, &mpi_type,
+                                         &mpi_type_size, &ndims);
+                PLOG((2, "PIOc_openfile_retry:nc_open for classic filename = %s mode = %d "
+                      "ierr = %d", filename, mode, ierr));
+            }
+            break;
 
 #ifdef _PNETCDF
-	case PIO_IOTYPE_PNETCDF:
-	    ierr = ncmpi_open(ios->io_comm, filename, mode, ios->info, &file->fh);
+        case PIO_IOTYPE_PNETCDF:
+            ierr = ncmpi_open(ios->io_comm, filename, mode, ios->info, &file->fh);
 
-	    // This should only be done with a file opened to append
-	    if (ierr == PIO_NOERR && (mode & PIO_WRITE))
-	    {
-		if (ios->iomaster == MPI_ROOT)
-		    PLOG((2, "%d Setting IO buffer %ld", __LINE__,
-			  pio_buffer_size_limit));
-		ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
-	    }
-	    PLOG((2, "ncmpi_open(%s) : fd = %d", filename, file->fh));
+            // This should only be done with a file opened to append
+            if (ierr == PIO_NOERR && (mode & PIO_WRITE))
+            {
+                if (ios->iomaster == MPI_ROOT)
+                    PLOG((2, "%d Setting IO buffer %ld", __LINE__,
+                          pio_buffer_size_limit));
+                ierr = ncmpi_buffer_attach(file->fh, pio_buffer_size_limit);
+            }
+            PLOG((2, "ncmpi_open(%s) : fd = %d", filename, file->fh));
 
-	    if (!ierr)
-		ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_PNETCDF,
-					 &nvars, &rec_var, &pio_type,
-					 &pio_type_size, &mpi_type,
-					 &mpi_type_size, &ndims);
-	    break;
+            if (!ierr)
+                ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_PNETCDF,
+                                         &nvars, &rec_var, &pio_type,
+                                         &pio_type_size, &mpi_type,
+                                         &mpi_type_size, &ndims);
+            break;
 #endif
 
-	default:
-	    return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
-	}
+        default:
+            return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
+        }
 
-	/* If the caller requested a retry, and we failed to open a
-	   file due to an incompatible type of NetCDF, try it once
-	   with just plain old basic NetCDF. */
-	if (retry)
-	{
-	    PLOG((2, "retry error code ierr = %d io_rank %d", ierr, ios->io_rank));
-	    if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
-	    {
-		if (ios->iomaster == MPI_ROOT)
-		    printf("PIO2 pio_file.c retry NETCDF\n");
+        /* If the caller requested a retry, and we failed to open a
+           file due to an incompatible type of NetCDF, try it once
+           with just plain old basic NetCDF. */
+        if (retry)
+        {
+            PLOG((2, "retry error code ierr = %d io_rank %d", ierr, ios->io_rank));
+            if ((ierr == NC_ENOTNC || ierr == NC_EINVAL) && (file->iotype != PIO_IOTYPE_NETCDF))
+            {
+                if (ios->iomaster == MPI_ROOT)
+                    printf("PIO2 pio_file.c retry NETCDF\n");
 
-		/* reset ierr on all tasks */
-		ierr = PIO_NOERR;
+                /* reset ierr on all tasks */
+                ierr = PIO_NOERR;
 
-		/* reset file markers for NETCDF on all tasks */
-		file->iotype = PIO_IOTYPE_NETCDF;
+                /* reset file markers for NETCDF on all tasks */
+                file->iotype = PIO_IOTYPE_NETCDF;
 
-		/* open netcdf file serially on main task */
-		if (ios->io_rank == 0)
-		{
-		    ierr = nc_open(filename, mode, &file->fh);
-		    if (ierr == PIO_NOERR)
-			ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
-						 &nvars, &rec_var, &pio_type,
-						 &pio_type_size, &mpi_type,
-						 &mpi_type_size, &ndims);
-		}
-		else
-		    file->do_io = 0;
-	    }
-	    PLOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d",
-		  filename, file->fh, file->iotype, file->do_io, ierr));
-	}
+                /* open netcdf file serially on main task */
+                if (ios->io_rank == 0)
+                {
+                    ierr = nc_open(filename, mode, &file->fh);
+                    if (ierr == PIO_NOERR)
+                        ierr = inq_file_metadata(file, file->fh, PIO_IOTYPE_NETCDF,
+                                                 &nvars, &rec_var, &pio_type,
+                                                 &pio_type_size, &mpi_type,
+                                                 &mpi_type_size, &ndims);
+                }
+                else
+                    file->do_io = 0;
+            }
+            PLOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d",
+                  filename, file->fh, file->iotype, file->do_io, ierr));
+        }
     }
 
     /* Broadcast and check the return code. */
     if (ios->ioroot == ios->union_rank)
-	PLOG((2, "Bcasting error code ierr %d ios->ioroot %d ios->my_comm %d",
-	      ierr, ios->ioroot, ios->my_comm));
+        PLOG((2, "Bcasting error code ierr %d ios->ioroot %d ios->my_comm %d",
+              ierr, ios->ioroot, ios->my_comm));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     PLOG((2, "Bcast openfile_retry error code ierr = %d", ierr));
 
     /* If there was an error, free allocated memory and deal with the error. */
     if (ierr)
     {
-	free(file);
-	return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
+        free(file);
+        return check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
     }
 
     /* Broadcast writability to all tasks. */
     if ((mpierr = MPI_Bcast(&file->writable, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     /* Broadcast some values to all tasks from io root. */
     if (ios->async)
     {
-	PLOG((3, "open bcasting pio_next_ncid %d ios->ioroot %d", pio_next_ncid, ios->ioroot));
-	if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        PLOG((3, "open bcasting pio_next_ncid %d ios->ioroot %d", pio_next_ncid, ios->ioroot));
+        if ((mpierr = MPI_Bcast(&pio_next_ncid, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     if ((mpierr = MPI_Bcast(&nvars, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     /* Non io tasks need to allocate to store info about variables. */
     if (nvars && !rec_var)
     {
-	if (!(rec_var = malloc(nvars * sizeof(int))))
-	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-	if (!(pio_type = malloc(nvars * sizeof(int))))
-	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-	if (!(pio_type_size = malloc(nvars * sizeof(int))))
-	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-	if (!(mpi_type = malloc(nvars * sizeof(MPI_Datatype))))
-	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-	if (!(mpi_type_size = malloc(nvars * sizeof(int))))
-	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-	if (!(ndims = malloc(nvars * sizeof(int))))
-	    return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(rec_var = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(pio_type = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(pio_type_size = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(mpi_type = malloc(nvars * sizeof(MPI_Datatype))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(mpi_type_size = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
+        if (!(ndims = malloc(nvars * sizeof(int))))
+            return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
     }
     if (nvars)
     {
-	if ((mpierr = MPI_Bcast(rec_var, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(pio_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(pio_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(mpi_type, nvars*(int)(sizeof(MPI_Datatype)/sizeof(int)), MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(mpi_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-	if ((mpierr = MPI_Bcast(ndims, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(rec_var, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(pio_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(pio_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(mpi_type, nvars*(int)(sizeof(MPI_Datatype)/sizeof(int)), MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(mpi_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        if ((mpierr = MPI_Bcast(ndims, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* With the netCDF integration layer, the ncid is assigned for PIO
@@ -2879,26 +2879,26 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
 #ifdef NETCDF_INTEGRATION
     if (use_ext_ncid)
     {
-	/* The ncid was assigned on the computational
-	 * processors. Change the ncid to one that I/O and
-	 * computational components can agree on. */
-	file->pio_ncid = pio_next_ncid++;
-	if ((ierr = nc4_file_change_ncid(*ncidp, file->pio_ncid)))
-	    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-	file->pio_ncid = file->pio_ncid << ID_SHIFT;
-	file->ncint_file++;
-	PLOG((2, "changed ncid to file->pio_ncid = %d", file->pio_ncid));
+        /* The ncid was assigned on the computational
+         * processors. Change the ncid to one that I/O and
+         * computational components can agree on. */
+        file->pio_ncid = pio_next_ncid++;
+        if ((ierr = nc4_file_change_ncid(*ncidp, file->pio_ncid)))
+            return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+        file->pio_ncid = file->pio_ncid << ID_SHIFT;
+        file->ncint_file++;
+        PLOG((2, "changed ncid to file->pio_ncid = %d", file->pio_ncid));
     }
     else
 #endif /* NETCDF_INTEGRATION */
     {
-	/* Create the ncid that the user will see. This is necessary
-	 * because otherwise ncids will be reused if files are opened
-	 * on multiple iosystems. */
-	file->pio_ncid = pio_next_ncid++;
+        /* Create the ncid that the user will see. This is necessary
+         * because otherwise ncids will be reused if files are opened
+         * on multiple iosystems. */
+        file->pio_ncid = pio_next_ncid++;
 
-	/* Return the PIO ncid to the user. */
-	*ncidp = file->pio_ncid;
+        /* Return the PIO ncid to the user. */
+        *ncidp = file->pio_ncid;
     }
 
     /* Add this file to the list of currently open files. */
@@ -2906,34 +2906,34 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
 
     /* Add info about the variables to the file_desc_t struct. */
     for (int v = 0; v < nvars; v++)
-	if ((ierr = add_to_varlist(v, rec_var[v], pio_type[v], pio_type_size[v],
-				   mpi_type[v], mpi_type_size[v], ndims[v],
-				   &file->varlist)))
-	    return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+        if ((ierr = add_to_varlist(v, rec_var[v], pio_type[v], pio_type_size[v],
+                                   mpi_type[v], mpi_type_size[v], ndims[v],
+                                   &file->varlist)))
+            return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
     file->nvars = nvars;
 
     /* Free resources. */
     if (nvars)
     {
-	if (rec_var)
-	    free(rec_var);
-	if (pio_type)
-	    free(pio_type);
-	if (pio_type_size)
-	    free(pio_type_size);
-	if (mpi_type)
-	    free(mpi_type);
-	if (mpi_type_size)
-	    free(mpi_type_size);
-	if (ndims)
-	    free(ndims);
+        if (rec_var)
+            free(rec_var);
+        if (pio_type)
+            free(pio_type);
+        if (pio_type_size)
+            free(pio_type_size);
+        if (mpi_type)
+            free(mpi_type);
+        if (mpi_type_size)
+            free(mpi_type_size);
+        if (ndims)
+            free(ndims);
     }
 
 #ifdef USE_MPE
     pio_stop_mpe_log(OPEN, __func__);
 #endif /* USE_MPE */
     PLOG((2, "Opened file %s file->pio_ncid = %d file->fh = %d ierr = %d",
-	  filename, file->pio_ncid, file->fh, ierr));
+          filename, file->pio_ncid, file->fh, ierr));
 
     return ierr;
 }
@@ -2951,7 +2951,7 @@ PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
  */
 int
 pioc_pnetcdf_inq_type(int ncid, nc_type xtype, char *name,
-		      PIO_Offset *sizep)
+                      PIO_Offset *sizep)
 {
     int typelen;
 
@@ -2960,31 +2960,31 @@ pioc_pnetcdf_inq_type(int ncid, nc_type xtype, char *name,
     case NC_UBYTE:
     case NC_BYTE:
     case NC_CHAR:
-	typelen = 1;
-	break;
+        typelen = 1;
+        break;
     case NC_SHORT:
     case NC_USHORT:
-	typelen = 2;
-	break;
+        typelen = 2;
+        break;
     case NC_UINT:
     case NC_INT:
     case NC_FLOAT:
-	typelen = 4;
-	break;
+        typelen = 4;
+        break;
     case NC_UINT64:
     case NC_INT64:
     case NC_DOUBLE:
-	typelen = 8;
-	break;
+        typelen = 8;
+        break;
     default:
-	return PIO_EBADTYPE;
+        return PIO_EBADTYPE;
     }
 
     /* If pointers were supplied, copy results. */
     if (sizep)
-	*sizep = typelen;
+        *sizep = typelen;
     if (name)
-	strcpy(name, "some type");
+        strcpy(name, "some type");
 
     return PIO_NOERR;
 }
@@ -3011,66 +3011,66 @@ pioc_change_def(int ncid, int is_enddef)
     /* Find the info about this file. When I check the return code
      * here, some tests fail. ???*/
     if ((ierr = pio_get_file(ncid, &file)))
-	return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
     {
-	if (!ios->ioproc)
-	{
-	    int msg = is_enddef ? PIO_MSG_ENDDEF : PIO_MSG_REDEF;
-	    if (ios->compmaster == MPI_ROOT)
-	      {
-		PLOG((2, "pioc_change_def request sent"));
-		mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
-	      }
-	    if (!mpierr)
-		mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
-	    PLOG((3, "pioc_change_def ncid = %d mpierr = %d", ncid, mpierr));
-	}
+        if (!ios->ioproc)
+        {
+            int msg = is_enddef ? PIO_MSG_ENDDEF : PIO_MSG_REDEF;
+            if (ios->compmaster == MPI_ROOT)
+              {
+                PLOG((2, "pioc_change_def request sent"));
+                mpierr = MPI_Send(&msg, 1, MPI_INT, ios->ioroot, 1, ios->union_comm);
+              }
+            if (!mpierr)
+                mpierr = MPI_Bcast(&ncid, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            PLOG((3, "pioc_change_def ncid = %d mpierr = %d", ncid, mpierr));
+        }
 
-	/* Handle MPI errors. */
-	PLOG((3, "pioc_change_def handling MPI errors my_comm=%d", ios->my_comm));
-	if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
-	    check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
-	if (mpierr)
-	    return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        /* Handle MPI errors. */
+        PLOG((3, "pioc_change_def handling MPI errors my_comm=%d", ios->my_comm));
+        if ((mpierr2 = MPI_Bcast(&mpierr, 1, MPI_INT, ios->comproot, ios->my_comm)))
+            check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
+        if (mpierr)
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
     PLOG((3, "pioc_change_def ios->ioproc = %d", ios->ioproc));
     if (ios->ioproc)
     {
-	PLOG((3, "pioc_change_def calling netcdf function file->fh = %d file->do_io = %d iotype = %d",
-	      file->fh, file->do_io, file->iotype));
+        PLOG((3, "pioc_change_def calling netcdf function file->fh = %d file->do_io = %d iotype = %d",
+              file->fh, file->do_io, file->iotype));
 #ifdef _PNETCDF
-	if (file->iotype == PIO_IOTYPE_PNETCDF)
-	{
-	    if (is_enddef)
-		ierr = ncmpi_enddef(file->fh);
-	    else
-		ierr = ncmpi_redef(file->fh);
-	}
+        if (file->iotype == PIO_IOTYPE_PNETCDF)
+        {
+            if (is_enddef)
+                ierr = ncmpi_enddef(file->fh);
+            else
+                ierr = ncmpi_redef(file->fh);
+        }
 #endif /* _PNETCDF */
-	if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
-	{
-	    if (is_enddef)
-	    {
-		PLOG((3, "pioc_change_def calling nc_enddef file->fh = %d", file->fh));
-		ierr = nc_enddef(file->fh);
-	    }
-	    else
-		ierr = nc_redef(file->fh);
-	}
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
+        {
+            if (is_enddef)
+            {
+                PLOG((3, "pioc_change_def calling nc_enddef file->fh = %d", file->fh));
+                ierr = nc_enddef(file->fh);
+            }
+            else
+                ierr = nc_redef(file->fh);
+        }
     }
 
     /* Broadcast and check the return code. */
     PLOG((3, "pioc_change_def bcasting return code ierr = %d", ierr));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-	return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     if (ierr)
-	return check_netcdf(file, ierr, __FILE__, __LINE__);
+        return check_netcdf(file, ierr, __FILE__, __LINE__);
     PLOG((3, "pioc_change_def succeeded"));
 
     return ierr;
@@ -3091,17 +3091,17 @@ iotype_is_valid(int iotype)
 
     /* All builds include netCDF. */
     if (iotype == PIO_IOTYPE_NETCDF)
-	ret++;
+        ret++;
 
     /* Some builds include netCDF-4. */
 #ifdef _NETCDF4
     if (iotype == PIO_IOTYPE_NETCDF4C || iotype == PIO_IOTYPE_NETCDF4P)
-	ret++;
+        ret++;
 #endif /* _NETCDF4 */
 
     /* Some builds include pnetcdf. */
     if (iotype == PIO_IOTYPE_PNETCDF)
-	ret++;
+        ret++;
 #ifdef _PNETCDF
 #endif /* _PNETCDF */
 
@@ -3145,27 +3145,27 @@ iotype_is_valid(int iotype)
  */
 int
 PIOc_set_rearr_opts(int iosysid, int comm_type, int fcd, bool enable_hs_c2i,
-		    bool enable_isend_c2i, int max_pend_req_c2i,
-		    bool enable_hs_i2c, bool enable_isend_i2c,
-		    int max_pend_req_i2c)
+                    bool enable_isend_c2i, int max_pend_req_c2i,
+                    bool enable_hs_i2c, bool enable_isend_i2c,
+                    int max_pend_req_i2c)
 {
     iosystem_desc_t *ios;
     rearr_opt_t user_rearr_opts = {
-	comm_type, fcd,
-	{enable_hs_c2i,enable_isend_c2i, max_pend_req_c2i},
-	{enable_hs_i2c, enable_isend_i2c, max_pend_req_i2c}
+        comm_type, fcd,
+        {enable_hs_c2i,enable_isend_c2i, max_pend_req_c2i},
+        {enable_hs_i2c, enable_isend_i2c, max_pend_req_i2c}
     };
 
     /* Check inputs. */
     if ((comm_type != PIO_REARR_COMM_P2P && comm_type != PIO_REARR_COMM_FC_1D_COMP2IO) ||
-	(fcd < 0 || fcd > PIO_REARR_COMM_FC_2D_DISABLE) ||
-	(max_pend_req_c2i != PIO_REARR_COMM_UNLIMITED_PEND_REQ && max_pend_req_c2i < 0) ||
-	(max_pend_req_i2c != PIO_REARR_COMM_UNLIMITED_PEND_REQ && max_pend_req_i2c < 0))
-	return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
+        (fcd < 0 || fcd > PIO_REARR_COMM_FC_2D_DISABLE) ||
+        (max_pend_req_c2i != PIO_REARR_COMM_UNLIMITED_PEND_REQ && max_pend_req_c2i < 0) ||
+        (max_pend_req_i2c != PIO_REARR_COMM_UNLIMITED_PEND_REQ && max_pend_req_i2c < 0))
+        return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
-	return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
     /* Set the options. */
     ios->rearr_opts = user_rearr_opts;
@@ -3202,42 +3202,42 @@ PIOc_set_rearr_opts(int iosysid, int comm_type, int fcd, bool enable_hs_c2i,
  */
 int
 determine_procs(int num_io_procs, int component_count, int *num_procs_per_comp,
-		int **proc_list, int **my_proc_list)
+                int **proc_list, int **my_proc_list)
 {
     /* If the user did not provide a list of processes for each
      * component, create one. */
     if (!proc_list)
     {
-	int last_proc = num_io_procs;
+        int last_proc = num_io_procs;
 
-	/* Fill the array of arrays. */
-	for (int cmp = 0; cmp < component_count; cmp++)
-	{
-	    PLOG((3, "calculating processors for component %d num_procs_per_comp[cmp] = %d",
-		  cmp, num_procs_per_comp[cmp]));
+        /* Fill the array of arrays. */
+        for (int cmp = 0; cmp < component_count; cmp++)
+        {
+            PLOG((3, "calculating processors for component %d num_procs_per_comp[cmp] = %d",
+                  cmp, num_procs_per_comp[cmp]));
 
-	    /* Allocate space for each array. */
-	    if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
-		return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+            /* Allocate space for each array. */
+            if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
+                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
-	    int proc;
-	    for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
-	    {
-		my_proc_list[cmp][proc - last_proc] = proc;
-		PLOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
-	    }
-	    last_proc = proc;
-	}
+            int proc;
+            for (proc = last_proc; proc < num_procs_per_comp[cmp] + last_proc; proc++)
+            {
+                my_proc_list[cmp][proc - last_proc] = proc;
+                PLOG((3, "my_proc_list[%d][%d] = %d", cmp, proc - last_proc, proc));
+            }
+            last_proc = proc;
+        }
     }
     else
     {
-	for (int cmp = 0; cmp < component_count; cmp++)
-	{
-	    /* Allocate space for each array. */
-	    if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
-		return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-	    memcpy(my_proc_list[cmp], proc_list[cmp], num_procs_per_comp[cmp] * sizeof(int));
-	}
+        for (int cmp = 0; cmp < component_count; cmp++)
+        {
+            /* Allocate space for each array. */
+            if (!(my_proc_list[cmp] = malloc(num_procs_per_comp[cmp] * sizeof(int))))
+                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+            memcpy(my_proc_list[cmp], proc_list[cmp], num_procs_per_comp[cmp] * sizeof(int));
+        }
     }
     return PIO_NOERR;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ project (PIOTests C Fortran)
 #  INCLUDE SOURCE DIRECTORIES
 #==============================================================================
 add_subdirectory (cunit)
+add_subdirectory (cperf)
 
 if (PIO_ENABLE_FORTRAN)
   add_subdirectory (unit)

--- a/tests/cperf/CMakeLists.txt
+++ b/tests/cperf/CMakeLists.txt
@@ -1,0 +1,47 @@
+include (LibMPI)
+
+include_directories("${CMAKE_SOURCE_DIR}/tests/cperf")
+include_directories("${CMAKE_SOURCE_DIR}/src/clib")
+include_directories("${CMAKE_BINARY_DIR}")
+
+# Compiler-specific compiler options
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c99")
+elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "PGI")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -c99")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -c99")
+elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c99")
+elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c99")
+endif()
+#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
+
+#==============================================================================
+#  PREPARE FOR TESTING
+#==============================================================================
+
+# Don't run these tests if we are using MPI SERIAL.
+if (NOT PIO_USE_MPISERIAL)
+  add_executable (piodecomptest EXCLUDE_FROM_ALL piodecomptest.c mpi_argp.c)
+  add_dependencies (tests piodecomptest)
+  target_link_libraries (piodecomptest pioc)
+endif()
+
+# Test Timeout in seconds.
+if (PIO_VALGRIND_CHECK)
+  set (DEFAULT_TEST_TIMEOUT 800)
+else ()
+  set (DEFAULT_TEST_TIMEOUT 600)
+endif ()
+
+if (NOT PIO_USE_MPISERIAL)
+  add_test(NAME piodecomptest
+    COMMAND piodecomptest
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+endif ()
+MESSAGE("CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS}")

--- a/tests/cperf/CMakeLists.txt
+++ b/tests/cperf/CMakeLists.txt
@@ -39,9 +39,4 @@ else ()
   set (DEFAULT_TEST_TIMEOUT 600)
 endif ()
 
-if (NOT PIO_USE_MPISERIAL)
-  add_test(NAME piodecomptest
-    COMMAND piodecomptest
-    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
-endif ()
 MESSAGE("CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS}")

--- a/tests/cperf/mpi_argp.c
+++ b/tests/cperf/mpi_argp.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <argp.h>
+
+/**
+ * Call <a href="http://www.gnu.org/s/libc/manual/html_node/Argp.html"
+ * >Argp</a>'s \c argp_parse in an MPI-friendly way.  Processes
+ * with nonzero rank will have their \c stdout and \c stderr redirected
+ * to <tt>/dev/null</tt> during \c argp_parse.
+ *
+ * @param rank MPI rank of this process.  Output from \c argp_parse
+ *             will only be observable from rank zero.
+ * @param argp      Per \c argp_parse semantics.
+ * @param argc      Per \c argp_parse semantics.
+ * @param argv      Per \c argp_parse semantics.
+ * @param flags     Per \c argp_parse semantics.
+ * @param arg_index Per \c argp_parse semantics.
+ * @param input     Per \c argp_parse semantics.
+ *
+ * @return Per \c argp_parse semantics.
+ */
+error_t mpi_argp_parse(const int rank,
+                       const struct argp *argp,
+                       int argc,
+                       char **argv,
+                       unsigned flags,
+                       int *arg_index,
+                       void *input)
+{
+    // Flush stdout, stderr
+    if (fflush(stdout))
+        perror("mpi_argp_parse error flushing stdout prior to redirect");
+    if (fflush(stderr))
+        perror("mpi_argp_parse error flushing stderr prior to redirect");
+
+    // Save stdout, stderr so we may restore them later
+    int stdout_copy, stderr_copy;
+    if ((stdout_copy = dup(fileno(stdout))) < 0)
+        perror("mpi_argp_parse error duplicating stdout");
+    if ((stderr_copy = dup(fileno(stderr))) < 0)
+        perror("mpi_argp_parse error duplicating stderr");
+
+    // On non-root processes redirect stdout, stderr to /dev/null
+    if (rank) {
+        if (!freopen("/dev/null", "a", stdout))
+            perror("mpi_argp_parse error redirecting stdout");
+        if (!freopen("/dev/null", "a", stderr))
+            perror("mpi_argp_parse error redirecting stderr");
+    }
+
+    // Invoke argp per http://www.gnu.org/s/libc/manual/html_node/Argp.html
+    error_t retval = argp_parse(argp, argc, argv, flags, arg_index, input);
+
+    // Flush stdout, stderr again
+    if (fflush(stdout))
+        perror("mpi_argp_parse error flushing stdout after redirect");
+    if (fflush(stderr))
+        perror("mpi_argp_parse error flushing stderr after redirect");
+
+    // Restore stdout, stderr
+    if (dup2(stdout_copy, fileno(stdout)) < 0)
+        perror("mpi_argp_parse error reopening stdout");
+    if (dup2(stderr_copy, fileno(stderr)) < 0)
+        perror("mpi_argp_parse error reopening stderr");
+
+    // Close saved versions of stdout, stderr
+    if (close(stdout_copy))
+        perror("mpi_argp_parse error closing stdout_copy");
+    if (close(stderr_copy))
+        perror("mpi_argp_parse error closing stderr_copy");
+
+    // Clear any errors that may have occurred on stdout, stderr
+    clearerr(stdout);
+    clearerr(stderr);
+
+    // Return what argp_parse returned
+    return retval;
+}

--- a/tests/cperf/piodecomptest.c
+++ b/tests/cperf/piodecomptest.c
@@ -1,0 +1,177 @@
+#include <config.h>
+#include <argp.h>
+#include <mpi.h>
+#include <pio.h>
+#include <pio_internal.h>
+
+const char *argp_program_version = "pioperformance 0.1";
+const char *argp_program_bug_address = "<https://github.com/NCAR/ParallelIO>";
+
+static char doc[] = 
+    "a test of pio for performance and correctness of a given decomposition";
+
+static struct argp_option options[] = {
+    {"wdecomp", 'w', "FILE", 0, "Decomposition file for write"},
+    {"rdecomp", 'r', "FILE", 0, "Decomposition file for read (same as write if not provided)"},
+    { 0 }
+};
+
+struct arguments 
+{
+    char *args[2];
+    char *wdecomp_file;
+    char *rdecomp_file;
+};
+
+static error_t
+parse_opt (int key, char *arg, struct argp_state *state)
+{
+    struct arguments *arguments = state->input;
+
+    switch (key)
+    {
+    case 'w':
+        arguments->wdecomp_file = arg;
+        break;
+    case 'r':
+        arguments->rdecomp_file = arg;
+        break;
+    case ARGP_KEY_ARG:
+        if (state->arg_num >= 2)
+            argp_usage(state);
+        arguments->args[state->arg_num] = arg;
+        break;
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+/* Our argp parser. */
+static struct argp argp = { options, parse_opt, 0, doc };
+
+error_t mpi_argp_parse(const int rank,
+                       const struct argp *argp,
+                       int argc,
+                       char **argv,
+                       unsigned flags,
+                       int *arg_index,
+                       void *input);
+
+static int debug = 0;
+
+double *varw, *varr;
+
+int test_write_darray(int iosys, const char decomp_file[], int rank)
+{
+    int ierr;
+    int comm_size;
+    int ncid;
+    int iotype = PIO_IOTYPE_PNETCDF;
+    int ndims;
+    int *global_dimlen;
+    int num_tasks;
+    int *maplen;
+    int maxmaplen;
+    int *full_map;
+    int *dimid;
+    int varid;
+    int globalsize;
+    int ioid;
+    char dimname[PIO_MAX_NAME];
+    char varname[PIO_MAX_NAME];
+
+    ierr = pioc_read_nc_decomp_int(iosys, decomp_file, &ndims, &global_dimlen, &num_tasks, 
+                                   &maplen, &maxmaplen, &full_map, NULL, NULL, NULL, NULL, NULL);
+    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+
+    ierr = MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+    /* TODO: allow comm_size to be >= num_tasks */
+    if(comm_size != num_tasks)
+    {
+        if(rank == 0)
+        {
+            printf("Not enough MPI tasks for decomp, expected task count %d\n",num_tasks);
+            ierr = MPI_Abort(MPI_COMM_WORLD, -1);
+        }
+    }
+       
+    ierr = PIOc_createfile(iosys, &ncid, &iotype, "testfile.nc", PIO_CLOBBER);
+    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+    
+    dimid = calloc(ndims,sizeof(int));
+    for(int i=0; i<ndims; i++)
+    {
+        sprintf(dimname,"dim%4.4d",i);
+        ierr = PIOc_def_dim(ncid, dimname, (PIO_Offset) global_dimlen[i], &(dimid[i]));
+        if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+    }
+    /* TODO: support multiple variables and types*/
+    sprintf(varname,"var%4.4d",0);
+    ierr = PIOc_def_var(ncid, varname, PIO_DOUBLE, ndims, dimid, &varid);
+    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+
+    free(dimid);
+    ierr = PIOc_enddef(ncid);
+    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+
+    PIO_Offset *dofmap;
+
+    if (!(dofmap = malloc(sizeof(PIO_Offset) * maplen[rank])))
+        return PIO_ENOMEM;
+
+    /* Copy array into PIO_Offset array. */
+    varw = malloc(sizeof(double)*maplen[rank]);
+    for (int e = 0; e < maplen[rank]; e++)
+    {
+        dofmap[e] = full_map[rank * maxmaplen + e];
+        varw[e] = dofmap[e];
+    }
+
+    ierr = PIOc_InitDecomp(iosys, PIO_DOUBLE, ndims, global_dimlen, maplen[rank],
+                           dofmap, &ioid, NULL, NULL, NULL);
+
+
+    ierr = PIOc_write_darray(ncid, varid, ioid, maplen[rank], varw, NULL);
+
+    ierr = PIOc_closefile(ncid);
+    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+
+    free(varw);
+
+    return ierr;
+}
+
+int main(int argc, char *argv[])
+{
+    struct arguments arguments;
+    int ierr;
+    int rank;
+    int iosys;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    arguments.wdecomp_file = NULL;
+    arguments.rdecomp_file = NULL;
+
+    mpi_argp_parse(rank, &argp, argc, argv, 0, 0, &arguments);
+
+    if(! arguments.wdecomp_file){
+        argp_usage(0);
+        MPI_Abort(MPI_COMM_WORLD, ierr);
+    }
+    if(! arguments.rdecomp_file)
+        arguments.rdecomp_file = arguments.wdecomp_file;
+
+    ierr = PIOc_Init_Intracomm(MPI_COMM_WORLD, 1, 1, 0, PIO_REARR_SUBSET, &iosys);
+    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+    
+    ierr = test_write_darray(iosys, arguments.wdecomp_file, rank);
+    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+
+    MPI_Finalize();
+
+}
+

--- a/tests/cperf/piodecomptest.c
+++ b/tests/cperf/piodecomptest.c
@@ -217,8 +217,8 @@ int test_read_darray(int iosys,const char decomp_file[], int rank)
     ierr = PIOc_closefile(ncid);
     if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
 
-    for(int i=0; i < maplen[rank]; i++)
-        printf("%d: varr[%d] = %f\n",rank, i, varr[i]);
+//    for(int i=0; i < maplen[rank]; i++)
+//        printf("%d: varr[%d] = %f\n",rank, i, varr[i]);
 
 
     return ierr;
@@ -243,22 +243,22 @@ int main(int argc, char *argv[])
 
     mpi_argp_parse(rank, &argp, argc, argv, 0, 0, &arguments);
 
-    if(! arguments.wdecomp_file){
-        argp_usage(0);
-        MPI_Abort(MPI_COMM_WORLD, ierr);
-    }
     if(! arguments.rdecomp_file)
         arguments.rdecomp_file = arguments.wdecomp_file;
 
-    ierr = PIOc_Init_Intracomm(MPI_COMM_WORLD, 1, 1, 0, PIO_REARR_BOX, &iosys);
-    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
-    
-//    ierr = test_write_darray(iosys, arguments.wdecomp_file, rank);
-//    if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
-
-    ierr = test_read_darray(iosys, arguments.rdecomp_file, rank);
+    ierr = PIOc_Init_Intracomm(MPI_COMM_WORLD, 1, 1, 0, PIO_REARR_SUBSET, &iosys);
     if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
 
+    if(arguments.wdecomp_file)
+    {
+        ierr = test_write_darray(iosys, arguments.wdecomp_file, rank);
+        if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+    }
+    if(arguments.rdecomp_file)
+    {
+        ierr = test_read_darray(iosys, arguments.rdecomp_file, rank);
+        if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
+    }
     MPI_Finalize();
 
 }

--- a/tests/cunit/test_darray_async.c
+++ b/tests/cunit/test_darray_async.c
@@ -245,7 +245,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm, MPI_Comm
         PBAIL(ret);
 
     /* Write the decomp file (on appropriate tasks). */
-    if ((ret = PIOc_write_nc_decomp(iosysid, decomp_filename, 0, ioid, NULL, NULL, 0)))
+    if ((ret = PIOc_write_nc_decomp(iosysid, decomp_filename, 0, ioid, "test_darray_async", " short history", 0)))
         return ret;
 
     int fortran_order;


### PR DESCRIPTION
Refactors the subset decomposition method to support multiple destinations for each source when reading.  This allows for example halo regions to be populated.    This method so far only works for the subset rearranger and the mapping file cannot be used for write since it would be in-determinant to have multiple sources for the same destination.  

