### PR TITLE
fortran pio_deletefile return code, optional for backward compatiblity

### DIFF
--- a/src/flib/piolib_mod.F90
+++ b/src/flib/piolib_mod.F90
@@ -1460,6 +1460,7 @@ contains
   !!
   !! @param ios a pio system handle
   !! @param fname a filename
+  !! @param rc an optional return code
   !! @author Jim Edwards
   !<
   subroutine pio_deletefile(ios, fname, rc)

--- a/src/flib/piolib_mod.F90
+++ b/src/flib/piolib_mod.F90
@@ -1462,10 +1462,12 @@ contains
   !! @param fname a filename
   !! @author Jim Edwards
   !<
-  subroutine pio_deletefile(ios, fname)
+  subroutine pio_deletefile(ios, fname, rc)
     type(iosystem_desc_t) :: ios
     character(len=*) :: fname
     integer :: ierr
+    integer, optional, intent(out) :: rc
+
     interface
        integer(c_int) function PIOc_deletefile(iosid, fname) &
             bind(C,name="PIOc_deletefile")
@@ -1476,7 +1478,7 @@ contains
     end interface
 
     ierr = PIOc_deletefile(ios%iosysid, trim(fname)//C_NULL_CHAR)
-
+    if(present(rc)) rc = ierr
   end subroutine pio_deletefile
 
   !>


### PR DESCRIPTION
Fixes #281 I did this with an optional field to maintain backward compatiblity.