### PR TITLE
#define PIO_64BIT_DATA NC_64BIT_DATA requires netcdf 4.4.0 or newer

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -675,10 +675,7 @@ enum PIO_ERROR_HANDLERS
 #define PIO_MAX_NAME NC_MAX_NAME /**< Max name length. */
 #define PIO_MAX_VAR_DIMS NC_MAX_VAR_DIMS /**< max per variable dimensions */
 #define PIO_64BIT_OFFSET NC_64BIT_OFFSET /**< Use large (64-bit) file offsets. Mode flag for nc_create(). */
-
-/** NC_64BIT_DATA This is a problem - need to define directly instead
- * of using include file. */
-#define PIO_64BIT_DATA 0x0010 /**< CDF5 foemat. */
+#define PIO_64BIT_DATA NC_64BIT_DATA /**< CDF5 format. */
 
 /** Define the netCDF-based error codes. */
 #define PIO_NOERR  NC_NOERR           /**< No Error */


### PR DESCRIPTION
We can safely define this now.   