### PR TITLE
make work with cmake 3.5.2 (esmf requirement)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # Jim Edwards
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.5.2)
 project (PIO C)
 
 # The project version number.
@@ -246,7 +246,8 @@ endif ()
 
 # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
 if (CMAKE_C_COMPILER_NAME STREQUAL "GNU")
-  if ("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER_EQUAL 10)
+  if ("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS 10)
+  else()
     set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
   endif()
 endif()


### PR DESCRIPTION
ESMF has a requirement to work with cmake 3.5.2, this change allows the older version.