### PR TITLE
Bug fix examples/c/piorcw.c

### DIFF
--- a/examples/c/piorcw.c
+++ b/examples/c/piorcw.c
@@ -109,7 +109,7 @@ int rcw_read_darray(int iosys,int rank)
     char dimname[PIO_MAX_NAME];
     char varname[PIO_MAX_NAME];
 
-    int ndims, nvars, natts, unlimdim;
+    int nvars, natts, unlimdim;
     dimlist *dim;
 
     ierr = MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -122,7 +122,7 @@ int rcw_read_darray(int iosys,int rank)
 
 
     dim = (dimlist *) malloc(ndims*sizeof(dimlist));
-    for(i=0; i<ndims; i++){
+    for(int i=0; i<ndims; i++){
         ierr = PIOc_inq_dim(ncid, i, dim[i].name, dim[i].value);
         if(ierr || debug) printf("%d %d i=%d\n",__LINE__,ierr, i);
     }
@@ -131,10 +131,12 @@ int rcw_read_darray(int iosys,int rank)
 
 
     /* TODO: support multiple variables and types*/
+    /*
     if(myvarname != NULL)
         sprintf(varname,"%s",myvarname);
     else
-        sprintf(varname,"var%4.4d",0);
+    */
+    sprintf(varname,"var%4.4d",0);
     ierr = PIOc_inq_varid(ncid, varname, &varid);
     if(ierr || debug) printf("%d %d\n",__LINE__,ierr);
 
@@ -221,7 +223,9 @@ int rcw_read_darray(int iosys,int rank)
 
 int main(int argc, char *argv[])
 {
+    /*
     struct arguments arguments;
+    */
     int ierr;
     int rank;
     int comm_size;


### PR DESCRIPTION
Compilation fails due to errors in examples/c/piorcw.c.

```
[ 95%] Building C object examples/c/CMakeFiles/piorcw.dir/piorcw.c.o
/home/ec2-user/ParallelIO-pio2_6_0/examples/c/piorcw.c(112): error: "ndims" has already been declared in the current scope
      int ndims, nvars, natts, unlimdim;
          ^

/home/ec2-user/ParallelIO-pio2_6_0/examples/c/piorcw.c(125): error: identifier "i" is undefined
      for(i=0; i<ndims; i++){
          ^

/home/ec2-user/ParallelIO-pio2_6_0/examples/c/piorcw.c(134): error: identifier "myvarname" is undefined
      if(myvarname != NULL)
         ^

/home/ec2-user/ParallelIO-pio2_6_0/examples/c/piorcw.c(224): error: incomplete type is not allowed
      struct arguments arguments;
                       ^

compilation aborted for /home/ec2-user/ParallelIO-pio2_6_0/examples/c/piorcw.c (code 2)
make[2]: *** [examples/c/CMakeFiles/piorcw.dir/piorcw.c.o] Error 2
make[1]: *** [examples/c/CMakeFiles/piorcw.dir/all] Error 2
make: *** [all] Error 2
```

Note there is still a warning when compiling piorcw:

```
/home/ec2-user/ParallelIO/examples/c/piorcw.c(126): warning #167: argument of type "int" is incompatible with parameter of type "MPI_Offset={long long} *"
          ierr = PIOc_inq_dim(ncid, i, dim[i].name, dim[i].value);
```

This PR fixes issue #1964