### PR TITLE
remove unused protex markups

### DIFF
--- a/examples/basic/kinds_mod.F90
+++ b/examples/basic/kinds_mod.F90
@@ -2,7 +2,7 @@
 
  module kinds_mod
 
-!BOP
+!
 ! !MODULE: kinds_mod
 !
 ! !DESCRIPTION:
@@ -31,9 +31,9 @@
       r4        = selected_real_kind(6)  ,&
       r8        = selected_real_kind(13)
 
-!EOP
-!BOC
-!EOC
+!
+!
+!
 !***********************************************************************
 
  end module kinds_mod

--- a/src/gptl/perf_utils.F90
+++ b/src/gptl/perf_utils.F90
@@ -317,7 +317,7 @@ END SUBROUTINE shr_mpi_bcastl0
 
 !================== Routines from csm_share/shr/shr_file_mod.F90 ===============
 !===============================================================================
-!BOP ===========================================================================
+!===========================================================================
 !
 ! !IROUTINE: shr_file_getUnit -- Get a free FORTRAN unit number
 !
@@ -333,7 +333,7 @@ INTEGER FUNCTION shr_file_getUnit ()
 
    implicit none
 
-!EOP
+!
 
    !----- local parameters -----
    integer(SHR_KIND_IN),parameter :: shr_file_minUnit = 10      ! Min unit number to give
@@ -367,7 +367,7 @@ END FUNCTION shr_file_getUnit
 !===============================================================================
 
 !===============================================================================
-!BOP ===========================================================================
+!===============================================================================
 !
 ! !IROUTINE: shr_file_freeUnit -- Free up a FORTRAN unit number
 !
@@ -387,7 +387,7 @@ SUBROUTINE shr_file_freeUnit ( unit)
 
    integer(SHR_KIND_IN),intent(in) :: unit  ! unit number to be freed
 
-!EOP
+!
 
    !----- local parameters -----
    integer(SHR_KIND_IN),parameter :: shr_file_minUnit = 10      ! Min unit number to give


### PR DESCRIPTION
Remove protex markups, ParallelIO does not use protex and they cause issues in ESMF.