### PR TITLE
Add check to accomodate move away from _FillValue in libnetcdf

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -27,6 +27,11 @@
     (((NC_VERSION_MAJOR == Maj) && (NC_VERSION_MINOR == Min) && (NC_VERSION_PATCH >= Pat)) || \
      ((NC_VERSION_MAJOR == Maj) && (NC_VERSION_MINOR > Min)) || (NC_VERSION_MAJOR > Maj))
 
+#if defined(NC_FillValue)
+#define NCDF_FillValue NC_FillValue
+#elif defined(_FillValue)
+#define NCDF_Fillvalue _FillValue
+#endif
 
 /** PIO_OFFSET is an integer type of size sufficient to represent the
  * size (in bytes) of the largest file supported by MPI. This is not

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2574,7 +2574,7 @@ PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
 
             if (!ierr && fill_valuep)
             {
-                ierr = nc_get_att(file->fh, varid, _FillValue, fill_valuep);
+                ierr = nc_get_att(file->fh, varid, NCDF_FillValue, fill_valuep);
                 if (ierr == NC_ENOTATT)
                 {
                     char char_fill_value = NC_FILL_CHAR;

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2430,7 +2430,7 @@ PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_valuep)
             {
                 ierr = nc_set_fill(file->fh, NC_FILL, NULL);
                 if (!ierr)
-                    ierr = nc_put_att(file->fh, varid, _FillValue, xtype, 1, fill_valuep);
+                    ierr = nc_put_att(file->fh, varid, NCDF_FillValue, xtype, 1, fill_valuep);
             }
         }
         else


### PR DESCRIPTION
Adopted from the approach taken by `GDAL` to address the same issue [see reference here](https://github.com/OSGeo/gdal/blob/9ada0c882751f18c8156aa2fd51afd6f6540a46f/frmts/netcdf/netcdfdataset.h#L184).  This will allow `ParallelIO` to compile without having to worry about changing any workflows around the `--enable-legacy-macros` flag [being introduced in v4.9.3](https://github.com/Unidata/netcdf-c/issues/3029). 