### PR TITLE
Fix issues that prevent compilation in Cygwin

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -175,8 +175,8 @@ endif ()
 
 include(CheckTypeSize)
 check_type_size("size_t" SIZEOF_SIZE_T)
-CHECK_TYPE_SIZE("long long" SIZEOF_LONG_LONG)
-if (NOT ${SIZEOF_SIZE_T} EQUAL ${SIZEOF_LONG_LONG})
+check_type_size("long long" SIZEOF_LONG_LONG)
+if (NOT "${SIZEOF_SIZE_T}" STREQUAL "${SIZEOF_LONG_LONG}")
   message (FATAL_ERROR "size_t and long long must be the same size!")
 endif ()
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -9,7 +9,15 @@
 #include <pio.h>
 #include <pio_internal.h>
 
+#if defined __has_include
+#if __has_include (<execinfo.h>)
+#define PLATFORM_HAS_EXECINFO
+#endif /* __has_include (<execinfo.h>) */
+#endif /* __has_include */
+
+#ifdef PLATFORM_HAS_EXECINFO
 #include <execinfo.h>
+#endif /* PLATFORM_HAS_EXECINFO */
 
 /** This is used with text decomposition files. */
 #define VERSNO 2001
@@ -522,6 +530,7 @@ pio_log(int severity, const char *fmt, ...)
 void
 print_trace(FILE *fp)
 {
+#ifdef PLATFORM_HAS_EXECINFO
     void *array[10];
     size_t size;
     char **strings;
@@ -540,6 +549,9 @@ print_trace(FILE *fp)
         fprintf(fp,"%s\n", strings[i]);
 
     free(strings);
+#else
+    (void)fp;
+#endif /* PLATFORM_HAS_EXECINFO */
 }
 
 /**
@@ -1532,6 +1544,7 @@ pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, 
                                  strlen(my_order_str) + 1, my_order_str)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
+#ifdef PLATFORM_HAS_EXECINFO
     /* Write an attribute with the stack trace. This can be helpful
      * for debugging. */
     void *bt[MAX_BACKTRACE];
@@ -1562,6 +1575,7 @@ pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, 
     if ((ret = PIOc_put_att_text(ncid, NC_GLOBAL, DECOMP_BACKTRACE_ATT_NAME,
                                  strlen(full_bt) + 1, full_bt)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+#endif /* PLATFORM_HAS_EXECINFO */
 
     /* We need a dimension for the dimensions in the data. (Example:
      * for 4D data we will need to store 4 dimension IDs.) */


### PR DESCRIPTION
[See my PR for ESMF](https://github.com/esmf-org/esmf/pull/348). ESMF uses ParallelIO, and it fails to build through cygwin because of a few small issues in ParallelIO. Here, I try to address those:

- In the src/clib/CMakeLists.txt, there is a check that long long and size_t are the same size. On cygwin, these sizes cannot be retrieved, which makes them both empty strings. This causes the check to fail, because empty strings cannot be parsed as numbers so ${SIZEOF_SIZE_T} EQUAL ${SIZEOF_LONG_LONG} evaluates to false in CMake. I modified the check to simply test if they are the same, not if they are parsable numbers and the same.
- In the src/clib/pioc_support.c there is an include of execinfo.h. This header is missing on many platforms, including Cygwin. I have added a more portable check to see if the header is available, and I have excluded the include and the use of the backtrace functionality from that file when execinfo.h is not available. The backtrace functionality appears to be added as some useful logging for debugging purposes, but not as a necessary feature of the library, so I hope I was correct that it could simply be turned off. I have tried to suppress any warnings of unused variables.

Thank you for considering this, and please let me know if I should make changes!