### PR TITLE
Check Fortran compiler name instead of C compiler name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ if (PIO_ENABLE_COVERAGE)
 endif ()
 
 # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
-if (CMAKE_C_COMPILER_NAME STREQUAL "GNU")
+if (CMAKE_Fortran_COMPILER_NAME STREQUAL "GNU")
   if ("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS 10)
     message (WARNING "gfortran version is ${CMAKE_Fortran_COMPILER_VERSION}")
   else()


### PR DESCRIPTION
There is some logic in the CMakeLists.txt file that checks the name of the C compiler to determine if it is the GNU compiler. This logic should be changed to check the name of the Fortran compiler instead. This is important on a Mac where the C compiler is clang and the Fortran compiler is gfortran.

Without this change, I was getting build failures on my Mac in gptl and the tests. This change resolved those build failures (changing warnings to errors).