### PR TITLE
Bump CMake required version to 3.5.2

### DIFF
--- a/doc/source/Installing.txt
+++ b/doc/source/Installing.txt
@@ -82,7 +82,7 @@ autotools build.
 
  - @ref mach_walkthrough
 
-To configure the build, PIO requires CMake version 2.8.12+.  The typical
+To configure the build, PIO requires CMake version 3.5.2+.  The typical
 configuration with CMake can be done as follows:
 
     > CC=mpicc FC=mpif90 cmake [-DOPTION1=value1 -DOPTION2=value2 ...] /path/to/pio/source

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.2)
 include (CheckFunctionExists)
 project (PIOC C)
 

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.2)
 project (PIOF Fortran)
 include (CheckFunctionExists)
 include (ExternalProject)

--- a/src/gptl/CMakeLists.txt
+++ b/src/gptl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.2)
 project (GPTL C Fortran)
 include (CheckFunctionExists)
 include (FortranCInterface)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5.2)
 project (PIOTests C Fortran)
 
 #==============================================================================


### PR DESCRIPTION
Updates CMake version requirement from 2.8.12 to 3.5.2 in all files. Fixes [issue](https://github.com/NCAR/ParallelIO/issues/2006) with CMake 4.0.0.