### PR TITLE
Include lib/CMAKE_LIBRARY_ARCHITECTURE in LibFind

### DIFF
--- a/cmake/LibFind.cmake
+++ b/cmake/LibFind.cmake
@@ -254,7 +254,7 @@ function (find_package_component PKG)
                 find_library (${PKGCOMP}_LIBRARY
                               NAMES ${${PKGCOMP}_LIBRARY_NAMES}
                               PATHS ${${PKGCOMP}_PREFIX}
-                              PATH_SUFFIXES lib
+                              PATH_SUFFIXES lib lib/${CMAKE_LIBRARY_ARCHITECTURE}
                               NO_DEFAULT_PATH)
 
                 # If found, check if library is static or dynamic
@@ -266,7 +266,7 @@ function (find_package_component PKG)
                         find_shared_library (${PKGCOMP}_SHARED_LIBRARY
                                              NAMES ${${PKGCOMP}_LIBRARY_NAMES}
                                              PATHS ${${PKGCOMP}_PREFIX}
-                                             PATH_SUFFIXES lib
+                                             PATH_SUFFIXES lib lib/${CMAKE_LIBRARY_ARCHITECTURE}
                                              NO_DEFAULT_PATH)
                         if (${PKGCOMP}_SHARED_LIBRARY)
                             set (${PKGCOMP}_LIBRARY ${${PKGCOMP}_SHARED_LIBRARY})
@@ -278,7 +278,7 @@ function (find_package_component PKG)
                         find_static_library (${PKGCOMP}_STATIC_LIBRARY
                                              NAMES ${${PKGCOMP}_LIBRARY_NAMES}
                                              PATHS ${${PKGCOMP}_PREFIX}
-                                             PATH_SUFFIXES lib
+                                             PATH_SUFFIXES lib lib/${CMAKE_LIBRARY_ARCHITECTURE}
                                              NO_DEFAULT_PATH)
                         if (${PKGCOMP}_STATIC_LIBRARY)
                             set (${PKGCOMP}_LIBRARY ${${PKGCOMP}_STATIC_LIBRARY})
@@ -311,7 +311,9 @@ function (find_package_component PKG)
         mark_as_advanced (${PKGCOMP}_INCLUDE_DIR ${PKGCOMP}_LIBRARY)
 
         # HACK For bug in CMake v3.0:
-        set (${PKGCOMP}_FOUND ${${PKGCOMPUP}_FOUND})
+        if (NOT DEFINED ${PKGCOMP}_FOUND AND DEFINED ${PKGCOMPUP}_FOUND)
+            set (${PKGCOMP}_FOUND ${${PKGCOMPUP}_FOUND})
+        endif ()
 
         # Set return variables
         if (${PKGCOMP}_FOUND)


### PR DESCRIPTION
## Issue
apt installs NetCDF libraries to `/usr/lib/<architecture>` instead of `/usr/lib`. It's possible to configure Spack to use an externally installed NetCDF library using `packages.yaml`. So if you want parallelio to find libraries installed by apt that are externally configured for Spack then you need to search the `/usr/lib/<architecture>` directory. Note that I am using apt to install libraries because I'm building container images using emulation for multiple architectures. If I were to build each library (instead of using binaries provided by apt) then it would take 12 hours (an estimate) and that's not possible for automated deployment from GitHub runners.

example packages.yaml file
```yaml
packages:
  netcdf-c:
    externals:
    - spec: netcdf-c@4.9.3%gcc@15.2.0
      prefix: /usr
```

## Changes
This fix adds lib/${CMAKE_LIBRARY_ARCHITECTURE} to the search suffixes in LibFind.cmake. It also fixes an issue setting ${PKGCOMP}_FOUND in the same file.

## Testing
I've lightly tested this in a dev container. It can use more robust testing.