### PR TITLE
update version to 2.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ project(PIO LANGUAGES C)
 
 # The project version number (modern style)
 set(VERSION_MAJOR 2 CACHE STRING "Project major version number.")
-set(VERSION_MINOR 6 CACHE STRING "Project minor version number.")
-set(VERSION_PATCH 9 CACHE STRING "Project patch version number.")
+set(VERSION_MINOR 7 CACHE STRING "Project minor version number.")
+set(VERSION_PATCH 0 CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(PIO_VERSION_MAJOR ${VERSION_MAJOR})

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 ## Ed Hartnett 8/16/17
 
 # Initialize autoconf and automake.
-AC_INIT(pio, 2.6.9)
+AC_INIT(pio, 2.7.0)
 AC_CONFIG_SRCDIR(src/clib/pio_darray.c)
 AM_INIT_AUTOMAKE([foreign serial-tests])
 
@@ -10,16 +10,16 @@ AM_INIT_AUTOMAKE([foreign serial-tests])
 # The PIO version, again. Use AC_SUBST for pio_meta.h and
 # AC_DEFINE_UNQUOTED for config.h.
 AC_SUBST([PIO_VERSION_MAJOR]) PIO_VERSION_MAJOR=2
-AC_SUBST([PIO_VERSION_MINOR]) PIO_VERSION_MINOR=6
-AC_SUBST([PIO_VERSION_PATCH]) PIO_VERSION_PATCH=9
+AC_SUBST([PIO_VERSION_MINOR]) PIO_VERSION_MINOR=7
+AC_SUBST([PIO_VERSION_PATCH]) PIO_VERSION_PATCH=0
 AC_DEFINE_UNQUOTED([PIO_VERSION_MAJOR], [$PIO_VERSION_MAJOR], [PIO major version])
 AC_DEFINE_UNQUOTED([PIO_VERSION_MINOR], [$PIO_VERSION_MINOR], [PIO minor version])
 AC_DEFINE_UNQUOTED([PIO_VERSION_PATCH], [$PIO_VERSION_PATCH], [PIO patch version])
 
 # Once more for the documentation.
 AC_SUBST([VERSION_MAJOR], [2])
-AC_SUBST([VERSION_MINOR], [6])
-AC_SUBST([VERSION_PATCH], [9])
+AC_SUBST([VERSION_MINOR], [7])
+AC_SUBST([VERSION_PATCH], [0])
 
 
 # The m4 directory holds macros for autoconf.


### PR DESCRIPTION
This pull request updates the project version from 2.6.9 to 2.7.0 across the build configuration files to reflect a new release.

Version update:

* Updated the version numbers in `CMakeLists.txt` to set `VERSION_MINOR` to 7 and `VERSION_PATCH` to 0.
* Updated the version numbers in `configure.ac` to set `PIO_VERSION_MINOR` and `VERSION_MINOR` to 7, and `PIO_VERSION_PATCH` and `VERSION_PATCH` to 0.